### PR TITLE
Add token cost safeguards for tool-calling loop

### DIFF
--- a/src/components/ComparisonDisplay.tsx
+++ b/src/components/ComparisonDisplay.tsx
@@ -24,6 +24,7 @@ interface StreamingPanelState {
   isComplete: boolean;
   duration_ms?: number;
   tokens_used?: number;
+  token_limit_exceeded?: boolean;
   tools_called?: ToolCall[];
 }
 
@@ -94,6 +95,7 @@ export default function ComparisonDisplay({
         content={withMcpContent}
         duration_ms={isStreaming ? streamingWithMcp?.duration_ms : withMcp?.duration_ms}
         tokens_used={isStreaming ? streamingWithMcp?.tokens_used : withMcp?.tokens_used}
+        token_limit_exceeded={isStreaming ? streamingWithMcp?.token_limit_exceeded : undefined}
         tools_called={isStreaming ? streamingWithMcp?.tools_called : withMcp?.tools_called}
         isLoading={isLoading && !isStreaming}
         variant="with-mcp"

--- a/src/components/ResponsePanel.tsx
+++ b/src/components/ResponsePanel.tsx
@@ -12,6 +12,7 @@ interface ResponsePanelProps {
   content: string;
   duration_ms?: number;
   tokens_used?: number;
+  token_limit_exceeded?: boolean;
   tools_called?: ToolCall[];
   isLoading?: boolean;
   variant: 'without-mcp' | 'with-mcp';
@@ -28,6 +29,7 @@ export default function ResponsePanel({
   content,
   duration_ms,
   tokens_used,
+  token_limit_exceeded,
   tools_called,
   isLoading,
   variant,
@@ -114,6 +116,7 @@ export default function ResponsePanel({
           toolsCalled={tools_called}
           duration_ms={duration_ms}
           tokens_used={tokens_used}
+          token_limit_exceeded={token_limit_exceeded}
           isComplete={isStreaming ? !!duration_ms : !!content}
           isActive={!!isStreaming && !duration_ms}
           showFooter={!isLoading && !!(duration_ms || tokens_used)}

--- a/src/components/shared/McpResponseDisplay.tsx
+++ b/src/components/shared/McpResponseDisplay.tsx
@@ -16,6 +16,7 @@ interface McpResponseDisplayProps {
   toolsCalled?: ToolCall[];
   duration_ms?: number;
   tokens_used?: number;
+  token_limit_exceeded?: boolean;
   isComplete?: boolean;
   isActive?: boolean;
   showFooter?: boolean;
@@ -177,6 +178,7 @@ export default function McpResponseDisplay({
   toolsCalled = [],
   duration_ms,
   tokens_used,
+  token_limit_exceeded,
   isComplete,
   isActive,
   showFooter,
@@ -361,7 +363,12 @@ export default function McpResponseDisplay({
             )}
             {tokens_used && (
               <span>
-                <strong>Tokens:</strong> {tokens_used}
+                <strong>Tokens:</strong> {tokens_used.toLocaleString()}
+                {token_limit_exceeded && (
+                  <span style={{ color: 'var(--nyc-caution)', marginLeft: '6px' }}>
+                    (limit reached)
+                  </span>
+                )}
               </span>
             )}
           </div>

--- a/src/hooks/useStreamingComparison.ts
+++ b/src/hooks/useStreamingComparison.ts
@@ -45,6 +45,7 @@ interface PanelState {
   isComplete: boolean;
   duration_ms?: number;
   tokens_used?: number;
+  token_limit_exceeded?: boolean;
   tools_called?: ToolCall[];
   error?: string;
 }
@@ -419,6 +420,7 @@ function handleEvent(
         content: string;
         duration_ms: number;
         tokens_used: number;
+        token_limit_exceeded?: boolean;
         tools_called?: ToolCall[];
       };
       setState(prev => {
@@ -449,6 +451,7 @@ function handleEvent(
             content: data.content,
             duration_ms: data.duration_ms,
             tokens_used: data.tokens_used,
+            token_limit_exceeded: data.token_limit_exceeded,
             tools_called: data.tools_called,
             isComplete: true,
             progress: null,

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -8,19 +8,20 @@ export const socrataMcpTools: ChatCompletionTool[] = [
       name: 'get_data',
       description: `Unified Socrata open data access tool. Supports multiple operation types:
 - catalog: Search the catalog for datasets matching a query on a Socrata portal
-- metadata: Get detailed metadata about a specific dataset (IMPORTANT: pass dataset_id in the "query" parameter, not "dataset_id")
+- metadata: Get detailed metadata about a specific dataset
 - query: Execute a SoQL query against a dataset to fetch and filter data
-- metrics: Get metrics/statistics about a dataset
+- metrics: Get row count, view count, last-updated timestamps for a dataset
 
 IMPORTANT TIPS:
-1. For type=metadata, pass the dataset ID in the "query" parameter (e.g., "query": "erm2-nwe9")
+1. For type=metadata and type=metrics, pass the dataset ID in "dataset_id"
 2. For type=query, ALWAYS start by fetching a sample with no WHERE clause to see actual column values
 3. NYC 311 data uses field names like: complaint_type, descriptor, created_date, community_board
 4. Field values are case-sensitive - fetch sample data first to see exact formats
 
 Examples:
 - Search catalog: { "type": "catalog", "portal": "data.cityofnewyork.us", "query": "311 complaints" }
-- Get metadata: { "type": "metadata", "portal": "data.cityofnewyork.us", "query": "erm2-nwe9" }
+- Get metadata: { "type": "metadata", "portal": "data.cityofnewyork.us", "dataset_id": "erm2-nwe9" }
+- Get metrics: { "type": "metrics", "portal": "data.cityofnewyork.us", "dataset_id": "erm2-nwe9" }
 - Fetch sample data first: { "type": "query", "portal": "data.cityofnewyork.us", "dataset_id": "erm2-nwe9", "limit": 5 }
 - Query with filter: { "type": "query", "portal": "data.cityofnewyork.us", "dataset_id": "erm2-nwe9", "select": "complaint_type, COUNT(*) as count", "group": "complaint_type", "order": "count DESC", "limit": 10 }`,
       parameters: {
@@ -41,7 +42,7 @@ Examples:
           },
           dataset_id: {
             type: 'string',
-            description: 'Dataset identifier (required for type=query)',
+            description: 'Dataset identifier (required for type=query, metadata, and metrics)',
           },
           limit: {
             type: 'number',

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -25,6 +25,7 @@ export interface CompletionResult {
   content: string;
   duration_ms: number;
   tokens_used: number;
+  token_limit_exceeded?: boolean;
   tools_called?: {
     name: string;
     args: Record<string, unknown>;
@@ -33,6 +34,33 @@ export interface CompletionResult {
     operationType?: string;
     reason?: string;
   }[];
+}
+
+// Token safety limits
+const MAX_TOKENS_PER_REQUEST = 100_000;
+const MAX_TOOL_RESULT_CHARS = 25_000;
+
+// Truncate large tool results to limit input token growth
+function truncateToolResult(result: string): string {
+  if (result.length <= MAX_TOOL_RESULT_CHARS) return result;
+
+  try {
+    const parsed = JSON.parse(result);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      // Keep enough rows to stay under the limit
+      const sampleRow = JSON.stringify(parsed[0]);
+      const rowSize = sampleRow.length + 2; // comma + newline
+      const maxRows = Math.max(5, Math.floor(MAX_TOOL_RESULT_CHARS / rowSize));
+      const truncated = parsed.slice(0, maxRows);
+      return JSON.stringify(truncated) +
+        `\n[Truncated: showing ${truncated.length} of ${parsed.length} rows]`;
+    }
+  } catch {
+    // Not JSON — fall through to raw truncation
+  }
+
+  return result.slice(0, MAX_TOOL_RESULT_CHARS) +
+    `\n[Truncated: result was ${result.length} characters]`;
 }
 
 export async function queryWithoutMcpStreaming(
@@ -119,6 +147,8 @@ export async function queryWithMcpStreaming(
 
     let iterations = 0;
     const maxIterations = 10;
+    let cumulativeTokens = response.usage?.total_tokens || 0;
+    let tokenLimitExceeded = false;
 
     // Handle tool calls iteratively
     while (response.choices[0]?.message?.tool_calls && iterations < maxIterations) {
@@ -170,10 +200,13 @@ export async function queryWithMcpStreaming(
               callbacks.onProgress(panel, resultMessage, { phase: 'tool_result', iteration: currentIteration, args });
             }
 
+            // Truncate large results before feeding back as context
+            const truncatedResult = truncateToolResult(result);
+
             messages.push({
               role: 'tool',
               tool_call_id: toolCall.id,
-              content: result,
+              content: truncatedResult,
             });
           } catch (error) {
             messages.push({
@@ -183,6 +216,13 @@ export async function queryWithMcpStreaming(
             });
           }
         }
+      }
+
+      // Check token limit before making the next LLM call
+      if (cumulativeTokens >= MAX_TOKENS_PER_REQUEST) {
+        tokenLimitExceeded = true;
+        callbacks.onProgress(panel, `Token limit reached (${cumulativeTokens.toLocaleString()} tokens used). Generating response with data collected so far...`, { phase: 'synthesize' });
+        break;
       }
 
       // Narrate the thinking step
@@ -197,24 +237,32 @@ export async function queryWithMcpStreaming(
         max_tokens: 2000,
       });
 
+      // Track cumulative tokens
+      cumulativeTokens += response.usage?.total_tokens || 0;
+
       iterations++;
     }
 
-    // Handle max iterations case
+    // Handle max iterations, token limit, or pending tool calls
     const lastMessage = response.choices[0]?.message;
-    if (!lastMessage?.content && (iterations >= maxIterations || lastMessage?.tool_calls)) {
+    if (!lastMessage?.content && (iterations >= maxIterations || tokenLimitExceeded || lastMessage?.tool_calls)) {
       if (lastMessage?.tool_calls) {
         messages.push(lastMessage);
+        const abortReason = tokenLimitExceeded
+          ? 'Token budget exceeded. Please provide a summary based on the data already collected.'
+          : 'Tool call limit reached. Please provide a summary based on the data already collected.';
         for (const toolCall of lastMessage.tool_calls) {
           messages.push({
             role: 'tool',
             tool_call_id: toolCall.id,
-            content: 'Tool call limit reached. Please provide a summary based on the data already collected.',
+            content: abortReason,
           });
         }
       }
 
-      callbacks.onProgress(panel, 'Generating final response...', { phase: 'synthesize' });
+      if (!tokenLimitExceeded) {
+        callbacks.onProgress(panel, 'Generating final response...', { phase: 'synthesize' });
+      }
 
       // Make final streaming call without tools
       const finalStream = await openrouter.chat.completions.create({
@@ -231,7 +279,7 @@ export async function queryWithMcpStreaming(
       });
 
       let content = '';
-      let tokensUsed = 0;
+      let finalCallTokens = 0;
 
       for await (const chunk of finalStream) {
         const delta = chunk.choices[0]?.delta?.content;
@@ -240,15 +288,17 @@ export async function queryWithMcpStreaming(
           callbacks.onToken(panel, delta);
         }
         if (chunk.usage?.total_tokens) {
-          tokensUsed = chunk.usage.total_tokens;
+          finalCallTokens = chunk.usage.total_tokens;
         }
       }
 
+      cumulativeTokens += finalCallTokens;
       const duration_ms = Date.now() - startTime;
       callbacks.onComplete(panel, {
         content,
         duration_ms,
-        tokens_used: tokensUsed,
+        tokens_used: cumulativeTokens,
+        token_limit_exceeded: tokenLimitExceeded,
         tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
       });
       return;
@@ -270,10 +320,11 @@ export async function queryWithMcpStreaming(
       }
 
       const duration_ms = Date.now() - startTime;
+      // cumulativeTokens already includes this response's tokens from the loop
       callbacks.onComplete(panel, {
         content,
         duration_ms,
-        tokens_used: response.usage?.total_tokens || 0,
+        tokens_used: cumulativeTokens,
         tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
       });
     } else {
@@ -288,7 +339,7 @@ export async function queryWithMcpStreaming(
       });
 
       let content = '';
-      let tokensUsed = 0;
+      let finalCallTokens = 0;
 
       for await (const chunk of finalStream) {
         const delta = chunk.choices[0]?.delta?.content;
@@ -297,15 +348,16 @@ export async function queryWithMcpStreaming(
           callbacks.onToken(panel, delta);
         }
         if (chunk.usage?.total_tokens) {
-          tokensUsed = chunk.usage.total_tokens;
+          finalCallTokens = chunk.usage.total_tokens;
         }
       }
 
+      cumulativeTokens += finalCallTokens;
       const duration_ms = Date.now() - startTime;
       callbacks.onComplete(panel, {
         content,
         duration_ms,
-        tokens_used: tokensUsed,
+        tokens_used: cumulativeTokens,
         tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
       });
     }


### PR DESCRIPTION
## Summary
- **Cumulative token tracking**: Sums `total_tokens` across all LLM calls in the tool-calling loop, not just the final call
- **Token limit**: Aborts loop at 100K cumulative tokens, sends synthesize event so the UI knows it was a cost limit
- **Response truncation**: Caps tool results at 25K chars before feeding back as context — the main driver of input token growth
- **Display**: Footer shows comma-formatted cumulative total with "(limit reached)" warning when applicable
- **Tool description fix**: Removed the "pass dataset_id in query" workaround now that the MCP server accepts `portal` and `dataset_id` directly

## Test plan
- [x] Token count shows realistic cumulative totals (32K-56K for multi-step queries vs ~2-4K previously)
- [x] Comma formatting works (e.g., "56,509")
- [x] `token_limit_exceeded` flag threads through to footer display
- [x] TypeScript type-checks cleanly

Addresses #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)