### PR TITLE
Fetch skill guidance from MCP server prompt endpoint

### DIFF
--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
     await incrementRateLimit(identifier, isAuthenticated);
 
     // System prompts
-    const systemPromptWithMcp = buildSystemPrompt(portal);
+    const systemPromptWithMcp = await buildSystemPrompt(portal);
     const systemPromptWithoutMcp = `You are a helpful assistant.
 When answering questions about civic data, government statistics, or local information,
 do your best to provide helpful information based on your training data.

--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     await incrementRateLimit(identifier, isAuthenticated);
 
     // System prompt for the MCP-enabled query - uses skill module
-    const systemPromptWithMcp = buildSystemPrompt(portal);
+    const systemPromptWithMcp = await buildSystemPrompt(portal);
 
     // System prompt for the non-MCP query (to make it fair)
     const systemPromptWithoutMcp = `You are a helpful assistant.

--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -1,4 +1,4 @@
-const MCP_URL = process.env.SOCRATA_MCP_URL || 'https://socrata-mcp-server.onrender.com';
+const MCP_URL = process.env.SOCRATA_MCP_URL || 'https://opengov-mcp-server.onrender.com';
 
 interface McpToolResult {
   content?: Array<{
@@ -135,6 +135,118 @@ async function makeToolCall(name: string, args: Record<string, unknown>): Promis
     }
     throw new Error('Failed to parse MCP response JSON');
   }
+}
+
+interface McpPromptResult {
+  messages?: Array<{
+    role: string;
+    content: { type: string; text?: string } | Array<{ type: string; text?: string }>;
+  }>;
+}
+
+export async function callMcpPrompt(name: string, args: Record<string, string>): Promise<string> {
+  // Ensure we have a session
+  if (!sessionId) {
+    sessionId = await initializeSession();
+  }
+
+  try {
+    return await makePromptCall(name, args);
+  } catch (error) {
+    // If session expired, try reinitializing
+    if (error instanceof Error && error.message.includes('session')) {
+      sessionId = await initializeSession();
+      return await makePromptCall(name, args);
+    }
+    throw error;
+  }
+}
+
+async function makePromptCall(name: string, args: Record<string, string>): Promise<string> {
+  console.log('[MCP] Getting prompt:', name, 'with args:', JSON.stringify(args));
+
+  const response = await fetch(`${MCP_URL}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      'mcp-session-id': sessionId!,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: Date.now(),
+      method: 'prompts/get',
+      params: { name, arguments: args },
+    }),
+    signal: AbortSignal.timeout(10_000), // 10s timeout for cold starts
+  });
+
+  if (!response.ok) {
+    throw new Error(`MCP prompt error: ${response.status} ${response.statusText}`);
+  }
+
+  const text = await response.text();
+  console.log('[MCP] Prompt raw response:', text.substring(0, 500));
+
+  // Parse SSE response format
+  const lines = text.split('\n');
+  let jsonData = '';
+
+  for (const line of lines) {
+    if (line.startsWith('data:')) {
+      jsonData = line.slice(5).trim();
+      break;
+    }
+  }
+
+  if (!jsonData) {
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed.result) {
+        return formatPromptResult(parsed.result);
+      }
+      if (parsed.error) {
+        throw new Error(parsed.error.message || 'MCP prompt error');
+      }
+    } catch (e) {
+      if (e instanceof Error && !e.message.includes('parse') && !e.message.includes('Unexpected')) {
+        throw e;
+      }
+    }
+    throw new Error('Failed to parse MCP prompt response');
+  }
+
+  const parsed = JSON.parse(jsonData);
+  if (parsed.result) {
+    return formatPromptResult(parsed.result);
+  }
+  if (parsed.error) {
+    throw new Error(parsed.error.message || 'MCP prompt error');
+  }
+  throw new Error('Unexpected MCP prompt response format');
+}
+
+function formatPromptResult(result: McpPromptResult): string {
+  if (!result.messages || !Array.isArray(result.messages)) {
+    throw new Error('MCP prompt returned no messages');
+  }
+
+  return result.messages
+    .map(msg => {
+      const content = msg.content;
+      if (Array.isArray(content)) {
+        return content
+          .filter(item => item.type === 'text' && item.text)
+          .map(item => item.text)
+          .join('\n');
+      }
+      if (typeof content === 'object' && content.type === 'text' && content.text) {
+        return content.text;
+      }
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
 }
 
 function formatMcpResult(result: McpToolResult): string {

--- a/src/lib/mcp/socrata-skill.ts
+++ b/src/lib/mcp/socrata-skill.ts
@@ -1,7 +1,10 @@
 // Socrata MCP Skill - Domain knowledge for querying Socrata open data portals
-// Based on: civic-ai-tools/docs/opengov-skill.md
+// Fetched from MCP server's prompt endpoint at runtime, with hardcoded fallback.
 
-export const SOCRATA_SKILL = `
+import { callMcpPrompt } from './client';
+
+// Fallback constant used when the MCP server is unreachable
+export const SOCRATA_SKILL_FALLBACK = `
 ## CRITICAL REQUIREMENTS
 - NEVER hallucinate data - only report what tool calls actually return
 - ALWAYS discover columns first with SELECT * LIMIT 1 before querying unfamiliar datasets
@@ -95,12 +98,39 @@ Note: SF search sometimes returns incorrect results. Use dataset IDs directly:
   return portalSpecificGuidance[portal] || '';
 };
 
-export const buildSystemPrompt = (portal: string): string => {
-  const portalGuidance = getSkillForPortal(portal);
+// Cached skill guidance from MCP server
+let cachedSkillGuidance: string | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+async function fetchSkillGuidance(): Promise<string> {
+  const now = Date.now();
+  if (cachedSkillGuidance && now - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedSkillGuidance;
+  }
+
+  try {
+    console.log('[Skill] Fetching skill guidance from MCP server...');
+    const guidance = await callMcpPrompt('skill-guidance', { modality: 'web' });
+    cachedSkillGuidance = guidance;
+    cacheTimestamp = now;
+    console.log('[Skill] Fetched skill guidance successfully (%d chars)', guidance.length);
+    return guidance;
+  } catch (error) {
+    console.warn('[Skill] Failed to fetch skill guidance, using fallback:', error instanceof Error ? error.message : error);
+    return SOCRATA_SKILL_FALLBACK;
+  }
+}
+
+export const buildSystemPrompt = async (portal: string): Promise<string> => {
+  const [skillGuidance, portalGuidance] = await Promise.all([
+    fetchSkillGuidance(),
+    Promise.resolve(getSkillForPortal(portal)),
+  ]);
 
   return `You are a helpful assistant with access to Socrata open data portals via the get_data tool.
 
-${SOCRATA_SKILL}
+${skillGuidance}
 
 ## PORTAL-SPECIFIC GUIDANCE
 Default portal: ${portal}


### PR DESCRIPTION
## Summary
- Replace hardcoded `SOCRATA_SKILL` constant with runtime fetch from MCP server's `prompts/get` endpoint (`skill-guidance`, modality: `web`)
- Cache fetched guidance for 5 minutes with graceful fallback to renamed `SOCRATA_SKILL_FALLBACK` constant if server is unreachable (10s timeout)
- Fix MCP server fallback URL to `opengov-mcp-server.onrender.com`

## Changes
- **`src/lib/mcp/client.ts`** — Add `callMcpPrompt()` following same JSON-RPC/SSE pattern as `callMcpTool()`
- **`src/lib/mcp/socrata-skill.ts`** — Rename constant to `SOCRATA_SKILL_FALLBACK`, add cached `fetchSkillGuidance()`, make `buildSystemPrompt()` async
- **`src/app/api/compare/route.ts`** — `await` the now-async `buildSystemPrompt()`
- **`src/app/api/compare-stream/route.ts`** — `await` the now-async `buildSystemPrompt()`

## Test plan
- [x] Verified skill guidance fetched from local MCP server (9937 chars)
- [x] Verified skill guidance fetched from Render deployment (`opengov-mcp-server.onrender.com`)
- [x] Verified fallback to hardcoded constant when server is unreachable
- [x] `npm run build` passes cleanly

Closes civic-ai-tools#24 (session 3b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)