### PR TITLE
M9.1: Multi-MCP routing and Google Data Commons integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ OPENROUTER_API_KEY=sk-or-...
 # socrata-mcp-server
 SOCRATA_MCP_URL=https://socrata-mcp.civicaitools.org
 
+# Data Commons MCP (Google-hosted; US demographic + federal statistical data)
+# The hosted endpoint requires an X-API-Key header. Free key from
+# https://apikeys.datacommons.org — anonymous access is not permitted.
+DATA_COMMONS_MCP_URL=https://api.datacommons.org/mcp
+DATA_COMMONS_API_KEY=
+
 # GitHub OAuth (create at github.com/settings/developers)
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,11 +183,15 @@ Required in `.env.local`:
 ```
 OPENROUTER_API_KEY=sk-or-...
 SOCRATA_MCP_URL=https://socrata-mcp-server.onrender.com
+DATA_COMMONS_MCP_URL=https://api.datacommons.org/mcp
+DATA_COMMONS_API_KEY=                # From https://apikeys.datacommons.org (free)
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 NEXTAUTH_SECRET=        # openssl rand -base64 32
 NEXTAUTH_URL=http://localhost:3000  # or production URL
 ```
+
+The `DATA_COMMONS_MCP_URL` / `DATA_COMMONS_API_KEY` pair powers the second MCP data source (Google Data Commons; US demographic + federal statistical data via a hosted HTTPS endpoint that Google launched 2026-02-09). The hosted endpoint is mandatory-auth via an `X-API-Key` header — anonymous access is not permitted, so `DATA_COMMONS_API_KEY` must be set or Data Commons tool calls will fail.
 
 Optional (production only):
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,12 @@ This repo is public. Strategic and relationship context — specific external st
 
 When contributing code, docs, commit messages, issue bodies, PR descriptions, or starter prompts for implementation chats that will commit to this repo, use neutral phrasing: "an external stakeholder," "an upcoming demo," "a follow-up meeting" — not specific names. If a task prompt you received includes strategic context, scrub it before producing any content destined for this repo.
 
+## Secret hygiene
+
+Never `cat`, `head`, `tail`, or otherwise dump the full contents of `.env*` files, `auth.json` files, `credentials*` files, `*.pem`, `*.key`, or any file under `~/.ssh`, `~/.aws`, or `~/Library/Application Support/*/auth.json`. If you need a single env var value, `grep '^VAR_NAME=' .env.local` for just that variable name (not the value). For CLI session tokens, prefer running the CLI command directly over reading its session file. If you think you need to dump a secrets file, stop and ask first.
+
+This repo's `.env.local` contains critical infrastructure secrets including the Ed25519 evidence signing key (`EVIDENCE_SIGNING_KEY`) that anchors the cryptographic evidence chain. Secrets live in 1Password — `.env.local` files contain only `op://` references, not real values. Never generate, display, or handle signing keys or other sensitive values from within a Claude Code session; use a separate terminal.
+
 ## Commands
 
 ```bash

--- a/docs/key-rotation.md
+++ b/docs/key-rotation.md
@@ -1,0 +1,150 @@
+# Evidence signing key rotation
+
+This runbook describes how to rotate the Ed25519 platform signing key that
+anchors the cryptographic evidence chain. Follow it for both preventive
+rotations (scheduled) and compromise rotations (incident response). The two
+paths differ only in the final registry status you flip the previous key to
+— `deprecated` for preventive, `revoked` for compromise.
+
+## Background
+
+Evidence packages are signed with an Ed25519 key referenced by a stable
+identifier (`kid`) embedded in both the package's canonical hash and its
+signature blob. The platform publishes the set of authorized keys and their
+lifecycle status at
+[`/.well-known/evidence-public-keys.json`](../public/.well-known/evidence-public-keys.json).
+Verifiers fetch the registry, match on `(kid, publicKey)`, and apply the
+status semantics encoded in that file.
+
+Rotation is the act of introducing a new active key while transitioning the
+previous key to `deprecated` (still valid for pre-rotation signatures) or
+`revoked` (invalid unconditionally).
+
+Per-key fields in the registry:
+
+| Field           | Meaning                                                                          |
+| --------------- | -------------------------------------------------------------------------------- |
+| `kid`           | Stable identifier, e.g. `platform:evidence-2026-04`.                             |
+| `publicKey`     | Base64 DER-encoded Ed25519 public key.                                           |
+| `status`        | `active` \| `deprecated` \| `revoked`.                                           |
+| `activatedAt`   | ISO timestamp when the key started signing packages.                             |
+| `deprecatedAt`  | ISO timestamp when the key was retired from signing (deprecation only).          |
+| `revokedAt`     | ISO timestamp when the key was marked compromised (revocation only).             |
+
+The `platform:` prefix in the kid is reserved for keys owned by the civicaitools.org platform. Future per-user keys (see the Phase 7 plan) will
+use a `user:<user-id>:<key-name>` prefix, so the registry schema does not
+need a separate scope field.
+
+## Environment variables
+
+The running website reads two variables to sign packages:
+
+- `EVIDENCE_SIGNING_KEY` — base64 DER PKCS8 private key. **Sensitive.**
+- `EVIDENCE_KEY_ID` — stable kid string. Non-sensitive.
+
+A third variable, `EVIDENCE_PUBLIC_KEY`, holds the public key counterpart and
+is not directly read by the signing code — it exists so the registry file
+can be updated from a shell without re-deriving the public key from the
+private one.
+
+A fourth variable, `EVIDENCE_TRUST_REGISTRY_URL`, is optional and overrides
+the default registry URL (`${NEXTAUTH_URL}/.well-known/evidence-public-keys.json`).
+Useful for previews or local dev when you want the verifier to hit a
+different registry.
+
+## Preventive rotation
+
+Run when the previous key has been in service long enough to warrant a
+scheduled swap. No incident. Pre-rotation evidence packages remain
+verifiable after the rotation.
+
+1. **Generate a new keypair outside Claude Code.** In a separate terminal:
+
+   ```bash
+   openssl genpkey -algorithm Ed25519 -out new-evidence.pem
+   ```
+
+   Derive the base64 DER PKCS8 encoding of the private key and the DER SPKI
+   encoding of the public key. Record both in 1Password as a new item named
+   after the new kid.
+
+2. **Pick a new kid.** Conventionally `platform:evidence-YYYY-MM`, bumped
+   by the rotation month. Keep the `platform:` prefix.
+
+3. **Update the trust registry.** In a PR on the `civic-ai-tools-website`
+   repo, edit
+   [`public/.well-known/evidence-public-keys.json`](../public/.well-known/evidence-public-keys.json):
+
+   - Insert the new key as `active` with the new `activatedAt` ISO
+     timestamp.
+   - Flip the previous key's `status` to `deprecated`, set `deprecatedAt`
+     to the same ISO timestamp, and leave `revokedAt` as `null`.
+
+4. **Merge and deploy the registry** before rotating env vars. Verifiers
+   must be able to see the new key before they see any package signed by
+   it.
+
+5. **Update Vercel env vars.** In the Vercel dashboard (not the CLI from a
+   Claude Code session), set `EVIDENCE_SIGNING_KEY` and
+   `EVIDENCE_KEY_ID` to the new values on both production and preview.
+   Trigger a redeploy.
+
+6. **Smoke test.** Publish a fresh evidence package, verify it via the
+   `/evidence/[slug]` verify action (key trust should read "Signed with
+   active key"), then verify a known pre-rotation package (key trust
+   should read "Signed with deprecated key before rotation").
+
+## Compromise rotation
+
+Run when the previous `EVIDENCE_SIGNING_KEY` has been exposed and must be
+treated as untrusted. The steps are the same as preventive rotation with
+two differences: the previous key becomes `revoked` rather than
+`deprecated`, and pre-exposure packages are **not** preserved as verifiable
+(because we cannot distinguish legitimate pre-exposure signatures from
+forged ones).
+
+1. **Rotate `EVIDENCE_SIGNING_KEY` in Vercel first.** Do not wait for the
+   registry PR. Exposure time is the variable that matters most; every
+   minute the compromised key stays active is a minute an attacker could
+   mint a forged signature.
+
+2. **Generate the new keypair, pick a new kid, update 1Password** as in
+   preventive rotation.
+
+3. **Update the trust registry.** Insert the new key as `active`, flip the
+   compromised key's `status` to `revoked`, set `revokedAt` to the exposure
+   detection timestamp (or earlier if known), and leave `deprecatedAt` as
+   `null`. Merge and deploy.
+
+4. **Audit exposed packages.** Enumerate every package previously signed
+   with the revoked key. Withdraw any that cannot be re-published (public
+   artifacts, citations) — withdrawal preserves the cryptographic chain
+   while surfacing the revoked state to readers. Re-publish any that can
+   be, now signed under the new key.
+
+5. **Smoke test.** Publish a fresh evidence package under the new key,
+   verify it, then re-verify a package signed under the revoked key — its
+   key trust row should read "Key revoked — do not trust" and its
+   `verified` flag should be `false`.
+
+6. **Post-mortem.** Write up the exposure vector and add any new harness
+   controls (PreToolUse hook patterns, deny rules, 1Password migrations)
+   to the security hardening plan.
+
+## Notes
+
+- Never paste private key material into a Claude Code session. Always use a
+  separate terminal for key generation and 1Password for storage.
+- Rekor entries from the previous key remain in the transparency log
+  forever — that's by design. After rotation, those entries are still
+  fetchable but verifying them against the trust registry applies the new
+  `deprecated` or `revoked` semantics.
+- The in-memory registry cache on the verify route is scoped to the
+  serverless function instance. After the registry file changes, callers
+  may see the old file for up to an hour per warm instance; force
+  invalidation by redeploying.
+- When rotating the kid, every subsequent published package hashes the new
+  kid into its canonical JSON. Pre-rotation packages keep their old kid
+  baked in, so the verify route must look up both old and new keys in the
+  same registry — which is why old entries stay in the registry with
+  `deprecated` or `revoked` status rather than being removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",
+        "@noble/curves": "^2.2.0",
         "@vercel/blob": "^2.3.3",
         "@vercel/kv": "^3.0.0",
         "bpmn-js": "^18.12.0",
@@ -2112,6 +2113,33 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --test --experimental-strip-types 'src/**/*.test.ts'",
     "sync-fallback": "node scripts/sync-fallback.mjs",
     "update-portals": "node scripts/update-portals.mjs",
     "db:generate": "drizzle-kit generate",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",
+    "@noble/curves": "^2.2.0",
     "@vercel/blob": "^2.3.3",
     "@vercel/kv": "^3.0.0",
     "bpmn-js": "^18.12.0",

--- a/public/.well-known/evidence-public-keys.json
+++ b/public/.well-known/evidence-public-keys.json
@@ -8,7 +8,7 @@
   "keys": [
     {
       "kid": "platform:evidence-2026-04",
-      "publicKey": "MCowBQYDK2VwAyEA4wfeXXP8Li+GwQ4umOw/KG2St8mRTjIA3im/GAhmgMo=",
+      "publicKey": "MCowBQYDK2VwAyEAqd/MVdHJFPLi8nxxwmqWsDdgz8yssU76unJMHW3xaAE=",
       "status": "active",
       "activatedAt": "2026-04-15T00:00:00.000Z",
       "deprecatedAt": null,

--- a/public/.well-known/evidence-public-keys.json
+++ b/public/.well-known/evidence-public-keys.json
@@ -8,7 +8,7 @@
   "keys": [
     {
       "kid": "platform:evidence-2026-04",
-      "publicKey": "REPLACE_WITH_EVIDENCE_PUBLIC_KEY_VALUE",
+      "publicKey": "MCowBQYDK2VwAyEA4wfeXXP8Li+GwQ4umOw/KG2St8mRTjIA3im/GAhmgMo=",
       "status": "active",
       "activatedAt": "2026-04-15T00:00:00.000Z",
       "deprecatedAt": null,

--- a/public/.well-known/evidence-public-keys.json
+++ b/public/.well-known/evidence-public-keys.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "Platform trust registry for civicaitools.org evidence packages. Verifiers fetch this file, match the (kid, publicKey) pair embedded in a package's signature, and apply the status semantics below. See docs/key-rotation.md for the rotation runbook.",
+  "statusSemantics": {
+    "active": "Valid for signing new packages and for verification.",
+    "deprecated": "Cannot sign new packages. Signatures are valid for verification only when the package's Rekor integratedTime precedes deprecatedAt.",
+    "revoked": "Never valid — any signature is treated as suspect regardless of when the package was integrated."
+  },
+  "keys": [
+    {
+      "kid": "platform:evidence-2026-04",
+      "publicKey": "REPLACE_WITH_EVIDENCE_PUBLIC_KEY_VALUE",
+      "status": "active",
+      "activatedAt": "2026-04-15T00:00:00.000Z",
+      "deprecatedAt": null,
+      "revokedAt": null
+    }
+  ]
+}

--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -58,7 +58,8 @@ export async function POST(request: NextRequest) {
       'analysis.portal': portal,
     });
 
-    // Fetch skill guidance (with trace span)
+    // Fetch skill guidance (with trace span). The composed prompt now spans
+    // both MCP sources (Socrata + Data Commons), so record both server URLs.
     const skillFetchSpanId = trace.startSpan('skill_fetch');
     const systemPromptWithMcp = await buildSystemPrompt(portal);
     const systemPromptHash = hash(systemPromptWithMcp);
@@ -66,6 +67,7 @@ export async function POST(request: NextRequest) {
       'skill.text_hash': systemPromptHash,
       'skill.text': systemPromptWithMcp,
       'skill.mcp_server_url': process.env.SOCRATA_MCP_URL || 'https://socrata-mcp.civicaitools.org',
+      'skill.data_commons_url': process.env.DATA_COMMONS_MCP_URL || 'https://api.datacommons.org/mcp',
     });
 
     const systemPromptWithoutMcp = `You are a helpful assistant.

--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -2,8 +2,8 @@ import { NextRequest } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { queryWithoutMcpStreaming, queryWithMcpStreaming, type StreamCallbacks, type ProgressOpts } from '@/lib/openrouter-streaming';
-import { socrataMcpTools } from '@/lib/mcp/tools';
-import { callMcpTool } from '@/lib/mcp/client';
+import { mcpTools } from '@/lib/mcp/tools';
+import { callMcpTool, routeTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
 import { headers } from 'next/headers';
@@ -107,9 +107,10 @@ Be honest if you don't have access to current or real-time data.`;
         const mcpQuery = queryWithMcpStreaming(
           query,
           model,
-          socrataMcpTools,
+          mcpTools,
           async (name, args) => {
-            if (!args.portal) {
+            // Socrata tools expect a portal; Data Commons tools don't.
+            if (name === 'get_data' && !args.portal) {
               args.portal = portal;
             }
             // Race the MCP call against a timeout so one slow tool call
@@ -127,7 +128,7 @@ Be honest if you don't have access to current or real-time data.`;
           },
           systemPromptWithMcp,
           callbacks,
-          { builder: trace, parentSpanId: trace.rootSpanId, systemPromptHash },
+          { builder: trace, parentSpanId: trace.rootSpanId, systemPromptHash, resolveToolSource: (name) => routeTool(name).sourceId },
         );
 
         if (mcpOnly) {

--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { queryWithoutMcp, queryWithMcp } from '@/lib/openrouter';
-import { socrataMcpTools } from '@/lib/mcp/tools';
+import { mcpTools } from '@/lib/mcp/tools';
 import { callMcpTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
@@ -65,10 +65,10 @@ Be honest if you don't have access to current or real-time data.`;
       queryWithMcp(
         query,
         model,
-        socrataMcpTools,
+        mcpTools,
         async (name, args) => {
-          // Inject default portal if not specified
-          if (!args.portal) {
+          // Socrata tools expect a portal; Data Commons tools don't — only inject the default for Socrata's `get_data`.
+          if (name === 'get_data' && !args.portal) {
             args.portal = portal;
           }
           return callMcpTool(name, args);

--- a/src/app/api/evidence/[slug]/replay/route.ts
+++ b/src/app/api/evidence/[slug]/replay/route.ts
@@ -7,7 +7,7 @@ import { db } from '@/lib/db';
 import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
-import { socrataMcpTools } from '@/lib/mcp/tools';
+import { mcpTools } from '@/lib/mcp/tools';
 import { callMcpTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import type { EvidencePackage } from '@/lib/evidence/packager';
@@ -115,7 +115,7 @@ export async function POST(
     let response = await openrouter.chat.completions.create({
       model,
       messages,
-      tools: socrataMcpTools,
+      tools: mcpTools,
       tool_choice: 'auto',
       max_tokens: 4000,
     });
@@ -135,7 +135,8 @@ export async function POST(
         if (toolCall.type !== 'function') continue;
 
         const args = JSON.parse(toolCall.function.arguments);
-        if (!args.portal) args.portal = portal;
+        // Socrata's get_data expects a portal; Data Commons tools don't — only inject for Socrata.
+        if (toolCall.function.name === 'get_data' && !args.portal) args.portal = portal;
         toolsCalled.push({ name: toolCall.function.name, args });
 
         try {
@@ -168,7 +169,7 @@ export async function POST(
       response = await openrouter.chat.completions.create({
         model,
         messages,
-        tools: socrataMcpTools,
+        tools: mcpTools,
         tool_choice: 'auto',
         max_tokens: 4000,
       });

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -3,7 +3,14 @@ import { db } from '@/lib/db';
 import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
-import { verifySignature, verifyRekorEntry, recomputePackageHash } from '@/lib/evidence/verify';
+import {
+  verifySignature,
+  verifyRekorEntry,
+  recomputePackageHash,
+  verifyKeyTrust,
+  loadTrustRegistry,
+  type KeyTrustResult,
+} from '@/lib/evidence/verify';
 
 export async function GET(
   _request: NextRequest,
@@ -36,9 +43,13 @@ export async function GET(
 
   // Step 2: Verify signature
   let signatureValid: boolean | null = null;
+  let sigPublicKey: string | undefined;
+  let sigKid: string | undefined;
   if (record.basePackageSignature && record.basePackageHash) {
     try {
       const sigData = JSON.parse(record.basePackageSignature);
+      sigPublicKey = sigData.publicKey;
+      sigKid = sigData.kid;
       signatureValid = verifySignature(
         record.basePackageHash,
         sigData.signature,
@@ -49,15 +60,17 @@ export async function GET(
     }
   }
 
-  // Step 3: Verify Rekor entry
+  // Step 3: Verify Rekor entry (also gives us integratedTime for key-trust)
   let rekorVerified: boolean | null = null;
   let rekorDetails: { logIndex?: number; logEntryUrl?: string } | null = null;
+  let rekorIntegratedTime: number | undefined;
   if (record.basePackageRekorEntryId && record.basePackageHash) {
     const rekorResult = await verifyRekorEntry(
       record.basePackageRekorEntryId,
       record.basePackageHash,
     );
     rekorVerified = rekorResult.verified;
+    rekorIntegratedTime = rekorResult.integratedTime;
     if (rekorResult.logIndex !== undefined) {
       rekorDetails = {
         logIndex: rekorResult.logIndex,
@@ -66,17 +79,30 @@ export async function GET(
     }
   }
 
+  // Step 4: Verify key trust against the platform trust registry.
+  // Packages signed before #66 shipped won't have a `kid` stored alongside
+  // the signature. The P5 plan resets evidence state before publishing any
+  // real packages, so a missing kid is an unsigned / pre-registry package
+  // and we surface `registry_unavailable` to make that explicit.
+  let keyTrust: KeyTrustResult | null = null;
+  if (sigPublicKey && sigKid) {
+    const registry = await loadTrustRegistry();
+    keyTrust = verifyKeyTrust(sigPublicKey, sigKid, rekorIntegratedTime, registry);
+  }
+
   return NextResponse.json({
     hashMatch,
     signatureValid,
     rekorVerified,
     hasTimestamp: !!record.basePackageRfc3161Timestamp,
+    keyTrust,
     details: {
       storedHash: record.basePackageHash,
       recomputedHash,
       hasSigning: !!record.basePackageSignature,
       hasRekor: !!record.basePackageRekorEntryId,
       rekor: rekorDetails,
+      kid: sigKid,
     },
   });
 }

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -85,18 +85,9 @@ export async function GET(
   // real packages, so a missing kid is an unsigned / pre-registry package
   // and we surface `registry_unavailable` to make that explicit.
   let keyTrust: KeyTrustResult | null = null;
-  let registryPublicKeyForKid: string | undefined;
   if (sigPublicKey && sigKid) {
     const registry = await loadTrustRegistry();
     keyTrust = verifyKeyTrust(sigPublicKey, sigKid, rekorIntegratedTime, registry);
-    // Diagnostic: when the registry has an entry with the same kid but a
-    // different public key, surface that key so a mismatch (usually a
-    // rotation-sync bug between EVIDENCE_SIGNING_KEY and the registry
-    // file) can be diagnosed from the verify response.
-    if (registry) {
-      const entry = registry.keys.find((k) => k.kid === sigKid);
-      registryPublicKeyForKid = entry?.publicKey;
-    }
   }
 
   return NextResponse.json({
@@ -112,10 +103,6 @@ export async function GET(
       hasRekor: !!record.basePackageRekorEntryId,
       rekor: rekorDetails,
       kid: sigKid,
-      // Diagnostic: both publicKeys (base64 SPKI DER) for easy diff when
-      // `keyTrust.status === 'unknown_key'`. Public keys are non-sensitive.
-      signaturePublicKey: sigPublicKey,
-      registryPublicKey: registryPublicKeyForKid,
     },
   });
 }

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -85,9 +85,18 @@ export async function GET(
   // real packages, so a missing kid is an unsigned / pre-registry package
   // and we surface `registry_unavailable` to make that explicit.
   let keyTrust: KeyTrustResult | null = null;
+  let registryPublicKeyForKid: string | undefined;
   if (sigPublicKey && sigKid) {
     const registry = await loadTrustRegistry();
     keyTrust = verifyKeyTrust(sigPublicKey, sigKid, rekorIntegratedTime, registry);
+    // Diagnostic: when the registry has an entry with the same kid but a
+    // different public key, surface that key so a mismatch (usually a
+    // rotation-sync bug between EVIDENCE_SIGNING_KEY and the registry
+    // file) can be diagnosed from the verify response.
+    if (registry) {
+      const entry = registry.keys.find((k) => k.kid === sigKid);
+      registryPublicKeyForKid = entry?.publicKey;
+    }
   }
 
   return NextResponse.json({
@@ -103,6 +112,10 @@ export async function GET(
       hasRekor: !!record.basePackageRekorEntryId,
       rekor: rekorDetails,
       kid: sigKid,
+      // Diagnostic: both publicKeys (base64 SPKI DER) for easy diff when
+      // `keyTrust.status === 'unknown_key'`. Public keys are non-sensitive.
+      signaturePublicKey: sigPublicKey,
+      registryPublicKey: registryPublicKeyForKid,
     },
   });
 }

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -143,7 +143,12 @@ export async function POST(request: NextRequest) {
       basePackageHash: packageHash,
       basePackageStorageKey: blobUrl,
       basePackageSignature: signResult
-        ? JSON.stringify({ signature: signResult.signature, publicKey: signResult.publicKey, algorithm: signResult.algorithm })
+        ? JSON.stringify({
+            signature: signResult.signature,
+            publicKey: signResult.publicKey,
+            algorithm: signResult.algorithm,
+            kid: signResult.kid,
+          })
         : null,
       basePackageRfc3161Timestamp: rfc3161Token,
       basePackageRekorEntryId: rekorResult?.entryId || null,

--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -80,16 +80,51 @@ function CitePopover({ title, creatorName, createdAt, slug, onClose }: {
   );
 }
 
+type KeyTrustStatus =
+  | 'active'
+  | 'deprecated_valid'
+  | 'deprecated_invalid'
+  | 'revoked'
+  | 'unknown_key'
+  | 'registry_unavailable';
+
+interface KeyTrust {
+  status: KeyTrustStatus;
+  verified: boolean;
+  kid: string;
+  deprecatedAt?: string | null;
+  revokedAt?: string | null;
+}
+
 interface VerifyResult {
   hashMatch: boolean;
   signatureValid: boolean | null;
   rekorVerified: boolean | null;
   hasTimestamp: boolean;
+  keyTrust: KeyTrust | null;
   details: {
     hasSigning: boolean;
     hasRekor: boolean;
     rekor?: { logIndex?: number; logEntryUrl?: string } | null;
+    kid?: string;
   };
+}
+
+function keyTrustCopy(keyTrust: KeyTrust): string {
+  switch (keyTrust.status) {
+    case 'active':
+      return `Signed with active key (${keyTrust.kid})`;
+    case 'deprecated_valid':
+      return `Signed with deprecated key before rotation (${keyTrust.kid})`;
+    case 'deprecated_invalid':
+      return `Key deprecated before this signature — do not trust (${keyTrust.kid})`;
+    case 'revoked':
+      return `Key revoked — do not trust (${keyTrust.kid})`;
+    case 'unknown_key':
+      return `Key not in platform trust registry (${keyTrust.kid})`;
+    case 'registry_unavailable':
+      return 'Trust registry unavailable — could not verify key';
+  }
 }
 
 function VerifyCheck({ label, status, detail }: { label: string; status: boolean | null; detail?: string }) {
@@ -201,6 +236,19 @@ export default function EvidenceActions({
                 : verifyResult.signatureValid
                   ? 'Valid Ed25519 signature'
                   : 'Invalid signature'
+            }
+          />
+          <VerifyCheck
+            label="Key trust"
+            status={
+              verifyResult.keyTrust === null
+                ? null
+                : verifyResult.keyTrust.verified
+            }
+            detail={
+              verifyResult.keyTrust === null
+                ? 'No signing key recorded'
+                : keyTrustCopy(verifyResult.keyTrust)
             }
           />
           <VerifyCheck

--- a/src/lib/evidence/data-sources.test.ts
+++ b/src/lib/evidence/data-sources.test.ts
@@ -1,0 +1,207 @@
+// Unit tests for the M9.3 multi-source dataSources extraction used by the
+// evidence packager. These verify:
+//   - A Socrata-only analysis still produces the same-shape dataSources array
+//     it produced pre-M9.3, with the additive `sourceId: 'socrata'` field.
+//   - A multi-source analysis emits distinct entries tagged with `sourceId`.
+//   - Unknown/missing sources on spans fall back via the tool-name map so the
+//     provenance chain stays intact.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildDataSources,
+  resolveToolSource,
+  type ToolCallSummary,
+} from './data-sources.ts';
+
+interface SpanStub {
+  name: string;
+  attributes: Array<{ key: string; value: { stringValue?: string } }>;
+}
+
+function traceWithToolSpans(spans: SpanStub[]): Record<string, unknown> {
+  return {
+    resourceSpans: [
+      {
+        scopeSpans: [{ spans }],
+      },
+    ],
+  };
+}
+
+function toolSpan(source: string, attrs: Record<string, string> = {}): SpanStub {
+  const allAttrs: Record<string, string> = { 'mcp.source': source, ...attrs };
+  return {
+    name: 'mcp_tool_call',
+    attributes: Object.entries(allAttrs).map(([key, stringValue]) => ({
+      key,
+      value: { stringValue },
+    })),
+  };
+}
+
+const NOW = '2026-04-16T00:00:00.000Z';
+
+test('Socrata-only: one entry per unique dataset_id, tagged sourceId=socrata', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    }, // duplicate dataset — should be deduped
+    {
+      name: 'get_data',
+      args: { type: 'metadata', portal: 'data.cityofnewyork.us', dataset_id: '43nn-pn8j' },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+    toolSpan('socrata', { 'tool.dataset_id': '43nn-pn8j', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 2);
+  const first = entries[0];
+  assert.equal(first.sourceId, 'socrata');
+  assert.equal(first.catalogType, 'socrata');
+  assert.equal(first.portalUrl, 'https://data.cityofnewyork.us');
+  assert.equal(first.datasetId, 'erm2-nwe9');
+  assert.equal(first.datasetUrl, 'https://data.cityofnewyork.us/d/erm2-nwe9');
+  assert.equal(first.accessTimestamp, NOW);
+  for (const entry of entries) {
+    assert.ok(entry.sourceId, `entry is missing sourceId: ${JSON.stringify(entry)}`);
+  }
+});
+
+test('Data Commons only: emits a single aggregate entry tagged sourceId=data-commons', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'search_indicators', args: { query: 'median household income' } },
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Median_Income_Household', place_dcid: 'geoId/36061' },
+    },
+  ];
+  const trace = traceWithToolSpans([toolSpan('data-commons'), toolSpan('data-commons')]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  assert.equal(entry.sourceId, 'data-commons');
+  assert.equal(entry.catalogType, 'data-commons');
+  assert.equal(entry.portalUrl, 'https://api.datacommons.org/mcp');
+  // No per-dataset identifier for DC — the knowledge graph isn't dataset-keyed.
+  assert.equal(entry.datasetId, undefined);
+  assert.equal(entry.datasetUrl, undefined);
+});
+
+test('Multi-source: Socrata + Data Commons in one analysis produce distinct entries', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'search_indicators', args: { query: 'median household income' } },
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Median_Income_Household', place_dcid: 'geoId/36061' },
+    },
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('data-commons'),
+    toolSpan('data-commons'),
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 2);
+  const socrataEntry = entries.find((s) => s.sourceId === 'socrata');
+  const dcEntry = entries.find((s) => s.sourceId === 'data-commons');
+  assert.ok(socrataEntry, 'missing socrata dataSource entry');
+  assert.ok(dcEntry, 'missing data-commons dataSource entry');
+  assert.equal(socrataEntry!.datasetId, 'erm2-nwe9');
+  assert.equal(dcEntry!.portalUrl, 'https://api.datacommons.org/mcp');
+});
+
+test('Empty trace falls back to tool-name source mapping (Socrata)', () => {
+  // `/api/evidence/test/route.ts` ships an empty trace. The static tool-name
+  // map should still identify `get_data` as Socrata so the existing test
+  // scaffolding keeps producing a valid dataSources entry.
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+  ];
+  const trace = { resourceSpans: [] };
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'socrata');
+  assert.equal(entries[0].datasetId, 'erm2-nwe9');
+});
+
+test('Empty trace falls back to tool-name mapping (Data Commons)', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Count_Person', place_dcid: 'country/USA' },
+    },
+  ];
+  const trace = { resourceSpans: [] };
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'data-commons');
+});
+
+test('Regression: Socrata-only entry shape is backward-compatible (new sourceId is additive)', () => {
+  // The shape must contain every field the pre-M9.3 code produced, plus the
+  // new additive `sourceId`. Downstream consumers that ignore unknown fields
+  // continue to work.
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  const expectedKeys = ['sourceId', 'catalogType', 'portalUrl', 'datasetId', 'datasetUrl', 'accessTimestamp'];
+  for (const key of expectedKeys) {
+    assert.ok(key in entry, `Socrata entry missing expected key: ${key}`);
+  }
+});
+
+test('Trace span mcp.source wins over tool-name mapping when they disagree', () => {
+  // Defensive: if a trace span somehow tags `get_data` as data-commons
+  // (should never happen in practice), trust the trace — it's the M9.1 source
+  // of truth. This keeps the invariant simple: trace → fallback → fallback.
+  const tc: ToolCallSummary = {
+    name: 'get_data',
+    args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+  };
+  const span = toolSpan('data-commons');
+  assert.equal(resolveToolSource(tc, span), 'data-commons');
+});
+
+test('Unknown tool with no trace span defaults to socrata (pre-M9.1 backward compat)', () => {
+  const tc: ToolCallSummary = { name: 'mystery_tool', args: {} };
+  assert.equal(resolveToolSource(tc, undefined), 'socrata');
+});

--- a/src/lib/evidence/data-sources.ts
+++ b/src/lib/evidence/data-sources.ts
@@ -1,0 +1,129 @@
+// Multi-source extraction used by the evidence packager (M9.3).
+//
+// Walks the trace's `mcp_tool_call` spans plus the caller-supplied tool-call
+// summary to produce one `dataSources` entry per (source, datasetId) tuple.
+// Pure module — no `process.env`, no `crypto`, no upstream dependencies other
+// than the static tool-name→source map — so it can be unit-tested in
+// isolation via the node test runner.
+
+import { sourceIdForToolName } from '../mcp/operation-types.ts';
+
+// Endpoint URL used to tag Data Commons data-source entries. Kept as a
+// module-scoped constant (not read from process.env) so the function stays
+// pure. Overriding the hosted endpoint via env is out of scope for M9.3.
+const DATA_COMMONS_ENDPOINT = 'https://api.datacommons.org/mcp';
+
+export interface ToolCallSummary {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface DataSourceEntry {
+  /** Stable source identifier — matches the registry source ids used in
+   *  the routing layer and the PROV-O `civic:sourceId` attribute.
+   *  `socrata` or `data-commons` today. */
+  sourceId: string;
+  catalogType: string;
+  portalUrl: string;
+  /** Socrata dataset id. Absent for sources that don't expose a per-dataset
+   *  URL (e.g. Data Commons, whose query surface is DCIDs). */
+  datasetId?: string;
+  /** Canonical per-dataset URL. Absent for sources without one. */
+  datasetUrl?: string;
+  accessTimestamp: string;
+}
+
+interface TraceSpan {
+  name: string;
+  attributes?: Array<{ key: string; value?: { stringValue?: string; intValue?: string; boolValue?: boolean } }>;
+}
+
+function getToolSpans(trace: Record<string, unknown>): TraceSpan[] {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spans = (trace as any)?.resourceSpans?.[0]?.scopeSpans?.[0]?.spans;
+    if (!Array.isArray(spans)) return [];
+    return (spans as TraceSpan[]).filter((s) => s.name === 'mcp_tool_call');
+  } catch {
+    return [];
+  }
+}
+
+function spanAttr(span: TraceSpan | undefined, key: string): string | undefined {
+  if (!span) return undefined;
+  const attr = span.attributes?.find((a) => a.key === key);
+  return attr?.value?.stringValue ?? attr?.value?.intValue ?? undefined;
+}
+
+/**
+ * Resolve the MCP source for a tool call. Prefers the `mcp.source` attribute
+ * recorded on the matching `mcp_tool_call` span (the M9.1 source of truth);
+ * falls back to the static tool-name mapping for packages written before
+ * M9.1 or callers that ship an empty trace (e.g. `/api/evidence/test`).
+ *
+ * Tool calls are paired to spans by index — `openrouter-streaming.ts` emits
+ * one span per call in order, so positional matching is exact in the normal
+ * flow. When the counts diverge, the static map still identifies the source.
+ */
+export function resolveToolSource(
+  toolCall: ToolCallSummary,
+  span: TraceSpan | undefined,
+): string {
+  return spanAttr(span, 'mcp.source')
+    ?? sourceIdForToolName(toolCall.name)
+    ?? 'socrata';
+}
+
+/**
+ * Build the per-source evidence-package `dataSources` array.
+ *
+ * Socrata contributes one entry per unique `dataset_id` observed across tool
+ * calls. Data Commons contributes a single aggregate entry when any DC tool
+ * call was made (its knowledge graph isn't dataset-keyed). Each entry is
+ * tagged with `sourceId` so downstream consumers can distinguish provenance.
+ */
+export function buildDataSources(
+  toolCalls: ToolCallSummary[],
+  trace: Record<string, unknown>,
+  fallbackPortal: string,
+  now: string,
+): DataSourceEntry[] {
+  const toolSpans = getToolSpans(trace);
+  const socrataByDataset = new Map<string, { portalUrl: string; datasetId: string }>();
+  let dataCommonsAccessed = false;
+
+  for (let i = 0; i < toolCalls.length; i++) {
+    const tc = toolCalls[i];
+    const source = resolveToolSource(tc, toolSpans[i]);
+    if (source === 'socrata') {
+      const datasetId = tc.args.dataset_id as string | undefined;
+      const portal = (tc.args.portal as string) || fallbackPortal;
+      if (datasetId && !socrataByDataset.has(datasetId)) {
+        socrataByDataset.set(datasetId, { portalUrl: `https://${portal}`, datasetId });
+      }
+    } else if (source === 'data-commons') {
+      dataCommonsAccessed = true;
+    }
+  }
+
+  const entries: DataSourceEntry[] = [];
+  for (const { portalUrl, datasetId } of socrataByDataset.values()) {
+    entries.push({
+      sourceId: 'socrata',
+      catalogType: 'socrata',
+      portalUrl,
+      datasetId,
+      datasetUrl: `${portalUrl}/d/${datasetId}`,
+      accessTimestamp: now,
+    });
+  }
+  if (dataCommonsAccessed) {
+    entries.push({
+      sourceId: 'data-commons',
+      catalogType: 'data-commons',
+      portalUrl: DATA_COMMONS_ENDPOINT,
+      accessTimestamp: now,
+    });
+  }
+  return entries;
+}

--- a/src/lib/evidence/packager.ts
+++ b/src/lib/evidence/packager.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { buildProvenanceGraph, type ProvGraph } from './provenance';
 import { buildDataSources, type DataSourceEntry } from './data-sources';
+import { getActiveKeyId } from './signing';
 import { deriveOperationType } from '../mcp/operation-types';
 
 const PACKAGE_SCHEMA_VERSION = '0.1.0';
@@ -38,6 +39,11 @@ export interface EvidencePackage {
     schemaVersion: string;
     packageId: string;
     createdAt: string;
+    /** Key identifier that signed this package. Captured in the canonical
+     *  hash so a kid swap produces a different hash (defense against
+     *  post-hoc trust-registry relabeling). Verifiers cross-check this
+     *  against the `kid` embedded in the signature blob. */
+    signingKeyId: string;
   };
   prompt: {
     hash: string;
@@ -145,6 +151,7 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
       schemaVersion: PACKAGE_SCHEMA_VERSION,
       packageId,
       createdAt: now,
+      signingKeyId: getActiveKeyId(),
     },
     prompt: {
       hash: promptHash,

--- a/src/lib/evidence/packager.ts
+++ b/src/lib/evidence/packager.ts
@@ -1,5 +1,7 @@
 import crypto from 'crypto';
 import { buildProvenanceGraph, type ProvGraph } from './provenance';
+import { buildDataSources, type DataSourceEntry } from './data-sources';
+import { deriveOperationType } from '../mcp/operation-types';
 
 const PACKAGE_SCHEMA_VERSION = '0.1.0';
 
@@ -52,13 +54,7 @@ export interface EvidencePackage {
     resultRows?: number;
     resultColumns?: number;
   }>;
-  dataSources: Array<{
-    catalogType: string;
-    portalUrl: string;
-    datasetId: string;
-    datasetUrl: string;
-    accessTimestamp: string;
-  }>;
+  dataSources: DataSourceEntry[];
   cost: {
     promptTokens?: number;
     completionTokens?: number;
@@ -120,7 +116,7 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
   // Extract queries (only tool calls with operation type)
   const queries = input.toolCalls.map(tc => ({
     tool: tc.name,
-    operationType: tc.operationType || (tc.args.type as string) || 'unknown',
+    operationType: tc.operationType || deriveOperationType(tc.name, tc.args) || 'unknown',
     arguments: tc.args,
     datasetId: (tc.args.dataset_id as string) || undefined,
     portal: (tc.args.portal as string) || undefined,
@@ -129,22 +125,7 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
     resultColumns: tc.resultSummary?.columns,
   }));
 
-  // Extract unique data sources from tool calls
-  const sourceMap = new Map<string, { portalUrl: string; datasetId: string }>();
-  for (const tc of input.toolCalls) {
-    const datasetId = tc.args.dataset_id as string | undefined;
-    const portal = (tc.args.portal as string) || input.portal;
-    if (datasetId && !sourceMap.has(datasetId)) {
-      sourceMap.set(datasetId, { portalUrl: `https://${portal}`, datasetId });
-    }
-  }
-  const dataSources = Array.from(sourceMap.values()).map(s => ({
-    catalogType: 'socrata',
-    portalUrl: s.portalUrl,
-    datasetId: s.datasetId,
-    datasetUrl: `${s.portalUrl}/d/${s.datasetId}`,
-    accessTimestamp: now,
-  }));
+  const dataSources = buildDataSources(input.toolCalls, input.trace, input.portal, now);
 
   const totalTokens = (input.tokenUsage.promptTokens || 0) + (input.tokenUsage.completionTokens || 0);
   const skillMeta = extractSkillMetadata(input.trace);

--- a/src/lib/evidence/provenance.ts
+++ b/src/lib/evidence/provenance.ts
@@ -81,10 +81,12 @@ export function buildProvenanceGraph(
   }
   graph.push(promptEntity);
 
-  // Skill guidance (from skill_fetch span)
+  // Skill guidance (from skill_fetch span). The skill MCP server URL points at
+  // the prompt source (Socrata today). Multi-source analyses still fetch a
+  // single skill; per-source tool agents are emitted from the tool spans below.
   const skillSpan = spans.find(s => s.name === 'skill_fetch');
   const skillHash = skillSpan ? getAttr(skillSpan.attributes, 'skill.text_hash') : undefined;
-  const mcpServerUrl = skillSpan ? getAttr(skillSpan.attributes, 'skill.mcp_server_url') : undefined;
+  const skillServerUrl = skillSpan ? getAttr(skillSpan.attributes, 'skill.mcp_server_url') : undefined;
 
   if (skillHash) {
     graph.push({
@@ -115,15 +117,55 @@ export function buildProvenanceGraph(
     'dcterms:description': 'Large language model via OpenRouter',
   });
 
-  // MCP server
-  const serverUrl = mcpServerUrl || `https://socrata-mcp.civicaitools.org`;
-  const serverUrn = `urn:civic-evidence:mcp-server:${encodeURIComponent(serverUrl)}`;
-  graph.push({
-    '@id': serverUrn,
-    '@type': ['prov:Agent', 'prov:SoftwareAgent'],
-    'dcterms:title': 'Socrata MCP Server',
-    'civic:serverUrl': serverUrl,
-  });
+  // MCP server agents — one per distinct data source that appears in the
+  // trace. M9.1 added `mcp.source` to every tool span; evidence records
+  // published before M9.1 have no source attribute, so they fall back to
+  // `socrata` (the only source at the time) for backwards compatibility.
+  const toolSpans = spans.filter(s => s.name === 'mcp_tool_call');
+  const sourceAgentMap: Record<string, { urn: string; title: string; serverUrl: string }> = {
+    socrata: {
+      urn: `urn:civic-evidence:mcp-server:socrata`,
+      title: 'Socrata MCP Server',
+      serverUrl: skillServerUrl || 'https://socrata-mcp.civicaitools.org',
+    },
+    'data-commons': {
+      urn: `urn:civic-evidence:mcp-server:data-commons`,
+      title: 'Google Data Commons MCP Server',
+      serverUrl: 'https://api.datacommons.org/mcp',
+    },
+  };
+
+  const sourcesInTrace = new Set<string>();
+  for (const span of toolSpans) {
+    const source = getAttr(span.attributes, 'mcp.source') || 'socrata';
+    sourcesInTrace.add(source);
+  }
+  // Always emit the Socrata agent when a skill was fetched (the skill prompt
+  // itself currently comes from the Socrata MCP, so the agent needs to exist
+  // whether or not a tool call hit it in this specific analysis).
+  if (skillHash) sourcesInTrace.add('socrata');
+
+  for (const sourceId of sourcesInTrace) {
+    const meta = sourceAgentMap[sourceId] ?? {
+      urn: `urn:civic-evidence:mcp-server:${encodeURIComponent(sourceId)}`,
+      title: `${sourceId} MCP Server`,
+      serverUrl: sourceId,
+    };
+    graph.push({
+      '@id': meta.urn,
+      '@type': ['prov:Agent', 'prov:SoftwareAgent'],
+      'dcterms:title': meta.title,
+      'civic:serverUrl': meta.serverUrl,
+      'civic:sourceId': sourceId,
+    });
+  }
+
+  // Resolve a source id to its agent URN, falling back to socrata for
+  // pre-M9.1 evidence records that never tagged the span.
+  function agentUrnForSource(sourceId: string | undefined): string {
+    const id = sourceId || 'socrata';
+    return sourceAgentMap[id]?.urn ?? sourceAgentMap.socrata.urn;
+  }
 
   // Platform
   graph.push({
@@ -173,7 +215,6 @@ export function buildProvenanceGraph(
   }
 
   // MCP tool call spans
-  const toolSpans = spans.filter(s => s.name === 'mcp_tool_call');
   const dataResponseUrns: string[] = [];
 
   for (const span of toolSpans) {
@@ -185,6 +226,8 @@ export function buildProvenanceGraph(
     const opType = getAttr(span.attributes, 'tool.operation_type') || 'unknown';
     const datasetId = getAttr(span.attributes, 'tool.dataset_id');
     const portalDomain = getAttr(span.attributes, 'tool.portal_domain') || portal;
+    const toolSource = getAttr(span.attributes, 'mcp.source') || 'socrata';
+    const toolAgentUrn = agentUrnForSource(toolSource);
 
     // SoQL query entity
     const queryUrn = urn(packageId, 'query', queryHash);
@@ -214,16 +257,23 @@ export function buildProvenanceGraph(
       const dataUrn = urn(packageId, 'data', responseHash);
       dataResponseUrns.push(dataUrn);
 
+      // Description varies by source — Socrata has a portal domain, Data
+      // Commons calls run against a knowledge graph keyed by DCIDs.
+      const description = toolSource === 'socrata'
+        ? `Data response from ${portalDomain}`
+        : `Data response from ${sourceAgentMap[toolSource]?.title || toolSource}`;
+
       const dataNode: ProvNode = {
         '@id': dataUrn,
         '@type': 'prov:Entity',
         'civic:contentHash': `sha256:${responseHash}`,
-        'dcterms:description': `Data response from ${portalDomain}`,
+        'dcterms:description': description,
+        'civic:sourceId': toolSource,
         'prov:wasGeneratedBy': { '@id': toolCallUrn },
       };
 
-      // Croissant 1.1 placeholder
-      if (datasetId) {
+      // Croissant 1.1 placeholder — only meaningful for Socrata today
+      if (toolSource === 'socrata' && datasetId) {
         dataNode['civic:datasetId'] = datasetId;
         dataNode['civic:portalDomain'] = portalDomain;
         dataNode['civic:datasetUrl'] = `https://${portalDomain}/d/${datasetId}`;
@@ -236,13 +286,16 @@ export function buildProvenanceGraph(
       graph.push(dataNode);
     }
 
-    // Tool call activity
+    // Tool call activity — associated with the MCP source agent that handled
+    // the call. In multi-source analyses each call may target a different
+    // agent (e.g. socrata for `get_data`, data-commons for `get_observations`).
     const toolCallNode: ProvNode = {
       '@id': toolCallUrn,
       '@type': 'prov:Activity',
       'dcterms:description': `MCP tool call: ${toolName} (${opType})`,
+      'civic:sourceId': toolSource,
       'prov:used': [{ '@id': queryUrn }],
-      'prov:wasAssociatedWith': { '@id': serverUrn },
+      'prov:wasAssociatedWith': { '@id': toolAgentUrn },
     };
     if (span.startTimeUnixNano) {
       toolCallNode['prov:startedAtTime'] = { '@value': nanoToIso(span.startTimeUnixNano), '@type': 'xsd:dateTime' };

--- a/src/lib/evidence/signing.test.ts
+++ b/src/lib/evidence/signing.test.ts
@@ -1,0 +1,128 @@
+// Regression tests for the signing path.
+//
+// Covers the Ed25519 → Ed25519ph switch (required by Rekor's hashedrekord
+// verifier since 2024-03) and the sign/verify round-trip. If these break,
+// the `/evidence/[slug]` verification UI will silently mark a real signature
+// as invalid, and Rekor will reject the submission with
+// `failed to verify signature`.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { signPackage, getActiveKeyId } from './signing.ts';
+import { verifySignature } from './verify.ts';
+
+function generateTestKeyEnv(): { privB64: string; pubB64: string } {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+  const privB64 = privateKey.export({ format: 'der', type: 'pkcs8' }).toString('base64');
+  const pubB64 = publicKey.export({ format: 'der', type: 'spki' }).toString('base64');
+  return { privB64, pubB64 };
+}
+
+function withSigningEnv<T>(privB64: string, kid: string | undefined, fn: () => T): T {
+  const origPriv = process.env.EVIDENCE_SIGNING_KEY;
+  const origKid = process.env.EVIDENCE_KEY_ID;
+  process.env.EVIDENCE_SIGNING_KEY = privB64;
+  if (kid === undefined) delete process.env.EVIDENCE_KEY_ID;
+  else process.env.EVIDENCE_KEY_ID = kid;
+  try {
+    return fn();
+  } finally {
+    if (origPriv === undefined) delete process.env.EVIDENCE_SIGNING_KEY;
+    else process.env.EVIDENCE_SIGNING_KEY = origPriv;
+    if (origKid === undefined) delete process.env.EVIDENCE_KEY_ID;
+    else process.env.EVIDENCE_KEY_ID = origKid;
+  }
+}
+
+const SAMPLE_HASH = 'acdb56712cc0e735589e39d485dcd2c3d34a611b6752ab2f8b703e13008a3004';
+
+test('signPackage returns an Ed25519ph SignResult with kid, DER public key, 64-byte signature', () => {
+  const { privB64 } = generateTestKeyEnv();
+  const result = withSigningEnv(privB64, 'platform:test-key', () => signPackage(SAMPLE_HASH));
+  assert.ok(result, 'signPackage returned null');
+  assert.equal(result!.algorithm, 'Ed25519ph');
+  assert.equal(result!.kid, 'platform:test-key');
+  assert.ok(result!.signature, 'signature missing');
+  assert.ok(result!.publicKey, 'publicKey missing');
+  // Ed25519 signatures are always 64 bytes
+  assert.equal(Buffer.from(result!.signature, 'base64').length, 64);
+});
+
+test('signPackage returns null when EVIDENCE_SIGNING_KEY is not set', () => {
+  const orig = process.env.EVIDENCE_SIGNING_KEY;
+  delete process.env.EVIDENCE_SIGNING_KEY;
+  try {
+    assert.equal(signPackage(SAMPLE_HASH), null);
+  } finally {
+    if (orig !== undefined) process.env.EVIDENCE_SIGNING_KEY = orig;
+  }
+});
+
+test('Round-trip: verifySignature accepts a signature produced by signPackage', () => {
+  const { privB64 } = generateTestKeyEnv();
+  const result = withSigningEnv(privB64, 'platform:test-key', () => signPackage(SAMPLE_HASH));
+  assert.ok(result);
+  const verified = verifySignature(SAMPLE_HASH, result!.signature, result!.publicKey);
+  assert.equal(verified, true, 'sign/verify round-trip failed — Ed25519ph mismatch?');
+});
+
+test('verifySignature rejects a tampered package hash', () => {
+  const { privB64 } = generateTestKeyEnv();
+  const result = withSigningEnv(privB64, 'platform:test-key', () => signPackage(SAMPLE_HASH));
+  assert.ok(result);
+  const tamperedHash = SAMPLE_HASH.replace(/a/g, 'b');
+  assert.equal(verifySignature(tamperedHash, result!.signature, result!.publicKey), false);
+});
+
+test('verifySignature rejects a signature produced by a different key', () => {
+  const { privB64: privA } = generateTestKeyEnv();
+  const { pubB64: pubB } = generateTestKeyEnv();
+  const result = withSigningEnv(privA, 'platform:test-key', () => signPackage(SAMPLE_HASH));
+  assert.ok(result);
+  // swap the verifying public key for a different one
+  assert.equal(verifySignature(SAMPLE_HASH, result!.signature, pubB), false);
+});
+
+test('verifySignature rejects a malformed signature', () => {
+  const { pubB64 } = generateTestKeyEnv();
+  // 'AAAA' decodes to 3 zero bytes — nowhere near the 64 an Ed25519 sig has
+  assert.equal(verifySignature(SAMPLE_HASH, 'AAAA', pubB64), false);
+});
+
+test('getActiveKeyId returns EVIDENCE_KEY_ID when set, default otherwise', () => {
+  const orig = process.env.EVIDENCE_KEY_ID;
+  try {
+    process.env.EVIDENCE_KEY_ID = 'platform:custom-kid';
+    assert.equal(getActiveKeyId(), 'platform:custom-kid');
+    delete process.env.EVIDENCE_KEY_ID;
+    assert.equal(getActiveKeyId(), 'platform:evidence-2026-04');
+  } finally {
+    if (orig === undefined) delete process.env.EVIDENCE_KEY_ID;
+    else process.env.EVIDENCE_KEY_ID = orig;
+  }
+});
+
+test('Cross-check: signature verifies as Ed25519ph (prehashed with SHA-512)', async () => {
+  // Independent verification via @noble/curves directly. Catches the case
+  // where signPackage accidentally switches back to pure Ed25519 — a pure
+  // Ed25519 signature would NOT verify as Ed25519ph, and Rekor would reject
+  // it in production.
+  const { privB64 } = generateTestKeyEnv();
+  const result = withSigningEnv(privB64, 'platform:test-key', () => signPackage(SAMPLE_HASH));
+  assert.ok(result);
+
+  const { ed25519ph } = await import('@noble/curves/ed25519.js');
+  const pubKeyObj = crypto.createPublicKey({
+    key: Buffer.from(result!.publicKey, 'base64'),
+    format: 'der',
+    type: 'spki',
+  });
+  const pubBytes = Uint8Array.from(Buffer.from(pubKeyObj.export({ format: 'jwk' }).x as string, 'base64url'));
+  const sigBytes = Uint8Array.from(Buffer.from(result!.signature, 'base64'));
+  const messageBytes = Uint8Array.from(Buffer.from(SAMPLE_HASH, 'utf-8'));
+
+  assert.equal(ed25519ph.verify(sigBytes, messageBytes, pubBytes), true);
+});

--- a/src/lib/evidence/signing.test.ts
+++ b/src/lib/evidence/signing.test.ts
@@ -11,7 +11,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { signPackage, getActiveKeyId } from './signing.ts';
+import { signPackage, getActiveKeyId, rekorHashForPackage } from './signing.ts';
 import { verifySignature } from './verify.ts';
 
 function generateTestKeyEnv(): { privB64: string; pubB64: string } {
@@ -103,6 +103,23 @@ test('getActiveKeyId returns EVIDENCE_KEY_ID when set, default otherwise', () =>
     if (orig === undefined) delete process.env.EVIDENCE_KEY_ID;
     else process.env.EVIDENCE_KEY_ID = orig;
   }
+});
+
+test('rekorHashForPackage: SHA-512 of UTF-8 of hex package hash', () => {
+  // The value Rekor stores in spec.data.hash.value for a signed package
+  // is SHA-512 over the UTF-8 bytes of the hex SHA-256 hash — matching
+  // what signPackage signs via Ed25519ph's internal prehash. This
+  // invariant is what verifyRekorEntry compares against; any drift between
+  // sign-time and verify-time derivation silently breaks Rekor
+  // verification in the UI.
+  const packageHash = 'acdb56712cc0e735589e39d485dcd2c3d34a611b6752ab2f8b703e13008a3004';
+  const expected = crypto
+    .createHash('sha512')
+    .update(Buffer.from(packageHash, 'utf-8'))
+    .digest('hex');
+  assert.equal(rekorHashForPackage(packageHash), expected);
+  // SHA-512 hex is always 128 characters
+  assert.equal(rekorHashForPackage(packageHash).length, 128);
 });
 
 test('Cross-check: signature verifies as Ed25519ph (prehashed with SHA-512)', async () => {

--- a/src/lib/evidence/signing.ts
+++ b/src/lib/evidence/signing.ts
@@ -135,6 +135,23 @@ export async function getRfc3161Timestamp(packageHash: string): Promise<string |
 }
 
 /**
+ * Derive the hex value that Rekor stores in `spec.data.hash.value` for
+ * a given package. Rekor's hashedrekord Ed25519ph verifier treats this
+ * value as the SHA-512 prehash of the signed message, so we mirror that
+ * here: SHA-512 over the UTF-8 bytes of the hex package hash.
+ *
+ * Exported so `verifyRekorEntry` in `verify.ts` can recompute the same
+ * expected value when cross-checking a Rekor entry — the raw SHA-256
+ * `packageHash` does NOT match what Rekor stores.
+ */
+export function rekorHashForPackage(packageHash: string): string {
+  return crypto
+    .createHash('sha512')
+    .update(Buffer.from(packageHash, 'utf-8'))
+    .digest('hex');
+}
+
+/**
  * Re-encode a base64 SPKI-DER public key as a base64-wrapped PEM block.
  * Rekor's `x509.NewPublicKey` requires PEM — raw base64 DER is rejected
  * with "invalid public key: failure decoding PEM".
@@ -171,8 +188,7 @@ export async function publishToRekor(
   publicKeyDerB64: string,
 ): Promise<RekorResult | null> {
   try {
-    const messageBytes = Buffer.from(packageHash, 'utf-8');
-    const sha512HashHex = crypto.createHash('sha512').update(messageBytes).digest('hex');
+    const sha512HashHex = rekorHashForPackage(packageHash);
     const pubKeyPemB64 = derPublicKeyToPemBase64(publicKeyDerB64);
 
     const body = {

--- a/src/lib/evidence/signing.ts
+++ b/src/lib/evidence/signing.ts
@@ -1,6 +1,15 @@
 import crypto from 'crypto';
+import { ed25519ph } from '@noble/curves/ed25519.js';
 
-const ALGORITHM = 'Ed25519';
+// Signature algorithm identifier stored alongside each signature and
+// embedded in the evidence package metadata. Rekor's hashedrekord
+// verifier (sigstore/rekor@v1.x, 2024+) requires Ed25519ph (pre-hashed
+// Ed25519 with SHA-512) for bare Ed25519 public keys rather than pure
+// Ed25519 — see https://github.com/sigstore/rekor/pull/1945. Node's
+// crypto.sign doesn't expose Ed25519ph, so we use @noble/curves for the
+// sign/verify path. The key material on disk is unchanged: same Ed25519
+// keypair, just a different signing algorithm.
+const ALGORITHM = 'Ed25519ph';
 
 // Default key identifier used when `EVIDENCE_KEY_ID` is not set. The
 // `platform:` prefix leaves room for per-user scopes in the future
@@ -33,8 +42,47 @@ interface RekorResult {
 }
 
 /**
- * Sign a package hash with the platform Ed25519 key.
- * Returns null if EVIDENCE_SIGNING_KEY is not configured.
+ * Extract the 32-byte raw Ed25519 private key seed from a PKCS8 DER key.
+ * Noble's Ed25519ph API takes raw seed bytes; Node's crypto produces
+ * PKCS8 DER. We go through JWK because that's the supported
+ * interchange format exposed by Node's KeyObject.
+ */
+function extractRawPrivateKey(privKeyB64Der: string): Uint8Array {
+  const privateKey = crypto.createPrivateKey({
+    key: Buffer.from(privKeyB64Der, 'base64'),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  const jwk = privateKey.export({ format: 'jwk' });
+  if (!jwk.d) throw new Error('Ed25519 private key JWK missing "d"');
+  return Uint8Array.from(Buffer.from(jwk.d, 'base64url'));
+}
+
+/**
+ * Derive the SPKI DER public key from a PKCS8 DER private key. Retained as
+ * `publicKey` in SignResult (base64 DER) so on-disk and in-registry
+ * encodings are stable across the Ed25519 / Ed25519ph switch; Rekor
+ * submission re-encodes to PEM where required.
+ */
+function derivePublicKeyDer(privKeyB64Der: string): string {
+  const privateKey = crypto.createPrivateKey({
+    key: Buffer.from(privKeyB64Der, 'base64'),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  const pubKeyDer = crypto.createPublicKey(privateKey).export({ format: 'der', type: 'spki' });
+  return pubKeyDer.toString('base64');
+}
+
+/**
+ * Sign a package hash with the platform Ed25519 key using Ed25519ph
+ * (SHA-512 pre-hash). Returns null if EVIDENCE_SIGNING_KEY is not
+ * configured.
+ *
+ * The signed message is the UTF-8 bytes of the package hex hash — same
+ * convention used on the verify side. Ed25519ph prehashes this internally
+ * with SHA-512 to produce the 64-byte digest that the signature commits
+ * to, which is also what Rekor stores as `spec.data.hash`.
  */
 export function signPackage(packageHash: string): SignResult | null {
   const privKeyB64 = process.env.EVIDENCE_SIGNING_KEY;
@@ -43,21 +91,14 @@ export function signPackage(packageHash: string): SignResult | null {
     return null;
   }
 
-  const privateKey = crypto.createPrivateKey({
-    key: Buffer.from(privKeyB64, 'base64'),
-    format: 'der',
-    type: 'pkcs8',
-  });
-
-  const signature = crypto.sign(null, Buffer.from(packageHash, 'utf-8'), privateKey);
-
-  // Derive public key from private key
-  const publicKey = crypto.createPublicKey(privateKey);
-  const pubKeyDer = publicKey.export({ format: 'der', type: 'spki' });
+  const privBytes = extractRawPrivateKey(privKeyB64);
+  const message = Buffer.from(packageHash, 'utf-8');
+  const signature = ed25519ph.sign(message, privBytes);
+  const pubKeyDerB64 = derivePublicKeyDer(privKeyB64);
 
   return {
-    signature: signature.toString('base64'),
-    publicKey: pubKeyDer.toString('base64'),
+    signature: Buffer.from(signature).toString('base64'),
+    publicKey: pubKeyDerB64,
     algorithm: ALGORITHM,
     kid: getActiveKeyId(),
   };
@@ -94,26 +135,56 @@ export async function getRfc3161Timestamp(packageHash: string): Promise<string |
 }
 
 /**
+ * Re-encode a base64 SPKI-DER public key as a base64-wrapped PEM block.
+ * Rekor's `x509.NewPublicKey` requires PEM — raw base64 DER is rejected
+ * with "invalid public key: failure decoding PEM".
+ */
+function derPublicKeyToPemBase64(pubKeyDerB64: string): string {
+  // PEM is the DER bytes in base64, line-wrapped to 64 chars, between
+  // BEGIN/END banners. Rekor accepts either the raw PEM or a base64 of
+  // the PEM; we use the latter because every other `content` field in
+  // the submission body is base64-encoded.
+  const pemBody = pubKeyDerB64.match(/.{1,64}/g)?.join('\n') ?? pubKeyDerB64;
+  const pem = `-----BEGIN PUBLIC KEY-----\n${pemBody}\n-----END PUBLIC KEY-----\n`;
+  return Buffer.from(pem).toString('base64');
+}
+
+/**
  * Publish package hash + signature to Sigstore Rekor transparency log.
  * Returns entry metadata, or null on failure.
+ *
+ * Rekor's hashedrekord v0.0.1 verifier applies Ed25519ph for bare
+ * Ed25519 keys, which means:
+ *   - `data.hash.algorithm` must be `sha512`
+ *   - `data.hash.value` must be hex(SHA-512(signed message))
+ *   - `signature.content` must be an Ed25519ph signature over the same
+ *     signed message (see `signPackage` above)
+ *   - `publicKey.content` must be base64(PEM-wrapped SPKI DER)
+ *
+ * The signed message in our system is the UTF-8 hex representation of
+ * the SHA-256 package hash, preserved here so the Rekor-stored digest
+ * can be independently reproduced from `basePackageHash`.
  */
 export async function publishToRekor(
   packageHash: string,
   signature: string,
-  publicKey: string,
+  publicKeyDerB64: string,
 ): Promise<RekorResult | null> {
   try {
-    // Rekor hashedrekord v0.0.1 format
+    const messageBytes = Buffer.from(packageHash, 'utf-8');
+    const sha512HashHex = crypto.createHash('sha512').update(messageBytes).digest('hex');
+    const pubKeyPemB64 = derPublicKeyToPemBase64(publicKeyDerB64);
+
     const body = {
       apiVersion: '0.0.1',
       kind: 'hashedrekord',
       spec: {
         data: {
-          hash: { algorithm: 'sha256', value: packageHash },
+          hash: { algorithm: 'sha512', value: sha512HashHex },
         },
         signature: {
           content: signature,
-          publicKey: { content: Buffer.from(publicKey, 'base64').toString('base64') },
+          publicKey: { content: pubKeyPemB64 },
         },
       },
     };

--- a/src/lib/evidence/signing.ts
+++ b/src/lib/evidence/signing.ts
@@ -2,10 +2,28 @@ import crypto from 'crypto';
 
 const ALGORITHM = 'Ed25519';
 
-interface SignResult {
+// Default key identifier used when `EVIDENCE_KEY_ID` is not set. The
+// `platform:` prefix leaves room for per-user scopes in the future
+// (e.g. `user:<uuid>:<key-name>`) without a trust-registry schema migration —
+// see Phase 5 of the security hardening plan.
+const DEFAULT_KEY_ID = 'platform:evidence-2026-04';
+
+export interface SignResult {
   signature: string;   // base64
   publicKey: string;   // base64 (DER-encoded public key)
   algorithm: string;
+  /** Stable key identifier — matches an entry in the trust registry at
+   *  `/.well-known/evidence-public-keys.json`. */
+  kid: string;
+}
+
+/**
+ * Read the active key identifier. Returns `EVIDENCE_KEY_ID` when set, and
+ * falls back to the default platform kid otherwise. The kid is not secret —
+ * it's the registry lookup handle for the matching public key.
+ */
+export function getActiveKeyId(): string {
+  return process.env.EVIDENCE_KEY_ID || DEFAULT_KEY_ID;
 }
 
 interface RekorResult {
@@ -41,6 +59,7 @@ export function signPackage(packageHash: string): SignResult | null {
     signature: signature.toString('base64'),
     publicKey: pubKeyDer.toString('base64'),
     algorithm: ALGORITHM,
+    kid: getActiveKeyId(),
   };
 }
 

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -8,6 +8,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   verifyKeyTrust,
+  loadTrustRegistry,
+  clearTrustRegistryCache,
   type TrustRegistry,
 } from './verify.ts';
 
@@ -217,6 +219,34 @@ test('Rotation scenario: old key deprecated + new key active, both resolve corre
   const forged = verifyKeyTrust(PUB, NEW_KID, undefined, registry);
   assert.equal(forged.status, 'unknown_key');
   assert.equal(forged.verified, false);
+});
+
+// --- loadTrustRegistry: filesystem read path (Bug 1 fix) ---
+//
+// Vercel preview deployments put an HTML auth wall in front of
+// `/.well-known/*` URLs, so the loader must read the registry from disk
+// instead of fetching HTTP. These tests exercise that path against the
+// real file checked into `public/.well-known/evidence-public-keys.json`.
+
+test('loadTrustRegistry reads the checked-in registry from disk', async () => {
+  clearTrustRegistryCache();
+  // Point the HTTP URL at a guaranteed-invalid host; the loader should
+  // still succeed because the filesystem path is tried first.
+  const registry = await loadTrustRegistry('http://127.0.0.1:1/invalid');
+  assert.ok(registry, 'loadTrustRegistry returned undefined even though the on-disk registry exists');
+  assert.ok(registry!.keys.length > 0);
+  const activeKey = registry!.keys.find((k) => k.status === 'active');
+  assert.ok(activeKey, 'registry should have at least one active key');
+  assert.ok(activeKey!.kid.startsWith('platform:'));
+  assert.ok(activeKey!.publicKey && !activeKey!.publicKey.includes('REPLACE_WITH'));
+});
+
+test('loadTrustRegistry caches the disk read across calls', async () => {
+  clearTrustRegistryCache();
+  const a = await loadTrustRegistry('http://127.0.0.1:1/invalid');
+  const b = await loadTrustRegistry('http://127.0.0.1:1/invalid');
+  // Same reference → served from cache, not re-read.
+  assert.strictEqual(a, b);
 });
 
 test('Compromise scenario: revoked key + replacement active key', () => {

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -1,0 +1,253 @@
+// Unit tests for the P5 key-trust verification path added to verify.ts.
+// Exercises each registry status + rotation edge case documented in the
+// trust-registry runbook (docs/key-rotation.md).
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  verifyKeyTrust,
+  type TrustRegistry,
+} from './verify.ts';
+
+const KID = 'platform:evidence-2026-04';
+const NEW_KID = 'platform:evidence-2027-04';
+const PUB = 'MCowBQYDK2VwAyEA-PLACEHOLDER-ACTIVE-KEY';
+const NEW_PUB = 'MCowBQYDK2VwAyEA-PLACEHOLDER-NEW-KEY';
+const OTHER_PUB = 'MCowBQYDK2VwAyEA-PLACEHOLDER-OTHER-KEY';
+
+function registryWith(keys: TrustRegistry['keys']): TrustRegistry {
+  return { keys };
+}
+
+// --- Active keys ---
+
+test('active key: (kid, publicKey) match → verified', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'active',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: null,
+      revokedAt: null,
+    },
+  ]);
+  const result = verifyKeyTrust(PUB, KID, undefined, registry);
+  assert.equal(result.status, 'active');
+  assert.equal(result.verified, true);
+  assert.equal(result.kid, KID);
+});
+
+test('active key: public key mismatch → unknown_key', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'active',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: null,
+      revokedAt: null,
+    },
+  ]);
+  const result = verifyKeyTrust(OTHER_PUB, KID, undefined, registry);
+  assert.equal(result.status, 'unknown_key');
+  assert.equal(result.verified, false);
+});
+
+test('active key: kid mismatch → unknown_key (defense against kid swap)', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'active',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: null,
+      revokedAt: null,
+    },
+  ]);
+  // Caller claims the public key was signed with a different kid.
+  const result = verifyKeyTrust(PUB, 'platform:different-kid', undefined, registry);
+  assert.equal(result.status, 'unknown_key');
+  assert.equal(result.verified, false);
+});
+
+// --- Revoked keys ---
+
+test('revoked key: never verified, even with matching pair', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'revoked',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: null,
+      revokedAt: '2026-05-01T12:00:00.000Z',
+    },
+  ]);
+  // Even a package integrated well before revocation is not trusted — we
+  // assume the compromise window is unbounded.
+  const earlyIntegratedTime = new Date('2026-04-16T00:00:00.000Z').getTime() / 1000;
+  const result = verifyKeyTrust(PUB, KID, earlyIntegratedTime, registry);
+  assert.equal(result.status, 'revoked');
+  assert.equal(result.verified, false);
+  assert.equal(result.revokedAt, '2026-05-01T12:00:00.000Z');
+});
+
+// --- Deprecated keys ---
+
+test('deprecated key + integratedTime before deprecatedAt → deprecated_valid', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'deprecated',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: '2027-04-15T00:00:00.000Z',
+      revokedAt: null,
+    },
+  ]);
+  const beforeDeprecation = new Date('2027-01-01T00:00:00.000Z').getTime() / 1000;
+  const result = verifyKeyTrust(PUB, KID, beforeDeprecation, registry);
+  assert.equal(result.status, 'deprecated_valid');
+  assert.equal(result.verified, true);
+});
+
+test('deprecated key + integratedTime after deprecatedAt → deprecated_invalid', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'deprecated',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: '2027-04-15T00:00:00.000Z',
+      revokedAt: null,
+    },
+  ]);
+  const afterDeprecation = new Date('2027-05-01T00:00:00.000Z').getTime() / 1000;
+  const result = verifyKeyTrust(PUB, KID, afterDeprecation, registry);
+  assert.equal(result.status, 'deprecated_invalid');
+  assert.equal(result.verified, false);
+});
+
+test('deprecated key + undefined integratedTime → deprecated_invalid (fail closed)', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'deprecated',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: '2027-04-15T00:00:00.000Z',
+      revokedAt: null,
+    },
+  ]);
+  // Without a Rekor integratedTime we can't prove the package is pre-
+  // deprecation — the secure default is to fail.
+  const result = verifyKeyTrust(PUB, KID, undefined, registry);
+  assert.equal(result.status, 'deprecated_invalid');
+  assert.equal(result.verified, false);
+});
+
+test('deprecated key without deprecatedAt timestamp → deprecated_invalid (malformed registry)', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'deprecated',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: null, // malformed — deprecated but no timestamp
+      revokedAt: null,
+    },
+  ]);
+  const someTime = new Date('2027-01-01T00:00:00.000Z').getTime() / 1000;
+  const result = verifyKeyTrust(PUB, KID, someTime, registry);
+  assert.equal(result.status, 'deprecated_invalid');
+  assert.equal(result.verified, false);
+});
+
+// --- Registry unavailable / multi-key ---
+
+test('registry undefined → registry_unavailable', () => {
+  const result = verifyKeyTrust(PUB, KID, undefined, undefined);
+  assert.equal(result.status, 'registry_unavailable');
+  assert.equal(result.verified, false);
+});
+
+test('empty registry → unknown_key', () => {
+  const result = verifyKeyTrust(PUB, KID, undefined, registryWith([]));
+  assert.equal(result.status, 'unknown_key');
+  assert.equal(result.verified, false);
+});
+
+test('Rotation scenario: old key deprecated + new key active, both resolve correctly', () => {
+  // Mirrors the preventive-rotation state: previous kid marked
+  // deprecated, new kid marked active, both present in the registry.
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'deprecated',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: '2027-04-15T00:00:00.000Z',
+      revokedAt: null,
+    },
+    {
+      kid: NEW_KID,
+      publicKey: NEW_PUB,
+      status: 'active',
+      activatedAt: '2027-04-15T00:00:00.000Z',
+      deprecatedAt: null,
+      revokedAt: null,
+    },
+  ]);
+
+  // Pre-rotation package (old key): verifies if integrated pre-deprecation
+  const preRotation = new Date('2027-01-01T00:00:00.000Z').getTime() / 1000;
+  const oldResult = verifyKeyTrust(PUB, KID, preRotation, registry);
+  assert.equal(oldResult.status, 'deprecated_valid');
+  assert.equal(oldResult.verified, true);
+
+  // Post-rotation package (new key): verifies as active
+  const newResult = verifyKeyTrust(NEW_PUB, NEW_KID, undefined, registry);
+  assert.equal(newResult.status, 'active');
+  assert.equal(newResult.verified, true);
+
+  // Attempted forgery: old public key but claiming the new kid
+  const forged = verifyKeyTrust(PUB, NEW_KID, undefined, registry);
+  assert.equal(forged.status, 'unknown_key');
+  assert.equal(forged.verified, false);
+});
+
+test('Compromise scenario: revoked key + replacement active key', () => {
+  const registry = registryWith([
+    {
+      kid: KID,
+      publicKey: PUB,
+      status: 'revoked',
+      activatedAt: '2026-04-15T00:00:00.000Z',
+      deprecatedAt: null,
+      revokedAt: '2026-05-01T12:00:00.000Z',
+    },
+    {
+      kid: NEW_KID,
+      publicKey: NEW_PUB,
+      status: 'active',
+      activatedAt: '2026-05-01T12:00:00.000Z',
+      deprecatedAt: null,
+      revokedAt: null,
+    },
+  ]);
+
+  // Package signed with the revoked key — never trusted, even if integrated
+  // before the detection time.
+  const earlyIntegratedTime = new Date('2026-04-20T00:00:00.000Z').getTime() / 1000;
+  const compromised = verifyKeyTrust(PUB, KID, earlyIntegratedTime, registry);
+  assert.equal(compromised.status, 'revoked');
+  assert.equal(compromised.verified, false);
+
+  // Package signed with the replacement — verified normally.
+  const clean = verifyKeyTrust(NEW_PUB, NEW_KID, undefined, registry);
+  assert.equal(clean.status, 'active');
+  assert.equal(clean.verified, true);
+});

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -1,7 +1,29 @@
 import crypto from 'crypto';
+import { ed25519ph } from '@noble/curves/ed25519.js';
 
 /**
- * Verify an Ed25519 signature against a package hash.
+ * Extract the raw 32-byte Ed25519 public key from a base64 SPKI DER
+ * encoding via Node's JWK export. Noble's `ed25519ph.verify` wants raw
+ * key bytes; Node's crypto surfaces them through JWK.
+ */
+function extractRawPublicKey(publicKeyB64Der: string): Uint8Array {
+  const publicKey = crypto.createPublicKey({
+    key: Buffer.from(publicKeyB64Der, 'base64'),
+    format: 'der',
+    type: 'spki',
+  });
+  const jwk = publicKey.export({ format: 'jwk' });
+  if (!jwk.x) throw new Error('Ed25519 public key JWK missing "x"');
+  return Uint8Array.from(Buffer.from(jwk.x, 'base64url'));
+}
+
+/**
+ * Verify an Ed25519ph signature against the package hash.
+ *
+ * The signed message is the UTF-8 bytes of the package hex hash — the
+ * same convention used by `signPackage` in `signing.ts`. Ed25519ph
+ * prehashes the message with SHA-512 before the Ed25519 verify, which
+ * matches the format Rekor uses to validate the same signature.
  */
 export function verifySignature(
   packageHash: string,
@@ -9,17 +31,10 @@ export function verifySignature(
   publicKeyB64: string,
 ): boolean {
   try {
-    const publicKey = crypto.createPublicKey({
-      key: Buffer.from(publicKeyB64, 'base64'),
-      format: 'der',
-      type: 'spki',
-    });
-    return crypto.verify(
-      null,
-      Buffer.from(packageHash, 'utf-8'),
-      publicKey,
-      Buffer.from(signatureB64, 'base64'),
-    );
+    const pubBytes = extractRawPublicKey(publicKeyB64);
+    const sigBytes = Uint8Array.from(Buffer.from(signatureB64, 'base64'));
+    const messageBytes = Uint8Array.from(Buffer.from(packageHash, 'utf-8'));
+    return ed25519ph.verify(sigBytes, messageBytes, pubBytes);
   } catch (err) {
     console.error('[verify] Signature verification error:', err);
     return false;

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -80,3 +80,194 @@ export function recomputePackageHash(pkg: Record<string, unknown>): string {
   const canonical = JSON.stringify(pkg);
   return crypto.createHash('sha256').update(canonical).digest('hex');
 }
+
+// --- Trust registry ---
+//
+// The platform publishes its set of authorized signing keys at
+// `/.well-known/evidence-public-keys.json`. Verification treats the registry
+// as the source of truth for which `(kid, publicKey)` pairs are allowed and
+// for their rotation state. Keys that don't appear, or appear as revoked,
+// fail verification regardless of cryptographic correctness — a locally
+// valid signature from an unrecognised key is still not "trusted evidence".
+
+export type KeyLifecycleStatus = 'active' | 'deprecated' | 'revoked';
+
+export interface TrustRegistryKey {
+  kid: string;
+  publicKey: string;
+  status: KeyLifecycleStatus;
+  activatedAt: string;
+  deprecatedAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface TrustRegistry {
+  keys: TrustRegistryKey[];
+}
+
+export type KeyTrustStatus =
+  | 'active'                // active key — package is trusted
+  | 'deprecated_valid'      // deprecated key, but package was signed before deprecation
+  | 'deprecated_invalid'    // deprecated key, but package was signed after deprecation
+  | 'revoked'               // revoked key — package is never trusted
+  | 'unknown_key'           // (kid, publicKey) pair not found in registry
+  | 'registry_unavailable'; // registry could not be loaded
+
+export interface KeyTrustResult {
+  status: KeyTrustStatus;
+  /** `true` iff the status is `active` or `deprecated_valid`. */
+  verified: boolean;
+  kid: string;
+  activatedAt?: string;
+  deprecatedAt?: string | null;
+  revokedAt?: string | null;
+}
+
+/**
+ * Verify that a `(kid, publicKey)` pair is trusted by the platform registry,
+ * applying the rotation semantics documented in the P5 plan:
+ *   - `active` → trusted.
+ *   - `deprecated` → trusted only when `packageIntegratedTime` precedes
+ *     `deprecatedAt` (preventive rotation — pre-deprecation signatures
+ *     remain valid, signatures after the rotation point do not).
+ *   - `revoked` → never trusted (compromise — any signature during the
+ *     exposure window is treated as suspect).
+ *   - unknown pair → never trusted.
+ *
+ * The registry is passed in rather than fetched here so the caller can
+ * cache it and so the function stays pure for unit testing.
+ */
+export function verifyKeyTrust(
+  publicKey: string,
+  kid: string,
+  /** Rekor `integratedTime`, seconds since epoch. `undefined` when the
+   *  package has no Rekor entry or when Rekor verification failed. */
+  packageIntegratedTime: number | undefined,
+  registry: TrustRegistry | undefined,
+): KeyTrustResult {
+  if (!registry) {
+    return { status: 'registry_unavailable', verified: false, kid };
+  }
+
+  const match = registry.keys.find(
+    (k) => k.kid === kid && k.publicKey === publicKey,
+  );
+  if (!match) {
+    return { status: 'unknown_key', verified: false, kid };
+  }
+
+  if (match.status === 'revoked') {
+    return {
+      status: 'revoked',
+      verified: false,
+      kid,
+      activatedAt: match.activatedAt,
+      revokedAt: match.revokedAt,
+    };
+  }
+
+  if (match.status === 'deprecated') {
+    // Without a deprecation timestamp we cannot evaluate the time-bounded
+    // rule, so fail closed.
+    if (!match.deprecatedAt) {
+      return { status: 'deprecated_invalid', verified: false, kid };
+    }
+    // Without a Rekor integratedTime we cannot prove the package was signed
+    // before deprecation either — fail closed.
+    if (packageIntegratedTime === undefined) {
+      return {
+        status: 'deprecated_invalid',
+        verified: false,
+        kid,
+        activatedAt: match.activatedAt,
+        deprecatedAt: match.deprecatedAt,
+      };
+    }
+    const deprecationMs = new Date(match.deprecatedAt).getTime();
+    const integratedMs = packageIntegratedTime * 1000;
+    if (integratedMs < deprecationMs) {
+      return {
+        status: 'deprecated_valid',
+        verified: true,
+        kid,
+        activatedAt: match.activatedAt,
+        deprecatedAt: match.deprecatedAt,
+      };
+    }
+    return {
+      status: 'deprecated_invalid',
+      verified: false,
+      kid,
+      activatedAt: match.activatedAt,
+      deprecatedAt: match.deprecatedAt,
+    };
+  }
+
+  return {
+    status: 'active',
+    verified: true,
+    kid,
+    activatedAt: match.activatedAt,
+  };
+}
+
+// --- Registry loader ---
+//
+// Module-level TTL cache around the HTTP fetch. Keeps per-request latency low
+// without calling out for every `/evidence/[slug]` page load. The verify
+// route calls `loadTrustRegistry()` and passes the result into
+// `verifyKeyTrust` above.
+
+const REGISTRY_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface CacheEntry {
+  registry: TrustRegistry | undefined;
+  expiresAt: number;
+}
+
+const registryCache: Map<string, CacheEntry> = new Map();
+
+/** Resolve the URL for the platform trust registry. Can be overridden via
+ *  `EVIDENCE_TRUST_REGISTRY_URL` for previews or local dev. */
+export function getTrustRegistryUrl(): string {
+  const override = process.env.EVIDENCE_TRUST_REGISTRY_URL;
+  if (override) return override;
+  const site = process.env.NEXTAUTH_URL || 'https://civicaitools.org';
+  return `${site.replace(/\/$/, '')}/.well-known/evidence-public-keys.json`;
+}
+
+export async function loadTrustRegistry(
+  url: string = getTrustRegistryUrl(),
+): Promise<TrustRegistry | undefined> {
+  const cached = registryCache.get(url);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.registry;
+  }
+  const fetched = await fetchTrustRegistry(url);
+  registryCache.set(url, { registry: fetched, expiresAt: Date.now() + REGISTRY_TTL_MS });
+  return fetched;
+}
+
+/** For tests / rotation drills: drop the in-memory cache. */
+export function clearTrustRegistryCache(): void {
+  registryCache.clear();
+}
+
+async function fetchTrustRegistry(url: string): Promise<TrustRegistry | undefined> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) {
+      console.warn(`[verify] Trust registry fetch returned ${res.status}`);
+      return undefined;
+    }
+    const data = await res.json();
+    if (!data || !Array.isArray(data.keys)) {
+      console.warn('[verify] Trust registry has invalid shape');
+      return undefined;
+    }
+    return data as TrustRegistry;
+  } catch (err) {
+    console.warn('[verify] Trust registry fetch failed:', err instanceof Error ? err.message : err);
+    return undefined;
+  }
+}

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -1,5 +1,17 @@
 import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
 import { ed25519ph } from '@noble/curves/ed25519.js';
+import { rekorHashForPackage } from './signing.ts';
+
+// Build-time import of the checked-in trust registry. This is the most
+// reliable source on Vercel: a filesystem read relies on `process.cwd()`
+// resolving to a directory that actually contains the bundled `public/`
+// folder, and an HTTP fetch back to our own origin is blocked by
+// preview-deployment auth walls. The static import has Next.js bundle
+// the JSON into the function's module graph at build time so
+// `loadTrustRegistry` can return a result synchronously.
+import embeddedTrustRegistry from '../../../public/.well-known/evidence-public-keys.json' with { type: 'json' };
 
 /**
  * Extract the raw 32-byte Ed25519 public key from a base64 SPKI DER
@@ -49,11 +61,18 @@ export interface RekorVerifyResult {
 }
 
 /**
- * Verify a Rekor transparency log entry matches the expected hash.
+ * Verify that a Rekor transparency log entry is consistent with a
+ * published package.
+ *
+ * The `packageHash` argument is the SHA-256 hash our system stores as
+ * `basePackageHash`. Rekor's entry does NOT store that value directly —
+ * it stores the SHA-512 prehash of the signed message
+ * (see `rekorHashForPackage` in signing.ts), because the submission uses
+ * Ed25519ph. We derive the expected Rekor hash here and compare.
  */
 export async function verifyRekorEntry(
   entryId: string,
-  expectedHash: string,
+  packageHash: string,
 ): Promise<RekorVerifyResult> {
   try {
     const response = await fetch(
@@ -69,12 +88,14 @@ export async function verifyRekorEntry(
     const entry = result[entryId] || Object.values(result)[0];
     if (!entry) return { verified: false };
 
-    // Decode the body to check the hash
+    // Decode the body and cross-check both hash algorithm and value.
     const body = JSON.parse(
       Buffer.from(entry.body, 'base64').toString('utf-8'),
     );
-    const recordedHash = body?.spec?.data?.hash?.value;
-    const verified = recordedHash === expectedHash;
+    const recordedHash: string | undefined = body?.spec?.data?.hash?.value;
+    const recordedAlgo: string | undefined = body?.spec?.data?.hash?.algorithm;
+    const expectedHash = rekorHashForPackage(packageHash);
+    const verified = recordedAlgo === 'sha512' && recordedHash === expectedHash;
 
     return {
       verified,
@@ -251,6 +272,9 @@ export function getTrustRegistryUrl(): string {
   return `${site.replace(/\/$/, '')}/.well-known/evidence-public-keys.json`;
 }
 
+/** Filesystem location of the registry within the Next.js build output. */
+const REGISTRY_PUBLIC_PATH = path.join('public', '.well-known', 'evidence-public-keys.json');
+
 export async function loadTrustRegistry(
   url: string = getTrustRegistryUrl(),
 ): Promise<TrustRegistry | undefined> {
@@ -258,14 +282,51 @@ export async function loadTrustRegistry(
   if (cached && cached.expiresAt > Date.now()) {
     return cached.registry;
   }
-  const fetched = await fetchTrustRegistry(url);
-  registryCache.set(url, { registry: fetched, expiresAt: Date.now() + REGISTRY_TTL_MS });
-  return fetched;
+  // Resolution order:
+  //   1. Build-time bundled JSON (always present in the deploy artifact)
+  //   2. On-disk read (dev server, tests running from project root)
+  //   3. HTTP fetch (external verifiers / cross-origin)
+  // The HTTP path exists for external adopters; our own verify route
+  // should never need it because the bundled import is authoritative.
+  const resolved =
+    validateRegistry(embeddedTrustRegistry as unknown) ??
+    (await readTrustRegistryFromDisk()) ??
+    (await fetchTrustRegistry(url));
+  registryCache.set(url, { registry: resolved, expiresAt: Date.now() + REGISTRY_TTL_MS });
+  return resolved;
+}
+
+function validateRegistry(data: unknown): TrustRegistry | undefined {
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    Array.isArray((data as { keys?: unknown[] }).keys) &&
+    (data as { keys: TrustRegistryKey[] }).keys.every((k) => typeof k?.kid === 'string' && typeof k?.publicKey === 'string')
+  ) {
+    return data as TrustRegistry;
+  }
+  return undefined;
 }
 
 /** For tests / rotation drills: drop the in-memory cache. */
 export function clearTrustRegistryCache(): void {
   registryCache.clear();
+}
+
+async function readTrustRegistryFromDisk(): Promise<TrustRegistry | undefined> {
+  try {
+    const localPath = path.join(process.cwd(), REGISTRY_PUBLIC_PATH);
+    const json = await fs.readFile(localPath, 'utf-8');
+    return validateRegistry(JSON.parse(json));
+  } catch (err) {
+    // Not all runtimes have the file at the expected path (e.g. unit
+    // tests run from a different cwd). Silently fall through so callers
+    // can still try the HTTP URL.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn('[verify] Failed to read trust registry from disk:', err instanceof Error ? err.message : err);
+    }
+    return undefined;
+  }
 }
 
 async function fetchTrustRegistry(url: string): Promise<TrustRegistry | undefined> {
@@ -275,12 +336,14 @@ async function fetchTrustRegistry(url: string): Promise<TrustRegistry | undefine
       console.warn(`[verify] Trust registry fetch returned ${res.status}`);
       return undefined;
     }
-    const data = await res.json();
-    if (!data || !Array.isArray(data.keys)) {
-      console.warn('[verify] Trust registry has invalid shape');
+    const ct = res.headers.get('content-type') || '';
+    if (!ct.includes('json')) {
+      // Vercel preview protection returns an HTML auth wall with 200 OK.
+      // Refuse to treat that as the registry.
+      console.warn(`[verify] Trust registry fetch returned unexpected content-type "${ct}"`);
       return undefined;
     }
-    return data as TrustRegistry;
+    return validateRegistry(await res.json());
   } catch (err) {
     console.warn('[verify] Trust registry fetch failed:', err instanceof Error ? err.message : err);
     return undefined;

--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -1,5 +1,28 @@
-const MCP_URL = process.env.SOCRATA_MCP_URL || 'https://socrata-mcp.civicaitools.org';
+import {
+  buildMcpRegistry,
+  readMcpEnvFromProcess,
+  resolveServerForTool,
+  type McpRegistry,
+  type McpServerConfig,
+} from './registry';
+
 const MCP_TIMEOUT_MS = 45_000; // 45-second timeout for MCP server requests
+
+// M9.1: multi-MCP routing.
+//
+// The website now talks to more than one MCP server (Socrata + Google Data
+// Commons). Each server maintains its own `mcp-session-id` independently, so
+// session state is tracked per source rather than in a single module-level
+// variable. Tool calls route to the correct server based on tool name via the
+// registry in `./registry.ts`.
+//
+// Why: the research phase (M9.0) confirmed Data Commons ships a hosted HTTPS
+// MCP endpoint that is drop-in compatible with our existing HTTP/SSE client
+// pattern — so the per-server routing layer is the entire architectural
+// change needed. The skill-guidance prompt fetch still lives on the Socrata
+// server and continues to route through the `socrata` source explicitly.
+
+const registry: McpRegistry = buildMcpRegistry(readMcpEnvFromProcess());
 
 interface McpToolResult {
   content?: Array<{
@@ -15,18 +38,27 @@ function createTimeoutSignal(ms: number): { signal: AbortSignal; clear: () => vo
   return { signal: controller.signal, clear: () => clearTimeout(timer) };
 }
 
-// Session management
-let sessionId: string | null = null;
+// Per-server session state. Keyed by the server's sourceId.
+const sessionIds: Record<string, string | null> = {};
 
-async function initializeSession(): Promise<string> {
+function getSession(server: McpServerConfig): string | null {
+  return sessionIds[server.sourceId] ?? null;
+}
+
+function setSession(server: McpServerConfig, id: string | null): void {
+  sessionIds[server.sourceId] = id;
+}
+
+async function initializeSession(server: McpServerConfig): Promise<string> {
   const { signal, clear } = createTimeoutSignal(MCP_TIMEOUT_MS);
   let response: Response;
   try {
-    response = await fetch(`${MCP_URL}/mcp`, {
+    response = await fetch(server.endpointUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json, text/event-stream',
+        ...(server.headers || {}),
       },
       signal,
       body: JSON.stringify({
@@ -46,7 +78,7 @@ async function initializeSession(): Promise<string> {
   } catch (error) {
     clear();
     if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new Error(`MCP server did not respond within ${MCP_TIMEOUT_MS / 1000}s — the upstream server may be starting up or unresponsive. Please try again.`);
+      throw new Error(`MCP server "${server.sourceId}" did not respond within ${MCP_TIMEOUT_MS / 1000}s — the upstream server may be starting up or unresponsive. Please try again.`);
     }
     throw error;
   } finally {
@@ -54,50 +86,78 @@ async function initializeSession(): Promise<string> {
   }
 
   if (!response.ok) {
-    throw new Error(`MCP initialization failed: ${response.status}`);
+    throw new Error(`MCP initialization failed for "${server.sourceId}": ${response.status}`);
   }
 
-  // Get session ID from header
   const newSessionId = response.headers.get('mcp-session-id');
   if (!newSessionId) {
-    throw new Error('No session ID returned from MCP server');
+    throw new Error(`No session ID returned from MCP server "${server.sourceId}"`);
   }
 
   return newSessionId;
 }
 
-export async function callMcpTool(name: string, args: Record<string, unknown>): Promise<string> {
-  // Ensure we have a session
-  if (!sessionId) {
-    sessionId = await initializeSession();
+async function ensureSession(server: McpServerConfig): Promise<string> {
+  let id = getSession(server);
+  if (!id) {
+    id = await initializeSession(server);
+    setSession(server, id);
   }
+  return id;
+}
+
+/**
+ * Look up the server hosting this tool and return it, throwing a clear error
+ * if no server claims the tool. Exported for tests.
+ */
+export function routeTool(toolName: string): McpServerConfig {
+  const server = resolveServerForTool(registry, toolName);
+  if (!server) {
+    throw new Error(`No MCP server registered for tool "${toolName}"`);
+  }
+  return server;
+}
+
+export async function callMcpTool(name: string, args: Record<string, unknown>): Promise<string> {
+  const server = routeTool(name);
+  await ensureSession(server);
 
   try {
-    return await makeToolCall(name, args);
+    return await makeToolCall(server, name, args);
   } catch (error) {
-    // If session expired or rejected (400 = invalid session on server restart), reinitialize
+    // Session expired / server restart: clear and retry once.
     if (error instanceof Error && (error.message.includes('session') || error.message.includes('400'))) {
-      console.log('[MCP] Session rejected, reinitializing...');
-      sessionId = null;
-      sessionId = await initializeSession();
-      return await makeToolCall(name, args);
+      console.log(`[MCP:${server.sourceId}] Session rejected, reinitializing...`);
+      setSession(server, null);
+      await ensureSession(server);
+      return await makeToolCall(server, name, args);
     }
     throw error;
   }
 }
 
-async function makeToolCall(name: string, args: Record<string, unknown>): Promise<string> {
-  console.log('[MCP] Calling tool:', name, 'with args:', JSON.stringify(args));
+async function makeToolCall(
+  server: McpServerConfig,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  console.log(`[MCP:${server.sourceId}] Calling tool:`, name, 'with args:', JSON.stringify(args));
+
+  const sessionId = getSession(server);
+  if (!sessionId) {
+    throw new Error(`MCP session missing for server "${server.sourceId}"`);
+  }
 
   const { signal, clear } = createTimeoutSignal(MCP_TIMEOUT_MS);
   let response: Response;
   try {
-    response = await fetch(`${MCP_URL}/mcp`, {
+    response = await fetch(server.endpointUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json, text/event-stream',
-        'mcp-session-id': sessionId!,
+        'mcp-session-id': sessionId,
+        ...(server.headers || {}),
       },
       signal,
       body: JSON.stringify({
@@ -118,12 +178,12 @@ async function makeToolCall(name: string, args: Record<string, unknown>): Promis
   }
 
   if (!response.ok) {
-    console.error('[MCP] Server error:', response.status, response.statusText);
-    throw new Error(`MCP server error: ${response.status} ${response.statusText}`);
+    console.error(`[MCP:${server.sourceId}] Server error:`, response.status, response.statusText);
+    throw new Error(`MCP server "${server.sourceId}" error: ${response.status} ${response.statusText}`);
   }
 
   const text = await response.text();
-  console.log('[MCP] Raw response:', text.substring(0, 500));
+  console.log(`[MCP:${server.sourceId}] Raw response:`, text.substring(0, 500));
 
   // Parse SSE response format: "event: message\ndata: {...}\n\n"
   const lines = text.split('\n');
@@ -179,35 +239,50 @@ interface McpPromptResult {
   }>;
 }
 
+/**
+ * Prompt fetches are still Socrata-only today: skill guidance is served from
+ * the Socrata MCP server's `prompts/get` endpoint. Route explicitly so the
+ * intent is obvious when a second prompt source shows up later.
+ */
 export async function callMcpPrompt(name: string, args: Record<string, string>): Promise<string> {
-  // Ensure we have a session
-  if (!sessionId) {
-    sessionId = await initializeSession();
+  const server = registry.servers['socrata'];
+  if (!server) {
+    throw new Error('Socrata MCP server is not configured; cannot fetch prompt');
   }
+  await ensureSession(server);
 
   try {
-    return await makePromptCall(name, args);
+    return await makePromptCall(server, name, args);
   } catch (error) {
-    // If session expired or rejected (400 = invalid session on server restart), reinitialize
     if (error instanceof Error && (error.message.includes('session') || error.message.includes('400'))) {
-      console.log('[MCP] Session rejected, reinitializing...');
-      sessionId = null;
-      sessionId = await initializeSession();
-      return await makePromptCall(name, args);
+      console.log(`[MCP:${server.sourceId}] Session rejected, reinitializing...`);
+      setSession(server, null);
+      await ensureSession(server);
+      return await makePromptCall(server, name, args);
     }
     throw error;
   }
 }
 
-async function makePromptCall(name: string, args: Record<string, string>): Promise<string> {
-  console.log('[MCP] Getting prompt:', name, 'with args:', JSON.stringify(args));
+async function makePromptCall(
+  server: McpServerConfig,
+  name: string,
+  args: Record<string, string>,
+): Promise<string> {
+  console.log(`[MCP:${server.sourceId}] Getting prompt:`, name, 'with args:', JSON.stringify(args));
 
-  const response = await fetch(`${MCP_URL}/mcp`, {
+  const sessionId = getSession(server);
+  if (!sessionId) {
+    throw new Error(`MCP session missing for server "${server.sourceId}"`);
+  }
+
+  const response = await fetch(server.endpointUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Accept': 'application/json, text/event-stream',
-      'mcp-session-id': sessionId!,
+      'mcp-session-id': sessionId,
+      ...(server.headers || {}),
     },
     body: JSON.stringify({
       jsonrpc: '2.0',
@@ -223,7 +298,7 @@ async function makePromptCall(name: string, args: Record<string, string>): Promi
   }
 
   const text = await response.text();
-  console.log('[MCP] Prompt raw response:', text.substring(0, 500));
+  console.log(`[MCP:${server.sourceId}] Prompt raw response:`, text.substring(0, 500));
 
   // Parse SSE response format
   const lines = text.split('\n');

--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -4,23 +4,32 @@ import {
   resolveServerForTool,
   type McpRegistry,
   type McpServerConfig,
-} from './registry';
+} from './registry.ts';
 
 const MCP_TIMEOUT_MS = 45_000; // 45-second timeout for MCP server requests
 
 // M9.1: multi-MCP routing.
 //
-// The website now talks to more than one MCP server (Socrata + Google Data
-// Commons). Each server maintains its own `mcp-session-id` independently, so
-// session state is tracked per source rather than in a single module-level
-// variable. Tool calls route to the correct server based on tool name via the
-// registry in `./registry.ts`.
+// The website talks to more than one MCP server (Socrata + Google Data
+// Commons). Tool calls route to the correct server based on tool name via
+// the registry in `./registry.ts`.
 //
-// Why: the research phase (M9.0) confirmed Data Commons ships a hosted HTTPS
-// MCP endpoint that is drop-in compatible with our existing HTTP/SSE client
-// pattern — so the per-server routing layer is the entire architectural
-// change needed. The skill-guidance prompt fetch still lives on the Socrata
-// server and continues to route through the `socrata` source explicitly.
+// Session handling is intentionally flexible because the two servers use
+// different dialects of the MCP spec. The spec says the `mcp-session-id`
+// header is OPTIONAL: servers MAY issue one on `initialize`, and clients
+// MUST echo it back on subsequent requests only when it exists.
+//
+// - Socrata is stateful: `initialize` returns `mcp-session-id`, every
+//   `tools/call` must carry it back, and a server restart invalidates the
+//   session (which we detect and re-initialize on).
+// - Data Commons' hosted HTTPS endpoint at api.datacommons.org/mcp is
+//   stateless: `initialize` succeeds with no session header, and tool calls
+//   carry only Content-Type + Accept + the `X-API-Key` registry header.
+//
+// Each server's state therefore tracks both whether we've initialized and
+// whether that initialization produced a session id. Tool-call header
+// construction is factored into `buildMcpRequestHeaders` so it can be unit
+// tested against a stateless server config without network I/O.
 
 const registry: McpRegistry = buildMcpRegistry(readMcpEnvFromProcess());
 
@@ -32,34 +41,67 @@ interface McpToolResult {
   error?: string;
 }
 
+interface ServerState {
+  initialized: boolean;
+  /** Session id issued by the server on `initialize`, or null if stateless. */
+  sessionId: string | null;
+}
+
+const serverState: Record<string, ServerState> = {};
+
+function getServerState(server: McpServerConfig): ServerState {
+  let state = serverState[server.sourceId];
+  if (!state) {
+    state = { initialized: false, sessionId: null };
+    serverState[server.sourceId] = state;
+  }
+  return state;
+}
+
+function resetServerState(server: McpServerConfig): void {
+  serverState[server.sourceId] = { initialized: false, sessionId: null };
+}
+
 function createTimeoutSignal(ms: number): { signal: AbortSignal; clear: () => void } {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), ms);
   return { signal: controller.signal, clear: () => clearTimeout(timer) };
 }
 
-// Per-server session state. Keyed by the server's sourceId.
-const sessionIds: Record<string, string | null> = {};
-
-function getSession(server: McpServerConfig): string | null {
-  return sessionIds[server.sourceId] ?? null;
+/**
+ * Build the merged header set for any request to an MCP server. Combines the
+ * standard JSON/SSE headers, any registry-supplied per-server headers (e.g.
+ * Data Commons' `X-API-Key`), and a conditional `mcp-session-id` when a
+ * session id is present. Exported for unit tests — no network I/O.
+ */
+export function buildMcpRequestHeaders(
+  server: McpServerConfig,
+  sessionId: string | null,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json, text/event-stream',
+    ...(server.headers || {}),
+  };
+  if (sessionId) {
+    headers['mcp-session-id'] = sessionId;
+  }
+  return headers;
 }
 
-function setSession(server: McpServerConfig, id: string | null): void {
-  sessionIds[server.sourceId] = id;
-}
-
-async function initializeSession(server: McpServerConfig): Promise<string> {
+/**
+ * POST `initialize` to a server and return whatever session id the server
+ * issued — or `null` if the server is stateless and issued none. Either
+ * outcome is a successful initialization; the caller flips
+ * `state.initialized = true` on return.
+ */
+async function initializeSession(server: McpServerConfig): Promise<string | null> {
   const { signal, clear } = createTimeoutSignal(MCP_TIMEOUT_MS);
   let response: Response;
   try {
     response = await fetch(server.endpointUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json, text/event-stream',
-        ...(server.headers || {}),
-      },
+      headers: buildMcpRequestHeaders(server, null),
       signal,
       body: JSON.stringify({
         jsonrpc: '2.0',
@@ -89,21 +131,23 @@ async function initializeSession(server: McpServerConfig): Promise<string> {
     throw new Error(`MCP initialization failed for "${server.sourceId}": ${response.status}`);
   }
 
-  const newSessionId = response.headers.get('mcp-session-id');
-  if (!newSessionId) {
-    throw new Error(`No session ID returned from MCP server "${server.sourceId}"`);
-  }
-
-  return newSessionId;
+  // Session id header is optional per the MCP spec — stateless servers omit it.
+  return response.headers.get('mcp-session-id');
 }
 
-async function ensureSession(server: McpServerConfig): Promise<string> {
-  let id = getSession(server);
-  if (!id) {
-    id = await initializeSession(server);
-    setSession(server, id);
+/**
+ * Ensure a server has been initialized. Returns the session id issued during
+ * initialization, which may be `null` for stateless servers. Only triggers a
+ * real `initialize` call the first time (or after `resetServerState` on a
+ * session-expired retry).
+ */
+async function ensureInitialized(server: McpServerConfig): Promise<string | null> {
+  const state = getServerState(server);
+  if (!state.initialized) {
+    state.sessionId = await initializeSession(server);
+    state.initialized = true;
   }
-  return id;
+  return state.sessionId;
 }
 
 /**
@@ -120,16 +164,19 @@ export function routeTool(toolName: string): McpServerConfig {
 
 export async function callMcpTool(name: string, args: Record<string, unknown>): Promise<string> {
   const server = routeTool(name);
-  await ensureSession(server);
+  await ensureInitialized(server);
 
   try {
     return await makeToolCall(server, name, args);
   } catch (error) {
-    // Session expired / server restart: clear and retry once.
+    // For stateful servers (Socrata), a restart or session timeout can make a
+    // previously-valid session id stop working. Clear state and retry once.
+    // Stateless servers (Data Commons) never hit this branch — their session
+    // id is always null, and no server-side state means no invalidation.
     if (error instanceof Error && (error.message.includes('session') || error.message.includes('400'))) {
       console.log(`[MCP:${server.sourceId}] Session rejected, reinitializing...`);
-      setSession(server, null);
-      await ensureSession(server);
+      resetServerState(server);
+      await ensureInitialized(server);
       return await makeToolCall(server, name, args);
     }
     throw error;
@@ -143,22 +190,15 @@ async function makeToolCall(
 ): Promise<string> {
   console.log(`[MCP:${server.sourceId}] Calling tool:`, name, 'with args:', JSON.stringify(args));
 
-  const sessionId = getSession(server);
-  if (!sessionId) {
-    throw new Error(`MCP session missing for server "${server.sourceId}"`);
-  }
+  const state = getServerState(server);
+  const headers = buildMcpRequestHeaders(server, state.sessionId);
 
   const { signal, clear } = createTimeoutSignal(MCP_TIMEOUT_MS);
   let response: Response;
   try {
     response = await fetch(server.endpointUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json, text/event-stream',
-        'mcp-session-id': sessionId,
-        ...(server.headers || {}),
-      },
+      headers,
       signal,
       body: JSON.stringify({
         jsonrpc: '2.0',
@@ -249,15 +289,15 @@ export async function callMcpPrompt(name: string, args: Record<string, string>):
   if (!server) {
     throw new Error('Socrata MCP server is not configured; cannot fetch prompt');
   }
-  await ensureSession(server);
+  await ensureInitialized(server);
 
   try {
     return await makePromptCall(server, name, args);
   } catch (error) {
     if (error instanceof Error && (error.message.includes('session') || error.message.includes('400'))) {
       console.log(`[MCP:${server.sourceId}] Session rejected, reinitializing...`);
-      setSession(server, null);
-      await ensureSession(server);
+      resetServerState(server);
+      await ensureInitialized(server);
       return await makePromptCall(server, name, args);
     }
     throw error;
@@ -271,19 +311,12 @@ async function makePromptCall(
 ): Promise<string> {
   console.log(`[MCP:${server.sourceId}] Getting prompt:`, name, 'with args:', JSON.stringify(args));
 
-  const sessionId = getSession(server);
-  if (!sessionId) {
-    throw new Error(`MCP session missing for server "${server.sourceId}"`);
-  }
+  const state = getServerState(server);
+  const headers = buildMcpRequestHeaders(server, state.sessionId);
 
   const response = await fetch(server.endpointUrl, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json, text/event-stream',
-      'mcp-session-id': sessionId,
-      ...(server.headers || {}),
-    },
+    headers,
     body: JSON.stringify({
       jsonrpc: '2.0',
       id: Date.now(),

--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -45,6 +45,14 @@ interface ServerState {
   initialized: boolean;
   /** Session id issued by the server on `initialize`, or null if stateless. */
   sessionId: string | null;
+  /**
+   * Per-server `instructions` text captured from the `initialize` response's
+   * `result.instructions` field (MCP spec, optional). Data Commons' hosted
+   * endpoint returns a "Research Assistant" primer here that seeds the LLM
+   * system prompt; Socrata returns nothing useful. Null until initialized or
+   * when the server does not advertise any instructions.
+   */
+  instructions: string | null;
 }
 
 const serverState: Record<string, ServerState> = {};
@@ -52,14 +60,14 @@ const serverState: Record<string, ServerState> = {};
 function getServerState(server: McpServerConfig): ServerState {
   let state = serverState[server.sourceId];
   if (!state) {
-    state = { initialized: false, sessionId: null };
+    state = { initialized: false, sessionId: null, instructions: null };
     serverState[server.sourceId] = state;
   }
   return state;
 }
 
 function resetServerState(server: McpServerConfig): void {
-  serverState[server.sourceId] = { initialized: false, sessionId: null };
+  serverState[server.sourceId] = { initialized: false, sessionId: null, instructions: null };
 }
 
 function createTimeoutSignal(ms: number): { signal: AbortSignal; clear: () => void } {
@@ -89,13 +97,37 @@ export function buildMcpRequestHeaders(
   return headers;
 }
 
+interface InitializeResult {
+  sessionId: string | null;
+  instructions: string | null;
+}
+
 /**
- * POST `initialize` to a server and return whatever session id the server
- * issued — or `null` if the server is stateless and issued none. Either
- * outcome is a successful initialization; the caller flips
- * `state.initialized = true` on return.
+ * Extract the first JSON payload from an MCP response body. MCP servers may
+ * return either SSE-wrapped format ("event: message\ndata: {...}\n\n") or
+ * raw JSON. Returns null when no payload is recognizable.
  */
-async function initializeSession(server: McpServerConfig): Promise<string | null> {
+function extractMcpJsonPayload(text: string): string | null {
+  const lines = text.split('\n');
+  for (const line of lines) {
+    if (line.startsWith('data:')) {
+      return line.slice(5).trim();
+    }
+  }
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    return trimmed;
+  }
+  return null;
+}
+
+/**
+ * POST `initialize` to a server and return both the session id it issued
+ * (may be null for stateless servers) and any `result.instructions` text the
+ * server advertised (MCP spec, optional). Either outcome is a successful
+ * initialization; the caller flips `state.initialized = true` on return.
+ */
+async function initializeSession(server: McpServerConfig): Promise<InitializeResult> {
   const { signal, clear } = createTimeoutSignal(MCP_TIMEOUT_MS);
   let response: Response;
   try {
@@ -132,22 +164,73 @@ async function initializeSession(server: McpServerConfig): Promise<string | null
   }
 
   // Session id header is optional per the MCP spec — stateless servers omit it.
-  return response.headers.get('mcp-session-id');
+  const sessionId = response.headers.get('mcp-session-id');
+
+  // Parse the body for a `result.instructions` field. MCP servers that ship
+  // a pre-canned LLM primer advertise it here; others omit it. Parse failures
+  // are tolerated silently — initialization itself is still successful.
+  let instructions: string | null = null;
+  try {
+    const text = await response.text();
+    const jsonData = extractMcpJsonPayload(text);
+    if (jsonData) {
+      const parsed = JSON.parse(jsonData);
+      const rawInstructions = parsed?.result?.instructions;
+      if (typeof rawInstructions === 'string' && rawInstructions.length > 0) {
+        instructions = rawInstructions;
+        console.log(
+          `[MCP:${server.sourceId}] Captured server instructions (${rawInstructions.length} chars) from initialize response`,
+        );
+      }
+    }
+  } catch (error) {
+    console.warn(
+      `[MCP:${server.sourceId}] Could not parse initialize response body for instructions:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+
+  return { sessionId, instructions };
 }
 
 /**
  * Ensure a server has been initialized. Returns the session id issued during
  * initialization, which may be `null` for stateless servers. Only triggers a
  * real `initialize` call the first time (or after `resetServerState` on a
- * session-expired retry).
+ * session-expired retry). Also caches any `instructions` text the server
+ * advertised so the skill-composition layer can read it without a second call.
  */
 async function ensureInitialized(server: McpServerConfig): Promise<string | null> {
   const state = getServerState(server);
   if (!state.initialized) {
-    state.sessionId = await initializeSession(server);
+    const { sessionId, instructions } = await initializeSession(server);
+    state.sessionId = sessionId;
+    state.instructions = instructions;
     state.initialized = true;
   }
   return state.sessionId;
+}
+
+/**
+ * Fetch the per-server `instructions` text captured during initialize, if
+ * the server advertised any. Initializes the server lazily if it hasn't been
+ * touched yet. Returns null when the server did not advertise instructions
+ * or initialization failed — callers should treat an empty result as a
+ * soft failure and compose the skill prompt without the server's text.
+ */
+export async function getServerInstructions(sourceId: string): Promise<string | null> {
+  const server = registry.servers[sourceId];
+  if (!server) return null;
+  try {
+    await ensureInitialized(server);
+  } catch (error) {
+    console.warn(
+      `[MCP:${sourceId}] Could not initialize for instructions fetch:`,
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+  return getServerState(server).instructions;
 }
 
 /**

--- a/src/lib/mcp/data-commons-skill.ts
+++ b/src/lib/mcp/data-commons-skill.ts
@@ -1,0 +1,123 @@
+// Data Commons MCP Skill — Domain knowledge for querying Google Data Commons.
+//
+// Source of truth: civic-ai-tools/docs/skills/data-commons.md
+// Manually embedded here for M9.2 (multi-MCP skill guidance). Inline code
+// spans from the markdown source are stripped so the content can live in a
+// plain template literal without backtick escaping — matches the approach
+// used by SOCRATA_SKILL_FALLBACK in ./socrata-skill.ts.
+//
+// If you change the guidance: update civic-ai-tools/docs/skills/data-commons.md
+// first (source of truth), then re-sync this constant by hand. A sync script
+// is planned as post-M9 cleanup.
+
+export const DATA_COMMONS_SKILL = `
+# Data Commons Companion Skill — Base Guidance
+
+Universal guidance for querying federal and international statistical data through the Google Data Commons MCP server.
+
+## Purpose and when to use
+
+Data Commons is a unified knowledge graph of aggregated statistics from authoritative sources: U.S. Census Bureau (ACS, Decennial), BLS, CDC, Department of Education, EPA, and many international statistical agencies. Use it for demographic, labor, health, education, and environment indicators — anything that answers "how many people / what share / what rate" for a place and a time.
+
+- **Use Data Commons when** the question needs an ACS / Decennial / BLS / CDC / NCES / EPA figure with an auditable source and vintage.
+- **Use Socrata when** the question is about city operational data (311, permits, crime, inspections, licenses, payroll, violations) or data that changes daily.
+- **Use both when** equity questions need operational data joined against demographic context. See *Cross-source decision logic* below.
+
+## Two-tool workflow
+
+Data Commons exposes two tools:
+
+| Tool | Purpose |
+|------|---------|
+| search_indicators | Discover the variable DCID matching a natural-language request for a place |
+| get_observations | Retrieve actual values for a variable DCID at a place DCID (with an optional date range) |
+
+**The default workflow is two-step: search first, then fetch.** Do not skip search_indicators. Data Commons has hundreds of thousands of statistical variables with precise, non-obvious names, and guessing a DCID burns tool calls on empty responses.
+
+### Worked example
+
+User: *"What was the median household income for Manhattan?"*
+
+1. Call search_indicators with "median household income" and place DCID geoId/36061 (NY County = Manhattan). The response includes candidate variable DCIDs — typically Median_Income_Household and close relatives.
+2. Call get_observations with that variable DCID and place DCID. The response is observations from ACS 5-Year Estimates.
+3. Report the figure with source (ACS 5-Year Estimates) and vintage (e.g., 2020-2024).
+
+Echo the DCID you picked back to the user so variable-selection mistakes get caught before they propagate.
+
+## DCID patterns
+
+Every place and every statistical variable in Data Commons has a **DCID** (Data Commons identifier). Two families matter most.
+
+### Place DCIDs
+
+| Pattern | Example | Meaning |
+|---------|---------|---------|
+| country/USA | country/USA | Country |
+| geoId/XX | geoId/36 | US state (2-digit FIPS — 36 = New York) |
+| geoId/XXXXX | geoId/36061 | US county (5-digit FIPS — 36061 = NY County / Manhattan) |
+| geoId/XXXXXXX | geoId/3651000 | US city or incorporated place (7-digit FIPS — 3651000 = New York City) |
+| geoId/<11-digit FIPS> | geoId/36061010100 | US census tract |
+| geoId/<12-digit FIPS> | geoId/360610101001 | US census block group |
+| zip/XXXXX | zip/10001 | ZIP Code Tabulation Area (ZCTA) |
+
+Place hierarchies nest: block group → tract → county → state → country. Always pass the most specific DCID the question permits, and verify with the user whether "Manhattan" means the county (geoId/36061), the borough neighborhood, or a narrower slice before committing.
+
+### Variable DCIDs
+
+Variable DCIDs are mixed-case, loosely snake-case-ish, and often long and descriptive:
+
+- Count_Person — total population
+- Median_Income_Household — median household income
+- Count_Person_BelowPovertyLevelInThePast12Months — persons below poverty (ACS count)
+- Percent_Person_BelowPovertyLevelInThePast12Months — same, as a percent
+
+Never invent a variable DCID from pattern-matching against similar-looking ones. Always discover it with search_indicators.
+
+## Small-area coverage and limitations
+
+Data Commons natively supports **US census tract**, **US census block group**, **ZCTA** (zip/XXXXX), county, state, and country place types.
+
+Data Commons does **NOT** natively support NYC community districts, city council districts, Neighborhood Tabulation Areas, Chicago community areas, or arbitrary municipal boundaries beyond incorporated-place FIPS codes.
+
+For civic analyses that need community-district or council-district resolution, the current pattern is to **work at the census tract level** and state the geography choice explicitly in the output. A tract-to-admin-geography crosswalk utility is planned as follow-up work and tracked separately; do not emulate it by guessing tract memberships.
+
+## Aggregation semantics — silent wrong answers
+
+**This is the single biggest risk of Data Commons queries.** Unlike a SoQL error that returns 0 rows or a 400 status, a wrong Data Commons query returns a plausible-looking but incorrect number. No exception, no warning, no hint that the variable, time range, or place type was off.
+
+To prevent silent wrong answers:
+
+1. **Verify the variable matches intent.** If the user asks for "poverty rate," return the percent variable (Percent_Person_BelowPovertyLevelInThePast12Months), not the raw count. When search_indicators returns multiple candidates, echo the top 2-3 and narrate your choice.
+2. **Confirm the place type.** A "Manhattan" answer at county resolution is a different number than at block-group resolution. State which place type you queried: *"I queried at the county level (NY County, geoId/36061)."*
+3. **Surface the vintage.** ACS releases annually; "2023" could be ACS 1-Year 2023 or ACS 5-Year 2019-2023 depending on availability. Put the vintage inline with the value, not in a footnote.
+4. **Cite the source provider.** Every observation includes provenance — dataset, statistical agency, release. Surface these alongside the number. A figure without its source is not a Data Commons answer.
+5. **Flag ambiguity.** If search_indicators returns several plausible variables and you cannot confidently narrow, stop and ask the user to clarify before returning a number.
+
+## Cross-source decision logic
+
+When a question touches both demographic data (Data Commons) and civic operational data (Socrata), plan the work before making tool calls:
+
+1. **Split the question.** Which part is demographic, which is operational?
+2. **Fetch operational data from Socrata** at the most specific geography it supports.
+3. **Fetch demographic data from Data Commons** at census tract, or the nearest supported geography.
+4. **Join on tract DCID**, not on mismatched place types. If a question cannot be answered at tract resolution (e.g., "by community district"), explain the geography gap rather than joining across mismatched units.
+5. **Attribute each number to its source in the output.** The reader should see at a glance which figures came from Socrata and which from Data Commons.
+
+If a question is genuinely ambiguous — "how many New Yorkers earn under $50k?" could be ACS or NYC payroll — ask one brief clarifying question before querying.
+
+## Attribution and provenance
+
+Attribute every Data Commons observation with the **source dataset** (e.g., "ACS 5-Year Estimates, 2020-2024"), the **statistical agency** (e.g., "U.S. Census Bureau"), and the **place DCID** and **variable DCID** used, so the answer is reproducible.
+
+When a Data Commons call is part of an analysis published as an evidence package on civicaitools.org, the evidence chain captures the DCIDs, variable, vintage, and place type automatically. The provenance graph emits Data Commons as a distinct prov:Agent alongside Socrata agents so a reader verifying the package can tell exactly which numbers came from which source.
+
+## Empty or unrelated results
+
+If search_indicators returns empty or obviously irrelevant variables, it usually means one of:
+
+1. The variable exists but is suppressed at that resolution (ACS small-area non-publication)
+2. The place DCID is wrong — re-check the FIPS pattern
+3. The question cannot be answered from Data Commons and needs a different source (Socrata, a direct API, or web search)
+
+Do not fabricate a value. Report the empty result, state the DCID and query you tried, and suggest a narrower geography or an alternative source.
+`;

--- a/src/lib/mcp/operation-types.test.ts
+++ b/src/lib/mcp/operation-types.test.ts
@@ -1,0 +1,64 @@
+// Unit tests for operation-type and source derivation used by the M9.3
+// multi-source evidence integration.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveOperationType, sourceIdForToolName } from './operation-types.ts';
+
+test('Data Commons: search_indicators maps to "search"', () => {
+  assert.equal(deriveOperationType('search_indicators', { query: 'median income' }), 'search');
+});
+
+test('Data Commons: get_observations maps to "query"', () => {
+  assert.equal(
+    deriveOperationType('get_observations', {
+      variable_dcid: 'Median_Income_Household',
+      place_dcid: 'geoId/36061',
+    }),
+    'query',
+  );
+});
+
+test('Data Commons: tool-name mapping wins even if args.type is present', () => {
+  // Defensive: even if an LLM hallucinated a `type` arg for a DC tool, the
+  // tool-name mapping is still authoritative.
+  assert.equal(
+    deriveOperationType('get_observations', { type: 'catalog', variable_dcid: 'X' }),
+    'query',
+  );
+});
+
+test('Socrata get_data falls through to args.type', () => {
+  assert.equal(deriveOperationType('get_data', { type: 'query', dataset_id: 'abc-1234' }), 'query');
+  assert.equal(deriveOperationType('get_data', { type: 'catalog' }), 'catalog');
+  assert.equal(deriveOperationType('get_data', { type: 'metadata' }), 'metadata');
+  assert.equal(deriveOperationType('get_data', { type: 'metrics' }), 'metrics');
+});
+
+test('Unknown tool with no args.type returns undefined', () => {
+  assert.equal(deriveOperationType('mystery_tool', {}), undefined);
+});
+
+test('args.type that is not a string is ignored', () => {
+  // Be defensive: if an args.type comes through as a non-string, don't coerce.
+  assert.equal(deriveOperationType('get_data', { type: 42 }), undefined);
+  assert.equal(deriveOperationType('get_data', { type: null }), undefined);
+});
+
+test('sourceIdForToolName: Socrata tools', () => {
+  assert.equal(sourceIdForToolName('get_data'), 'socrata');
+  assert.equal(sourceIdForToolName('search'), 'socrata');
+  assert.equal(sourceIdForToolName('fetch'), 'socrata');
+});
+
+test('sourceIdForToolName: Data Commons tools', () => {
+  assert.equal(sourceIdForToolName('search_indicators'), 'data-commons');
+  assert.equal(sourceIdForToolName('get_observations'), 'data-commons');
+});
+
+test('sourceIdForToolName: unknown tool returns undefined', () => {
+  assert.equal(sourceIdForToolName('mystery_tool'), undefined);
+  assert.equal(sourceIdForToolName(''), undefined);
+});

--- a/src/lib/mcp/operation-types.ts
+++ b/src/lib/mcp/operation-types.ts
@@ -1,0 +1,46 @@
+// Map an MCP tool call to its semantic operation type — the label surfaced
+// in traces (`tool.operation_type`), the UI, and evidence packages
+// (queries[].operationType).
+//
+// Socrata's unified `get_data` tool carries the operation type in `args.type`
+// (catalog | metadata | query | metrics). Data Commons uses distinct tool
+// names for each operation and does not emit an `args.type` field, so the
+// mapping is by tool name instead.
+
+const TOOL_OPERATION_TYPES: Record<string, string> = {
+  search_indicators: 'search',
+  get_observations: 'query',
+};
+
+const SOURCE_BY_TOOL_NAME: Record<string, string> = {
+  get_data: 'socrata',
+  search: 'socrata',
+  fetch: 'socrata',
+  search_indicators: 'data-commons',
+  get_observations: 'data-commons',
+};
+
+/**
+ * Resolve the operation type for a tool call. Returns `undefined` when the
+ * operation cannot be determined — callers typically fall back to `'unknown'`.
+ */
+export function deriveOperationType(
+  toolName: string,
+  args: Record<string, unknown>,
+): string | undefined {
+  const mapped = TOOL_OPERATION_TYPES[toolName];
+  if (mapped) return mapped;
+  const argType = args.type;
+  return typeof argType === 'string' ? argType : undefined;
+}
+
+/**
+ * Static tool-name → source-id map. Used as a fallback when the trace does
+ * not carry an `mcp.source` attribute (pre-M9.1 packages, tests without a
+ * full trace). The authoritative runtime mapping lives in `./registry.ts`;
+ * this static version exists so pure-function callers (packager, tests) can
+ * resolve sources without reading `process.env`.
+ */
+export function sourceIdForToolName(toolName: string): string | undefined {
+  return SOURCE_BY_TOOL_NAME[toolName];
+}

--- a/src/lib/mcp/registry.test.ts
+++ b/src/lib/mcp/registry.test.ts
@@ -1,0 +1,112 @@
+// Unit tests for the multi-MCP routing registry.
+//
+// Run with: node --test --experimental-strip-types src/lib/mcp/registry.test.ts
+//
+// These tests assert the M9.1 routing contract: Socrata tool names route to
+// the Socrata endpoint; Data Commons tool names route to the Data Commons
+// endpoint with the X-API-Key header attached; unknown tools do not
+// accidentally resolve to either server.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildMcpRegistry,
+  resolveServerForTool,
+  readMcpEnvFromProcess,
+} from './registry.ts';
+
+const TEST_ENV = {
+  socrataUrl: 'https://socrata-mcp.example.org',
+  dataCommonsUrl: 'https://api.datacommons.org/mcp',
+  dataCommonsApiKey: 'test-key-abc',
+};
+
+test('Socrata tool names route to the Socrata endpoint', () => {
+  const registry = buildMcpRegistry(TEST_ENV);
+  for (const toolName of ['get_data', 'search', 'fetch']) {
+    const server = resolveServerForTool(registry, toolName);
+    assert.ok(server, `expected server for tool "${toolName}"`);
+    assert.equal(server!.sourceId, 'socrata');
+    assert.equal(server!.endpointUrl, 'https://socrata-mcp.example.org/mcp');
+    assert.equal(server!.headers, undefined, 'Socrata server carries no auth headers');
+  }
+});
+
+test('Data Commons tool names route to the Data Commons endpoint with X-API-Key', () => {
+  const registry = buildMcpRegistry(TEST_ENV);
+  for (const toolName of ['search_indicators', 'get_observations']) {
+    const server = resolveServerForTool(registry, toolName);
+    assert.ok(server, `expected server for tool "${toolName}"`);
+    assert.equal(server!.sourceId, 'data-commons');
+    assert.equal(server!.endpointUrl, 'https://api.datacommons.org/mcp');
+    assert.deepEqual(server!.headers, { 'X-API-Key': 'test-key-abc' });
+  }
+});
+
+test('Unknown tool names do not resolve to any server', () => {
+  const registry = buildMcpRegistry(TEST_ENV);
+  assert.equal(resolveServerForTool(registry, 'get_observation_typo'), undefined);
+  assert.equal(resolveServerForTool(registry, 'delete_data'), undefined);
+  assert.equal(resolveServerForTool(registry, ''), undefined);
+});
+
+test('Bare Socrata URL gets /mcp appended; Data Commons URL is not double-appended', () => {
+  const registry = buildMcpRegistry({
+    socrataUrl: 'https://socrata-mcp.example.org',
+    dataCommonsUrl: 'https://api.datacommons.org/mcp',
+  });
+  assert.equal(registry.servers.socrata.endpointUrl, 'https://socrata-mcp.example.org/mcp');
+  assert.equal(registry.servers['data-commons'].endpointUrl, 'https://api.datacommons.org/mcp');
+});
+
+test('Trailing slash on either env var is normalized', () => {
+  const registry = buildMcpRegistry({
+    socrataUrl: 'https://socrata-mcp.example.org/',
+    dataCommonsUrl: 'https://api.datacommons.org/mcp/',
+  });
+  assert.equal(registry.servers.socrata.endpointUrl, 'https://socrata-mcp.example.org/mcp');
+  assert.equal(registry.servers['data-commons'].endpointUrl, 'https://api.datacommons.org/mcp');
+});
+
+test('Missing Data Commons API key omits the auth header entirely', () => {
+  const registry = buildMcpRegistry({
+    socrataUrl: 'https://socrata-mcp.example.org',
+    dataCommonsUrl: 'https://api.datacommons.org/mcp',
+    // no dataCommonsApiKey
+  });
+  assert.equal(registry.servers['data-commons'].headers, undefined);
+});
+
+test('readMcpEnvFromProcess falls back to defaults when env vars are unset', () => {
+  const originalSocrata = process.env.SOCRATA_MCP_URL;
+  const originalDc = process.env.DATA_COMMONS_MCP_URL;
+  const originalKey = process.env.DATA_COMMONS_API_KEY;
+  delete process.env.SOCRATA_MCP_URL;
+  delete process.env.DATA_COMMONS_MCP_URL;
+  delete process.env.DATA_COMMONS_API_KEY;
+  try {
+    const env = readMcpEnvFromProcess();
+    assert.equal(env.socrataUrl, 'https://socrata-mcp.civicaitools.org');
+    assert.equal(env.dataCommonsUrl, 'https://api.datacommons.org/mcp');
+    assert.equal(env.dataCommonsApiKey, undefined);
+  } finally {
+    if (originalSocrata !== undefined) process.env.SOCRATA_MCP_URL = originalSocrata;
+    if (originalDc !== undefined) process.env.DATA_COMMONS_MCP_URL = originalDc;
+    if (originalKey !== undefined) process.env.DATA_COMMONS_API_KEY = originalKey;
+  }
+});
+
+test('Every tool appears in exactly one server (no accidental overlap)', () => {
+  const registry = buildMcpRegistry(TEST_ENV);
+  const allTools = new Map<string, string>();
+  for (const [sourceId, server] of Object.entries(registry.servers)) {
+    for (const tool of server.tools) {
+      assert.ok(
+        !allTools.has(tool),
+        `tool "${tool}" appears in both "${allTools.get(tool)}" and "${sourceId}"`,
+      );
+      allTools.set(tool, sourceId);
+    }
+  }
+  assert.equal(allTools.size, 5, 'registry should host exactly 5 tools in M9.1');
+});

--- a/src/lib/mcp/registry.test.ts
+++ b/src/lib/mcp/registry.test.ts
@@ -14,6 +14,7 @@ import {
   resolveServerForTool,
   readMcpEnvFromProcess,
 } from './registry.ts';
+import { buildMcpRequestHeaders } from './client.ts';
 
 const TEST_ENV = {
   socrataUrl: 'https://socrata-mcp.example.org',
@@ -94,6 +95,32 @@ test('readMcpEnvFromProcess falls back to defaults when env vars are unset', () 
     if (originalDc !== undefined) process.env.DATA_COMMONS_MCP_URL = originalDc;
     if (originalKey !== undefined) process.env.DATA_COMMONS_API_KEY = originalKey;
   }
+});
+
+test('Stateless server: request headers omit mcp-session-id, keep X-API-Key', () => {
+  // The Data Commons hosted endpoint is stateless and returns no
+  // mcp-session-id on initialize. Tool calls against such a server must
+  // still carry the registry-supplied headers (X-API-Key) but NOT an
+  // mcp-session-id header — which would otherwise be 'null' or 'undefined'
+  // coerced to a string.
+  const registry = buildMcpRegistry(TEST_ENV);
+  const dataCommons = registry.servers['data-commons'];
+  const headers = buildMcpRequestHeaders(dataCommons, null);
+  assert.equal(headers['Content-Type'], 'application/json');
+  assert.equal(headers['Accept'], 'application/json, text/event-stream');
+  assert.equal(headers['X-API-Key'], 'test-key-abc');
+  assert.ok(!('mcp-session-id' in headers), 'stateless server must not emit mcp-session-id header');
+
+  // Contrast: a stateful Socrata server with an issued session id should
+  // include the header.
+  const socrata = registry.servers.socrata;
+  const statefulHeaders = buildMcpRequestHeaders(socrata, 'session-xyz');
+  assert.equal(statefulHeaders['mcp-session-id'], 'session-xyz');
+
+  // Socrata before initialize completes (sessionId still null) — should also
+  // omit the header. Covers the `initialize` request itself.
+  const preInitHeaders = buildMcpRequestHeaders(socrata, null);
+  assert.ok(!('mcp-session-id' in preInitHeaders));
 });
 
 test('Every tool appears in exactly one server (no accidental overlap)', () => {

--- a/src/lib/mcp/registry.ts
+++ b/src/lib/mcp/registry.ts
@@ -1,0 +1,95 @@
+// Pure routing registry for the website's MCP clients.
+//
+// Each logical "source" (socrata, data-commons, ...) maps to an MCP server URL
+// plus the tools that server hosts. Kept side-effect-free and free of
+// `process.env` reads so it can be unit-tested in isolation — the caller
+// resolves env at construction time via `buildMcpRegistry`.
+
+export interface McpServerConfig {
+  /** Stable source identifier used in traces and provenance. */
+  sourceId: string;
+  /** Human-readable label for UI / trace attributes. */
+  label: string;
+  /** Full MCP endpoint URL the client POSTs to (always ends in `/mcp`). */
+  endpointUrl: string;
+  /** Extra headers to attach to every request to this server. */
+  headers?: Record<string, string>;
+  /** Tool names this server hosts. */
+  tools: string[];
+}
+
+export interface McpRegistry {
+  servers: Record<string, McpServerConfig>;
+  toolIndex: Record<string, string>;
+}
+
+export interface McpRegistryEnv {
+  socrataUrl: string;
+  dataCommonsUrl: string;
+  dataCommonsApiKey?: string;
+}
+
+const SOCRATA_TOOLS = ['get_data', 'search', 'fetch'];
+const DATA_COMMONS_TOOLS = ['search_indicators', 'get_observations'];
+
+/**
+ * Normalize a base URL to a POST-able MCP endpoint. The Socrata env var is
+ * historically a bare host (`https://socrata-mcp.civicaitools.org`) and the
+ * client appends `/mcp` per-call; Google's docs for Data Commons give the
+ * full `https://api.datacommons.org/mcp` URL. We accept either shape.
+ */
+function normalizeMcpEndpoint(url: string): string {
+  const trimmed = url.replace(/\/$/, '');
+  return trimmed.endsWith('/mcp') ? trimmed : `${trimmed}/mcp`;
+}
+
+/**
+ * Build a routing registry from resolved environment values. Callers should
+ * pass the env they actually want — the function does not read `process.env`
+ * so the same code path is exercised in dev, prod, and tests.
+ */
+export function buildMcpRegistry(env: McpRegistryEnv): McpRegistry {
+  const servers: Record<string, McpServerConfig> = {
+    socrata: {
+      sourceId: 'socrata',
+      label: 'Socrata MCP Server',
+      endpointUrl: normalizeMcpEndpoint(env.socrataUrl),
+      tools: SOCRATA_TOOLS,
+    },
+    'data-commons': {
+      sourceId: 'data-commons',
+      label: 'Google Data Commons MCP Server',
+      endpointUrl: normalizeMcpEndpoint(env.dataCommonsUrl),
+      headers: env.dataCommonsApiKey ? { 'X-API-Key': env.dataCommonsApiKey } : undefined,
+      tools: DATA_COMMONS_TOOLS,
+    },
+  };
+
+  const toolIndex: Record<string, string> = {};
+  for (const [sourceId, server] of Object.entries(servers)) {
+    for (const tool of server.tools) {
+      toolIndex[tool] = sourceId;
+    }
+  }
+
+  return { servers, toolIndex };
+}
+
+/** Look up the server that hosts a given tool name. Returns `undefined` for unknown tools. */
+export function resolveServerForTool(
+  registry: McpRegistry,
+  toolName: string,
+): McpServerConfig | undefined {
+  const sourceId = registry.toolIndex[toolName];
+  if (!sourceId) return undefined;
+  return registry.servers[sourceId];
+}
+
+/** Read the env values the website currently exposes to the MCP client. */
+export function readMcpEnvFromProcess(): McpRegistryEnv {
+  return {
+    socrataUrl: process.env.SOCRATA_MCP_URL || 'https://socrata-mcp.civicaitools.org',
+    dataCommonsUrl: process.env.DATA_COMMONS_MCP_URL || 'https://api.datacommons.org/mcp',
+    dataCommonsApiKey: process.env.DATA_COMMONS_API_KEY || undefined,
+  };
+}

--- a/src/lib/mcp/skill-composition.test.ts
+++ b/src/lib/mcp/skill-composition.test.ts
@@ -1,0 +1,265 @@
+// Unit tests for the skill-composition pure function.
+//
+// Run with: node --test --experimental-strip-types src/lib/mcp/skill-composition.test.ts
+//
+// composeSkillPrompt accepts an injected registry so tests can stub source
+// fetchText without mocking module imports. The default SKILL_REGISTRY is
+// covered by manual end-to-end verification on the Vercel preview, not here.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  composeSkillPrompt,
+  type SkillRegistry,
+  type SkillEntry,
+  type SourceId,
+} from './socrata-skill.ts';
+
+const TODAY = '2026-04-15';
+const PREAMBLE = 'PREAMBLE_BODY';
+const INTRO_LINE = 'You are a helpful assistant with access to civic and statistical data via MCP tools.';
+const TODAY_LINE = `Today's date is ${TODAY}. Always use this as the current date for interpreting relative time expressions like "last year" or "past two months."`;
+const OUTRO = 'When you get results, summarize clearly and cite the dataset ID (for Socrata) or the variable DCID + source dataset (for Data Commons).';
+
+function makeStubEntry(sourceId: SourceId, text: string): SkillEntry {
+  return {
+    sourceId,
+    async fetchText() {
+      return text;
+    },
+  };
+}
+
+function makePortalAwareEntry(sourceId: SourceId, prefix: string): SkillEntry {
+  return {
+    sourceId,
+    async fetchText(ctx) {
+      return `${prefix}(portal=${ctx.portal ?? 'none'}, today=${ctx.today})`;
+    },
+  };
+}
+
+function makeFailingEntry(sourceId: SourceId, message: string): SkillEntry {
+  return {
+    sourceId,
+    async fetchText() {
+      throw new Error(message);
+    },
+  };
+}
+
+const TWO_SOURCE_REGISTRY: SkillRegistry = {
+  socrata: makeStubEntry('socrata', 'SOCRATA_BLOCK'),
+  'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+};
+
+test('Both sources, typical context: intro+preamble, both source blocks in order, outro — joined by \\n\\n---\\n\\n', async () => {
+  const result = await composeSkillPrompt(
+    ['socrata', 'data-commons'],
+    { today: TODAY, preamble: PREAMBLE, portal: 'data.cityofnewyork.us' },
+    TWO_SOURCE_REGISTRY,
+  );
+
+  const expected = [
+    `${INTRO_LINE}\n\n${TODAY_LINE}\n\n${PREAMBLE}`,
+    'SOCRATA_BLOCK',
+    'DATA_COMMONS_BLOCK',
+    OUTRO,
+  ].join('\n\n---\n\n');
+
+  assert.equal(result, expected);
+});
+
+test('activeSources order is preserved: data-commons before socrata renders DC first', async () => {
+  const result = await composeSkillPrompt(
+    ['data-commons', 'socrata'],
+    { today: TODAY, preamble: PREAMBLE },
+    TWO_SOURCE_REGISTRY,
+  );
+
+  const dcIndex = result.indexOf('DATA_COMMONS_BLOCK');
+  const socrataIndex = result.indexOf('SOCRATA_BLOCK');
+  assert.ok(dcIndex >= 0 && socrataIndex >= 0, 'both source blocks should appear');
+  assert.ok(dcIndex < socrataIndex, 'data-commons should render before socrata when listed first');
+});
+
+test('Socrata only: no Data Commons block in output', async () => {
+  const result = await composeSkillPrompt(
+    ['socrata'],
+    { today: TODAY, preamble: PREAMBLE, portal: 'data.cityofnewyork.us' },
+    TWO_SOURCE_REGISTRY,
+  );
+
+  assert.ok(result.includes('SOCRATA_BLOCK'), 'Socrata block should be present');
+  assert.ok(!result.includes('DATA_COMMONS_BLOCK'), 'Data Commons block should be absent');
+
+  const expected = [
+    `${INTRO_LINE}\n\n${TODAY_LINE}\n\n${PREAMBLE}`,
+    'SOCRATA_BLOCK',
+    OUTRO,
+  ].join('\n\n---\n\n');
+  assert.equal(result, expected);
+});
+
+test('Data Commons only: no Socrata block in output', async () => {
+  const result = await composeSkillPrompt(
+    ['data-commons'],
+    { today: TODAY, preamble: PREAMBLE },
+    TWO_SOURCE_REGISTRY,
+  );
+
+  assert.ok(result.includes('DATA_COMMONS_BLOCK'), 'Data Commons block should be present');
+  assert.ok(!result.includes('SOCRATA_BLOCK'), 'Socrata block should be absent');
+
+  const expected = [
+    `${INTRO_LINE}\n\n${TODAY_LINE}\n\n${PREAMBLE}`,
+    'DATA_COMMONS_BLOCK',
+    OUTRO,
+  ].join('\n\n---\n\n');
+  assert.equal(result, expected);
+});
+
+test('Empty activeSources: intro + preamble + outro, no source blocks', async () => {
+  const result = await composeSkillPrompt(
+    [],
+    { today: TODAY, preamble: PREAMBLE },
+    TWO_SOURCE_REGISTRY,
+  );
+
+  const expected = [
+    `${INTRO_LINE}\n\n${TODAY_LINE}\n\n${PREAMBLE}`,
+    OUTRO,
+  ].join('\n\n---\n\n');
+  assert.equal(result, expected);
+  assert.ok(!result.includes('SOCRATA_BLOCK'));
+  assert.ok(!result.includes('DATA_COMMONS_BLOCK'));
+});
+
+test('Missing preamble: intro alone in first block, no extra separator', async () => {
+  const result = await composeSkillPrompt(
+    ['socrata'],
+    { today: TODAY },
+    TWO_SOURCE_REGISTRY,
+  );
+
+  const expected = [
+    `${INTRO_LINE}\n\n${TODAY_LINE}`,
+    'SOCRATA_BLOCK',
+    OUTRO,
+  ].join('\n\n---\n\n');
+  assert.equal(result, expected);
+});
+
+test('Unknown sourceId in activeSources: warning logged, source skipped, others render', async () => {
+  // Capture console.warn output
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+
+  try {
+    const result = await composeSkillPrompt(
+      ['socrata', 'mystery-source' as SourceId, 'data-commons'],
+      { today: TODAY, preamble: PREAMBLE },
+      TWO_SOURCE_REGISTRY,
+    );
+
+    assert.ok(result.includes('SOCRATA_BLOCK'), 'real sources still render');
+    assert.ok(result.includes('DATA_COMMONS_BLOCK'), 'real sources still render');
+    assert.ok(!result.includes('mystery-source'), 'unknown source name does not leak into prompt');
+    assert.ok(
+      warnings.some((w) => w.includes('mystery-source') && w.includes('Unknown sourceId')),
+      'a warning was logged about the unknown sourceId',
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test('Failing fetchText: error logged, source omitted, composition completes with other sources', async () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+
+  try {
+    const registry: SkillRegistry = {
+      socrata: makeFailingEntry('socrata', 'simulated socrata outage'),
+      'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+    };
+    const result = await composeSkillPrompt(
+      ['socrata', 'data-commons'],
+      { today: TODAY, preamble: PREAMBLE },
+      registry,
+    );
+
+    assert.ok(result.includes('DATA_COMMONS_BLOCK'), 'surviving source still renders');
+    assert.ok(!result.includes('SOCRATA_BLOCK'), 'failed source is omitted');
+    assert.ok(
+      warnings.some((w) => w.includes('socrata') && w.includes('simulated socrata outage')),
+      'a warning was logged about the failed source',
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test('Returning empty string from fetchText: source omitted with no separator', async () => {
+  const registry: SkillRegistry = {
+    socrata: makeStubEntry('socrata', ''),
+    'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+  };
+  const result = await composeSkillPrompt(
+    ['socrata', 'data-commons'],
+    { today: TODAY, preamble: PREAMBLE },
+    registry,
+  );
+
+  // No double separator from the dropped Socrata block.
+  assert.ok(!result.includes('---\n\n\n\n---'));
+  // Data Commons block lands directly after the preamble block.
+  assert.ok(result.includes(`${PREAMBLE}\n\n---\n\nDATA_COMMONS_BLOCK`));
+});
+
+test('Returning whitespace-only from fetchText: source omitted', async () => {
+  const registry: SkillRegistry = {
+    socrata: makeStubEntry('socrata', '   \n  \n  '),
+    'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+  };
+  const result = await composeSkillPrompt(
+    ['socrata', 'data-commons'],
+    { today: TODAY, preamble: PREAMBLE },
+    registry,
+  );
+
+  assert.ok(result.includes('DATA_COMMONS_BLOCK'));
+  assert.ok(!result.includes('   \n  \n  '));
+});
+
+test('SkillContext is threaded through to fetchText (portal + today visible)', async () => {
+  const registry: SkillRegistry = {
+    socrata: makePortalAwareEntry('socrata', 'SOCRATA_'),
+    'data-commons': makePortalAwareEntry('data-commons', 'DC_'),
+  };
+  const result = await composeSkillPrompt(
+    ['socrata', 'data-commons'],
+    { today: TODAY, preamble: PREAMBLE, portal: 'data.cityofchicago.org' },
+    registry,
+  );
+
+  assert.ok(result.includes('SOCRATA_(portal=data.cityofchicago.org, today=2026-04-15)'));
+  assert.ok(result.includes('DC_(portal=data.cityofchicago.org, today=2026-04-15)'));
+});
+
+test('No-preamble + empty sources: intro joins directly to outro by separator (preamble omitted, no double separator)', async () => {
+  const result = await composeSkillPrompt(
+    [],
+    { today: TODAY },
+    TWO_SOURCE_REGISTRY,
+  );
+
+  const expected = `${INTRO_LINE}\n\n${TODAY_LINE}\n\n---\n\n${OUTRO}`;
+  assert.equal(result, expected);
+});

--- a/src/lib/mcp/socrata-skill.ts
+++ b/src/lib/mcp/socrata-skill.ts
@@ -1,7 +1,23 @@
-// Socrata MCP Skill - Domain knowledge for querying Socrata open data portals
-// Fetched from MCP server's prompt endpoint at runtime, with hardcoded fallback.
+// Multi-source MCP skill composition for the civic-ai-tools website.
+//
+// Despite the filename (historical — Socrata was the only source pre-M9.1),
+// `buildSystemPrompt` now composes the full multi-source system prompt:
+//
+//   1. Cross-source preamble  — "you have access to two data sources..."
+//   2. Socrata skill          — fetched from the Socrata MCP server's
+//                                prompts/get endpoint with a hardcoded
+//                                fallback; portal-specific guidance appended
+//   3. Data Commons server instructions — captured from the Data Commons
+//                                initialize response's `result.instructions`
+//                                field (MCP spec). Omitted when absent.
+//   4. Data Commons augmentation — DATA_COMMONS_SKILL from
+//                                ./data-commons-skill.ts (M9.2 skill doc).
+//
+// The order matters for LLM attention: cross-source decision logic lands
+// first so the model reads it before diving into source-specific details.
 
-import { callMcpPrompt } from './client';
+import { callMcpPrompt, getServerInstructions } from './client.ts';
+import { DATA_COMMONS_SKILL } from './data-commons-skill.ts';
 
 // Fallback constant used when the MCP server is unreachable.
 // NOTE: This may be stale — it was last synced at PR #19 and may be missing
@@ -418,23 +434,153 @@ async function fetchSkillGuidance(): Promise<string> {
   }
 }
 
+/**
+ * Identifier for an MCP data source. Mirrors the keys in `./registry.ts` so a
+ * source's skill text is keyed the same way as its tool routing. Adding a
+ * third source means widening this union and adding one entry to
+ * `SKILL_REGISTRY` below — no changes to `composeSkillPrompt` itself.
+ */
+export type SourceId = 'socrata' | 'data-commons';
+
+/**
+ * Inputs handed to every `SkillEntry.fetchText` call. Sources are free to
+ * ignore fields that don't apply to them (e.g. Data Commons ignores `portal`).
+ */
+export interface SkillContext {
+  /** Default Socrata portal, used by the Socrata entry to append portal-specific guidance. */
+  portal?: string;
+  /** Today's date as YYYY-MM-DD; used in the intro block. */
+  today: string;
+  /** Cross-source preamble inserted between the intro and the per-source blocks. Optional. */
+  preamble?: string;
+}
+
+/**
+ * One source's contribution to the composed system prompt. `fetchText` may do
+ * async I/O (MCP prompt fetch, `initialize`-time instructions). It must catch
+ * its own errors and return an empty string to opt out gracefully — the
+ * composer treats empty strings as "skip this source".
+ */
+export interface SkillEntry {
+  sourceId: SourceId;
+  fetchText(ctx: SkillContext): Promise<string>;
+}
+
+/**
+ * Map from `SourceId` to the entry that produces its skill text. `Partial`
+ * because tests inject smaller registries containing only the entries under
+ * test, and because the composer's "unknown sourceId" branch must be reachable
+ * from a real call site, not just from a hand-rolled stub.
+ */
+export type SkillRegistry = Partial<Record<SourceId, SkillEntry>>;
+
+const CROSS_SOURCE_PREAMBLE = `You have access to TWO MCP data sources through the tools below.
+
+1. **Socrata open data portals** — city operational data such as 311 requests, building permits, inspections, crime, housing violations, payroll, and licenses. Tools: get_data, search, fetch.
+2. **Google Data Commons** — authoritative federal and international statistical data from the U.S. Census Bureau (ACS, Decennial), BLS, CDC, Department of Education, EPA, and other official agencies. Tools: search_indicators, get_observations.
+
+When a question is about demographics, poverty, income, education, health, labor, or environment for a defined geography, prefer Data Commons. When a question is about city operations or anything that changes daily, prefer Socrata. When a question needs both — equity analyses that join city operations against demographic context — plan a multi-step analysis and attribute each figure to its source. See the Cross-source decision logic section in the Data Commons guidance below for the join pattern.`;
+
+const INTRO_TEMPLATE = (today: string) =>
+  `You are a helpful assistant with access to civic and statistical data via MCP tools.
+
+Today's date is ${today}. Always use this as the current date for interpreting relative time expressions like "last year" or "past two months."`;
+
+const OUTRO =
+  'When you get results, summarize clearly and cite the dataset ID (for Socrata) or the variable DCID + source dataset (for Data Commons).';
+
+/**
+ * Default registry. One entry per source the website talks to. Each entry's
+ * `fetchText` returns the source's pre-composed block of skill text, ready to
+ * be joined into the final prompt by `composeSkillPrompt`. The blocks are
+ * deliberately self-contained so the composer doesn't need source-specific
+ * branches.
+ */
+const SKILL_REGISTRY: SkillRegistry = {
+  socrata: {
+    sourceId: 'socrata',
+    async fetchText(ctx) {
+      const guidance = await fetchSkillGuidance();
+      const portalSection = ctx.portal
+        ? `\n\n## PORTAL-SPECIFIC GUIDANCE\nDefault portal: ${ctx.portal}\n${getSkillForPortal(ctx.portal)}`
+        : '';
+      return `# Socrata skill guidance\n\n${guidance}${portalSection}`;
+    },
+  },
+  'data-commons': {
+    sourceId: 'data-commons',
+    async fetchText() {
+      const instructions = await getServerInstructions('data-commons');
+      const instructionsBlock = instructions
+        ? `# Data Commons server instructions (from initialize response)\n\n${instructions}`
+        : '# Data Commons server instructions\n\n(The Data Commons MCP server did not advertise per-server instructions on initialize — composing with the embedded Data Commons skill only.)';
+      return `${instructionsBlock}\n\n---\n\n${DATA_COMMONS_SKILL}`;
+    },
+  },
+};
+
+/**
+ * Compose a multi-source LLM system prompt by joining an intro block, an
+ * optional cross-source preamble, one block per active source, and an outro.
+ * Pure aside from the I/O each registry entry chooses to do — the composer
+ * itself has no `process.env` reads, no global mutable state, and no
+ * source-specific branches.
+ *
+ * The default registry argument is the module-level `SKILL_REGISTRY`. Tests
+ * inject custom registries to exercise composition logic without mocking
+ * module imports; production callers leave the registry off.
+ *
+ * Sources that throw, return an empty string, or are missing from the
+ * registry are skipped silently with a warning logged. Composition always
+ * succeeds; an empty `activeSources` produces intro + preamble + outro.
+ */
+export async function composeSkillPrompt(
+  activeSources: SourceId[],
+  context: SkillContext,
+  registry: SkillRegistry = SKILL_REGISTRY,
+): Promise<string> {
+  const intro = INTRO_TEMPLATE(context.today);
+  const introBlock = context.preamble ? `${intro}\n\n${context.preamble}` : intro;
+
+  const sourceTexts = await Promise.all(
+    activeSources.map(async (sourceId) => {
+      const entry = registry[sourceId];
+      if (!entry) {
+        console.warn(`[composeSkillPrompt] Unknown sourceId "${sourceId}" — skipping`);
+        return '';
+      }
+      try {
+        return await entry.fetchText(context);
+      } catch (error) {
+        console.warn(
+          `[composeSkillPrompt] Failed to fetch text for "${sourceId}":`,
+          error instanceof Error ? error.message : error,
+        );
+        return '';
+      }
+    }),
+  );
+
+  const parts: string[] = [introBlock];
+  for (const text of sourceTexts) {
+    if (text && text.trim().length > 0) {
+      parts.push(text);
+    }
+  }
+  parts.push(OUTRO);
+
+  return parts.join('\n\n---\n\n');
+}
+
+/**
+ * Thin wrapper kept for backward compatibility with the existing route
+ * handlers. Delegates to `composeSkillPrompt` with the default active source
+ * list (`['socrata', 'data-commons']`) and the cross-source preamble.
+ */
 export const buildSystemPrompt = async (portal: string): Promise<string> => {
-  const [skillGuidance, portalGuidance] = await Promise.all([
-    fetchSkillGuidance(),
-    Promise.resolve(getSkillForPortal(portal)),
-  ]);
-
-  const today = new Date().toISOString().split('T')[0];
-
-  return `You are a helpful assistant with access to Socrata open data portals via the get_data tool.
-
-Today's date is ${today}. Always use this as the current date for interpreting relative time expressions like "last year" or "past two months."
-
-${skillGuidance}
-
-## PORTAL-SPECIFIC GUIDANCE
-Default portal: ${portal}
-${portalGuidance}
-
-When you get results, summarize clearly and cite the dataset ID used.`;
+  return composeSkillPrompt(['socrata', 'data-commons'], {
+    portal,
+    today: new Date().toISOString().split('T')[0],
+    preamble: CROSS_SOURCE_PREAMBLE,
+  });
 };

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -1,7 +1,11 @@
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
 
-// Tool definitions for OpenRouter that map to socrata-mcp-server tools
-export const socrataMcpTools: ChatCompletionTool[] = [
+// Unified OpenRouter function-calling schema spanning every MCP source the
+// website talks to. The client in `./client.ts` uses the tool name to route
+// each call to the correct MCP server via `./registry.ts`.
+
+// --- Socrata MCP (city open data portals) ---
+const socrataMcpTools: ChatCompletionTool[] = [
   {
     type: 'function',
     function: {
@@ -73,6 +77,128 @@ Examples:
       },
     },
   },
+];
+
+// --- Google Data Commons MCP (US demographic + federal statistical data) ---
+// Two-tool surface: discover variables/topics with `search_indicators`, then
+// fetch observed values with `get_observations`. Tools hit the hosted
+// endpoint at https://api.datacommons.org/mcp. Full aggregation-semantics
+// guidance (variable DCIDs, place hierarchies, vintage, margins of error) is
+// a M9.2 concern and lives in the skill prompt, not the tool descriptions.
+const dataCommonsMcpTools: ChatCompletionTool[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'search_indicators',
+      description: `Discover statistical variables and topics available in Google Data Commons — the knowledge graph aggregating US Census Bureau (ACS, Decennial), BLS, CDC, Department of Education, EPA, and many international statistical sources.
+
+Use this first when the user asks for demographic, economic, health, education, or environmental statistics and you don't already know the exact variable DCID. The tool returns candidate variable DCIDs that you then pass to get_observations.
+
+IMPORTANT: Data Commons uses DCIDs (Data Commons identifiers) rather than raw Census field names. Always discover the variable DCID via search_indicators before calling get_observations — guessing the DCID silently returns wrong data.
+
+Examples:
+- { "query": "median household income", "places": ["geoId/3604600637"] }  // search near a NYC census tract
+- { "query": "poverty rate", "parent_place": "geoId/36061" }  // search indicators scoped to New York County
+- { "query": "asthma prevalence adults" }  // free-text topic search`,
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Free-text search query (e.g., "median household income", "poverty rate", "asthma prevalence")',
+          },
+          places: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional list of place DCIDs to scope the search to — the tool returns variables that have observations for those places.',
+          },
+          parent_place: {
+            type: 'string',
+            description: 'Optional parent place DCID — the tool returns variables that cover children of this place.',
+          },
+          per_search_limit: {
+            type: 'number',
+            description: 'Max results per category (default: 10)',
+          },
+          include_topics: {
+            type: 'boolean',
+            description: 'Include topic-level results alongside individual variables (default: true)',
+          },
+          maybe_bilateral: {
+            type: 'boolean',
+            description: 'Include bilateral (two-place) variables such as trade flows (default: false)',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_observations',
+      description: `Fetch statistical observations for a Data Commons variable at a specified place and time.
+
+Requires a variable_dcid (discovered via search_indicators) and a place_dcid. Common place DCID patterns:
+- Country: "country/USA"
+- State: "geoId/36" (NY)
+- County: "geoId/36061" (New York County)
+- Census Tract: "geoId/36061013700" (state + county + tract FIPS)
+- ZCTA: "zip/10001"
+
+Use child_place_type to fetch observations for all children of a place at a given geography level (e.g., all tracts within a county).
+
+CRITICAL: Data Commons returns wrong data silently if you pick the wrong variable, time range, or place type. Always prefer the latest vintage unless the user explicitly asks for a historical series. Cite the variable DCID and observation date in your summary.
+
+Examples:
+- Latest median household income for a NYC census tract:
+  { "variable_dcid": "Median_Income_Household", "place_dcid": "geoId/36061013700" }
+- All tracts in New York County (Manhattan):
+  { "variable_dcid": "Median_Income_Household", "place_dcid": "geoId/36061", "child_place_type": "CensusTract" }
+- Historical range:
+  { "variable_dcid": "Count_Person", "place_dcid": "country/USA", "date_range_start": "2015", "date_range_end": "2023" }`,
+      parameters: {
+        type: 'object',
+        properties: {
+          variable_dcid: {
+            type: 'string',
+            description: 'Data Commons identifier for the statistical variable (e.g., "Median_Income_Household"). Discover via search_indicators.',
+          },
+          place_dcid: {
+            type: 'string',
+            description: 'Data Commons identifier for the place (e.g., "geoId/36061" for New York County, "country/USA", "zip/10001")',
+          },
+          child_place_type: {
+            type: 'string',
+            description: 'Optional child geography to enumerate (e.g., "CensusTract", "County", "State"). Returns observations for every child of place_dcid at this level.',
+          },
+          source_override: {
+            type: 'string',
+            description: 'Optional override for the upstream data source when multiple sources provide the same variable.',
+          },
+          date: {
+            type: 'string',
+            description: 'Specific observation date (default: "LATEST"). Use ISO year or YYYY-MM format.',
+          },
+          date_range_start: {
+            type: 'string',
+            description: 'Start of a date range query (inclusive). Use with date_range_end instead of date.',
+          },
+          date_range_end: {
+            type: 'string',
+            description: 'End of a date range query (inclusive).',
+          },
+        },
+        required: ['variable_dcid', 'place_dcid'],
+      },
+    },
+  },
+];
+
+/** Unified tool schema exposed to OpenRouter. The client in ./client.ts routes each call to the correct MCP server by tool name. */
+export const mcpTools: ChatCompletionTool[] = [
+  ...socrataMcpTools,
+  ...dataCommonsMcpTools,
 ];
 
 // Model definitions for the model selector

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -8,6 +8,12 @@ export interface TraceContext {
   builder: TraceBuilder;
   parentSpanId: string;
   systemPromptHash?: string;
+  /**
+   * Optional hook that maps a tool name to its MCP source id (e.g. "socrata",
+   * "data-commons"). When provided, the source is recorded on each
+   * `mcp_tool_call` span so the PROV-O builder can distinguish servers.
+   */
+  resolveToolSource?: (toolName: string) => string | undefined;
 }
 
 const openrouter = new OpenAI({
@@ -197,11 +203,16 @@ export async function queryWithMcpStreaming(
           toolsCalled.push(toolEntry);
           callbacks.onProgress(panel, progressMessage, { phase: 'tool_start', iteration: currentIteration, args });
 
-          // Trace: start MCP tool call span
+          // Trace: start MCP tool call span.
+          // `mcp.source` distinguishes which MCP server handled the call so the
+          // PROV-O builder can emit a distinct prov:Agent per source (see
+          // provenance.ts). Unknown tools fall back to "unknown".
+          const toolSource = trace?.resolveToolSource?.(toolCall.function.name) ?? 'unknown';
           const toolTraceSpanId = trace?.builder.startSpan('mcp_tool_call', trace.parentSpanId, {
             'tool.name': toolCall.function.name,
             'tool.operation_type': operationType || 'unknown',
             'tool.arguments': JSON.stringify(args),
+            'mcp.source': toolSource,
             ...(args.dataset_id ? { 'tool.dataset_id': String(args.dataset_id) } : {}),
             ...(args.portal ? { 'tool.portal_domain': String(args.portal) } : {}),
           });

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/reso
 import { formatToolProgress, formatToolResult, generateToolReason, type PanelType, type ProgressPhase } from './streaming';
 import type { TraceBuilder } from './evidence/trace';
 import { hash as traceHash } from './evidence/trace';
+import { deriveOperationType } from './mcp/operation-types';
 
 export interface TraceContext {
   builder: TraceBuilder;
@@ -194,7 +195,7 @@ export async function queryWithMcpStreaming(
       for (const toolCall of toolCalls) {
         if (toolCall.type === 'function') {
           const args = JSON.parse(toolCall.function.arguments);
-          const operationType = (args.type as string) || undefined;
+          const operationType = deriveOperationType(toolCall.function.name, args);
           const reason = generateToolReason(args);
           const toolEntry: typeof toolsCalled[number] = { name: toolCall.function.name, args, operationType, reason };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

- Adds Google Data Commons as a second MCP data source alongside Socrata, routed through a new pure-TypeScript `src/lib/mcp/registry.ts`. Per-server session tracking, per-tool routing, normalized endpoint URLs, and an optional `X-API-Key` header for the hosted Data Commons endpoint.
- Expands the OpenRouter function-calling schema from the single `get_data` Socrata tool to five tools (`get_data`, `search`, `fetch`, `search_indicators`, `get_observations`). `socrataMcpTools` renamed to `mcpTools`; the three callers (`compare`, `compare-stream`, evidence replay) updated to pass the unified set and to inject the default portal only for Socrata's `get_data`.
- Captures `mcp.source` on every `mcp_tool_call` span via an optional `resolveToolSource` hook on `TraceContext`. `buildProvenanceGraph` now emits one `prov:Agent` per distinct source in the trace and attributes each tool call activity + data response entity to its source. Pre-M9.1 evidence records fall back to `socrata` for backwards compatibility.
- Adds unit tests for the routing contract (`src/lib/mcp/registry.test.ts`) runnable via `npm test` using Node 22's built-in test runner and `--experimental-strip-types` — no new dev dependencies.

## Decisions

- **PROV-O agent identity (M9.1 open question A):** full implementation rather than TODO placeholder — the hook point in `provenance.ts` was clean (~25 minutes of work). Multi-source traces now produce legible provenance graphs immediately.
- **Self-hosted Data Commons fallback (M9.1 open question B):** no fallback in M9.1. The hosted endpoint at `api.datacommons.org/mcp` is the documented primary deployment and is drop-in compatible. Revisit post-demo if rate limiting surfaces as a real constraint.

## Local smoke test results

- `npm run build`: clean, no type errors
- `npm test`: 8/8 routing tests pass
- Socrata regression: real answer returned (`11,393 noise complaints` for NYC 311 Mar 1–7 2026), `mcp.source=socrata` on the tool span, `tool.response_hash` populated
- Data Commons routing: the LLM selected `search_indicators` with `geoId/36061`, the client routed to `https://api.datacommons.org/mcp`, and the hosted endpoint returned a `401` as expected without an API key. `mcp.source=data-commons` recorded on the span. Routing confirmed end-to-end; a real data return needs `DATA_COMMONS_API_KEY` set on the preview env

## Out of scope

- Skill guidance covering Data Commons tool selection and aggregation semantics (M9.2 — scheduled next)
- `data-sources.json` multi-source aggregation and UI source attribution (M9.3 / M9.4)
- The M8 demo analysis itself (waits on M9.2 + M9.3)

## Test plan

- [ ] Set `DATA_COMMONS_MCP_URL` and `DATA_COMMONS_API_KEY` on the Vercel preview (plus production) via the project env settings
- [ ] Preview build completes cleanly in Vercel with no type errors or new runtime errors in the logs
- [ ] Open the preview and run a Socrata-only query (e.g. "how many 311 noise complaints in NYC last month?") — regression still works end to end
- [ ] On the preview, run a demographic query that should trigger Data Commons (e.g. "use Data Commons to get the median household income for geoId/36061") — returns real data once the API key is present
- [ ] Publish a new evidence record from the preview, verify its integrity checks pass, then withdraw it — confirms the multi-source PROV-O graph serializes correctly and the withdrawal flow is unbroken
- [ ] Confirm the evidence detail page renders a PROV-O graph that shows the right `prov:Agent` entries (socrata or data-commons, depending on which tools ran)