### PR TITLE
Surface legacy_embedded key trust for pre-registry packages

### DIFF
--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -115,6 +115,54 @@ The Vercel Blob URL is not returned directly — fetch `/api/evidence/<slug>` to
 
 ---
 
+## Signing and trust registry
+
+Every published package is signed with an Ed25519ph key held by the civicaitools.org platform. Verifiers cross-check both the signature math and a trust-registry lookup.
+
+### Package fields that reflect signing
+
+- `metadata.signingKeyId` — stable key identifier (e.g. `platform:evidence-2026-04`). Captured inside the canonical JSON and therefore part of the package hash. A `kid` swap produces a different hash, which prevents post-hoc trust-registry relabeling from silently changing which key a package appears to be signed by.
+- The signature blob stored on the database row (`basePackageSignature`) carries matching `signature`, `publicKey`, `algorithm`, and `kid` fields. Verify responses expose the `kid` at `details.kid` so clients can cross-check against the registry without re-reading the package.
+
+### Trust registry endpoint
+
+The platform publishes the set of authorised signing keys at:
+
+```
+GET https://civicaitools.org/.well-known/evidence-public-keys.json
+```
+
+Each entry carries a `kid`, the base64 DER public key, and lifecycle metadata (`status` ∈ `active | deprecated | revoked`, `activatedAt`, `deprecatedAt`, `revokedAt`). Verifiers match on the `(kid, publicKey)` pair and apply the status semantics documented inline at the top of the JSON file. The rotation runbook lives at [`docs/key-rotation.md`](../key-rotation.md).
+
+### Verify response and `keyTrust`
+
+`GET /api/evidence/<slug>/verify` returns a `keyTrust` object describing the registry verdict:
+
+| Status                 | Meaning                                                                                         |
+|------------------------|-------------------------------------------------------------------------------------------------|
+| `active`               | Kid matches an active registry entry — trusted.                                                 |
+| `deprecated_valid`     | Kid matches a deprecated entry, but the package was integrated into Rekor before deprecation.   |
+| `deprecated_invalid`   | Kid matches a deprecated entry and was integrated after deprecation, or has no Rekor timestamp. |
+| `revoked`              | Kid matches a revoked entry — never trusted, regardless of integration time.                    |
+| `unknown_key`          | `(kid, publicKey)` pair not present in the registry.                                            |
+| `registry_unavailable` | Registry could not be loaded (network / build / cache miss).                                    |
+| `legacy_embedded`      | Signature predates the trust registry (no `kid` stored). The embedded public key still verifies mathematically but the registry cannot vouch for it. Rendered as a neutral badge rather than a failure. |
+
+External clients that want to verify packages offline should fetch both the package JSON and `/.well-known/evidence-public-keys.json`, recompute the SHA-256 hash, verify the Ed25519ph signature against the embedded public key, then look the `(kid, publicKey)` pair up in the registry and apply the same status semantics.
+
+### Signing-side env vars
+
+Callers publishing through `POST /api/evidence` do not set these themselves — the platform server supplies them. They are listed here so developers running a private fork or the dev server know what drives the signing path:
+
+| Env var                        | Purpose                                                                 |
+|--------------------------------|-------------------------------------------------------------------------|
+| `EVIDENCE_SIGNING_KEY`         | Base64 DER PKCS8 Ed25519 private key. Sensitive.                        |
+| `EVIDENCE_KEY_ID`              | Stable kid string (e.g. `platform:evidence-2026-04`). Non-sensitive.    |
+| `EVIDENCE_PUBLIC_KEY`          | Public half of the signing key. Used only for registry updates.         |
+| `EVIDENCE_TRUST_REGISTRY_URL`  | Optional override for the default `${NEXTAUTH_URL}/.well-known/...` URL. Useful for previews. |
+
+---
+
 ## Error responses
 
 | Status | Body                                                              | Cause                                                                                           |
@@ -267,4 +315,5 @@ These are implementation details that may surprise an external client. None of t
 
 ## Change log
 
+- **2026-04-18** — Added the [Signing and trust registry](#signing-and-trust-registry) section. Documents the `metadata.signingKeyId` field now included in the canonical package hash, the `/.well-known/evidence-public-keys.json` registry endpoint, the `keyTrust` verdicts returned by `GET /api/evidence/<slug>/verify` (including the new `legacy_embedded` state for pre-registry packages), and the signing-side env vars (`EVIDENCE_SIGNING_KEY`, `EVIDENCE_KEY_ID`, `EVIDENCE_PUBLIC_KEY`, `EVIDENCE_TRUST_REGISTRY_URL`). Backwards-compatible at the publish path — clients do not need any changes.
 - **2026-04-17** — Initial documentation published. Tracks the endpoint as of commit [`a8cdc8c`](https://github.com/npstorey/civic-ai-tools-website/commit/a8cdc8c) (M9.3 ship, v0.7.0).

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -9,6 +9,7 @@ import {
   recomputePackageHash,
   verifyKeyTrust,
   loadTrustRegistry,
+  legacyEmbeddedKeyTrust,
   type KeyTrustResult,
 } from '@/lib/evidence/verify';
 
@@ -80,14 +81,19 @@ export async function GET(
   }
 
   // Step 4: Verify key trust against the platform trust registry.
-  // Packages signed before #66 shipped won't have a `kid` stored alongside
-  // the signature. The P5 plan resets evidence state before publishing any
-  // real packages, so a missing kid is an unsigned / pre-registry package
-  // and we surface `registry_unavailable` to make that explicit.
+  // Three paths:
+  //   - Signature with a kid → registry lookup via `verifyKeyTrust`.
+  //   - Signature without a kid (pre-#66 package) → `legacy_embedded`: the
+  //     embedded public key verified the signature mathematically, but the
+  //     registry cannot vouch for it. The UI renders this as neutral rather
+  //     than failed so older packages aren't visually penalized.
+  //   - No signature at all → keep `keyTrust: null`.
   let keyTrust: KeyTrustResult | null = null;
   if (sigPublicKey && sigKid) {
     const registry = await loadTrustRegistry();
     keyTrust = verifyKeyTrust(sigPublicKey, sigKid, rekorIntegratedTime, registry);
+  } else if (sigPublicKey) {
+    keyTrust = legacyEmbeddedKeyTrust();
   }
 
   return NextResponse.json({

--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -86,12 +86,15 @@ type KeyTrustStatus =
   | 'deprecated_invalid'
   | 'revoked'
   | 'unknown_key'
-  | 'registry_unavailable';
+  | 'registry_unavailable'
+  | 'legacy_embedded';
 
 interface KeyTrust {
   status: KeyTrustStatus;
   verified: boolean;
-  kid: string;
+  /** Optional because `legacy_embedded` signatures predate the trust
+   *  registry and therefore have no kid. */
+  kid?: string;
   deprecatedAt?: string | null;
   revokedAt?: string | null;
 }
@@ -124,7 +127,21 @@ function keyTrustCopy(keyTrust: KeyTrust): string {
       return `Key not in platform trust registry (${keyTrust.kid})`;
     case 'registry_unavailable':
       return 'Trust registry unavailable — could not verify key';
+    case 'legacy_embedded':
+      return 'Signed with legacy embedded key (pre-trust-registry package)';
   }
+}
+
+/**
+ * Map a key-trust result onto the icon state used by `VerifyCheck`:
+ *   - `true`  → ✅ green (registry-validated)
+ *   - `false` → ❌ red (registry says untrusted)
+ *   - `null`  → ➖ neutral (no signing key, or pre-registry legacy package)
+ */
+function keyTrustIconStatus(keyTrust: KeyTrust | null): boolean | null {
+  if (keyTrust === null) return null;
+  if (keyTrust.status === 'legacy_embedded') return null;
+  return keyTrust.verified;
 }
 
 function VerifyCheck({ label, status, detail }: { label: string; status: boolean | null; detail?: string }) {
@@ -240,11 +257,7 @@ export default function EvidenceActions({
           />
           <VerifyCheck
             label="Key trust"
-            status={
-              verifyResult.keyTrust === null
-                ? null
-                : verifyResult.keyTrust.verified
-            }
+            status={keyTrustIconStatus(verifyResult.keyTrust)}
             detail={
               verifyResult.keyTrust === null
                 ? 'No signing key recorded'

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -10,6 +10,7 @@ import {
   verifyKeyTrust,
   loadTrustRegistry,
   clearTrustRegistryCache,
+  legacyEmbeddedKeyTrust,
   type TrustRegistry,
 } from './verify.ts';
 
@@ -247,6 +248,22 @@ test('loadTrustRegistry caches the disk read across calls', async () => {
   const b = await loadTrustRegistry('http://127.0.0.1:1/invalid');
   // Same reference → served from cache, not re-read.
   assert.strictEqual(a, b);
+});
+
+// --- Legacy embedded keys (pre-#66 packages) ---
+//
+// Packages signed before the trust registry shipped don't carry a `kid`
+// alongside the signature. The signature itself still verifies
+// mathematically against the embedded public key, so we surface a distinct
+// `legacy_embedded` status rather than treating these as unsigned or
+// registry-failed. The UI renders it as neutral (➖) so existing artifacts
+// aren't visually penalised.
+
+test('legacyEmbeddedKeyTrust: pre-registry signatures get a neutral verdict', () => {
+  const result = legacyEmbeddedKeyTrust();
+  assert.equal(result.status, 'legacy_embedded');
+  assert.equal(result.verified, false);
+  assert.equal(result.kid, undefined);
 });
 
 test('Compromise scenario: revoked key + replacement active key', () => {

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -147,16 +147,32 @@ export type KeyTrustStatus =
   | 'deprecated_invalid'    // deprecated key, but package was signed after deprecation
   | 'revoked'               // revoked key — package is never trusted
   | 'unknown_key'           // (kid, publicKey) pair not found in registry
-  | 'registry_unavailable'; // registry could not be loaded
+  | 'registry_unavailable'  // registry could not be loaded
+  | 'legacy_embedded';      // signature predates the trust registry (no kid stored)
 
 export interface KeyTrustResult {
   status: KeyTrustStatus;
-  /** `true` iff the status is `active` or `deprecated_valid`. */
+  /** `true` iff the status is `active` or `deprecated_valid`. Legacy-embedded
+   *  signatures are intentionally surfaced as `verified: false` because the
+   *  trust registry cannot vouch for them — the UI renders them as neutral
+   *  rather than failed. */
   verified: boolean;
-  kid: string;
+  /** The registry `kid` when available. Omitted for `legacy_embedded` /
+   *  pre-registry packages because the signature has no kid to report. */
+  kid?: string;
   activatedAt?: string;
   deprecatedAt?: string | null;
   revokedAt?: string | null;
+}
+
+/**
+ * Build a `KeyTrustResult` for a package whose signature predates the trust
+ * registry — i.e. has a valid public key but no `kid`. We accept that the
+ * embedded key verified the signature mathematically while making clear in
+ * the UI that no registry check was performed.
+ */
+export function legacyEmbeddedKeyTrust(): KeyTrustResult {
+  return { status: 'legacy_embedded', verified: false };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a new `legacy_embedded` keyTrust status for evidence packages whose signatures predate the trust registry (no `kid` stored alongside the signature). The embedded public key still verifies mathematically, but the registry cannot vouch for it, so the verdict surfaces with a neutral badge rather than `null` or a failure.
- Detail-page UI renders the neutral state with dedicated copy ("Signed with legacy embedded key (pre-trust-registry package)") so older artefacts aren't visually penalised.
- `docs/api/evidence-publish.md` gets a new **Signing and trust registry** section covering `metadata.signingKeyId`, the `/.well-known/evidence-public-keys.json` endpoint, the full `keyTrust` verdict table (including the new state), and the signing-side env vars.

Closes the remaining acceptance item on #66 (backwards-compatible verification for pre-registry packages).

## Changes

- `src/lib/evidence/verify.ts` — extend `KeyTrustStatus` union, make `KeyTrustResult.kid` optional, export `legacyEmbeddedKeyTrust()`.
- `src/app/api/evidence/[slug]/verify/route.ts` — branch on `sigKid` so signatures without a kid resolve to the legacy state.
- `src/components/evidence/EvidenceActions.tsx` — extend the UI `KeyTrustStatus` type, add a `legacy_embedded` copy case, map it to the neutral ➖ icon via a small helper.
- `src/lib/evidence/verify.test.ts` — regression test for `legacyEmbeddedKeyTrust()`.
- `docs/api/evidence-publish.md` — new Signing and trust registry section + change-log entry.

No DB schema changes; no new env vars; no publish-path changes — this is verification-side only.

## Test plan

- [x] `npm test` — 74 tests pass locally (was 73; added 1).
- [x] `npx tsc --noEmit` — clean.
- [ ] Vercel preview: fetch `GET /api/evidence/<slug>/verify` for an existing package (e.g. `bronx-county-demographic-profile-acs-5-year-2020-2024-a9e428`) and confirm it returns `keyTrust.status === "active"` (post-registry) — still verifies cleanly.
- [ ] Vercel preview: fetch the verify endpoint for a pre-kid legacy package (if any remain) and confirm it returns `keyTrust.status === "legacy_embedded"` with `verified: false`.
- [ ] Vercel preview: open an evidence detail page, click "Verify Integrity", and confirm the Key trust row renders ➖ + "Signed with legacy embedded key" for a legacy package.