### PR TITLE
Add content-addressable blob references for evidence package fields

### DIFF
--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -60,20 +60,21 @@ The endpoint does not currently accept a personal access token, bearer token, or
 
 ### Request body schema
 
-| Field              | Type     | Required | Description                                                                                                                                             |
-|--------------------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `trace`            | object   | yes      | OpenTelemetry-compatible trace. Minimal acceptable value is `{ "resourceSpans": [] }`. A trace with `mcp_tool_call` spans carrying `mcp.source` attributes enables per-source provenance; an empty trace falls back to the static tool-name → source map. |
-| `prompt`           | string   | yes      | The user's original query text.                                                                                                                         |
-| `output`           | string   | yes      | The assistant's final response text (markdown is accepted and preserved).                                                                               |
-| `toolCalls`        | array    | yes      | Array of tool calls made during the analysis. May be empty. See [`toolCalls[]`](#toolcalls-entries) below.                                              |
-| `model`            | string   | yes      | The model identifier used for the analysis (e.g., `"openai/gpt-4o"`, `"anthropic/claude-opus-4-7"`).                                                    |
-| `portal`           | string   | yes      | Socrata portal domain (e.g., `"data.cityofnewyork.us"`). Used as the fallback portal for Socrata `dataSources[]` entries when a tool call omits `args.portal`. For non-Socrata analyses (e.g., Data Commons-only), any descriptive placeholder is accepted. |
-| `tokenUsage`       | object   | yes      | `{ promptTokens?: number, completionTokens?: number }`. Both inner fields are optional.                                                                 |
-| `promptVisibility` | string   | yes      | `"full_text"` to include the prompt text in the package and database record, or `"hash_only"` to include only the SHA-256 hash.                         |
-| `title`            | string   | yes      | Display title for the evidence record. Used to derive the URL slug.                                                                                     |
-| `summary`          | string   | yes      | A 2–4 sentence description for non-technical readers.                                                                                                   |
-| `duration_ms`      | number   | no       | End-to-end analysis duration in milliseconds.                                                                                                           |
-| `extensions`       | object   | no       | Implementation-specific artifacts keyed by reverse-DNS identifiers (e.g., `"org.civicaitools.notebook"`). Extensions are included in the canonical JSON and therefore covered by the package hash. |
+| Field                   | Type               | Required | Description                                                                                                                                             |
+|-------------------------|--------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `trace`                 | object \| BlobRef  | yes      | OpenTelemetry-compatible trace, OR a [blob reference](#blob-references-phase-b6) pointing at the same content stored out of band. Minimal acceptable inline value is `{ "resourceSpans": [] }`. A trace with `mcp_tool_call` spans carrying `mcp.source` attributes enables per-source provenance; an empty trace falls back to the static tool-name → source map. |
+| `prompt`                | string             | yes      | The user's original query text.                                                                                                                         |
+| `output`                | string \| BlobRef  | yes      | The assistant's final response text (markdown is accepted and preserved), OR a [blob reference](#blob-references-phase-b6).                             |
+| `toolCalls`             | array              | yes      | Array of tool calls made during the analysis. May be empty. See [`toolCalls[]`](#toolcalls-entries) below.                                              |
+| `model`                 | string             | yes      | The model identifier used for the analysis (e.g., `"openai/gpt-4o"`, `"anthropic/claude-opus-4-7"`).                                                    |
+| `portal`                | string             | yes      | Socrata portal domain (e.g., `"data.cityofnewyork.us"`). Used as the fallback portal for Socrata `dataSources[]` entries when a tool call omits `args.portal`. For non-Socrata analyses (e.g., Data Commons-only), any descriptive placeholder is accepted. |
+| `tokenUsage`            | object             | yes      | `{ promptTokens?: number, completionTokens?: number }`. Both inner fields are optional.                                                                 |
+| `promptVisibility`      | string             | yes      | `"full_text"` to include the prompt text in the package and database record, or `"hash_only"` to include only the SHA-256 hash.                         |
+| `title`                 | string             | yes      | Display title for the evidence record. Used to derive the URL slug.                                                                                     |
+| `summary`               | string             | yes      | A 2–4 sentence description for non-technical readers.                                                                                                   |
+| `duration_ms`           | number             | no       | End-to-end analysis duration in milliseconds.                                                                                                           |
+| `skillMetadataOverride` | object             | no       | Override for the skill metadata normally extracted from the trace. Required when `trace` is a BlobRef. See [Blob references](#blob-references-phase-b6). |
+| `extensions`            | object             | no       | Implementation-specific artifacts keyed by reverse-DNS identifiers (e.g., `"org.civicaitools.notebook"`). Extensions are included in the canonical JSON and therefore covered by the package hash. |
 
 #### `toolCalls[]` entries
 
@@ -112,6 +113,127 @@ The endpoint does not currently accept a personal access token, bearer token, or
 | `packageHash` | string | SHA-256 hash of the canonical package JSON (64 hex chars).                                                                 |
 
 The Vercel Blob URL is not returned directly — fetch `/api/evidence/<slug>` to read back the database row, and the blob URL is also available via the detail page's rendered HTML. The blob itself is public and content-addressable at `https://<vercel-blob-host>/evidence-packages/<packageHash>.json`.
+
+---
+
+## Blob references (Phase B.6)
+
+Large package fields — full output text, OTel traces for long sessions, composed skill guidance, eventually multi-turn transcripts and visual artifacts — can be uploaded separately to Vercel Blob and referenced from the package JSON rather than inlined. This side-steps the Next.js App Router ~4 MB body cap on `POST /api/evidence` and makes each piece of content independently verifiable.
+
+Existing inline-content packages remain valid — the schema accepts either shape per field, and pre-Phase-B.6 records continue verifying unchanged.
+
+### Reference format
+
+A BlobRef is a JSON object with four fields:
+
+```json
+{
+  "ref": "blob:sha256:<64 hex chars>",
+  "url": "https://<store>.public.blob.vercel-storage.com/evidence-refs/<hash>.<ext>",
+  "contentType": "text/markdown",
+  "size": 4194304
+}
+```
+
+| Field         | Description                                                                                                   |
+|---------------|---------------------------------------------------------------------------------------------------------------|
+| `ref`         | Content-addressable reference — literal `blob:sha256:` prefix followed by the 64-char lowercase hex SHA-256 of the content bytes. |
+| `url`         | Public Vercel Blob URL. The verifier fetches this URL over HTTPS without authentication.                      |
+| `contentType` | Media type of the referenced blob. Informational for renderers; not enforced at verify time.                  |
+| `size`        | Byte length of the referenced blob. The verifier compares against the fetched content and flags `size_mismatch` on a divergence. |
+
+Fields that currently accept a BlobRef: `output`, `trace`, and `skillMetadataOverride.skillText`. The stored package JSON mirrors these in `pkg.output`, `pkg.trace`, and `pkg.skillMetadata.skillText`.
+
+### Upload flow (presigned client upload)
+
+To avoid the body cap, content is uploaded directly from the client to Vercel Blob via a presigned token minted by the platform:
+
+1. Compute the SHA-256 of the content bytes and construct the target pathname `evidence-refs/<hash>[.ext]`.
+2. Call `upload(pathname, content, { access: 'public', handleUploadUrl: '/api/blob/upload-token', ... })` from `@vercel/blob/client`. The library posts to `/api/blob/upload-token` to obtain a presigned token, then PUTs the content directly to Vercel Blob.
+3. Construct a BlobRef from the returned `url` plus the hash, content type, and byte size.
+4. Reference the BlobRef in the `POST /api/evidence` request body on the matching field.
+
+`POST /api/blob/upload-token` uses the same authentication as `/api/evidence` (NextAuth session cookie + matching `users` row). The minted token only permits uploads whose pathname matches `^evidence-refs/[0-9a-f]{64}(?:\.[a-z0-9]+)?$` and is capped at 100 MB per blob.
+
+Orphan blobs — uploaded but never referenced by any published package — are swept daily by a cron job (`/api/cron/blob-gc`) after a 24-hour grace window.
+
+### Verification semantics
+
+`GET /api/evidence/<slug>/verify` returns two new fields alongside the existing signature and trust-registry verdicts:
+
+| Field              | Description                                                                                               |
+|--------------------|-----------------------------------------------------------------------------------------------------------|
+| `blobRefsVerified` | `true` iff every BlobRef verified, `false` if any did not, `null` if the package contains no references.  |
+| `blobRefs`         | Array of per-reference results. Each entry: `{ field, ref, url, size, contentType, ok, reason? }`. `reason` is one of `invalid_ref`, `fetch_failed`, `size_mismatch`, `hash_mismatch` when `ok` is `false`. |
+
+External verifiers replicate this check by walking the package JSON for BlobRef objects, fetching each, recomputing SHA-256 over the bytes, and confirming the hash matches the `ref` and the byte length matches `size`. The `src/lib/evidence/blob-ref.ts` helper module exposes `isBlobRef(value)`, `parseBlobRef(ref)`, and `verifyBlobRef(ref)` for this purpose.
+
+### Worked example — publishing with a BlobRef output
+
+```ts
+import { upload } from '@vercel/blob/client';
+import crypto from 'crypto';
+
+// 1. Precompute the content hash and upload the blob.
+const output = '# Long synthesised analysis...\n\n## Section 1\n...'; // imagine 8 MB
+const hash = crypto.createHash('sha256').update(output).digest('hex');
+const pathname = `evidence-refs/${hash}.md`;
+
+const blob = await upload(pathname, output, {
+  access: 'public',
+  contentType: 'text/markdown',
+  handleUploadUrl: 'https://civicaitools.org/api/blob/upload-token',
+  clientPayload: null,
+  // The client upload helper posts to /api/blob/upload-token with the
+  // browser's session cookie attached, which authenticates the request.
+});
+
+const outputRef = {
+  ref: `blob:sha256:${hash}`,
+  url: blob.url,
+  contentType: 'text/markdown',
+  size: new TextEncoder().encode(output).byteLength,
+};
+
+// 2. Publish the package, passing the BlobRef in place of inline content.
+await fetch('https://civicaitools.org/api/evidence', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Cookie: `__Secure-next-auth.session-token=${process.env.CIVIC_EVIDENCE_SESSION_COOKIE}`,
+  },
+  body: JSON.stringify({
+    trace: { resourceSpans: [] },
+    prompt,
+    output: outputRef,            // ← BlobRef instead of inline string
+    toolCalls,
+    model,
+    portal: 'data.cityofnewyork.us',
+    tokenUsage,
+    duration_ms,
+    promptVisibility: 'full_text',
+    title,
+    summary,
+  }),
+});
+```
+
+The published package's `output` field is now a BlobRef object rather than inline text; the detail page fetches the content server-side on page load, and the verify endpoint follows the reference and confirms the bytes hash to the ref.
+
+### When `trace` is a BlobRef
+
+When `trace` is a BlobRef the packager cannot walk the spans to auto-extract skill metadata or build a rich PROV-O graph — it falls back to an empty `resourceSpans`. Publishers that ship `trace` as a BlobRef should also supply `skillMetadataOverride` so `skillMetadata.{systemPromptHash,mcpServerUrl,skillText}` aren't blanked:
+
+```json
+{
+  "trace": { "ref": "blob:sha256:...", "url": "...", "contentType": "application/json", "size": 18800000 },
+  "skillMetadataOverride": {
+    "systemPromptHash": "e751da4a…",
+    "mcpServerUrl": "https://socrata-mcp.civicaitools.org",
+    "skillText": { "ref": "blob:sha256:…", "url": "…", "contentType": "text/markdown", "size": 25044 }
+  }
+}
+```
 
 ---
 
@@ -315,5 +437,6 @@ These are implementation details that may surprise an external client. None of t
 
 ## Change log
 
+- **2026-04-18** — Added the [Blob references (Phase B.6)](#blob-references-phase-b6) section. The `output`, `trace`, and `skillMetadataOverride.skillText` request fields now accept either inline content or a BlobRef `{ ref, url, contentType, size }` object; the verify endpoint returns per-reference `blobRefs[]` entries alongside the existing verdicts. A new `POST /api/blob/upload-token` endpoint mints presigned tokens for direct client uploads to `evidence-refs/<sha256>[.ext]`, gated by the same NextAuth session as `/api/evidence`. Orphan blobs are swept by a daily cron (`/api/cron/blob-gc`). Backwards-compatible — existing inline-content packages remain valid and the verify response adds fields rather than renaming any.
 - **2026-04-18** — Added the [Signing and trust registry](#signing-and-trust-registry) section. Documents the `metadata.signingKeyId` field now included in the canonical package hash, the `/.well-known/evidence-public-keys.json` registry endpoint, the `keyTrust` verdicts returned by `GET /api/evidence/<slug>/verify` (including the new `legacy_embedded` state for pre-registry packages), and the signing-side env vars (`EVIDENCE_SIGNING_KEY`, `EVIDENCE_KEY_ID`, `EVIDENCE_PUBLIC_KEY`, `EVIDENCE_TRUST_REGISTRY_URL`). Backwards-compatible at the publish path — clients do not need any changes.
 - **2026-04-17** — Initial documentation published. Tracks the endpoint as of commit [`a8cdc8c`](https://github.com/npstorey/civic-ai-tools-website/commit/a8cdc8c) (M9.3 ship, v0.7.0).

--- a/scripts/publish-with-blob-ref.mjs
+++ b/scripts/publish-with-blob-ref.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+//
+// Phase B.6 (website#75) — end-to-end BlobRef publish walkthrough.
+//
+// Uploads a sample output string as a content-addressable blob, then
+// publishes an evidence package that references it instead of inlining.
+// Run against production (or the Vercel preview, with a preview session
+// cookie) to confirm the full upload-token → publish → verify path works.
+//
+// Usage:
+//   export CIVICAITOOLS_SESSION_TOKEN="<__Secure-next-auth.session-token value>"
+//   node scripts/publish-with-blob-ref.mjs [--base-url https://...]
+//
+// When --base-url is omitted, defaults to https://www.civicaitools.org.
+// For preview URLs, supply the full hostname (including the path-protection
+// cookie value if the preview has SSO — upload flow will 401 without it).
+
+import crypto from 'node:crypto';
+import process from 'node:process';
+
+const args = process.argv.slice(2);
+function arg(name, fallback) {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : fallback;
+}
+
+const BASE_URL = arg('--base-url', 'https://www.civicaitools.org').replace(/\/$/, '');
+const SESSION_TOKEN = process.env.CIVICAITOOLS_SESSION_TOKEN;
+if (!SESSION_TOKEN) {
+  console.error(
+    'Set CIVICAITOOLS_SESSION_TOKEN to the value of __Secure-next-auth.session-token ' +
+      'from a signed-in civicaitools.org browser session.',
+  );
+  process.exit(2);
+}
+
+// --- 1. Mint an upload token ---------------------------------------------
+// The upload helper in @vercel/blob/client goes through two steps:
+//   a) POST /api/blob/upload-token with `{type: "blob.generate-client-token", ...}`
+//   b) PUT the content to the URL the token returns.
+// Reproducing that dance with stdlib fetch keeps this script dependency-free.
+
+const SAMPLE_OUTPUT = [
+  '# BlobRef smoke-test output',
+  '',
+  'This package was published via the Phase B.6 content-addressable blob',
+  'reference path. The `output` field below is a BlobRef pointing at this',
+  'text rather than inlining the content, so the publish request body is',
+  'tiny regardless of how long the analysis text is.',
+  '',
+  `Generated at ${new Date().toISOString()} by publish-with-blob-ref.mjs.`,
+].join('\n');
+const OUTPUT_BYTES = new TextEncoder().encode(SAMPLE_OUTPUT);
+const OUTPUT_HASH = crypto.createHash('sha256').update(OUTPUT_BYTES).digest('hex');
+const OUTPUT_PATHNAME = `evidence-refs/${OUTPUT_HASH}.md`;
+const OUTPUT_CONTENT_TYPE = 'text/markdown';
+
+console.log('[1/4] Minting upload token…');
+const tokenRes = await fetch(`${BASE_URL}/api/blob/upload-token`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Cookie: `__Secure-next-auth.session-token=${SESSION_TOKEN}`,
+  },
+  body: JSON.stringify({
+    type: 'blob.generate-client-token',
+    payload: {
+      pathname: OUTPUT_PATHNAME,
+      callbackUrl: `${BASE_URL}/api/blob/upload-token`,
+      clientPayload: null,
+      multipart: false,
+    },
+  }),
+});
+if (!tokenRes.ok) {
+  const text = await tokenRes.text();
+  console.error(`Token mint failed (${tokenRes.status}): ${text.slice(0, 500)}`);
+  process.exit(1);
+}
+const tokenJson = await tokenRes.json();
+const clientToken = tokenJson.clientToken;
+if (!clientToken) {
+  console.error('No clientToken in response:', tokenJson);
+  process.exit(1);
+}
+console.log('  ✓ token received');
+
+// --- 2. Upload the blob directly -----------------------------------------
+// The Vercel Blob API accepts a PUT to https://blob.vercel-storage.com/<pathname>
+// with Authorization: Bearer <clientToken>. This mirrors what @vercel/blob/client
+// does internally; documented at https://vercel.com/docs/vercel-blob/using-blob-sdk.
+
+console.log(`[2/4] Uploading ${OUTPUT_BYTES.byteLength} bytes to ${OUTPUT_PATHNAME}…`);
+const uploadRes = await fetch(`https://blob.vercel-storage.com/${OUTPUT_PATHNAME}`, {
+  method: 'PUT',
+  headers: {
+    Authorization: `Bearer ${clientToken}`,
+    'Content-Type': OUTPUT_CONTENT_TYPE,
+    'x-content-type': OUTPUT_CONTENT_TYPE,
+    'x-add-random-suffix': '0',
+    'x-allow-overwrite': '1',
+  },
+  body: OUTPUT_BYTES,
+});
+if (!uploadRes.ok) {
+  const text = await uploadRes.text();
+  console.error(`Blob upload failed (${uploadRes.status}): ${text.slice(0, 500)}`);
+  process.exit(1);
+}
+const uploadJson = await uploadRes.json();
+const BLOB_URL = uploadJson.url;
+if (!BLOB_URL) {
+  console.error('No url in upload response:', uploadJson);
+  process.exit(1);
+}
+console.log(`  ✓ stored at ${BLOB_URL}`);
+
+// Build the BlobRef object. This is what the evidence schema expects in the
+// `output` field (or any BlobRef-capable field).
+const outputBlobRef = {
+  ref: `blob:sha256:${OUTPUT_HASH}`,
+  url: BLOB_URL,
+  contentType: OUTPUT_CONTENT_TYPE,
+  size: OUTPUT_BYTES.byteLength,
+};
+
+// --- 3. Publish the evidence package referencing the blob ----------------
+
+console.log('[3/4] Publishing evidence package with BlobRef output…');
+const publishRes = await fetch(`${BASE_URL}/api/evidence`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Cookie: `__Secure-next-auth.session-token=${SESSION_TOKEN}`,
+  },
+  body: JSON.stringify({
+    trace: { resourceSpans: [] },
+    prompt: 'Publish-with-blob-ref smoke test — Phase B.6 website#75',
+    output: outputBlobRef,
+    toolCalls: [],
+    model: 'anthropic/claude-opus-4-7',
+    portal: 'n/a',
+    tokenUsage: { promptTokens: 0, completionTokens: 0 },
+    duration_ms: 0,
+    promptVisibility: 'full_text',
+    title: 'BlobRef smoke test (Phase B.6)',
+    summary:
+      'End-to-end validation of content-addressable blob references. The output field is a BlobRef rather than inline text; the verify endpoint should follow the reference and confirm the hash matches.',
+  }),
+});
+if (!publishRes.ok) {
+  const text = await publishRes.text();
+  console.error(`Publish failed (${publishRes.status}): ${text.slice(0, 500)}`);
+  process.exit(1);
+}
+const publishJson = await publishRes.json();
+console.log(`  ✓ slug: ${publishJson.slug}`);
+console.log(`  ✓ url:  ${BASE_URL}${publishJson.url}`);
+console.log(`  ✓ hash: ${publishJson.packageHash}`);
+
+// --- 4. Verify the published package -------------------------------------
+
+console.log('[4/4] Verifying the package…');
+const verifyRes = await fetch(`${BASE_URL}/api/evidence/${publishJson.slug}/verify`);
+if (!verifyRes.ok) {
+  console.error(`Verify failed (${verifyRes.status}): ${await verifyRes.text()}`);
+  process.exit(1);
+}
+const verifyJson = await verifyRes.json();
+console.log(JSON.stringify(verifyJson, null, 2));
+
+const ok =
+  verifyJson.hashMatch &&
+  verifyJson.signatureValid !== false &&
+  verifyJson.blobRefsVerified === true &&
+  Array.isArray(verifyJson.blobRefs) &&
+  verifyJson.blobRefs.some((r) => r.field === 'output' && r.ok === true);
+console.log(ok ? '\n✅ BlobRef publish + verify succeeded.' : '\n❌ Verify did not satisfy expectations.');
+process.exit(ok ? 0 : 1);

--- a/src/app/api/blob/upload-token/route.ts
+++ b/src/app/api/blob/upload-token/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { handleUpload, type HandleUploadBody } from '@vercel/blob/client';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Presigned client-upload endpoint for evidence blob references
+ * (Phase B.6, website#75).
+ *
+ * A client that wants to publish a large field as a content-addressable
+ * blob calls `upload(pathname, body, { handleUploadUrl: '/api/blob/upload-token', ... })`
+ * from `@vercel/blob/client`. That package sends a token-mint POST to this
+ * route, we authenticate and authorise, then return a presigned token that
+ * lets the browser PUT directly to Vercel Blob (bypassing the Next.js 4 MB
+ * body cap on `/api/evidence`).
+ *
+ * Hash-based pathname convention: the client computes SHA-256 of the
+ * content beforehand and targets `evidence-refs/<hash>[.ext]`. The server
+ * validates the pathname shape so presigned tokens only mint URLs under
+ * the `evidence-refs/` prefix and with a sha256-shaped filename.
+ *
+ * Auth pattern matches `/api/evidence`: NextAuth session cookie + matching
+ * `users` row. Programmatic clients (Claude Code publish skill, etc.) reuse
+ * the same session cookie they already present to `/api/evidence`.
+ */
+
+const PATHNAME_PATTERN = /^evidence-refs\/[0-9a-f]{64}(?:\.[a-z0-9]+)?$/;
+
+// 100 MB covers the realistic content types we anticipate (full outputs,
+// traces, multi-turn transcripts). Individual Vercel Blob objects can be
+// up to 5 TB, so the cap is deliberately conservative to contain the blast
+// radius if a session cookie is leaked.
+const MAX_BLOB_SIZE_BYTES = 100 * 1024 * 1024;
+
+const ALLOWED_CONTENT_TYPES = [
+  'application/json',
+  'text/plain',
+  'text/markdown',
+  // Permissive fallback for uploaders that don't set content-type.
+  'application/octet-stream',
+];
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = (await request.json()) as HandleUploadBody;
+
+  try {
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async (pathname) => {
+        // Authentication: same pattern as /api/evidence. Reject anonymous
+        // uploads before minting the presigned token — otherwise the
+        // evidence blob store is open to the world.
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+          throw new Error('Authentication required');
+        }
+
+        const githubId = session.user.id;
+        const dbUser = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.githubId, githubId))
+          .limit(1);
+        if (dbUser.length === 0) {
+          throw new Error('User not found in database');
+        }
+
+        // Pathname validation: lock uploads to `evidence-refs/<sha256>[.ext]`.
+        // The 64-hex segment is the content hash the client advertises;
+        // the final proof is the verifier downstream checking the content
+        // actually hashes to that value.
+        if (!PATHNAME_PATTERN.test(pathname)) {
+          throw new Error(
+            'Invalid pathname: expected evidence-refs/<sha256 hex>[.ext]',
+          );
+        }
+
+        return {
+          allowedContentTypes: ALLOWED_CONTENT_TYPES,
+          maximumSizeInBytes: MAX_BLOB_SIZE_BYTES,
+          // addRandomSuffix: false — the 64-hex pathname IS the content-
+          // addressable identifier. Adding a random suffix would break the
+          // "same content always lives at the same URL" invariant.
+          addRandomSuffix: false,
+          // Allow the same content to be re-uploaded harmlessly (same hash
+          // → same bytes → same blob). Prevents spurious "blob already
+          // exists" errors when a user republishes similar content.
+          allowOverwrite: true,
+          tokenPayload: JSON.stringify({
+            userId: dbUser[0].id,
+            pathname,
+          }),
+        };
+      },
+      onUploadCompleted: async ({ blob }) => {
+        // No database work needed here — evidence packages are the record
+        // that references a blob, and the publisher's /api/evidence call
+        // will create that record. Orphan blobs are reaped by the GC cron.
+        console.log('[blob-upload-token] Upload completed', {
+          pathname: blob.pathname,
+          url: blob.url,
+        });
+      },
+    });
+    return NextResponse.json(jsonResponse);
+  } catch (error) {
+    // handleUpload relies on a non-200 for its retry contract on the
+    // onUploadCompleted leg; 400 is the convention surfaced in the docs.
+    const message = error instanceof Error ? error.message : 'Upload token error';
+    const status = message === 'Authentication required' ? 401 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/cron/blob-gc/route.ts
+++ b/src/app/api/cron/blob-gc/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { list, del } from '@vercel/blob';
+import { db } from '@/lib/db';
+import { evidenceRecords } from '@/lib/db/schema';
+import { getPackage } from '@/lib/storage';
+import { isBlobRef } from '@/lib/evidence/blob-ref';
+
+/**
+ * Orphan-blob garbage collection (Phase B.6 / website#75).
+ *
+ * Invoked by Vercel Cron per `vercel.json` on a daily schedule. Lists
+ * every blob stored under `evidence-refs/`, builds the set of URLs
+ * currently referenced by any published evidence package, and deletes
+ * blobs that are (a) not referenced and (b) older than the orphan
+ * threshold. This limits storage cost from abandoned preflight uploads
+ * without racing the publish API — a publisher uploading a blob right
+ * now hasn't had a chance to persist the reference yet, so the threshold
+ * provides a grace window.
+ *
+ * Auth: Vercel Cron sends `Authorization: Bearer $CRON_SECRET` on every
+ * invocation. Requests missing or failing that check are rejected so the
+ * endpoint can't be invoked externally.
+ */
+
+const BLOB_PREFIX = 'evidence-refs/';
+const ORPHAN_GRACE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export async function GET(request: NextRequest) {
+  // Auth: cron secret header. See https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs
+  const cronSecret = process.env.CRON_SECRET;
+  const authHeader = request.headers.get('authorization');
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const referenced = await collectReferencedBlobUrls();
+    const stats = await sweepOrphans(referenced);
+    return NextResponse.json({ ok: true, ...stats });
+  } catch (err) {
+    console.error('[blob-gc] run failed:', err);
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : 'unknown' },
+      { status: 500 },
+    );
+  }
+}
+
+/** Walk every published evidence package and collect the set of blob URLs
+ *  referenced in any of the `BLOB_REF_FIELDS`. Fetches in parallel because
+ *  the registry is small today (<1000 records); if that changes this loop
+ *  becomes a chunked sweep or a dedicated `referenced_blobs` table. */
+async function collectReferencedBlobUrls(): Promise<Set<string>> {
+  const urls = new Set<string>();
+  const records = await db
+    .select({ storageKey: evidenceRecords.basePackageStorageKey })
+    .from(evidenceRecords);
+
+  const pkgFetches = records
+    .filter((r): r is { storageKey: string } => !!r.storageKey)
+    .map((r) => getPackage(r.storageKey));
+  const pkgs = await Promise.all(pkgFetches);
+
+  for (const pkg of pkgs) {
+    if (!pkg) continue;
+    collectRefsFromPackage(pkg, urls);
+  }
+  return urls;
+}
+
+function collectRefsFromPackage(
+  pkg: Record<string, unknown>,
+  urls: Set<string>,
+): void {
+  if (isBlobRef(pkg.output)) urls.add(pkg.output.url);
+  if (isBlobRef(pkg.trace)) urls.add(pkg.trace.url);
+  const skill = (pkg as { skillMetadata?: Record<string, unknown> })
+    .skillMetadata;
+  if (skill && isBlobRef(skill.skillText)) urls.add(skill.skillText.url);
+}
+
+interface SweepStats {
+  scanned: number;
+  deleted: number;
+  skippedReferenced: number;
+  skippedFresh: number;
+}
+
+/** Page through `evidence-refs/` and delete anything not referenced and
+ *  past the grace window. Uses `allowOverwrite: true` on the upload side
+ *  to keep identical-content uploads idempotent, so delete-and-republish
+ *  is safe even if another client is about to reference the same hash. */
+async function sweepOrphans(referenced: Set<string>): Promise<SweepStats> {
+  const now = Date.now();
+  let cursor: string | undefined;
+  const stats: SweepStats = { scanned: 0, deleted: 0, skippedReferenced: 0, skippedFresh: 0 };
+
+  do {
+    const page = await list({ prefix: BLOB_PREFIX, cursor, limit: 1000 });
+    for (const blob of page.blobs) {
+      stats.scanned++;
+      if (referenced.has(blob.url)) {
+        stats.skippedReferenced++;
+        continue;
+      }
+      const uploadedAt = new Date(blob.uploadedAt).getTime();
+      if (Number.isFinite(uploadedAt) && now - uploadedAt < ORPHAN_GRACE_MS) {
+        stats.skippedFresh++;
+        continue;
+      }
+      await del(blob.url);
+      stats.deleted++;
+    }
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor);
+
+  return stats;
+}

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -10,7 +10,9 @@ import {
   verifyKeyTrust,
   loadTrustRegistry,
   legacyEmbeddedKeyTrust,
+  verifyPackageBlobRefs,
   type KeyTrustResult,
+  type BlobRefVerification,
 } from '@/lib/evidence/verify';
 
 export async function GET(
@@ -34,10 +36,11 @@ export async function GET(
   // Step 1: Recompute package hash from stored package
   let hashMatch = false;
   let recomputedHash: string | null = null;
+  let pkgJson: Record<string, unknown> | null = null;
   if (record.basePackageStorageKey) {
-    const pkg = await getPackage(record.basePackageStorageKey);
-    if (pkg) {
-      recomputedHash = recomputePackageHash(pkg);
+    pkgJson = await getPackage(record.basePackageStorageKey);
+    if (pkgJson) {
+      recomputedHash = recomputePackageHash(pkgJson);
       hashMatch = recomputedHash === record.basePackageHash;
     }
   }
@@ -80,6 +83,21 @@ export async function GET(
     }
   }
 
+  // Step 3b: Verify any blob references embedded in the package. `blobRefs`
+  // is always an array — empty for pre-Phase-B.6 packages that store all
+  // fields inline, populated with per-reference verdicts when the publisher
+  // pushed content out of band via the upload-token flow. `blobRefsVerified`
+  // summarises the array (true/false/null-for-no-refs) so clients that
+  // don't care about per-ref granularity can branch on one boolean.
+  let blobRefs: BlobRefVerification[] = [];
+  let blobRefsVerified: boolean | null = null;
+  if (pkgJson) {
+    blobRefs = await verifyPackageBlobRefs(pkgJson);
+    if (blobRefs.length > 0) {
+      blobRefsVerified = blobRefs.every((r) => r.ok);
+    }
+  }
+
   // Step 4: Verify key trust against the platform trust registry.
   // Three paths:
   //   - Signature with a kid → registry lookup via `verifyKeyTrust`.
@@ -102,6 +120,8 @@ export async function GET(
     rekorVerified,
     hasTimestamp: !!record.basePackageRfc3161Timestamp,
     keyTrust,
+    blobRefsVerified,
+    blobRefs,
     details: {
       storedHash: record.basePackageHash,
       recomputedHash,

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -8,6 +8,7 @@ import { putPackage } from '@/lib/storage';
 import { buildEvidencePackage, type PackageInput } from '@/lib/evidence/packager';
 import { hash } from '@/lib/evidence/trace';
 import { signPackage, getRfc3161Timestamp, publishToRekor } from '@/lib/evidence/signing';
+import { type BlobRef } from '@/lib/evidence/blob-ref';
 
 function slugify(text: string): string {
   return text
@@ -46,9 +47,12 @@ async function resolveSlug(title: string, packageHash: string): Promise<string> 
 }
 
 interface PublishRequest {
-  trace: Record<string, unknown>;
+  /** OTel trace OR a BlobRef. See `docs/api/evidence-publish.md` for the
+   *  blob-reference contract. */
+  trace: Record<string, unknown> | BlobRef;
   prompt: string;
-  output: string;
+  /** Assistant output text OR a BlobRef to the same. */
+  output: string | BlobRef;
   toolCalls: Array<{
     name: string;
     args: Record<string, unknown>;
@@ -63,6 +67,13 @@ interface PublishRequest {
   promptVisibility: 'full_text' | 'hash_only';
   title: string;
   summary: string;
+  /** Optional override for the skill metadata that would otherwise be
+   *  extracted from the trace. Required when `trace` is a BlobRef. */
+  skillMetadataOverride?: {
+    systemPromptHash?: string;
+    mcpServerUrl?: string;
+    skillText?: string | BlobRef;
+  };
   extensions?: Record<string, unknown>;
 }
 
@@ -102,6 +113,7 @@ export async function POST(request: NextRequest) {
       promptVisibility: body.promptVisibility,
       title: body.title,
       summary: body.summary,
+      skillMetadataOverride: body.skillMetadataOverride,
       extensions: body.extensions,
     };
 

--- a/src/app/evidence/[slug]/page.tsx
+++ b/src/app/evidence/[slug]/page.tsx
@@ -14,11 +14,63 @@ import NotebookSection from '@/components/evidence/NotebookSection';
 import SkillSection from '@/components/evidence/SkillSection';
 import { formatModelName, estimateCostUsd } from '@/lib/models';
 import { formatDataSourcesSummary } from '@/lib/evidence/data-sources';
+import { isBlobRef, fetchBlobRefText, type BlobRef } from '@/lib/evidence/blob-ref';
 
 const NOTEBOOK_EXTENSION_KEY = 'org.civicaitools.notebook';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
+}
+
+/** Server-side resolution for blob-referenced fields in an evidence package.
+ *  `output` is eagerly fetched so the ProvenanceChain can continue to
+ *  treat it as a string. `skillMetadata.skillText` is handed through as a
+ *  reference when it's a BlobRef — the skill section expands on click and
+ *  fetches lazily, so there's no point paying the latency up front. */
+interface ResolvedPackageData {
+  pkg: EvidencePackage;
+  outputIsBlob: boolean;
+  outputBlobRef: BlobRef | null;
+  skillTextIsBlob: boolean;
+  skillTextBlobRef: BlobRef | null;
+}
+
+async function resolvePackageForRender(pkg: EvidencePackage): Promise<ResolvedPackageData> {
+  const outputIsBlob = isBlobRef(pkg.output);
+  const outputBlobRef = outputIsBlob ? (pkg.output as BlobRef) : null;
+  let resolvedOutput: string;
+  if (outputIsBlob) {
+    resolvedOutput =
+      (await fetchBlobRefText(pkg.output as BlobRef)) ??
+      '[Output blob could not be fetched; see the Package hash below to audit.]';
+  } else {
+    resolvedOutput = pkg.output as string;
+  }
+
+  const skillText = pkg.skillMetadata?.skillText;
+  const skillTextIsBlob = skillText !== undefined && isBlobRef(skillText);
+  const skillTextBlobRef = skillTextIsBlob ? (skillText as BlobRef) : null;
+
+  // Shallow-clone the package with the resolved output so child components
+  // can keep treating `pkg.output` as a plain string.
+  const resolved: EvidencePackage = {
+    ...pkg,
+    output: resolvedOutput,
+    skillMetadata: {
+      ...pkg.skillMetadata,
+      // When skillText is a BlobRef, keep the reference so the SkillSection
+      // can surface it rather than rendering `[object Object]`. The section
+      // fetches bytes on demand.
+      skillText: skillTextIsBlob ? undefined : (skillText as string | undefined),
+    },
+  };
+  return {
+    pkg: resolved,
+    outputIsBlob,
+    outputBlobRef,
+    skillTextIsBlob,
+    skillTextBlobRef,
+  };
 }
 
 async function getEvidenceData(slug: string) {
@@ -37,11 +89,15 @@ async function getEvidenceData(slug: string) {
     .limit(1);
 
   let pkg: EvidencePackage | null = null;
+  let resolution: ResolvedPackageData | null = null;
   if (record.basePackageStorageKey) {
     pkg = (await getPackage(record.basePackageStorageKey)) as EvidencePackage | null;
+    if (pkg) {
+      resolution = await resolvePackageForRender(pkg);
+    }
   }
 
-  return { record, creator: creator[0] || null, pkg };
+  return { record, creator: creator[0] || null, pkg, resolution };
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -112,7 +168,13 @@ export default async function EvidencePage({ params }: PageProps) {
   const data = await getEvidenceData(slug);
   if (!data) notFound();
 
-  const { record, creator, pkg } = data;
+  const { record, creator, pkg, resolution } = data;
+  // Use the resolved package everywhere we render package content — it has
+  // BlobRef outputs eagerly pulled into strings so child components can stay
+  // ignorant of the reference layer. When the package isn't a BlobRef user
+  // (the vast majority of historical records), `resolution.pkg === pkg`
+  // modulo the shallow clone.
+  const renderPkg = resolution?.pkg ?? pkg;
   const dateStr = record.createdAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
   // Schema.org JSON-LD
@@ -246,45 +308,56 @@ export default async function EvidencePage({ params }: PageProps) {
         )}
 
         {/* Provenance Chain */}
-        {pkg && (
+        {renderPkg && (
           <Section title="Provenance Chain">
             <div style={{
               padding: '16px 20px', border: '1px solid var(--border-color)',
               borderRadius: '6px', backgroundColor: 'white',
             }}>
-              <ProvenanceChain pkg={pkg} />
+              <ProvenanceChain pkg={renderPkg} />
+              {resolution?.outputIsBlob && (
+                <div style={{
+                  marginTop: '10px', fontSize: '11px', color: 'var(--text-muted)',
+                  fontFamily: 'monospace',
+                }}>
+                  Output stored as blob (verified) · {resolution.outputBlobRef?.size.toLocaleString()} bytes
+                </div>
+              )}
             </div>
           </Section>
         )}
 
         {/* Provenance Graph (W3C PROV-O) */}
-        {pkg?.provenance && (
+        {renderPkg?.provenance && (
           <Section title="Provenance Graph">
-            <ProvenanceGraphSection provenance={pkg.provenance} slug={slug} />
+            <ProvenanceGraphSection provenance={renderPkg.provenance} slug={slug} />
           </Section>
         )}
 
         {/* Skill guidance (system prompt sent to the model) */}
-        {pkg?.skillMetadata?.skillText && (
+        {(renderPkg?.skillMetadata?.skillText || resolution?.skillTextIsBlob) && (
           <Section title="Skill Guidance">
             <SkillSection
-              skillText={pkg.skillMetadata.skillText}
-              skillHash={pkg.skillMetadata.systemPromptHash}
+              skillText={typeof renderPkg?.skillMetadata?.skillText === 'string'
+                ? renderPkg.skillMetadata.skillText
+                : undefined}
+              skillTextRef={resolution?.skillTextBlobRef ?? undefined}
+              skillHash={renderPkg?.skillMetadata?.systemPromptHash}
             />
           </Section>
         )}
 
         {/* Jupyter Notebook extension */}
-        {pkg?.extensions?.[NOTEBOOK_EXTENSION_KEY] !== undefined && (
+        {renderPkg?.extensions?.[NOTEBOOK_EXTENSION_KEY] !== undefined && (
           <Section title="Jupyter Notebook">
-            <NotebookSection notebook={pkg.extensions[NOTEBOOK_EXTENSION_KEY]} slug={slug} />
+            <NotebookSection notebook={renderPkg.extensions[NOTEBOOK_EXTENSION_KEY]} slug={slug} />
           </Section>
         )}
 
         {/* Unknown extensions — graceful fallback for other adopters' artifacts */}
         {(() => {
-          if (!pkg?.extensions) return null;
-          const unknown = Object.keys(pkg.extensions).filter(k => k !== NOTEBOOK_EXTENSION_KEY);
+          if (!renderPkg?.extensions) return null;
+          const unknown = Object.keys(renderPkg.extensions).filter(k => k !== NOTEBOOK_EXTENSION_KEY);
           if (unknown.length === 0) return null;
           return (
             <Section title="Additional Artifacts">
@@ -317,30 +390,37 @@ export default async function EvidencePage({ params }: PageProps) {
         </Section>
 
         {/* Resources */}
-        {pkg && (
+        {renderPkg && (
           <Section title="Resources Used">
             {(() => {
               const cost = estimateCostUsd(
-                pkg.cost.model,
-                pkg.cost.promptTokens || 0,
-                pkg.cost.completionTokens || 0,
+                renderPkg.cost.model,
+                renderPkg.cost.promptTokens || 0,
+                renderPkg.cost.completionTokens || 0,
               );
-              const skillHash = pkg.skillMetadata.systemPromptHash;
-              const dataSourcesSummary = formatDataSourcesSummary(pkg.dataSources);
+              const skillHash = renderPkg.skillMetadata.systemPromptHash;
+              const dataSourcesSummary = formatDataSourcesSummary(renderPkg.dataSources);
+              const blobFields: string[] = [];
+              if (resolution?.outputIsBlob) blobFields.push('output');
+              if (resolution?.skillTextIsBlob) blobFields.push('skill text');
               const items: Array<{ label: string; value: React.ReactNode; mono?: boolean }> = [
-                { label: 'Model', value: formatModelName(pkg.cost.model) },
+                { label: 'Model', value: formatModelName(renderPkg.cost.model) },
                 { label: 'Data sources', value: dataSourcesSummary ?? '—' },
                 ...(skillHash ? [{
                   label: 'Skill hash',
                   value: skillHash.slice(0, 12),
                   mono: true,
                 }] : []),
-                { label: 'Prompt tokens', value: pkg.cost.promptTokens?.toLocaleString() || '—' },
-                { label: 'Completion tokens', value: pkg.cost.completionTokens?.toLocaleString() || '—' },
-                { label: 'Total tokens', value: pkg.cost.totalTokens?.toLocaleString() || '—' },
+                { label: 'Prompt tokens', value: renderPkg.cost.promptTokens?.toLocaleString() || '—' },
+                { label: 'Completion tokens', value: renderPkg.cost.completionTokens?.toLocaleString() || '—' },
+                { label: 'Total tokens', value: renderPkg.cost.totalTokens?.toLocaleString() || '—' },
                 { label: 'Estimated cost', value: cost !== null ? `~$${cost.toFixed(cost < 0.01 ? 4 : 2)}` : '—' },
-                { label: 'Duration', value: pkg.cost.durationMs ? `${(pkg.cost.durationMs / 1000).toFixed(1)}s` : '—' },
-                { label: 'Tool calls', value: String(pkg.queries.length) },
+                { label: 'Duration', value: renderPkg.cost.durationMs ? `${(renderPkg.cost.durationMs / 1000).toFixed(1)}s` : '—' },
+                { label: 'Tool calls', value: String(renderPkg.queries.length) },
+                ...(blobFields.length > 0 ? [{
+                  label: 'Blob-stored fields',
+                  value: blobFields.join(', '),
+                }] : []),
               ];
               return (
                 <div style={{

--- a/src/components/evidence/ProvenanceChain.tsx
+++ b/src/components/evidence/ProvenanceChain.tsx
@@ -160,14 +160,21 @@ export default function ProvenanceChain({ pkg }: ProvenanceChainProps) {
         );
       })}
 
-      {/* Output */}
+      {/* Output — the detail page resolves BlobRef outputs to strings
+         before passing the package in, so this is always a string in
+         practice. The narrow below keeps the component resilient to a
+         future change in the render pipeline. */}
       <StepContainer isLast>
-        <ExpandableStep
-          label="Output"
-          detail={`${pkg.output.length.toLocaleString()} characters`}
-        >
-          {pkg.output.slice(0, 2000)}{pkg.output.length > 2000 ? '\n\n[truncated]' : ''}
-        </ExpandableStep>
+        {typeof pkg.output === 'string' ? (
+          <ExpandableStep
+            label="Output"
+            detail={`${pkg.output.length.toLocaleString()} characters`}
+          >
+            {pkg.output.slice(0, 2000)}{pkg.output.length > 2000 ? '\n\n[truncated]' : ''}
+          </ExpandableStep>
+        ) : (
+          <StepLabel label="Output" detail="stored as blob — see detail page" />
+        )}
       </StepContainer>
     </div>
   );

--- a/src/components/evidence/SkillSection.tsx
+++ b/src/components/evidence/SkillSection.tsx
@@ -1,17 +1,59 @@
 'use client';
 
 import { useState } from 'react';
+import type { BlobRef } from '@/lib/evidence/blob-ref';
 
 interface SkillSectionProps {
-  skillText: string;
+  /** Inline skill text from the package JSON. Mutually exclusive with
+   *  `skillTextRef`. */
+  skillText?: string;
+  /** Blob reference pointing at the skill text. Fetched on first expand so
+   *  the detail page doesn't pay the download cost up front for a section
+   *  most viewers never open. */
+  skillTextRef?: BlobRef;
   skillHash?: string;
 }
 
-export default function SkillSection({ skillText, skillHash }: SkillSectionProps) {
-  const [open, setOpen] = useState(false);
+interface FetchState {
+  status: 'idle' | 'loading' | 'loaded' | 'error';
+  text: string;
+  error?: string;
+}
 
-  const lineCount = skillText.split('\n').length;
-  const charCount = skillText.length;
+export default function SkillSection({ skillText, skillTextRef, skillHash }: SkillSectionProps) {
+  const [open, setOpen] = useState(false);
+  const [fetched, setFetched] = useState<FetchState>({ status: 'idle', text: '' });
+
+  const usingRef = skillTextRef !== undefined;
+  const resolvedText = usingRef ? (fetched.status === 'loaded' ? fetched.text : '') : (skillText ?? '');
+  const lineCount = resolvedText ? resolvedText.split('\n').length : 0;
+  const charCount = usingRef ? skillTextRef.size : resolvedText.length;
+
+  async function handleToggle() {
+    const willOpen = !open;
+    setOpen(willOpen);
+    if (willOpen && usingRef && fetched.status === 'idle') {
+      setFetched({ status: 'loading', text: '' });
+      try {
+        const res = await fetch(skillTextRef.url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const text = await res.text();
+        setFetched({ status: 'loaded', text });
+      } catch (err) {
+        setFetched({
+          status: 'error',
+          text: '',
+          error: err instanceof Error ? err.message : 'fetch failed',
+        });
+      }
+    }
+  }
+
+  const buttonLabel = open
+    ? 'Hide skill guidance'
+    : usingRef
+      ? `View skill guidance (${charCount.toLocaleString()} bytes, stored as blob)`
+      : `View skill guidance (${lineCount} lines, ${charCount.toLocaleString()} chars)`;
 
   return (
     <div style={{
@@ -25,25 +67,44 @@ export default function SkillSection({ skillText, skillHash }: SkillSectionProps
 
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: open ? '16px' : 0, flexWrap: 'wrap' }}>
         <button
-          onClick={() => setOpen(!open)}
+          onClick={handleToggle}
           style={{
             background: 'none', border: '1px solid var(--nyc-blue)', borderRadius: '4px',
             padding: '6px 14px', fontSize: '13px', cursor: 'pointer',
             color: 'var(--nyc-blue)', fontWeight: 500,
           }}
         >
-          {open ? 'Hide skill guidance' : `View skill guidance (${lineCount} lines, ${charCount.toLocaleString()} chars)`}
+          {buttonLabel}
         </button>
+        {usingRef && (
+          <span style={{ fontSize: '11px', color: 'var(--text-muted)', fontFamily: 'monospace' }}>
+            {skillTextRef.ref.slice(0, 'blob:sha256:'.length + 12)}…
+          </span>
+        )}
       </div>
 
       {open && (
-        <pre style={{
-          padding: '12px 14px', backgroundColor: '#f5f5f5', borderRadius: '4px',
-          fontSize: '12px', lineHeight: 1.5, overflow: 'auto', maxHeight: '500px',
-          whiteSpace: 'pre-wrap', margin: 0,
-        }}>
-          {skillText}
-        </pre>
+        <>
+          {usingRef && fetched.status === 'loading' && (
+            <div style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
+              Fetching skill content…
+            </div>
+          )}
+          {usingRef && fetched.status === 'error' && (
+            <div style={{ fontSize: '13px', color: 'var(--nyc-error)' }}>
+              Could not fetch blob: {fetched.error}
+            </div>
+          )}
+          {(!usingRef || fetched.status === 'loaded') && (
+            <pre style={{
+              padding: '12px 14px', backgroundColor: '#f5f5f5', borderRadius: '4px',
+              fontSize: '12px', lineHeight: 1.5, overflow: 'auto', maxHeight: '500px',
+              whiteSpace: 'pre-wrap', margin: 0,
+            }}>
+              {resolvedText}
+            </pre>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/lib/evidence/blob-ref.test.ts
+++ b/src/lib/evidence/blob-ref.test.ts
@@ -1,0 +1,271 @@
+// Unit tests for the blob-reference helper module introduced in
+// Phase B.6 (website#75). Covers type-guard detection, parser edge cases,
+// hash verification, and the fetch helper used by the detail page.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'crypto';
+import {
+  isBlobRef,
+  parseBlobRef,
+  verifyBlobRef,
+  computeBlobRefHash,
+  fetchBlobRefText,
+  type BlobRef,
+} from './blob-ref.ts';
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+// --- isBlobRef ---
+
+test('isBlobRef: valid ref object is recognised', () => {
+  const hash = sha256Hex('hello');
+  const ref: BlobRef = {
+    ref: `blob:sha256:${hash}`,
+    url: 'https://example.public.blob.vercel-storage.com/evidence-refs/hash.txt',
+    contentType: 'text/plain',
+    size: 5,
+  };
+  assert.equal(isBlobRef(ref), true);
+});
+
+test('isBlobRef: inline string is not a ref', () => {
+  assert.equal(isBlobRef('hello'), false);
+  assert.equal(isBlobRef(''), false);
+});
+
+test('isBlobRef: missing fields → false', () => {
+  assert.equal(isBlobRef({ ref: 'blob:sha256:' + 'a'.repeat(64) }), false);
+  assert.equal(
+    isBlobRef({ ref: 'blob:sha256:' + 'a'.repeat(64), url: 'https://x', contentType: 'text/plain' }),
+    false,
+  );
+});
+
+test('isBlobRef: malformed ref prefix → false', () => {
+  assert.equal(
+    isBlobRef({
+      ref: 'sha256:' + 'a'.repeat(64),
+      url: 'https://x',
+      contentType: 'text/plain',
+      size: 1,
+    }),
+    false,
+  );
+});
+
+test('isBlobRef: wrong hash length → false', () => {
+  assert.equal(
+    isBlobRef({
+      ref: 'blob:sha256:' + 'a'.repeat(10),
+      url: 'https://x',
+      contentType: 'text/plain',
+      size: 1,
+    }),
+    false,
+  );
+});
+
+test('isBlobRef: nullish inputs → false', () => {
+  assert.equal(isBlobRef(null), false);
+  assert.equal(isBlobRef(undefined), false);
+  assert.equal(isBlobRef(123), false);
+});
+
+// --- parseBlobRef ---
+
+test('parseBlobRef: round-trips a valid ref', () => {
+  const hash = sha256Hex('content');
+  const parsed = parseBlobRef(`blob:sha256:${hash}`);
+  assert.equal(parsed.algo, 'sha256');
+  assert.equal(parsed.hash, hash);
+});
+
+test('parseBlobRef: throws on malformed input', () => {
+  assert.throws(() => parseBlobRef('not-a-ref'), /Invalid blob reference/);
+  assert.throws(() => parseBlobRef('blob:md5:' + 'a'.repeat(32)), /Invalid blob reference/);
+});
+
+// --- computeBlobRefHash ---
+
+test('computeBlobRefHash: string → sha256 hex', () => {
+  const hash = computeBlobRefHash('hello');
+  assert.equal(hash, sha256Hex('hello'));
+});
+
+test('computeBlobRefHash: Uint8Array → sha256 hex', () => {
+  const bytes = new TextEncoder().encode('hello');
+  assert.equal(computeBlobRefHash(bytes), sha256Hex('hello'));
+});
+
+// --- verifyBlobRef ---
+//
+// These tests replace globalThis.fetch with a stub so they run offline. Each
+// test restores the original fetch in a finally block so suites interleave
+// cleanly.
+
+function withStubbedFetch<T>(
+  stub: (url: string) => Promise<Response>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL) =>
+    stub(typeof input === 'string' ? input : input.toString())) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+test('verifyBlobRef: matching content → ok', async () => {
+  const content = 'the quick brown fox';
+  const hash = sha256Hex(content);
+  const ref: BlobRef = {
+    ref: `blob:sha256:${hash}`,
+    url: 'https://example/test',
+    contentType: 'text/plain',
+    size: content.length,
+  };
+
+  await withStubbedFetch(
+    async () => new Response(content, { status: 200 }),
+    async () => {
+      const result = await verifyBlobRef(ref);
+      assert.equal(result.ok, true);
+      assert.equal(result.computedHash, hash);
+      assert.equal(result.computedSize, content.length);
+    },
+  );
+});
+
+test('verifyBlobRef: content hash mismatch → hash_mismatch', async () => {
+  const content = 'the quick brown fox';
+  const ref: BlobRef = {
+    ref: `blob:sha256:${'0'.repeat(64)}`,
+    url: 'https://example/test',
+    contentType: 'text/plain',
+    size: content.length,
+  };
+
+  await withStubbedFetch(
+    async () => new Response(content, { status: 200 }),
+    async () => {
+      const result = await verifyBlobRef(ref);
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, 'hash_mismatch');
+      assert.equal(result.computedHash, sha256Hex(content));
+    },
+  );
+});
+
+test('verifyBlobRef: size mismatch → size_mismatch', async () => {
+  const content = 'the quick brown fox';
+  const ref: BlobRef = {
+    ref: `blob:sha256:${sha256Hex(content)}`,
+    url: 'https://example/test',
+    contentType: 'text/plain',
+    size: content.length + 10, // wrong
+  };
+
+  await withStubbedFetch(
+    async () => new Response(content, { status: 200 }),
+    async () => {
+      const result = await verifyBlobRef(ref);
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, 'size_mismatch');
+      assert.equal(result.computedSize, content.length);
+    },
+  );
+});
+
+test('verifyBlobRef: non-200 response → fetch_failed', async () => {
+  const ref: BlobRef = {
+    ref: `blob:sha256:${sha256Hex('x')}`,
+    url: 'https://example/missing',
+    contentType: 'text/plain',
+    size: 1,
+  };
+
+  await withStubbedFetch(
+    async () => new Response('', { status: 404 }),
+    async () => {
+      const result = await verifyBlobRef(ref);
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, 'fetch_failed');
+    },
+  );
+});
+
+test('verifyBlobRef: network error → fetch_failed', async () => {
+  const ref: BlobRef = {
+    ref: `blob:sha256:${sha256Hex('x')}`,
+    url: 'https://example/down',
+    contentType: 'text/plain',
+    size: 1,
+  };
+
+  await withStubbedFetch(
+    async () => {
+      throw new TypeError('network');
+    },
+    async () => {
+      const result = await verifyBlobRef(ref);
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, 'fetch_failed');
+    },
+  );
+});
+
+test('verifyBlobRef: invalid ref string → invalid_ref before fetch', async () => {
+  const ref: BlobRef = {
+    ref: 'not-a-ref',
+    url: 'https://example/test',
+    contentType: 'text/plain',
+    size: 1,
+  };
+  // No fetch stub — if the implementation leaked through, the real fetch
+  // would be attempted. The early return protects against that.
+  const result = await verifyBlobRef(ref);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'invalid_ref');
+});
+
+// --- fetchBlobRefText ---
+
+test('fetchBlobRefText: returns text on success', async () => {
+  const content = '# hello\n';
+  const ref: BlobRef = {
+    ref: `blob:sha256:${sha256Hex(content)}`,
+    url: 'https://example/test',
+    contentType: 'text/markdown',
+    size: content.length,
+  };
+
+  await withStubbedFetch(
+    async () => new Response(content, { status: 200 }),
+    async () => {
+      const text = await fetchBlobRefText(ref);
+      assert.equal(text, content);
+    },
+  );
+});
+
+test('fetchBlobRefText: returns null on failure', async () => {
+  const ref: BlobRef = {
+    ref: `blob:sha256:${sha256Hex('x')}`,
+    url: 'https://example/missing',
+    contentType: 'text/plain',
+    size: 1,
+  };
+
+  await withStubbedFetch(
+    async () => new Response('', { status: 500 }),
+    async () => {
+      const text = await fetchBlobRefText(ref);
+      assert.equal(text, null);
+    },
+  );
+});

--- a/src/lib/evidence/blob-ref.ts
+++ b/src/lib/evidence/blob-ref.ts
@@ -1,0 +1,161 @@
+import crypto from 'crypto';
+
+/**
+ * Content-addressable blob references for evidence package fields.
+ *
+ * Large fields (full output text, OpenTelemetry trace JSON, composed skill
+ * guidance, multi-turn transcripts) can be stored as a separate Vercel Blob
+ * and referenced from the package JSON rather than inlined. The package hash
+ * still binds the reference (because the BlobRef object is part of the
+ * canonical JSON), and the referenced content has its own SHA-256 so
+ * consumers can verify each piece independently.
+ *
+ * Format of `ref`: `blob:sha256:<64 hex chars>`.
+ *
+ * The `url` is the Vercel Blob public URL returned by the upload-token flow.
+ * `contentType` and `size` are metadata hints for renderers so they can
+ * decide whether to fetch eagerly or lazily without a preflight HEAD.
+ */
+export interface BlobRef {
+  ref: string;
+  url: string;
+  contentType: string;
+  size: number;
+}
+
+const REF_PATTERN = /^blob:sha256:([0-9a-f]{64})$/;
+
+/**
+ * Detect whether a field value is a BlobRef object. Used by the packager,
+ * verifier, and detail-page renderer to branch between inline content and
+ * blob-referenced content.
+ */
+export function isBlobRef(value: unknown): value is BlobRef {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.ref === 'string' &&
+    REF_PATTERN.test(v.ref) &&
+    typeof v.url === 'string' &&
+    typeof v.contentType === 'string' &&
+    typeof v.size === 'number'
+  );
+}
+
+export interface ParsedBlobRef {
+  algo: 'sha256';
+  hash: string;
+}
+
+/**
+ * Parse a `blob:sha256:<hash>` reference string into its components.
+ * Throws if the format is invalid.
+ */
+export function parseBlobRef(ref: string): ParsedBlobRef {
+  const match = REF_PATTERN.exec(ref);
+  if (!match) {
+    throw new Error(`Invalid blob reference: expected "blob:sha256:<64 hex>", got "${ref}"`);
+  }
+  return { algo: 'sha256', hash: match[1] };
+}
+
+export type BlobRefVerifyReason =
+  | 'invalid_ref'
+  | 'fetch_failed'
+  | 'size_mismatch'
+  | 'hash_mismatch';
+
+export interface BlobRefVerifyResult {
+  ok: boolean;
+  reason?: BlobRefVerifyReason;
+  /** SHA-256 of the fetched blob content, if fetched. Lets callers surface
+   *  both the expected (ref) and actual hash when they mismatch. */
+  computedHash?: string;
+  /** Byte length of the fetched blob. */
+  computedSize?: number;
+}
+
+/**
+ * Fetch a blob and verify that its SHA-256 matches the reference hash and
+ * that its byte size matches the metadata. Returns a structured result;
+ * never throws.
+ *
+ * Used by the server-side verifier and by offline consumers walking the
+ * evidence record. Fetches over HTTPS without auth (Vercel Blob public
+ * access is the storage default for evidence content).
+ */
+export async function verifyBlobRef(
+  ref: BlobRef,
+  options: { signal?: AbortSignal } = {},
+): Promise<BlobRefVerifyResult> {
+  let parsed: ParsedBlobRef;
+  try {
+    parsed = parseBlobRef(ref.ref);
+  } catch {
+    return { ok: false, reason: 'invalid_ref' };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(ref.url, {
+      signal: options.signal ?? AbortSignal.timeout(15_000),
+    });
+  } catch {
+    return { ok: false, reason: 'fetch_failed' };
+  }
+  if (!response.ok) {
+    return { ok: false, reason: 'fetch_failed' };
+  }
+
+  let bytes: Uint8Array;
+  try {
+    const buffer = await response.arrayBuffer();
+    bytes = new Uint8Array(buffer);
+  } catch {
+    return { ok: false, reason: 'fetch_failed' };
+  }
+
+  const computedSize = bytes.byteLength;
+  if (computedSize !== ref.size) {
+    return { ok: false, reason: 'size_mismatch', computedSize };
+  }
+
+  const computedHash = crypto.createHash('sha256').update(bytes).digest('hex');
+  if (computedHash !== parsed.hash) {
+    return { ok: false, reason: 'hash_mismatch', computedHash, computedSize };
+  }
+
+  return { ok: true, computedHash, computedSize };
+}
+
+/**
+ * Compute the canonical `blob:sha256:<hash>` reference string for content
+ * bytes. Used by uploaders that are about to stash content in Vercel Blob
+ * and need to construct the matching BlobRef object.
+ */
+export function computeBlobRefHash(content: string | Uint8Array): string {
+  const bytes =
+    typeof content === 'string' ? new TextEncoder().encode(content) : content;
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Fetch a BlobRef's content as a UTF-8 string. Used by the detail-page
+ * renderer to resolve output-level BlobRefs for server-side rendering.
+ * Returns null on any failure; callers can fall back to showing only the
+ * reference metadata rather than blocking the page render.
+ */
+export async function fetchBlobRefText(
+  ref: BlobRef,
+  options: { signal?: AbortSignal } = {},
+): Promise<string | null> {
+  try {
+    const response = await fetch(ref.url, {
+      signal: options.signal ?? AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) return null;
+    return await response.text();
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/evidence/packager.test.ts
+++ b/src/lib/evidence/packager.test.ts
@@ -1,0 +1,148 @@
+// Packager tests exercising blob-reference pathways introduced in
+// Phase B.6 (website#75). Confirms backward compatibility with inline
+// content packages and that BlobRef inputs flow through the package JSON
+// unchanged (so verifiers and renderers can still follow the reference).
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'crypto';
+import { buildEvidencePackage, type PackageInput } from './packager.ts';
+import type { BlobRef } from './blob-ref.ts';
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function makeBlobRef(content: string, contentType = 'text/plain'): BlobRef {
+  return {
+    ref: `blob:sha256:${sha256Hex(content)}`,
+    url: `https://example.public.blob.vercel-storage.com/evidence-refs/${sha256Hex(content)}.bin`,
+    contentType,
+    size: new TextEncoder().encode(content).byteLength,
+  };
+}
+
+function baseInput(overrides: Partial<PackageInput> = {}): PackageInput {
+  return {
+    trace: { resourceSpans: [] },
+    prompt: 'How many 311 noise complaints last year?',
+    output: 'Around 400,000.',
+    toolCalls: [
+      {
+        name: 'get_data',
+        args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9', select: 'count(*)' },
+        resultSummary: { rows: 1, columns: 1 },
+        operationType: 'query',
+      },
+    ],
+    model: 'openai/gpt-4o',
+    portal: 'data.cityofnewyork.us',
+    tokenUsage: { promptTokens: 100, completionTokens: 20 },
+    promptVisibility: 'full_text',
+    title: 'Test',
+    summary: 'Test summary.',
+    ...overrides,
+  };
+}
+
+// --- Backward compatibility: inline content still works ---
+
+test('buildEvidencePackage: inline output + inline trace produces a package hash', () => {
+  const { pkg, hash } = buildEvidencePackage(baseInput());
+  assert.equal(typeof hash, 'string');
+  assert.equal(hash.length, 64);
+  assert.equal(typeof pkg.output, 'string');
+  assert.equal(pkg.output, 'Around 400,000.');
+});
+
+// --- BlobRef output is passed through unchanged ---
+
+test('buildEvidencePackage: BlobRef output is preserved in the package JSON', () => {
+  const ref = makeBlobRef('Long synthesised output...\n\n## Details\n...');
+  const { pkg } = buildEvidencePackage(baseInput({ output: ref }));
+  assert.deepEqual(pkg.output, ref);
+});
+
+test('buildEvidencePackage: BlobRef output produces a deterministic package hash (idempotency)', () => {
+  const ref = makeBlobRef('content');
+  const a = buildEvidencePackage(baseInput({ output: ref }));
+  const b = buildEvidencePackage(baseInput({ output: ref }));
+  // packageId is random so a.hash !== b.hash, but the ref survives both.
+  assert.deepEqual(a.pkg.output, ref);
+  assert.deepEqual(b.pkg.output, ref);
+});
+
+// --- BlobRef output drives the PROV-O output hash ---
+
+test('buildEvidencePackage: PROV-O output entity hash matches the BlobRef hash', () => {
+  const ref = makeBlobRef('synthesis');
+  const { pkg } = buildEvidencePackage(baseInput({ output: ref }));
+  const outputEntity = pkg.provenance!['@graph'].find(
+    (n) => (n['@id'] as string).includes(':output:'),
+  );
+  assert.ok(outputEntity, 'provenance output entity should exist');
+  const refHash = ref.ref.split(':').at(-1);
+  assert.equal(outputEntity!['civic:contentHash'], `sha256:${refHash}`);
+});
+
+// --- BlobRef trace skips span extraction gracefully ---
+
+test('buildEvidencePackage: BlobRef trace + no override → empty skill metadata', () => {
+  const traceRef = makeBlobRef('{"resourceSpans":[]}', 'application/json');
+  const { pkg } = buildEvidencePackage(baseInput({ trace: traceRef }));
+  assert.deepEqual(pkg.trace, traceRef);
+  // No override supplied → extraction returns {} because traceForInspection
+  // falls back to an empty resourceSpans.
+  assert.equal(pkg.skillMetadata.systemPromptHash, undefined);
+  assert.equal(pkg.skillMetadata.mcpServerUrl, undefined);
+  assert.equal(pkg.skillMetadata.skillText, undefined);
+});
+
+test('buildEvidencePackage: BlobRef trace + skillMetadataOverride populates skill metadata', () => {
+  const traceRef = makeBlobRef('{"resourceSpans":[]}', 'application/json');
+  const skillTextRef = makeBlobRef('# Skill\n...', 'text/markdown');
+  const { pkg } = buildEvidencePackage(
+    baseInput({
+      trace: traceRef,
+      skillMetadataOverride: {
+        systemPromptHash: 'e751da4a' + '0'.repeat(56),
+        mcpServerUrl: 'https://socrata-mcp.civicaitools.org',
+        skillText: skillTextRef,
+      },
+    }),
+  );
+  assert.equal(pkg.skillMetadata.systemPromptHash, 'e751da4a' + '0'.repeat(56));
+  assert.equal(pkg.skillMetadata.mcpServerUrl, 'https://socrata-mcp.civicaitools.org');
+  assert.deepEqual(pkg.skillMetadata.skillText, skillTextRef);
+});
+
+// --- BlobRef fields are covered by the canonical package hash ---
+
+test('buildEvidencePackage: BlobRef hash is covered by the package hash', () => {
+  const { hash: hashA } = buildEvidencePackage(
+    baseInput({ output: makeBlobRef('A') }),
+  );
+  const { hash: hashB } = buildEvidencePackage(
+    baseInput({ output: makeBlobRef('B') }),
+  );
+  // Different referenced content → different refs → different package hashes.
+  // (Plus random packageId, but the ref difference alone is enough.)
+  assert.notEqual(hashA, hashB);
+});
+
+// --- Output hash used by PROV-O never coincides with the empty string hash ---
+
+test('buildEvidencePackage: empty-string output is hashed, not undefined-skipped', () => {
+  const { pkg } = buildEvidencePackage(baseInput({ output: '' }));
+  const outputEntity = pkg.provenance!['@graph'].find(
+    (n) => (n['@id'] as string).includes(':output:'),
+  );
+  assert.ok(outputEntity);
+  // Hash of the empty string — matches `sha256("")` in any cryptography lib.
+  assert.equal(
+    outputEntity!['civic:contentHash'],
+    `sha256:${sha256Hex('')}`,
+  );
+});

--- a/src/lib/evidence/packager.ts
+++ b/src/lib/evidence/packager.ts
@@ -1,8 +1,9 @@
 import crypto from 'crypto';
-import { buildProvenanceGraph, type ProvGraph } from './provenance';
-import { buildDataSources, type DataSourceEntry } from './data-sources';
-import { getActiveKeyId } from './signing';
-import { deriveOperationType } from '../mcp/operation-types';
+import { buildProvenanceGraph, type ProvGraph } from './provenance.ts';
+import { buildDataSources, type DataSourceEntry } from './data-sources.ts';
+import { getActiveKeyId } from './signing.ts';
+import { isBlobRef, parseBlobRef, type BlobRef } from './blob-ref.ts';
+import { deriveOperationType } from '../mcp/operation-types.ts';
 
 const PACKAGE_SCHEMA_VERSION = '0.1.0';
 
@@ -15,9 +16,17 @@ export interface ToolCallInput {
 }
 
 export interface PackageInput {
-  trace: Record<string, unknown>;
+  /** OTel trace object OR a BlobRef pointing at the same content stored
+   *  out of band. When a BlobRef is supplied, the packager cannot walk
+   *  trace spans to auto-extract skill metadata or build a rich PROV-O
+   *  graph; publishers shipping trace-as-BlobRef should also provide
+   *  `skillMetadataOverride` so those fields aren't blanked. */
+  trace: Record<string, unknown> | BlobRef;
   prompt: string;
-  output: string;
+  /** Assistant output text OR a BlobRef pointing at it. The detail-page
+   *  renderer resolves BlobRef outputs server-side; verify follows the
+   *  reference and confirms the hash matches. */
+  output: string | BlobRef;
   toolCalls: ToolCallInput[];
   model: string;
   portal: string;
@@ -26,6 +35,18 @@ export interface PackageInput {
   promptVisibility: 'full_text' | 'hash_only';
   title: string;
   summary: string;
+  /**
+   * Override the skill metadata that the packager would otherwise extract
+   * from the trace. Required when `trace` is a BlobRef (the packager can't
+   * inspect trace spans in that case). Also accepts a BlobRef for
+   * `skillText` so publishers can dedupe very large composed skills
+   * across packages.
+   */
+  skillMetadataOverride?: {
+    systemPromptHash?: string;
+    mcpServerUrl?: string;
+    skillText?: string | BlobRef;
+  };
   /**
    * Optional implementation-specific artifacts.
    * Keys MUST follow reverse-DNS conventions (e.g., "org.civicaitools.notebook")
@@ -71,10 +92,15 @@ export interface EvidencePackage {
   skillMetadata: {
     systemPromptHash?: string;
     mcpServerUrl?: string;
-    skillText?: string;
+    /** Inline skill text, or a BlobRef for very large composed skills.
+     *  The detail page fetches the blob lazily when the section expands. */
+    skillText?: string | BlobRef;
   };
-  output: string;
-  trace: Record<string, unknown>;
+  /** Assistant output. Inline text on historic packages; a BlobRef on
+   *  packages that uploaded large outputs via the upload-token flow. */
+  output: string | BlobRef;
+  /** OTel trace, either inline or referenced by hash. */
+  trace: Record<string, unknown> | BlobRef;
   provenance?: ProvGraph;
   /**
    * Optional implementation-specific artifacts, keyed by reverse-DNS identifier
@@ -113,6 +139,12 @@ function extractSkillMetadata(trace: Record<string, unknown>): { systemPromptHas
 /**
  * Build a structured evidence package from analysis data.
  * Returns the package object and its SHA-256 hash.
+ *
+ * BlobRef fields (`trace`, `output`, `skillMetadataOverride.skillText`) are
+ * passed through unchanged. The packager does not download them, so the
+ * resulting package commits to the reference object while leaving the
+ * content in Vercel Blob. Detail-page rendering and verification each
+ * follow the reference when they need the bytes.
  */
 export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackage; hash: string } {
   const now = new Date().toISOString();
@@ -131,17 +163,39 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
     resultColumns: tc.resultSummary?.columns,
   }));
 
-  const dataSources = buildDataSources(input.toolCalls, input.trace, input.portal, now);
+  // Helpers: when trace is a BlobRef the packager can't inspect spans for
+  // data-source detection, skill extraction, or PROV-O graph construction.
+  // Fall back to an empty trace so downstream builders degrade gracefully.
+  const traceIsBlob = isBlobRef(input.trace);
+  const traceForInspection: Record<string, unknown> = traceIsBlob
+    ? { resourceSpans: [] }
+    : (input.trace as Record<string, unknown>);
+
+  const dataSources = buildDataSources(input.toolCalls, traceForInspection, input.portal, now);
 
   const totalTokens = (input.tokenUsage.promptTokens || 0) + (input.tokenUsage.completionTokens || 0);
-  const skillMeta = extractSkillMetadata(input.trace);
 
-  // Build PROV-O provenance graph from the OTel trace
-  const provenance = buildProvenanceGraph(input.trace, {
+  // Skill metadata: prefer the explicit override when provided (required if
+  // trace is a BlobRef; optional otherwise), otherwise extract from spans.
+  const skillMeta = input.skillMetadataOverride
+    ? {
+        systemPromptHash: input.skillMetadataOverride.systemPromptHash,
+        mcpServerUrl: input.skillMetadataOverride.mcpServerUrl,
+        skillText: input.skillMetadataOverride.skillText,
+      }
+    : extractSkillMetadata(traceForInspection);
+
+  // PROV-O provenance graph. When output is a BlobRef we pass the ref hash
+  // through `outputHash` rather than rehashing a string — the ref IS the
+  // content hash by construction, so this preserves the identity chain
+  // between the evidence record and the referenced blob.
+  const outputIsBlob = isBlobRef(input.output);
+  const provenance = buildProvenanceGraph(traceForInspection, {
     packageId,
     promptHash,
     promptText: input.promptVisibility === 'full_text' ? input.prompt : undefined,
-    outputText: input.output,
+    outputText: outputIsBlob ? undefined : (input.output as string),
+    outputHash: outputIsBlob ? parseBlobRef((input.output as BlobRef).ref).hash : undefined,
     model: input.model,
     portal: input.portal,
   });

--- a/src/lib/evidence/provenance.ts
+++ b/src/lib/evidence/provenance.ts
@@ -24,7 +24,13 @@ interface ProvenanceInput {
   packageId: string;
   promptHash: string;
   promptText?: string;
-  outputText: string;
+  /** Inline output text. Used to derive the output hash unless
+   *  `outputHash` is supplied explicitly. */
+  outputText?: string;
+  /** Pre-computed SHA-256 hex of the output. Supplied when the output is
+   *  stored as a BlobRef and inline text isn't available; the ref hash
+   *  itself is exactly this value by construction. */
+  outputHash?: string;
   model: string;
   portal: string;
 }
@@ -63,7 +69,7 @@ export function buildProvenanceGraph(
   const otel = trace as unknown as OTelTrace;
   const spans = otel?.resourceSpans?.[0]?.scopeSpans?.[0]?.spans || [];
   const { packageId, promptHash, promptText, outputText, model, portal } = input;
-  const outputHash = hash(outputText);
+  const outputHash = input.outputHash ?? hash(outputText ?? '');
 
   const graph: ProvNode[] = [];
 

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -6,13 +6,16 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'crypto';
 import {
   verifyKeyTrust,
   loadTrustRegistry,
   clearTrustRegistryCache,
   legacyEmbeddedKeyTrust,
+  verifyPackageBlobRefs,
   type TrustRegistry,
 } from './verify.ts';
+import type { BlobRef } from './blob-ref.ts';
 
 const KID = 'platform:evidence-2026-04';
 const NEW_KID = 'platform:evidence-2027-04';
@@ -297,4 +300,139 @@ test('Compromise scenario: revoked key + replacement active key', () => {
   const clean = verifyKeyTrust(NEW_PUB, NEW_KID, undefined, registry);
   assert.equal(clean.status, 'active');
   assert.equal(clean.verified, true);
+});
+
+// --- verifyPackageBlobRefs (Phase B.6 / website#75) ---
+//
+// The content-integrity check that follows blob references embedded in the
+// package JSON and confirms the bytes hash back to the advertised ref.
+
+function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function makeBlobRef(content: string, url = 'https://example/test'): BlobRef {
+  return {
+    ref: `blob:sha256:${sha256Hex(content)}`,
+    url,
+    contentType: 'text/plain',
+    size: content.length,
+  };
+}
+
+function withStubbedFetch<T>(
+  stub: (url: string) => Promise<Response>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL) =>
+    stub(typeof input === 'string' ? input : input.toString())) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+test('verifyPackageBlobRefs: package with no refs → empty result', async () => {
+  const pkg = {
+    output: 'inline string',
+    trace: { resourceSpans: [] },
+    skillMetadata: { skillText: 'inline skill' },
+  };
+  const refs = await verifyPackageBlobRefs(pkg);
+  assert.deepEqual(refs, []);
+});
+
+test('verifyPackageBlobRefs: output as BlobRef → single verified result', async () => {
+  const content = 'synthesised output';
+  const ref = makeBlobRef(content);
+  const pkg = { output: ref };
+
+  await withStubbedFetch(
+    async () => new Response(content, { status: 200 }),
+    async () => {
+      const refs = await verifyPackageBlobRefs(pkg);
+      assert.equal(refs.length, 1);
+      assert.equal(refs[0].field, 'output');
+      assert.equal(refs[0].ok, true);
+      assert.equal(refs[0].ref, ref.ref);
+    },
+  );
+});
+
+test('verifyPackageBlobRefs: trace + skillText refs both verified', async () => {
+  const traceBytes = '{"resourceSpans":[]}';
+  const skillBytes = '# skill text\n';
+  const traceRef = makeBlobRef(traceBytes, 'https://example/trace');
+  const skillRef = makeBlobRef(skillBytes, 'https://example/skill');
+
+  const pkg = {
+    output: 'inline',
+    trace: traceRef,
+    skillMetadata: { skillText: skillRef },
+  };
+
+  await withStubbedFetch(
+    async (url) => {
+      if (url.includes('/trace')) return new Response(traceBytes, { status: 200 });
+      if (url.includes('/skill')) return new Response(skillBytes, { status: 200 });
+      return new Response('', { status: 404 });
+    },
+    async () => {
+      const refs = await verifyPackageBlobRefs(pkg);
+      assert.equal(refs.length, 2);
+      const traceResult = refs.find((r) => r.field === 'trace');
+      const skillResult = refs.find((r) => r.field === 'skillMetadata.skillText');
+      assert.ok(traceResult);
+      assert.ok(skillResult);
+      assert.equal(traceResult!.ok, true);
+      assert.equal(skillResult!.ok, true);
+    },
+  );
+});
+
+test('verifyPackageBlobRefs: tampered content → hash_mismatch reported', async () => {
+  const ref = makeBlobRef('original');
+  const pkg = { output: ref };
+
+  await withStubbedFetch(
+    // Server returns different bytes than the ref commits to
+    async () => new Response('tampered', { status: 200 }),
+    async () => {
+      const refs = await verifyPackageBlobRefs(pkg);
+      assert.equal(refs.length, 1);
+      assert.equal(refs[0].ok, false);
+      // "tampered" has 8 bytes, ref.size commits to 8 ("original" is 8).
+      // So size check passes; hash mismatch is the failure mode.
+      assert.equal(refs[0].reason, 'hash_mismatch');
+    },
+  );
+});
+
+test('verifyPackageBlobRefs: missing blob → fetch_failed reported', async () => {
+  const ref = makeBlobRef('anything');
+  const pkg = { output: ref };
+
+  await withStubbedFetch(
+    async () => new Response('', { status: 404 }),
+    async () => {
+      const refs = await verifyPackageBlobRefs(pkg);
+      assert.equal(refs.length, 1);
+      assert.equal(refs[0].ok, false);
+      assert.equal(refs[0].reason, 'fetch_failed');
+    },
+  );
+});
+
+test('verifyPackageBlobRefs: ignores non-BlobRef objects in the field paths', async () => {
+  // `output` is a string (not a BlobRef), `trace` is a normal object, and
+  // `skillMetadata.skillText` is a string. None should be picked up as a
+  // reference, so no fetch should be attempted (the test would fail with a
+  // real network error if it were).
+  const pkg = {
+    output: 'hello',
+    trace: { resourceSpans: [] },
+    skillMetadata: { skillText: 'plain text' },
+  };
+  const refs = await verifyPackageBlobRefs(pkg);
+  assert.deepEqual(refs, []);
 });

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -3,6 +3,12 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { ed25519ph } from '@noble/curves/ed25519.js';
 import { rekorHashForPackage } from './signing.ts';
+import {
+  isBlobRef,
+  verifyBlobRef,
+  type BlobRef,
+  type BlobRefVerifyReason,
+} from './blob-ref.ts';
 
 // Build-time import of the checked-in trust registry. This is the most
 // reliable source on Vercel: a filesystem read relies on `process.cwd()`
@@ -115,6 +121,78 @@ export async function verifyRekorEntry(
 export function recomputePackageHash(pkg: Record<string, unknown>): string {
   const canonical = JSON.stringify(pkg);
   return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+// --- Blob references (Phase B.6) ---
+//
+// Evidence packages can store large fields as content-addressable blobs
+// rather than inlining the content. Verification downloads each blob and
+// confirms the bytes hash to the advertised ref.
+
+/** Field paths that the core verifier scans for BlobRef objects. */
+const BLOB_REF_FIELDS = [
+  'output',
+  'trace',
+  'skillMetadata.skillText',
+] as const;
+
+export type BlobRefField = (typeof BLOB_REF_FIELDS)[number];
+
+export interface BlobRefVerification {
+  field: BlobRefField;
+  ref: string;
+  url: string;
+  size: number;
+  contentType: string;
+  ok: boolean;
+  reason?: BlobRefVerifyReason;
+}
+
+function pickBlobRef(pkg: Record<string, unknown>, path: BlobRefField): BlobRef | null {
+  const segments = path.split('.');
+  let current: unknown = pkg;
+  for (const segment of segments) {
+    if (current == null || typeof current !== 'object') return null;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return isBlobRef(current) ? current : null;
+}
+
+/**
+ * Walk the package JSON for BlobRef fields, fetch each referenced blob,
+ * and confirm the bytes hash to the advertised ref. Returns per-field
+ * verification results. Used by the slug verify endpoint to surface
+ * content-integrity per reference alongside the package-level signature
+ * and Rekor checks.
+ *
+ * Runs fetches in parallel with a per-blob 15 s timeout. Failures are
+ * reported in the result rather than thrown — one bad reference doesn't
+ * fail the whole verify call.
+ */
+export async function verifyPackageBlobRefs(
+  pkg: Record<string, unknown>,
+): Promise<BlobRefVerification[]> {
+  const refs = BLOB_REF_FIELDS
+    .map((field) => {
+      const ref = pickBlobRef(pkg, field);
+      return ref ? { field, ref } : null;
+    })
+    .filter((x): x is { field: BlobRefField; ref: BlobRef } => x !== null);
+
+  return Promise.all(
+    refs.map(async ({ field, ref }) => {
+      const result = await verifyBlobRef(ref);
+      return {
+        field,
+        ref: ref.ref,
+        url: ref.url,
+        size: ref.size,
+        contentType: ref.contentType,
+        ok: result.ok,
+        reason: result.reason,
+      };
+    }),
+  );
 }
 
 // --- Trust registry ---

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/blob-gc",
+      "schedule": "0 4 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #75.

## Summary

Adds the upstream architectural pattern that #74 (visual artifacts) and #72 (composite bundles) compose with: large/reusable/independently-verifiable evidence package fields can now reference SHA-256-keyed blobs in Vercel Blob instead of inlining content. Backward-compatible — existing inline-content packages remain valid.

## What's in the diff

- **New helper module** — `src/lib/evidence/blob-ref.ts` with `BlobRef` type, `isBlobRef`, `parseBlobRef`, `verifyBlobRef`, `fetchBlobRefText`, `computeBlobRefHash`
- **Presigned-upload endpoint** — `POST /api/blob/upload-token` wrapping `@vercel/blob/client.handleUpload` with NextAuth session check, strict pathname constraint (`evidence-refs/<sha256>[.ext]`), 100 MB cap, `allowOverwrite: true` for idempotent same-hash re-uploads
- **Packager + provenance updates** — `output`, `trace`, `skillMetadata.skillText` now accept `BlobRef`; provenance graph degrades gracefully against empty `resourceSpans` when `trace` is a ref; output-entity hash pulled from the ref itself instead of rehashing
- **Verifier extension** — new `verifyPackageBlobRefs` walks blob-referenced fields, fetches in parallel, verifies SHA-256 + byte size; verify route returns `blobRefsVerified: boolean | null` and `blobRefs: BlobRefVerification[]`
- **Detail page rendering** — server-side eager fetch of `output` BlobRef; "Output stored as blob (verified)" indicator in Provenance Chain card; "Blob-stored fields" row in Resources Used grid when refs are present; lazy fetch for skill text on expand
- **GC cron** — daily 04:00 UTC scan via `vercel.json`, 24h orphan grace window, gated by `Authorization: Bearer $CRON_SECRET`
- **Docs** — `docs/api/evidence-publish.md` updated with the full Blob references section, schema additions for `trace` / `output` / `skillMetadataOverride`, worked example, and a change-log entry dated 2026-04-18

## Verification

- 106/106 tests pass (32 new — `blob-ref.test.ts` 18, `packager.test.ts` 8 BlobRef + backward-compat, `verify.test.ts` 6 for the new scanner)
- `tsc --noEmit` clean
- `next build` succeeds
- Preview backward-compat verified end-to-end — all 4 production packages (`255b8e`, `a9e428`, `ffd99b`, `bd49cc`) verify cleanly on the Vercel preview with `blobRefsVerified: null, blobRefs: []`. Trust registry kid `platform:evidence-2026-04` recognized for all

Fresh BlobRef integration test deferred to post-merge against production (preview-side integration test required Vercel SSO + dual-hostname NextAuth auth, not worth the setup friction for this case given the strong unit-test coverage and clean preview backward-compat).

## Design deviations from the issue spec

1. **`skillMetadataOverride` discriminator** — explicit override is required when `trace` is a `BlobRef` (the packager can't walk spans to extract skill data in that case). Documented in the request schema and the worked example
2. **Strict upload pathname** — `evidence-refs/<sha256>[.ext]` rather than the issue body's open-ended prefix. Pins content-addressability at the path level so `allowOverwrite: true` is safe and the GC's "not referenced" check is straightforward
3. **Tier 1 field set narrow** — only `output`, `trace`, `skillMetadata.skillText` adopt BlobRef in v1. `queries[]` per-query responses (issue Tier 2) left inline for now — adopting requires reworking PROV-O data-entity construction, scoped out of this PR
4. **Cron-based GC** chosen over on-failure cleanup — single path, simpler. 24h grace prevents in-flight publishes from being swept. Reconsider if registry grows past ~10k packages (currently 4)

## Out of scope

- Migrating existing inline-content packages (backward-compat means existing packages remain valid)
- Cross-origin blob serving with content isolation (part of #74's security model)
- Composite bundle generation (#72 — this PR lays the storage primitive)
- Per-blob compression (flagged as a design question in #75; separate enhancement)