### PR TITLE
Add OAuth 2.0 device flow for programmatic auth (#73)

### DIFF
--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -24,39 +24,55 @@ The same endpoint is used whether the caller is the website chat UI, a script, o
 
 ## Authentication
 
-### Pattern
+The endpoint accepts two auth methods. **Bearer tokens are preferred for programmatic clients**; the session cookie path remains working indefinitely for browser flows and one-off curls.
 
-Authentication is handled by [NextAuth](https://next-auth.js.org/) with GitHub as the OAuth provider. The endpoint reads the session via `getServerSession(authOptions)` and requires both:
+### Bearer tokens (preferred, OAuth 2.0 device flow)
 
-- A signed-in session (`session.user.id` must be populated from the GitHub user ID stored in the JWT), and
-- A matching row in the `users` table (populated on first sign-in by the NextAuth `signIn` callback).
+External clients — Claude Code publish skills, CI jobs, local CLIs, anything not running in a signed-in browser — should authenticate with a bearer token obtained through the [device authorization grant (RFC 8628)](https://datatracker.ietf.org/doc/html/rfc8628):
 
-Callers authenticate by presenting the NextAuth session cookie:
+1. **Client starts the flow.** POST `/api/auth/device/code` with a JSON body `{ "name": "my client", "scope": "evidence:publish" }`. The response includes a `device_code` (opaque, client-held), a short `user_code` for the human to type, a `verification_uri`, a `verification_uri_complete` (prefilled with the user code), an `expires_in` (seconds until the codes expire — currently 900 = 15 min), and a polling `interval` (seconds between polls — currently 5).
+2. **User approves in a browser.** The client displays the `user_code` and directs the user to `verification_uri_complete`. The user signs in at civicaitools.org with GitHub if not already signed in, reviews the client name and scope, and clicks **Approve** (or **Deny**).
+3. **Client polls for the token.** POST `/api/auth/device/token` with `{ "device_code": "..." }` at the returned interval. Responses:
+    - `200 OK` with `{ access_token, token_type: "Bearer", expires_at, expires_in, scope }` — approved; save the token.
+    - `400 { "error": "authorization_pending" }` — keep polling.
+    - `400 { "error": "slow_down" }` — client is polling too fast; add 5 seconds to the interval.
+    - `400 { "error": "expired_token" }` — the device code aged out; start over.
+    - `400 { "error": "invalid_grant" }` — unknown or already-exchanged code.
+4. **Use the token.** Send `Authorization: Bearer <access_token>` on subsequent writes to `/api/evidence` and `/api/blob/upload-token`. Tokens are valid for 90 days; re-run the flow when the token expires or is revoked.
 
-- **Development:** `next-auth.session-token`
-- **Production:** `__Secure-next-auth.session-token`
+Tokens are stored server-side as SHA-256 hashes — a database compromise leaks hashes, not usable tokens. Each token carries a scope (currently only `evidence:publish`); future capabilities will introduce new scope names rather than widening the existing one. Tokens can be revoked anytime from the [dashboard Tokens tab](https://www.civicaitools.org/dashboard); a revoked token starts returning `401` on the next request.
 
-### Obtaining a session cookie
+### Session cookie (legacy, browser-friendly)
 
-Sign in at `https://civicaitools.org` with GitHub in a regular browser session, then copy the value of the production cookie (`__Secure-next-auth.session-token`) from browser devtools. Store it in a secret manager (1Password, macOS keychain, `.env.local`) and pass it to the client as a `Cookie` header.
+The endpoint still accepts a NextAuth session cookie — `__Secure-next-auth.session-token` in production, `next-auth.session-token` in development — for browser flows and one-off scripts. Sign in at `https://civicaitools.org` with GitHub, then send the cookie as a `Cookie` header. Cookie-authed writes receive an `X-Auth-Deprecated: cookie` response header and a server-side log line nudging toward bearer tokens; no removal date is set.
 
-Session tokens expire; when a request starts returning `401`, sign in again and replace the stored cookie.
+### Server-side validation
 
-### Programmatic authentication
+Both paths resolve to the same DB user ID used for authorship and dashboard filters. The endpoint requires:
 
-The endpoint does not currently accept a personal access token, bearer token, or OAuth device-flow credential. Any external client must present a valid NextAuth session cookie. See [known chat-flow assumptions](#known-chat-flow-assumptions) and the follow-up issue link at the bottom of this document for the longer-term path.
+- A valid bearer token with scope `evidence:publish` and non-null `expires_at > now`, OR
+- A signed-in NextAuth session whose GitHub ID matches a row in the `users` table (populated on first sign-in by the NextAuth `signIn` callback).
+
+When both are presented, the bearer token takes precedence (an invalid bearer does **not** fall through to cookie auth — the request returns `401`).
+
+### Claude Code publish skill
+
+The bundled Claude Code skill at `civic-ai-tools/.claude/skills/publish-evidence/` ships a `publish.py` wrapper that implements all of the above. Run `publish.py --login` to execute the device flow and save a token to `~/.config/civic-ai-tools/credentials.json` (mode 0600); subsequent `publish.py --payload ...` calls pick it up automatically. See `civic-ai-tools/docs/publish-evidence.md` for the user walkthrough.
 
 ---
 
 ## Request
 
-| Property       | Value                                                                 |
-|----------------|-----------------------------------------------------------------------|
-| Method         | `POST`                                                                |
-| Path           | `/api/evidence`                                                       |
-| `Content-Type` | `application/json`                                                    |
-| `Cookie`       | `__Secure-next-auth.session-token=<token>` (production)               |
-| Body           | JSON object matching the [request body schema](#request-body-schema)  |
+| Property        | Value                                                                         |
+|-----------------|-------------------------------------------------------------------------------|
+| Method          | `POST`                                                                        |
+| Path            | `/api/evidence`                                                               |
+| `Content-Type`  | `application/json`                                                            |
+| `Authorization` | `Bearer <access_token>` (preferred) — obtained via the [device flow](#bearer-tokens-preferred-oauth-20-device-flow). |
+| `Cookie`        | `__Secure-next-auth.session-token=<token>` (legacy, production cookie name)   |
+| Body            | JSON object matching the [request body schema](#request-body-schema)          |
+
+Send exactly one auth header — when both are present, the `Authorization` header wins.
 
 ### Request body schema
 
@@ -289,7 +305,8 @@ Callers publishing through `POST /api/evidence` do not set these themselves — 
 
 | Status | Body                                                              | Cause                                                                                           |
 |--------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| `401`  | `{ "error": "Authentication required" }`                          | Missing or invalid NextAuth session cookie.                                                     |
+| `401`  | `{ "error": "Authentication required" }`                          | Missing, invalid, expired, or revoked bearer token; or missing/invalid NextAuth session cookie. |
+| `403`  | `{ "error": "Token missing required scope: evidence:publish" }`   | Bearer token is valid but does not hold the `evidence:publish` scope.                           |
 | `404`  | `{ "error": "User not found in database" }`                       | Session is valid but the user record has not been provisioned (can occur if `DATABASE_URL` was unset when the user first signed in — a re-sign-in fixes it). |
 | `500`  | `{ "error": "<message>" }` with `<message>` from the thrown error | Database, blob storage, or evidence-package-building failure.                                    |
 
@@ -310,12 +327,16 @@ Signing, RFC 3161 timestamp, and Rekor submission are non-blocking. Failures for
 ### 1. Publish an analysis with `curl`
 
 ```bash
-# Assumes $SESSION_COOKIE holds the value of __Secure-next-auth.session-token
-# from a signed-in civicaitools.org browser session.
+# Preferred: $CIVIC_EVIDENCE_TOKEN holds a bearer token obtained via
+# `publish.py --login` or a direct device-flow exchange against
+# /api/auth/device/{code,token}.
+#
+# Legacy alternative: replace `-H "Authorization: Bearer ..."` with
+# `-H "Cookie: __Secure-next-auth.session-token=${SESSION_COOKIE}"`.
 
 curl -sS -X POST https://civicaitools.org/api/evidence \
   -H "Content-Type: application/json" \
-  -H "Cookie: __Secure-next-auth.session-token=${SESSION_COOKIE}" \
+  -H "Authorization: Bearer ${CIVIC_EVIDENCE_TOKEN}" \
   -d '{
     "trace": { "resourceSpans": [] },
     "prompt": "How many 311 noise complaints did Manhattan receive last year?",
@@ -396,7 +417,10 @@ const res = await fetch('https://civicaitools.org/api/evidence', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Cookie': `__Secure-next-auth.session-token=${process.env.CIVIC_EVIDENCE_SESSION_COOKIE}`,
+    // Preferred bearer path:
+    'Authorization': `Bearer ${process.env.CIVIC_EVIDENCE_TOKEN}`,
+    // Legacy alternative (cookie):
+    // 'Cookie': `__Secure-next-auth.session-token=${process.env.CIVIC_EVIDENCE_SESSION_COOKIE}`,
   },
   body: JSON.stringify({
     trace: { resourceSpans: [] },
@@ -427,7 +451,7 @@ const { slug, url, packageHash } = await res.json();
 
 These are implementation details that may surprise an external client. None of them currently block external publishing; each is called out so a client author can make an informed choice.
 
-1. **Session-cookie-only authentication.** The endpoint has no bearer-token, API-key, or device-flow path. A client must reuse a cookie minted through GitHub OAuth in a browser. This is fine for single-developer use but awkward for automation. Tracked for follow-up work in [civic-ai-tools-website#73](https://github.com/npstorey/civic-ai-tools-website/issues/73) — programmatic authentication for external evidence publishers.
+1. ~~Session-cookie-only authentication.~~ **Resolved.** The endpoint now accepts OAuth 2.0 device-flow bearer tokens — see [Authentication](#authentication). Session cookies remain supported for backwards compatibility and one-off curls but carry an `X-Auth-Deprecated: cookie` response header. Issue [civic-ai-tools-website#73](https://github.com/npstorey/civic-ai-tools-website/issues/73) is closed.
 2. **`portal` is required but only meaningful for Socrata.** For Data Commons-only or other non-Socrata analyses, the field still has to be set; `"n/a"` or another placeholder is accepted. Relaxing this requires a schema change and is not in scope for the publish-schema documentation work.
 3. **`trace` format is OpenTelemetry JSON.** External clients that do not run OpenTelemetry internally can send `{ "resourceSpans": [] }`; per-source provenance will fall back to the static tool-name → source map (`get_data`/`search`/`fetch` → Socrata, `search_indicators`/`get_observations` → Data Commons). New tools added to the registry will need either the static map updated or a real trace.
 4. **Slug derivation is content-addressable, not user-provided.** The endpoint derives the URL slug from the title and the package hash. Clients cannot request a specific slug. A title change produces a different package hash only if the title is stored inside the package JSON — which it is not today (title and summary live on the database row, not in the canonical JSON), so re-publishing with a different title creates a different `evidence_records` row but an identical blob.
@@ -437,6 +461,7 @@ These are implementation details that may surprise an external client. None of t
 
 ## Change log
 
+- **2026-04-21** — Added OAuth 2.0 device-flow bearer-token authentication (closes [#73](https://github.com/npstorey/civic-ai-tools-website/issues/73)). New endpoints: `POST /api/auth/device/code` (start), `POST /api/auth/device/token` (poll), `POST /api/auth/device/approve` (user-facing), `GET /api/auth/device/lookup` (user-facing prefill), `GET /api/auth/tokens` (list), `DELETE /api/auth/tokens/:id` (revoke). Clients send `Authorization: Bearer <token>` on `POST /api/evidence` and `POST /api/blob/upload-token`; scope `evidence:publish` is required. Tokens live 90 days by default, are stored server-side as SHA-256 hashes, and can be revoked from the Dashboard **Tokens** tab. Session-cookie auth remains working indefinitely but now emits `X-Auth-Deprecated: cookie` on each cookie-authed response. Backwards-compatible — existing cookie-based clients continue working without changes.
 - **2026-04-18** — Added the [Blob references (Phase B.6)](#blob-references-phase-b6) section. The `output`, `trace`, and `skillMetadataOverride.skillText` request fields now accept either inline content or a BlobRef `{ ref, url, contentType, size }` object; the verify endpoint returns per-reference `blobRefs[]` entries alongside the existing verdicts. A new `POST /api/blob/upload-token` endpoint mints presigned tokens for direct client uploads to `evidence-refs/<sha256>[.ext]`, gated by the same NextAuth session as `/api/evidence`. Orphan blobs are swept by a daily cron (`/api/cron/blob-gc`). Backwards-compatible — existing inline-content packages remain valid and the verify response adds fields rather than renaming any.
 - **2026-04-18** — Added the [Signing and trust registry](#signing-and-trust-registry) section. Documents the `metadata.signingKeyId` field now included in the canonical package hash, the `/.well-known/evidence-public-keys.json` registry endpoint, the `keyTrust` verdicts returned by `GET /api/evidence/<slug>/verify` (including the new `legacy_embedded` state for pre-registry packages), and the signing-side env vars (`EVIDENCE_SIGNING_KEY`, `EVIDENCE_KEY_ID`, `EVIDENCE_PUBLIC_KEY`, `EVIDENCE_TRUST_REGISTRY_URL`). Backwards-compatible at the publish path — clients do not need any changes.
 - **2026-04-17** — Initial documentation published. Tracks the endpoint as of commit [`a8cdc8c`](https://github.com/npstorey/civic-ai-tools-website/commit/a8cdc8c) (M9.3 ship, v0.7.0).

--- a/drizzle/0006_mixed_sabra.sql
+++ b/drizzle/0006_mixed_sabra.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "api_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token_hash" text NOT NULL,
+	"token_prefix" text NOT NULL,
+	"name" text NOT NULL,
+	"scope" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "api_tokens_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "device_codes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"device_code" text NOT NULL,
+	"user_code" text NOT NULL,
+	"client_name" text NOT NULL,
+	"scope" text NOT NULL,
+	"approved_user_id" uuid,
+	"approved_at" timestamp with time zone,
+	"consumed_at" timestamp with time zone,
+	"last_polled_at" timestamp with time zone,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "device_codes_device_code_unique" UNIQUE("device_code"),
+	CONSTRAINT "device_codes_user_code_unique" UNIQUE("user_code")
+);
+--> statement-breakpoint
+ALTER TABLE "api_tokens" ADD CONSTRAINT "api_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "device_codes" ADD CONSTRAINT "device_codes_approved_user_id_users_id_fk" FOREIGN KEY ("approved_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,645 @@
+{
+  "id": "67d689ab-8037-40d3-bd33-20ec7c1d9d24",
+  "prevId": "6fbaff60-690a-489b-84fc-0bc2143538fd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_packages": {
+      "name": "attestation_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evidence_record_id": {
+          "name": "evidence_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attestation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_hash": {
+          "name": "package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references_base_hash": {
+          "name": "references_base_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_packages_evidence_record_id_evidence_records_id_fk": {
+          "name": "attestation_packages_evidence_record_id_evidence_records_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "evidence_records",
+          "columnsFrom": [
+            "evidence_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attestation_packages_creator_id_users_id_fk": {
+          "name": "attestation_packages_creator_id_users_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_approved_user_id_users_id_fk": {
+          "name": "device_codes_approved_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_records": {
+      "name": "evidence_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_visibility": {
+          "name": "prompt_visibility",
+          "type": "prompt_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_text'"
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_server": {
+          "name": "mcp_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civic_context": {
+          "name": "civic_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_hash": {
+          "name": "base_package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_storage_key": {
+          "name": "base_package_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_signature": {
+          "name": "base_package_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rfc3161_timestamp": {
+          "name": "base_package_rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_id": {
+          "name": "base_package_rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_inclusion_proof": {
+          "name": "base_package_rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "consistency_classification": {
+          "name": "consistency_classification",
+          "type": "consistency_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_reason": {
+          "name": "withdrawn_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_signature": {
+          "name": "withdrawal_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_timestamp": {
+          "name": "withdrawal_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_reason": {
+          "name": "reinstated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_signature": {
+          "name": "reinstatement_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_timestamp": {
+          "name": "reinstatement_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evidence_records_creator_id_users_id_fk": {
+          "name": "evidence_records_creator_id_users_id_fk",
+          "tableFrom": "evidence_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evidence_records_slug_unique": {
+          "name": "evidence_records_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attestation_type": {
+      "name": "attestation_type",
+      "schema": "public",
+      "values": [
+        "consistency",
+        "evaluation",
+        "re_evaluation",
+        "correction",
+        "expert_attestation"
+      ]
+    },
+    "public.consistency_classification": {
+      "name": "consistency_classification",
+      "schema": "public",
+      "values": [
+        "highly_reproducible",
+        "moderately_stable",
+        "inconsistent"
+      ]
+    },
+    "public.prompt_visibility": {
+      "name": "prompt_visibility",
+      "schema": "public",
+      "values": [
+        "full_text",
+        "hash_only"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "consistency_tested",
+        "evaluated",
+        "fully_attested"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776535815723,
       "tag": "0005_add_expert_attestation_enum",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776731843403,
+      "tag": "0006_mixed_sabra",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/auth/device/approve/route.ts
+++ b/src/app/api/auth/device/approve/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { eq } from 'drizzle-orm';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { deviceCodes, users } from '@/lib/db/schema';
+import { normalizeUserCode } from '@/lib/device-flow';
+
+/**
+ * User-facing approval endpoint. Called from /auth/device when the
+ * signed-in user clicks "Allow". Requires a NextAuth session cookie
+ * (never a bearer token — you can't approve your own token mint).
+ *
+ * Same-origin-only: checks the Origin header matches the deployment's
+ * base URL so a cross-site POST (with user's cookie) can't auto-approve
+ * an attacker-controlled device code.
+ */
+
+interface ApproveRequest {
+  user_code?: string;
+  decision?: 'approve' | 'deny';
+}
+
+function sameOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get('origin');
+  if (!origin) return false;
+  const expected = process.env.NEXTAUTH_URL;
+  if (!expected) {
+    // Dev fallback: allow the request's own host.
+    const host = request.headers.get('host');
+    return !!host && origin.endsWith(host);
+  }
+  return origin === expected.replace(/\/+$/, '');
+}
+
+export async function POST(request: NextRequest) {
+  if (!sameOrigin(request)) {
+    return NextResponse.json({ error: 'Forbidden (cross-origin)' }, { status: 403 });
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  let body: ApproveRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const userCode = normalizeUserCode(body.user_code ?? '');
+  if (!userCode) {
+    return NextResponse.json(
+      { error: 'Enter an 8-character code (e.g. ABCD-EFGH)' },
+      { status: 400 },
+    );
+  }
+
+  const decision = body.decision === 'deny' ? 'deny' : 'approve';
+
+  const rows = await db
+    .select()
+    .from(deviceCodes)
+    .where(eq(deviceCodes.userCode, userCode))
+    .limit(1);
+  if (rows.length === 0) {
+    return NextResponse.json(
+      { error: 'That code is not valid. Ask the client to start over.' },
+      { status: 404 },
+    );
+  }
+  const row = rows[0];
+
+  if (row.expiresAt.getTime() <= Date.now()) {
+    return NextResponse.json(
+      { error: 'That code has expired. Ask the client to start over.' },
+      { status: 410 },
+    );
+  }
+  if (row.approvedAt || row.consumedAt) {
+    return NextResponse.json(
+      { error: 'That code has already been used.' },
+      { status: 409 },
+    );
+  }
+
+  if (decision === 'deny') {
+    // Mark the row expired so the polling client sees `expired_token`
+    // rather than `authorization_pending` forever. We don't store a
+    // distinct "denied" state today — the signal to the client is the
+    // same: try again.
+    await db
+      .update(deviceCodes)
+      .set({ expiresAt: new Date() })
+      .where(eq(deviceCodes.id, row.id));
+    return NextResponse.json({ ok: true, decision: 'deny' });
+  }
+
+  // Approve. Look up the DB user ID from the GitHub ID in the session.
+  const githubId = session.user.id;
+  const dbUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.githubId, githubId))
+    .limit(1);
+  if (dbUser.length === 0) {
+    return NextResponse.json({ error: 'User not found in database' }, { status: 404 });
+  }
+  await db
+    .update(deviceCodes)
+    .set({ approvedUserId: dbUser[0].id, approvedAt: new Date() })
+    .where(eq(deviceCodes.id, row.id));
+
+  return NextResponse.json({
+    ok: true,
+    decision: 'approve',
+    clientName: row.clientName,
+    scope: row.scope,
+  });
+}

--- a/src/app/api/auth/device/code/route.ts
+++ b/src/app/api/auth/device/code/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { deviceCodes } from '@/lib/db/schema';
+import {
+  DEVICE_CODE_LIFETIME_SECONDS,
+  DEVICE_CODE_POLL_INTERVAL_SECONDS,
+  buildVerificationUri,
+  buildVerificationUriComplete,
+  generateDeviceCode,
+  generateUserCode,
+  getBaseUrl,
+} from '@/lib/device-flow';
+
+/**
+ * Device authorization grant start (RFC 8628 §3.1).
+ *
+ * A client posts `{ name, scope }` and receives a device_code,
+ * user_code, and the verification URL to display to the user. The
+ * client then polls /api/auth/device/token with the device_code until
+ * the user approves the flow in a browser.
+ */
+
+interface DeviceCodeRequest {
+  name?: string;
+  scope?: string;
+}
+
+const ALLOWED_SCOPES = new Set(['evidence:publish']);
+const MAX_NAME_LENGTH = 80;
+const MAX_USER_CODE_COLLISION_RETRIES = 5;
+
+export async function POST(request: NextRequest) {
+  let body: DeviceCodeRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+
+  const scope = (body.scope ?? 'evidence:publish').trim();
+  if (!ALLOWED_SCOPES.has(scope)) {
+    return NextResponse.json(
+      { error: 'invalid_scope', error_description: `Unknown scope: ${scope}` },
+      { status: 400 },
+    );
+  }
+
+  const rawName = (body.name ?? '').trim();
+  if (!rawName) {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: '`name` is required' },
+      { status: 400 },
+    );
+  }
+  const clientName = rawName.slice(0, MAX_NAME_LENGTH);
+
+  const deviceCode = generateDeviceCode();
+  const expiresAt = new Date(Date.now() + DEVICE_CODE_LIFETIME_SECONDS * 1000);
+
+  // Retry on the extraordinarily unlikely event of a user_code collision.
+  // Unique constraint makes this safe; we just want a nicer error than
+  // 500 if it does happen.
+  let userCode = '';
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < MAX_USER_CODE_COLLISION_RETRIES; attempt++) {
+    userCode = generateUserCode();
+    try {
+      await db.insert(deviceCodes).values({
+        deviceCode,
+        userCode,
+        clientName,
+        scope,
+        expiresAt,
+      });
+      lastError = null;
+      break;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  if (lastError) {
+    console.error('[api/auth/device/code] insert failed after retries', lastError);
+    return NextResponse.json(
+      { error: 'server_error', error_description: 'Could not allocate device code' },
+      { status: 500 },
+    );
+  }
+
+  const baseUrl = getBaseUrl(request);
+  return NextResponse.json({
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: buildVerificationUri(baseUrl),
+    verification_uri_complete: buildVerificationUriComplete(baseUrl, userCode),
+    expires_in: DEVICE_CODE_LIFETIME_SECONDS,
+    interval: DEVICE_CODE_POLL_INTERVAL_SECONDS,
+    scope,
+  });
+}

--- a/src/app/api/auth/device/lookup/route.ts
+++ b/src/app/api/auth/device/lookup/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { eq } from 'drizzle-orm';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { deviceCodes } from '@/lib/db/schema';
+import { normalizeUserCode } from '@/lib/device-flow';
+
+/**
+ * Lookup a device code by user_code so the /auth/device page can show
+ * "You're about to authorize `<client name>` with scope `<scope>`" before
+ * the user clicks Approve. Session-authed; returns only display-safe
+ * fields.
+ */
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  const userCodeParam = request.nextUrl.searchParams.get('user_code') ?? '';
+  const userCode = normalizeUserCode(userCodeParam);
+  if (!userCode) {
+    return NextResponse.json(
+      { error: 'Enter an 8-character code (e.g. ABCD-EFGH)' },
+      { status: 400 },
+    );
+  }
+
+  const rows = await db
+    .select({
+      clientName: deviceCodes.clientName,
+      scope: deviceCodes.scope,
+      approvedAt: deviceCodes.approvedAt,
+      consumedAt: deviceCodes.consumedAt,
+      expiresAt: deviceCodes.expiresAt,
+    })
+    .from(deviceCodes)
+    .where(eq(deviceCodes.userCode, userCode))
+    .limit(1);
+  if (rows.length === 0) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+  const row = rows[0];
+  const now = Date.now();
+  if (row.expiresAt.getTime() <= now) {
+    return NextResponse.json({ error: 'expired' }, { status: 410 });
+  }
+  if (row.consumedAt || row.approvedAt) {
+    return NextResponse.json({ error: 'already_used' }, { status: 409 });
+  }
+  return NextResponse.json({
+    userCode,
+    clientName: row.clientName,
+    scope: row.scope,
+    expiresAt: row.expiresAt.toISOString(),
+  });
+}

--- a/src/app/api/auth/device/token/route.ts
+++ b/src/app/api/auth/device/token/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { apiTokens, deviceCodes } from '@/lib/db/schema';
+import { mintRawToken } from '@/lib/api-auth';
+import {
+  API_TOKEN_LIFETIME_SECONDS,
+  DEVICE_CODE_POLL_INTERVAL_SECONDS,
+  DEVICE_CODE_SLOW_DOWN_INCREMENT_SECONDS,
+} from '@/lib/device-flow';
+
+/**
+ * Device authorization grant polling endpoint (RFC 8628 §3.4).
+ *
+ * Clients POST `{ device_code }` at the interval returned from
+ * /api/auth/device/code. Responses:
+ *
+ *   - 400 `authorization_pending` — user hasn't approved yet, keep polling
+ *   - 400 `slow_down` — client is polling too fast, add 5s to interval
+ *   - 400 `expired_token` — device_code has aged out (>15 min)
+ *   - 400 `access_denied` — code was denied (no DB row for this)
+ *   - 400 `invalid_grant` — unknown or already-consumed code
+ *   - 200 `{ access_token, token_type, expires_at, scope }` — approved
+ */
+
+interface TokenRequest {
+  device_code?: string;
+}
+
+export async function POST(request: NextRequest) {
+  let body: TokenRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+
+  const deviceCode = (body.device_code ?? '').trim();
+  if (!deviceCode) {
+    return NextResponse.json(
+      { error: 'invalid_request', error_description: '`device_code` is required' },
+      { status: 400 },
+    );
+  }
+
+  const rows = await db
+    .select()
+    .from(deviceCodes)
+    .where(eq(deviceCodes.deviceCode, deviceCode))
+    .limit(1);
+  if (rows.length === 0) {
+    return NextResponse.json({ error: 'invalid_grant' }, { status: 400 });
+  }
+  const row = rows[0];
+
+  // Polling too fast — enforce the minimum interval from RFC 8628.
+  const now = new Date();
+  const lastPolled = row.lastPolledAt?.getTime() ?? 0;
+  if (
+    lastPolled &&
+    now.getTime() - lastPolled < DEVICE_CODE_POLL_INTERVAL_SECONDS * 1000
+  ) {
+    await db
+      .update(deviceCodes)
+      .set({ lastPolledAt: now })
+      .where(eq(deviceCodes.id, row.id));
+    return NextResponse.json(
+      {
+        error: 'slow_down',
+        error_description: `Poll no faster than every ${DEVICE_CODE_POLL_INTERVAL_SECONDS + DEVICE_CODE_SLOW_DOWN_INCREMENT_SECONDS}s`,
+      },
+      { status: 400 },
+    );
+  }
+
+  // Record this poll for the next round's rate check.
+  await db
+    .update(deviceCodes)
+    .set({ lastPolledAt: now })
+    .where(eq(deviceCodes.id, row.id));
+
+  if (row.consumedAt) {
+    return NextResponse.json(
+      {
+        error: 'invalid_grant',
+        error_description: 'Device code already exchanged for a token',
+      },
+      { status: 400 },
+    );
+  }
+
+  if (row.expiresAt.getTime() <= now.getTime()) {
+    return NextResponse.json({ error: 'expired_token' }, { status: 400 });
+  }
+
+  if (!row.approvedUserId || !row.approvedAt) {
+    return NextResponse.json({ error: 'authorization_pending' }, { status: 400 });
+  }
+
+  // Approved — mint the bearer token and consume the device code.
+  const { raw, hash, prefix } = mintRawToken();
+  const tokenExpiresAt = new Date(Date.now() + API_TOKEN_LIFETIME_SECONDS * 1000);
+  await db.insert(apiTokens).values({
+    userId: row.approvedUserId,
+    tokenHash: hash,
+    tokenPrefix: prefix,
+    name: row.clientName,
+    scope: row.scope,
+    expiresAt: tokenExpiresAt,
+  });
+  await db
+    .update(deviceCodes)
+    .set({ consumedAt: now })
+    .where(eq(deviceCodes.id, row.id));
+
+  return NextResponse.json({
+    access_token: raw,
+    token_type: 'Bearer',
+    expires_at: tokenExpiresAt.toISOString(),
+    expires_in: API_TOKEN_LIFETIME_SECONDS,
+    scope: row.scope,
+  });
+}

--- a/src/app/api/auth/tokens/[id]/route.ts
+++ b/src/app/api/auth/tokens/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { and, eq, isNull } from 'drizzle-orm';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { apiTokens, users } from '@/lib/db/schema';
+
+/**
+ * DELETE /api/auth/tokens/:id — revoke a token the caller owns.
+ *
+ * Session-authed only. Ownership is enforced by the WHERE clause so a
+ * caller can't revoke another user's token.
+ */
+
+function sameOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get('origin');
+  if (!origin) return false;
+  const expected = process.env.NEXTAUTH_URL;
+  if (!expected) {
+    const host = request.headers.get('host');
+    return !!host && origin.endsWith(host);
+  }
+  return origin === expected.replace(/\/+$/, '');
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!sameOrigin(request)) {
+    return NextResponse.json({ error: 'Forbidden (cross-origin)' }, { status: 403 });
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: 'Missing token id' }, { status: 400 });
+  }
+
+  const githubId = session.user.id;
+  const dbUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.githubId, githubId))
+    .limit(1);
+  if (dbUser.length === 0) {
+    return NextResponse.json({ error: 'User not found in database' }, { status: 404 });
+  }
+
+  const result = await db
+    .update(apiTokens)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(apiTokens.id, id),
+        eq(apiTokens.userId, dbUser[0].id),
+        isNull(apiTokens.revokedAt),
+      ),
+    )
+    .returning({ id: apiTokens.id });
+
+  if (result.length === 0) {
+    return NextResponse.json(
+      { error: 'Token not found or already revoked' },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, id: result[0].id });
+}

--- a/src/app/api/auth/tokens/route.ts
+++ b/src/app/api/auth/tokens/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { apiTokens, users } from '@/lib/db/schema';
+
+/**
+ * GET /api/auth/tokens — list the caller's active tokens.
+ *
+ * Session-authed only (no self-listing via bearer — prevents a stolen
+ * token from enumerating siblings). Returns display-safe fields only;
+ * the raw token is never stored server-side, so it can't be surfaced
+ * here.
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  const githubId = session.user.id;
+  const dbUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.githubId, githubId))
+    .limit(1);
+  if (dbUser.length === 0) {
+    return NextResponse.json({ error: 'User not found in database' }, { status: 404 });
+  }
+
+  const rows = await db
+    .select({
+      id: apiTokens.id,
+      name: apiTokens.name,
+      tokenPrefix: apiTokens.tokenPrefix,
+      scope: apiTokens.scope,
+      createdAt: apiTokens.createdAt,
+      expiresAt: apiTokens.expiresAt,
+      lastUsedAt: apiTokens.lastUsedAt,
+    })
+    .from(apiTokens)
+    .where(
+      and(eq(apiTokens.userId, dbUser[0].id), isNull(apiTokens.revokedAt)),
+    )
+    .orderBy(desc(apiTokens.createdAt));
+
+  return NextResponse.json({
+    tokens: rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      tokenPrefix: r.tokenPrefix,
+      scope: r.scope,
+      createdAt: r.createdAt.toISOString(),
+      expiresAt: r.expiresAt.toISOString(),
+      lastUsedAt: r.lastUsedAt?.toISOString() ?? null,
+    })),
+  });
+}

--- a/src/app/api/blob/upload-token/route.ts
+++ b/src/app/api/blob/upload-token/route.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client';
-import { authOptions } from '@/lib/auth';
-import { db } from '@/lib/db';
-import { users } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { resolveRequestUser, hasScope } from '@/lib/api-auth';
 
 /**
  * Presigned client-upload endpoint for evidence blob references
@@ -53,20 +49,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       onBeforeGenerateToken: async (pathname) => {
         // Authentication: same pattern as /api/evidence. Reject anonymous
         // uploads before minting the presigned token — otherwise the
-        // evidence blob store is open to the world.
-        const session = await getServerSession(authOptions);
-        if (!session?.user?.id) {
+        // evidence blob store is open to the world. Accepts either a
+        // bearer token (preferred, device-flow minted, website#73) or a
+        // NextAuth session cookie.
+        const auth = await resolveRequestUser(request);
+        if (!auth) {
           throw new Error('Authentication required');
         }
-
-        const githubId = session.user.id;
-        const dbUser = await db
-          .select({ id: users.id })
-          .from(users)
-          .where(eq(users.githubId, githubId))
-          .limit(1);
-        if (dbUser.length === 0) {
-          throw new Error('User not found in database');
+        if (!hasScope(auth, 'evidence:publish')) {
+          throw new Error('Token missing required scope: evidence:publish');
         }
 
         // Pathname validation: lock uploads to `evidence-refs/<sha256>[.ext]`.
@@ -91,7 +82,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           // exists" errors when a user republishes similar content.
           allowOverwrite: true,
           tokenPayload: JSON.stringify({
-            userId: dbUser[0].id,
+            userId: auth.userId,
             pathname,
           }),
         };

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { users, evidenceRecords } from '@/lib/db/schema';
+import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { putPackage } from '@/lib/storage';
 import { buildEvidencePackage, type PackageInput } from '@/lib/evidence/packager';
 import { hash } from '@/lib/evidence/trace';
 import { signPackage, getRfc3161Timestamp, publishToRekor } from '@/lib/evidence/signing';
 import { type BlobRef } from '@/lib/evidence/blob-ref';
+import { resolveRequestUser, hasScope } from '@/lib/api-auth';
 
 function slugify(text: string): string {
   return text
@@ -79,24 +78,17 @@ interface PublishRequest {
 
 export async function POST(request: NextRequest) {
   try {
-    // Require authentication
-    const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
+    const auth = await resolveRequestUser(request);
+    if (!auth) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
-
-    // Look up internal DB user ID
-    const githubId = session.user.id;
-    const dbUser = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(eq(users.githubId, githubId))
-      .limit(1);
-
-    if (dbUser.length === 0) {
-      return NextResponse.json({ error: 'User not found in database' }, { status: 404 });
+    if (!hasScope(auth, 'evidence:publish')) {
+      return NextResponse.json(
+        { error: 'Token missing required scope: evidence:publish' },
+        { status: 403 },
+      );
     }
-    const userId = dbUser[0].id;
+    const userId = auth.userId;
 
     const body: PublishRequest = await request.json();
 
@@ -167,11 +159,20 @@ export async function POST(request: NextRequest) {
       basePackageRekorInclusionProof: rekorResult?.inclusionProof || null,
     });
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       slug,
       url: `/evidence/${slug}`,
       packageHash,
     });
+    if (auth.method === 'cookie') {
+      // Nudge toward programmatic device-flow tokens for non-browser
+      // clients. See docs/api/evidence-publish.md#authentication.
+      response.headers.set('X-Auth-Deprecated', 'cookie');
+      console.log('[api/evidence] cookie-auth publish (deprecated path)', {
+        userId,
+      });
+    }
+    return response;
   } catch (error) {
     console.error('Evidence publish error:', error);
     return NextResponse.json(

--- a/src/app/auth/device/DeviceApprovalPanel.tsx
+++ b/src/app/auth/device/DeviceApprovalPanel.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+interface LookupResponse {
+  userCode: string;
+  clientName: string;
+  scope: string;
+  expiresAt: string;
+}
+
+interface ApproveResponse {
+  ok: true;
+  decision: 'approve' | 'deny';
+  clientName?: string;
+  scope?: string;
+}
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'looking_up'; userCode: string }
+  | { kind: 'confirm'; info: LookupResponse }
+  | { kind: 'approving'; info: LookupResponse }
+  | { kind: 'approved'; info: LookupResponse }
+  | { kind: 'denied'; info: LookupResponse }
+  | { kind: 'error'; message: string };
+
+interface DeviceApprovalPanelProps {
+  initialUserCode: string;
+}
+
+const panelStyle: React.CSSProperties = {
+  padding: '20px',
+  border: '1px solid var(--border-color)',
+  borderRadius: '6px',
+  marginBottom: '16px',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: '13px',
+  fontWeight: 600,
+  marginBottom: '6px',
+  color: 'var(--text-primary)',
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  border: '1px solid var(--border-color)',
+  borderRadius: '4px',
+  fontSize: '16px',
+  fontFamily: 'monospace',
+  boxSizing: 'border-box',
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+};
+
+const buttonPrimary: React.CSSProperties = {
+  padding: '10px 18px',
+  border: 'none',
+  borderRadius: '4px',
+  fontSize: '14px',
+  fontWeight: 600,
+  cursor: 'pointer',
+  backgroundColor: 'var(--nyc-blue)',
+  color: 'white',
+};
+
+const buttonDanger: React.CSSProperties = {
+  ...buttonPrimary,
+  backgroundColor: 'var(--nyc-error)',
+};
+
+const buttonSecondary: React.CSSProperties = {
+  padding: '10px 18px',
+  border: '1px solid var(--border-color)',
+  borderRadius: '4px',
+  fontSize: '14px',
+  cursor: 'pointer',
+  backgroundColor: 'white',
+  color: 'var(--text-secondary)',
+};
+
+export default function DeviceApprovalPanel({
+  initialUserCode,
+}: DeviceApprovalPanelProps) {
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+  const [inputCode, setInputCode] = useState(initialUserCode);
+
+  const lookup = useCallback(async (userCode: string) => {
+    setPhase({ kind: 'looking_up', userCode });
+    try {
+      const res = await fetch(
+        `/api/auth/device/lookup?user_code=${encodeURIComponent(userCode)}`,
+      );
+      if (res.status === 404) {
+        setPhase({
+          kind: 'error',
+          message: 'That code is not valid. Ask the client to start over.',
+        });
+        return;
+      }
+      if (res.status === 410) {
+        setPhase({
+          kind: 'error',
+          message: 'That code has expired. Ask the client to start over.',
+        });
+        return;
+      }
+      if (res.status === 409) {
+        setPhase({
+          kind: 'error',
+          message: 'That code has already been used.',
+        });
+        return;
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: 'Lookup failed' }));
+        setPhase({
+          kind: 'error',
+          message: body.error || 'Lookup failed. Try again.',
+        });
+        return;
+      }
+      const info = (await res.json()) as LookupResponse;
+      setPhase({ kind: 'confirm', info });
+    } catch (err) {
+      setPhase({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Lookup failed',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initialUserCode) return;
+    // Defer to a microtask so the initial setState in `lookup` isn't
+    // synchronous with the render/effect cycle (avoids the
+    // set-state-in-effect lint rule and keeps the mount render clean).
+    const id = setTimeout(() => {
+      void lookup(initialUserCode);
+    }, 0);
+    return () => clearTimeout(id);
+  }, [initialUserCode, lookup]);
+
+  const submitCode = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const cleaned = inputCode.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+      if (cleaned.length !== 8) {
+        setPhase({
+          kind: 'error',
+          message: 'Enter the 8-character code shown by your client.',
+        });
+        return;
+      }
+      const formatted = `${cleaned.slice(0, 4)}-${cleaned.slice(4)}`;
+      void lookup(formatted);
+    },
+    [inputCode, lookup],
+  );
+
+  const act = useCallback(
+    async (info: LookupResponse, decision: 'approve' | 'deny') => {
+      setPhase({ kind: 'approving', info });
+      try {
+        const res = await fetch('/api/auth/device/approve', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user_code: info.userCode, decision }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Action failed' }));
+          setPhase({ kind: 'error', message: body.error || 'Action failed' });
+          return;
+        }
+        const result = (await res.json()) as ApproveResponse;
+        setPhase({
+          kind: result.decision === 'approve' ? 'approved' : 'denied',
+          info,
+        });
+      } catch (err) {
+        setPhase({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Action failed',
+        });
+      }
+    },
+    [],
+  );
+
+  if (phase.kind === 'approved') {
+    return (
+      <div style={panelStyle}>
+        <h2 style={{ fontSize: '18px', fontWeight: 600, marginBottom: '8px' }}>
+          Approved
+        </h2>
+        <p style={{ fontSize: '14px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+          <strong>{phase.info.clientName}</strong> is now authorized with scope{' '}
+          <code>{phase.info.scope}</code>. Return to your client — it should
+          receive a bearer token within a few seconds.
+        </p>
+      </div>
+    );
+  }
+
+  if (phase.kind === 'denied') {
+    return (
+      <div style={panelStyle}>
+        <h2 style={{ fontSize: '18px', fontWeight: 600, marginBottom: '8px' }}>
+          Denied
+        </h2>
+        <p style={{ fontSize: '14px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+          The request from <strong>{phase.info.clientName}</strong> was denied.
+          The device code has been invalidated.
+        </p>
+      </div>
+    );
+  }
+
+  if (phase.kind === 'confirm' || phase.kind === 'approving') {
+    const info = phase.info;
+    const busy = phase.kind === 'approving';
+    return (
+      <div style={panelStyle}>
+        <h2 style={{ fontSize: '18px', fontWeight: 600, marginBottom: '16px' }}>
+          Authorize this client?
+        </h2>
+        <div style={{ marginBottom: '16px' }}>
+          <div style={{ display: 'flex', fontSize: '13px', marginBottom: '8px' }}>
+            <span
+              style={{
+                width: '120px',
+                color: 'var(--text-muted)',
+              }}
+            >
+              Client
+            </span>
+            <strong>{info.clientName}</strong>
+          </div>
+          <div style={{ display: 'flex', fontSize: '13px', marginBottom: '8px' }}>
+            <span style={{ width: '120px', color: 'var(--text-muted)' }}>Scope</span>
+            <code>{info.scope}</code>
+          </div>
+          <div style={{ display: 'flex', fontSize: '13px', marginBottom: '8px' }}>
+            <span style={{ width: '120px', color: 'var(--text-muted)' }}>Code</span>
+            <code style={{ letterSpacing: '0.08em' }}>{info.userCode}</code>
+          </div>
+          <div style={{ display: 'flex', fontSize: '13px' }}>
+            <span style={{ width: '120px', color: 'var(--text-muted)' }}>
+              Expires
+            </span>
+            <span>{new Date(info.expiresAt).toLocaleString()}</span>
+          </div>
+        </div>
+        <p
+          style={{
+            fontSize: '13px',
+            color: 'var(--text-muted)',
+            lineHeight: 1.5,
+            marginBottom: '20px',
+          }}
+        >
+          Approving will mint a bearer token valid for 90 days that can publish
+          evidence on your behalf. You can revoke it anytime from the dashboard.
+        </p>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            onClick={() => act(info, 'approve')}
+            disabled={busy}
+            style={{ ...buttonPrimary, opacity: busy ? 0.6 : 1 }}
+          >
+            {busy ? 'Approving...' : 'Approve'}
+          </button>
+          <button
+            onClick={() => act(info, 'deny')}
+            disabled={busy}
+            style={{ ...buttonDanger, opacity: busy ? 0.6 : 1 }}
+          >
+            Deny
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Idle / looking_up / error → show the code-entry form.
+  return (
+    <div style={panelStyle}>
+      <form onSubmit={submitCode}>
+        <label htmlFor="user-code" style={labelStyle}>
+          User code
+        </label>
+        <input
+          id="user-code"
+          type="text"
+          autoComplete="off"
+          autoFocus
+          value={inputCode}
+          placeholder="ABCD-EFGH"
+          onChange={(e) => setInputCode(e.target.value)}
+          style={inputStyle}
+        />
+        {phase.kind === 'error' ? (
+          <div
+            style={{
+              marginTop: '8px',
+              fontSize: '13px',
+              color: 'var(--nyc-error)',
+            }}
+          >
+            {phase.message}
+          </div>
+        ) : null}
+        <div style={{ marginTop: '16px', display: 'flex', gap: '8px' }}>
+          <button
+            type="submit"
+            disabled={phase.kind === 'looking_up'}
+            style={{
+              ...buttonPrimary,
+              opacity: phase.kind === 'looking_up' ? 0.6 : 1,
+            }}
+          >
+            {phase.kind === 'looking_up' ? 'Looking up...' : 'Continue'}
+          </button>
+          {phase.kind === 'error' ? (
+            <button
+              type="button"
+              onClick={() => {
+                setPhase({ kind: 'idle' });
+                setInputCode('');
+              }}
+              style={buttonSecondary}
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/auth/device/DeviceSignInPanel.tsx
+++ b/src/app/auth/device/DeviceSignInPanel.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+
+interface DeviceSignInPanelProps {
+  callbackUrl: string;
+  prefilledUserCode: string;
+}
+
+export default function DeviceSignInPanel({
+  callbackUrl,
+  prefilledUserCode,
+}: DeviceSignInPanelProps) {
+  return (
+    <div
+      style={{
+        padding: '20px',
+        border: '1px solid var(--border-color)',
+        borderRadius: '6px',
+      }}
+    >
+      <p style={{ fontSize: '14px', marginBottom: '16px', lineHeight: 1.5 }}>
+        Sign in with GitHub to review the authorization request
+        {prefilledUserCode ? (
+          <>
+            {' '}for code <code style={{ fontWeight: 600 }}>{prefilledUserCode}</code>
+          </>
+        ) : null}
+        .
+      </p>
+      <button
+        onClick={() => signIn('github', { callbackUrl })}
+        className="nyc-button nyc-button-primary"
+        style={{ padding: '10px 18px', fontSize: '14px' }}
+      >
+        Sign in with GitHub
+      </button>
+    </div>
+  );
+}

--- a/src/app/auth/device/page.tsx
+++ b/src/app/auth/device/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { normalizeUserCode } from '@/lib/device-flow';
+import DeviceApprovalPanel from './DeviceApprovalPanel';
+import DeviceSignInPanel from './DeviceSignInPanel';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Authorize device - Civic AI Tools',
+  description: 'Authorize a CLI or external client to publish evidence on your behalf.',
+};
+
+interface PageProps {
+  searchParams: Promise<{ user_code?: string }>;
+}
+
+export default async function DeviceAuthPage({ searchParams }: PageProps) {
+  const session = await getServerSession(authOptions);
+  const { user_code: rawCode } = await searchParams;
+  const normalized = normalizeUserCode(rawCode ?? '');
+
+  const callbackUrl = normalized
+    ? `/auth/device?user_code=${encodeURIComponent(normalized)}`
+    : '/auth/device';
+
+  return (
+    <div style={{ maxWidth: '520px', margin: '0 auto', padding: '48px 24px 64px' }}>
+      <h1 style={{ fontSize: '24px', fontWeight: 700, marginBottom: '8px' }}>
+        Authorize device
+      </h1>
+      <p
+        style={{
+          fontSize: '14px',
+          color: 'var(--text-muted)',
+          marginBottom: '24px',
+          lineHeight: 1.5,
+        }}
+      >
+        A CLI or external client is requesting permission to publish evidence on
+        your behalf. Review the details below and approve only if you initiated
+        this request.
+      </p>
+
+      {session?.user?.id ? (
+        <DeviceApprovalPanel initialUserCode={normalized} />
+      ) : (
+        <DeviceSignInPanel callbackUrl={callbackUrl} prefilledUserCode={normalized} />
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { evidenceRecords, attestationPackages, users } from '@/lib/db/schema';
-import { eq, desc, and, ne, sql } from 'drizzle-orm';
+import { apiTokens, evidenceRecords, attestationPackages, users } from '@/lib/db/schema';
+import { eq, desc, and, ne, isNull, sql } from 'drizzle-orm';
 import DashboardTabs from '@/components/dashboard/DashboardTabs';
 
 export const dynamic = 'force-dynamic';
@@ -126,6 +126,28 @@ export default async function DashboardPage() {
     createdAt: a.createdAt.toISOString(),
   }));
 
+  // --- Tab 4: Tokens (device-flow-minted bearer tokens) ---
+  const tokens = await db
+    .select({
+      id: apiTokens.id,
+      name: apiTokens.name,
+      tokenPrefix: apiTokens.tokenPrefix,
+      scope: apiTokens.scope,
+      createdAt: apiTokens.createdAt,
+      expiresAt: apiTokens.expiresAt,
+      lastUsedAt: apiTokens.lastUsedAt,
+    })
+    .from(apiTokens)
+    .where(and(eq(apiTokens.userId, userId), isNull(apiTokens.revokedAt)))
+    .orderBy(desc(apiTokens.createdAt));
+
+  const tokenData = tokens.map(t => ({
+    ...t,
+    createdAt: t.createdAt.toISOString(),
+    expiresAt: t.expiresAt.toISOString(),
+    lastUsedAt: t.lastUsedAt?.toISOString() || null,
+  }));
+
   return (
     <div style={{ maxWidth: '900px', margin: '0 auto', padding: '40px 24px 64px' }}>
       <h1 style={{ fontSize: '28px', fontWeight: 700, marginBottom: '4px' }}>Dashboard</h1>
@@ -137,6 +159,7 @@ export default async function DashboardPage() {
         myEvidence={myEvidenceData}
         myEvaluations={myEvaluationsData}
         activity={activityData}
+        tokens={tokenData}
       />
     </div>
   );

--- a/src/components/dashboard/DashboardTabs.tsx
+++ b/src/components/dashboard/DashboardTabs.tsx
@@ -39,10 +39,21 @@ interface ActivityRow {
   creatorGithubUrl: string;
 }
 
+interface TokenRow {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  scope: string;
+  createdAt: string;
+  expiresAt: string;
+  lastUsedAt: string | null;
+}
+
 interface DashboardTabsProps {
   myEvidence: EvidenceRow[];
   myEvaluations: EvaluationRow[];
   activity: ActivityRow[];
+  tokens: TokenRow[];
 }
 
 // --- Shared styles ---
@@ -117,8 +128,8 @@ function EmptyState({ message, cta }: { message: string; cta?: { text: string; h
 
 // --- Main component ---
 
-export default function DashboardTabs({ myEvidence, myEvaluations, activity }: DashboardTabsProps) {
-  const [activeTab, setActiveTab] = useState<'evidence' | 'evaluations' | 'activity'>('evidence');
+export default function DashboardTabs({ myEvidence, myEvaluations, activity, tokens }: DashboardTabsProps) {
+  const [activeTab, setActiveTab] = useState<'evidence' | 'evaluations' | 'activity' | 'tokens'>('evidence');
 
   return (
     <>
@@ -132,11 +143,15 @@ export default function DashboardTabs({ myEvidence, myEvaluations, activity }: D
         <button onClick={() => setActiveTab('activity')} style={tabStyle(activeTab === 'activity')}>
           Activity ({activity.length})
         </button>
+        <button onClick={() => setActiveTab('tokens')} style={tabStyle(activeTab === 'tokens')}>
+          Tokens ({tokens.length})
+        </button>
       </div>
 
       {activeTab === 'evidence' && <MyEvidenceTab rows={myEvidence} />}
       {activeTab === 'evaluations' && <MyEvaluationsTab rows={myEvaluations} />}
       {activeTab === 'activity' && <ActivityTab rows={activity} />}
+      {activeTab === 'tokens' && <TokensTab rows={tokens} />}
     </>
   );
 }
@@ -487,6 +502,160 @@ function MyEvaluationsTab({ rows }: { rows: EvaluationRow[] }) {
         </Link>
       ))}
     </div>
+  );
+}
+
+function TokensTab({ rows }: { rows: TokenRow[] }) {
+  const router = useRouter();
+  const [revokeTarget, setRevokeTarget] = useState<TokenRow | null>(null);
+  const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState('');
+
+  const handleRevoke = useCallback(async () => {
+    if (!revokeTarget) return;
+    setRevoking(true);
+    setRevokeError('');
+    try {
+      const res = await fetch(`/api/auth/tokens/${revokeTarget.id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Revocation failed' }));
+        throw new Error(err.error || 'Revocation failed');
+      }
+      setRevokeTarget(null);
+      router.refresh();
+    } catch (err) {
+      setRevokeError(err instanceof Error ? err.message : 'Revocation failed');
+    } finally {
+      setRevoking(false);
+    }
+  }, [revokeTarget, router]);
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        message="No API tokens. External clients (like the Claude Code publish skill) can request a token by running `publish.py --login`, which starts a device authorization flow."
+      />
+    );
+  }
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        {rows.map((t) => {
+          const expired = new Date(t.expiresAt).getTime() <= Date.now();
+          return (
+            <div
+              key={t.id}
+              style={{
+                padding: '14px 18px',
+                border: '1px solid var(--border-color)', borderRadius: '6px',
+                opacity: expired ? 0.6 : 1,
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '10px', marginBottom: '6px' }}>
+                <div style={{ fontSize: '15px', fontWeight: 600 }}>
+                  {t.name}
+                </div>
+                <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'center' }}>
+                  <span style={{
+                    display: 'inline-block', padding: '2px 8px', borderRadius: '10px',
+                    fontSize: '11px', fontWeight: 600,
+                    backgroundColor: 'rgba(16, 63, 239, 0.1)', color: 'var(--nyc-blue)',
+                  }}>
+                    {t.scope}
+                  </span>
+                </div>
+              </div>
+              <div style={{ fontSize: '12px', color: 'var(--text-muted)', display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+                <code style={{ fontFamily: 'monospace' }}>{t.tokenPrefix}...</code>
+                <span>{'\u00b7'}</span>
+                <span>Created {formatDate(t.createdAt)}</span>
+                <span>{'\u00b7'}</span>
+                {expired ? (
+                  <span style={{ color: 'var(--nyc-error)' }}>Expired {formatDate(t.expiresAt)}</span>
+                ) : (
+                  <span>Expires {formatDate(t.expiresAt)}</span>
+                )}
+                <span>{'\u00b7'}</span>
+                <span>
+                  {t.lastUsedAt ? `Last used ${formatDate(t.lastUsedAt)}` : 'Never used'}
+                </span>
+                <span>{'\u00b7'}</span>
+                <button
+                  onClick={() => { setRevokeTarget(t); setRevokeError(''); }}
+                  style={{
+                    background: 'none', border: 'none', padding: 0,
+                    fontSize: '12px', color: 'var(--nyc-error)', cursor: 'pointer',
+                    textDecoration: 'underline',
+                  }}
+                >
+                  Revoke
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {revokeTarget && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 1000,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          }}
+          onClick={(e) => { if (e.target === e.currentTarget && !revoking) { setRevokeTarget(null); } }}
+        >
+          <div style={{
+            backgroundColor: 'white', borderRadius: '8px', width: '100%', maxWidth: '440px',
+            margin: '16px', padding: '24px',
+            boxShadow: '0 20px 60px rgba(0, 0, 0, 0.3)',
+          }}>
+            <h3 style={{ margin: '0 0 12px', fontSize: '16px', fontWeight: 600 }}>Revoke token</h3>
+            <p style={{ fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.6, margin: '0 0 16px' }}>
+              Revoking is immediate and permanent. Any client still using this
+              token will start seeing 401 Unauthorized responses. The client
+              will need to run a fresh login to get a new token.
+            </p>
+            <div style={{ fontSize: '13px', fontWeight: 500, marginBottom: '4px', color: 'var(--text-primary)' }}>
+              &ldquo;{revokeTarget.name}&rdquo; <code style={{ fontSize: '12px', color: 'var(--text-muted)' }}>({revokeTarget.tokenPrefix}...)</code>
+            </div>
+            {revokeError && (
+              <div style={{ marginTop: '8px', fontSize: '13px', color: 'var(--nyc-error)' }}>
+                {revokeError}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', marginTop: '16px' }}>
+              <button
+                onClick={() => setRevokeTarget(null)}
+                disabled={revoking}
+                style={{
+                  padding: '8px 16px', border: '1px solid var(--border-color)', borderRadius: '4px',
+                  fontSize: '13px', cursor: 'pointer', backgroundColor: 'white',
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleRevoke}
+                disabled={revoking}
+                style={{
+                  padding: '8px 16px', border: 'none', borderRadius: '4px',
+                  fontSize: '13px', fontWeight: 600, cursor: revoking ? 'not-allowed' : 'pointer',
+                  backgroundColor: 'var(--nyc-error)', color: 'white',
+                  opacity: revoking ? 0.6 : 1,
+                }}
+              >
+                {revoking ? 'Revoking...' : 'Revoke'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,0 +1,136 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { eq } from 'drizzle-orm';
+import { authOptions } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { apiTokens, users } from '@/lib/db/schema';
+
+/**
+ * Auth resolution for write endpoints (POST /api/evidence,
+ * POST /api/blob/upload-token, etc.).
+ *
+ * Supports two paths:
+ *  - `Authorization: Bearer evpub_...` — device-flow-minted token
+ *    (website#73 / RFC 8628). Preferred for programmatic clients.
+ *  - NextAuth session cookie — original path, kept working indefinitely
+ *    for browser flows and one-off curls. Responses from cookie-authed
+ *    writes carry `X-Auth-Deprecated: cookie` as a gentle nudge.
+ */
+
+const TOKEN_PREFIX = 'evpub_';
+const TOKEN_RANDOM_BYTES = 24; // 24 bytes → 32 base64url chars → ~192 bits
+const TOKEN_PREFIX_LENGTH = 12; // "evpub_" + 6 random chars, stored for UI
+
+const LAST_USED_UPDATE_THROTTLE_MS = 60_000;
+
+export type AuthMethod = 'cookie' | 'bearer';
+
+export interface AuthResult {
+  /** Internal DB user ID (not GitHub ID). */
+  userId: string;
+  method: AuthMethod;
+  /** Scopes the caller holds. Cookie auth returns `['*']` (unscoped). */
+  scopes: string[];
+  /** `api_tokens.id` — only set for bearer auth. */
+  tokenId?: string;
+}
+
+export function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+/**
+ * RFC 4648 §5 base64url, no padding. Used for opaque random tokens.
+ */
+function base64UrlRandom(bytes: number): string {
+  return randomBytes(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export function mintRawToken(): { raw: string; hash: string; prefix: string } {
+  const raw = TOKEN_PREFIX + base64UrlRandom(TOKEN_RANDOM_BYTES);
+  return {
+    raw,
+    hash: sha256Hex(raw),
+    prefix: raw.slice(0, TOKEN_PREFIX_LENGTH),
+  };
+}
+
+/**
+ * Checks a required scope against an auth result. Cookie auth holds `*`
+ * (browser flows are already gated by NextAuth + user session, not by
+ * scope). Bearer tokens carry an explicit scope assigned at mint time.
+ */
+export function hasScope(auth: AuthResult, required: string): boolean {
+  return auth.scopes.includes('*') || auth.scopes.includes(required);
+}
+
+async function resolveBearer(raw: string): Promise<AuthResult | null> {
+  if (!raw.startsWith(TOKEN_PREFIX)) return null;
+  const hash = sha256Hex(raw);
+  const rows = await db
+    .select()
+    .from(apiTokens)
+    .where(eq(apiTokens.tokenHash, hash))
+    .limit(1);
+  if (rows.length === 0) return null;
+  const token = rows[0];
+  if (token.revokedAt) return null;
+  if (token.expiresAt.getTime() <= Date.now()) return null;
+
+  // Fire-and-forget last_used_at update, throttled so we don't write on
+  // every request. Errors are swallowed — auth succeeds either way.
+  const lastUsed = token.lastUsedAt?.getTime() ?? 0;
+  if (Date.now() - lastUsed > LAST_USED_UPDATE_THROTTLE_MS) {
+    void db
+      .update(apiTokens)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(apiTokens.id, token.id))
+      .catch(() => {});
+  }
+
+  return {
+    userId: token.userId,
+    method: 'bearer',
+    scopes: [token.scope],
+    tokenId: token.id,
+  };
+}
+
+async function resolveCookie(): Promise<AuthResult | null> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return null;
+  const githubId = session.user.id;
+  const dbUser = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.githubId, githubId))
+    .limit(1);
+  if (dbUser.length === 0) return null;
+  return { userId: dbUser[0].id, method: 'cookie', scopes: ['*'] };
+}
+
+/**
+ * Resolves the caller's user ID and auth method. Returns `null` if
+ * neither a valid bearer token nor a valid session is present.
+ */
+export async function resolveRequestUser(
+  request: NextRequest,
+): Promise<AuthResult | null> {
+  const header = request.headers.get('authorization');
+  if (header) {
+    const match = header.match(/^Bearer\s+(\S+)$/i);
+    if (match) {
+      const bearer = await resolveBearer(match[1]);
+      if (bearer) return bearer;
+      // A bearer header was present but invalid — don't silently fall
+      // through to cookie auth, since the caller clearly intended bearer.
+      return null;
+    }
+  }
+  return resolveCookie();
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -115,3 +115,46 @@ export const attestationPackages = pgTable('attestation_packages', {
     .defaultNow()
     .notNull(),
 });
+
+// OAuth 2.0 device authorization grant (RFC 8628). A client (Claude Code
+// publish skill, CI job, etc.) creates a row with an opaque `device_code`
+// and a short human-readable `user_code`. The human visits /auth/device
+// while signed in, finds the row by `user_code`, and approves it; the
+// client polls `/api/auth/device/token` with the `device_code` to mint a
+// bearer token. Rows are single-use (`consumed_at`) and expire in ~15min.
+export const deviceCodes = pgTable('device_codes', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  deviceCode: text('device_code').notNull().unique(),
+  userCode: text('user_code').notNull().unique(),
+  clientName: text('client_name').notNull(),
+  scope: text('scope').notNull(),
+  approvedUserId: uuid('approved_user_id').references(() => users.id),
+  approvedAt: timestamp('approved_at', { withTimezone: true }),
+  consumedAt: timestamp('consumed_at', { withTimezone: true }),
+  lastPolledAt: timestamp('last_polled_at', { withTimezone: true }),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
+// Bearer tokens minted via the device flow. Stored as SHA-256 of the raw
+// token so a DB compromise doesn't leak tokens. `token_prefix` is the
+// first ~12 chars of the raw token (e.g. "evpub_XXXXXX") kept for UI
+// identification — it's not secret on its own and can't be used to auth.
+export const apiTokens = pgTable('api_tokens', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => users.id),
+  tokenHash: text('token_hash').notNull().unique(),
+  tokenPrefix: text('token_prefix').notNull(),
+  name: text('name').notNull(),
+  scope: text('scope').notNull(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+  revokedAt: timestamp('revoked_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});

--- a/src/lib/device-flow.ts
+++ b/src/lib/device-flow.ts
@@ -1,0 +1,89 @@
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Device authorization grant primitives (RFC 8628).
+ *
+ * - `device_code`: opaque, client-held, long random. Never shown to the
+ *   user; used only by the client when polling for the token.
+ * - `user_code`: short, human-readable, typed into the browser. Lives in
+ *   the URL of the verification_uri_complete so the user can click
+ *   through without typing, with the typed form as a fallback.
+ */
+
+// 32 bytes of randomness → ~256 bits, encoded as base64url → 43 chars.
+// Prefixed `dc_` so logs/greps can spot a device code quickly.
+const DEVICE_CODE_PREFIX = 'dc_';
+const DEVICE_CODE_BYTES = 32;
+
+// Confusable-character-free alphabet. 31 chars → ~40 bits over 8 chars,
+// which is plenty for a code that only lives 15 minutes and requires
+// both the code and a signed-in session to activate.
+const USER_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const USER_CODE_LENGTH = 8;
+
+// RFC 8628 §3.2 defaults: 15-minute lifetime, 5-second minimum poll.
+export const DEVICE_CODE_LIFETIME_SECONDS = 15 * 60;
+export const DEVICE_CODE_POLL_INTERVAL_SECONDS = 5;
+export const DEVICE_CODE_SLOW_DOWN_INCREMENT_SECONDS = 5;
+
+// Default token lifetime for device-flow-minted tokens.
+export const API_TOKEN_LIFETIME_SECONDS = 90 * 24 * 60 * 60;
+
+function base64UrlRandom(bytes: number): string {
+  return randomBytes(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export function generateDeviceCode(): string {
+  return DEVICE_CODE_PREFIX + base64UrlRandom(DEVICE_CODE_BYTES);
+}
+
+export function generateUserCode(): string {
+  const bytes = randomBytes(USER_CODE_LENGTH);
+  let code = '';
+  for (let i = 0; i < USER_CODE_LENGTH; i++) {
+    code += USER_CODE_ALPHABET[bytes[i] % USER_CODE_ALPHABET.length];
+  }
+  // XXXX-XXXX formatting: easier to type correctly.
+  return `${code.slice(0, 4)}-${code.slice(4)}`;
+}
+
+/**
+ * Normalize a user-typed code. Accepts lowercase and missing dash so a
+ * copy/paste with formatting drift still matches.
+ */
+export function normalizeUserCode(input: string): string {
+  const stripped = input.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+  if (stripped.length !== USER_CODE_LENGTH) return '';
+  return `${stripped.slice(0, 4)}-${stripped.slice(4)}`;
+}
+
+/**
+ * Returns the base URL for this deployment. Prefers `NEXTAUTH_URL` (set
+ * per-environment in Vercel); falls back to the request origin when
+ * called with one.
+ */
+export function getBaseUrl(request?: Request): string {
+  const fromEnv = process.env.NEXTAUTH_URL;
+  if (fromEnv) return fromEnv.replace(/\/+$/, '');
+  if (request) {
+    const url = new URL(request.url);
+    return `${url.protocol}//${url.host}`;
+  }
+  return 'http://localhost:3000';
+}
+
+export function buildVerificationUri(baseUrl: string): string {
+  return `${baseUrl}/auth/device`;
+}
+
+export function buildVerificationUriComplete(
+  baseUrl: string,
+  userCode: string,
+): string {
+  const encoded = encodeURIComponent(userCode);
+  return `${baseUrl}/auth/device?user_code=${encoded}`;
+}


### PR DESCRIPTION
## Summary

- Adds OAuth 2.0 device-authorization-grant (RFC 8628) as the preferred auth path for programmatic clients of `POST /api/evidence`.
- Session-cookie auth still works indefinitely; responses carry `X-Auth-Deprecated: cookie` as a nudge toward the new path.
- Closes #73.

### What's new

| Endpoint | Purpose |
|---|---|
| `POST /api/auth/device/code` | Client starts the flow — returns `device_code`, `user_code`, verification URL, polling interval. |
| `POST /api/auth/device/token` | Client polls for the bearer token. Returns `authorization_pending` / `slow_down` / `expired_token` / `invalid_grant` / `access_token`. |
| `POST /api/auth/device/approve` | User-facing approve/deny action, session-authed, same-origin only. |
| `GET /api/auth/device/lookup` | Prefills the `/auth/device` approval page with client name + scope. |
| `GET /api/auth/tokens` | Lists the caller's active tokens. |
| `DELETE /api/auth/tokens/:id` | Revokes a token the caller owns. |

### Schema changes (migration 0006)

Two new tables, both additive:

- `device_codes` — short-lived pending approvals, ~15 min lifetime, single-use via `consumed_at`.
- `api_tokens` — bearer tokens stored as SHA-256 hashes. `token_prefix` holds `evpub_XXXXXX` for UI identification (not secret on its own). 90-day default lifetime, scope `evidence:publish`.

The migration is safe to run against the shared Neon preview/prod DB at any time — existing code paths don't touch the new tables.

### UX

- `/auth/device` page accepts a user code (from query param or typed). Looks up the pending device code, shows **client name + scope + expiry**, requires a click to **Approve** (same model as GitHub's device flow).
- Dashboard gets a **Tokens** tab listing active tokens (name, `evpub_XXXXXX` prefix, scope, created/expires/last-used timestamps) with a per-token revoke button.

### Security notes

- Tokens stored as SHA-256 hashes server-side — DB compromise doesn't leak usable tokens.
- `user_code` is 8 chars from a confusable-free alphabet (~40 bits), only lives 15 minutes, requires a signed-in session to activate.
- Polling enforces the RFC-8628 minimum interval; too-fast polls return `slow_down` with an interval bump.
- Approve + revoke endpoints enforce same-origin via the `Origin` header — a cross-site POST with the user's cookie can't auto-approve an attacker-controlled device code.
- `Authorization: Bearer` takes precedence over `Cookie`; an **invalid** bearer returns 401 rather than falling through to cookie auth (callers who tried bearer clearly don't intend cookie).

### Companion PR

[npstorey/civic-ai-tools#40](https://github.com/npstorey/civic-ai-tools/pulls) (or similar) wires the Claude Code publish-evidence skill to the new flow: `publish.py --login / --logout / --list-tokens`.

## Pre-merge checklist

- [ ] Run migration against Neon: `cd civic-ai-tools-website && export $(grep DATABASE_URL .env.local) && npx drizzle-kit migrate`
- [ ] On the preview URL, run the device flow end-to-end from a CLI against `--base-url <preview>` and confirm a token lands in `~/.config/civic-ai-tools/credentials.json`.
- [ ] On the preview URL, `publish.py --payload <something> --base-url <preview>` succeeds with the bearer token.
- [ ] Dashboard **Tokens** tab renders the minted token, last-used updates on subsequent publishes (throttled 60s), revoke button immediately takes effect.
- [ ] Cookie-authed `POST /api/evidence` still works and returns `X-Auth-Deprecated: cookie`.

## Test plan

- [ ] `publish.py --login` completes (browser opens, approval page renders, token saved).
- [ ] Bearer-authed publish returns 200 with a valid slug.
- [ ] Revoked token returns 401 on the next publish attempt.
- [ ] Missing `evidence:publish` scope returns 403 (can be simulated by DB update).
- [ ] `GET /auth/device` without a session redirects through GitHub OAuth and back.
- [ ] `POST /api/auth/device/approve` from a cross-origin Origin returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)