### PR TITLE
Integrate Boston OpenContext as third MCP data source (#81)

### DIFF
--- a/src/lib/evidence/data-sources.test.ts
+++ b/src/lib/evidence/data-sources.test.ts
@@ -168,6 +168,87 @@ test('Empty trace falls back to tool-name mapping (Data Commons)', () => {
   assert.equal(entries[0].sourceId, 'data-commons');
 });
 
+test('Boston OpenContext only: emits a single aggregate entry tagged sourceId=boston-opencontext with catalogType=ckan', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'ckan__search_datasets', args: { query: '311 pothole requests' } },
+    {
+      name: 'ckan__aggregate_data',
+      args: {
+        resource_id: '8048697b-ad64-4bfc-b090-ee00169f2323',
+        group_by: ['neighborhood'],
+        metrics: { count: 'count(*)' },
+      },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('boston-opencontext'),
+    toolSpan('boston-opencontext'),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  assert.equal(entry.sourceId, 'boston-opencontext');
+  assert.equal(entry.catalogType, 'ckan');
+  assert.equal(entry.portalUrl, 'https://data.boston.gov');
+  // Boston rolls up per-source (not per-resource) — resource UUIDs live on the
+  // PROV-O graph's tool call activities, not in dataSources.
+  assert.equal(entry.datasetId, undefined);
+  assert.equal(entry.datasetUrl, undefined);
+  assert.equal(entry.accessTimestamp, NOW);
+});
+
+test('Three-source: Socrata + Data Commons + Boston OpenContext produce three distinct entries', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'search_indicators', args: { query: 'population' } },
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Count_Person', place_dcid: 'geoId/25025' },
+    },
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+    {
+      name: 'ckan__aggregate_data',
+      args: { resource_id: 'boston-311-uuid', group_by: ['neighborhood'], metrics: { count: 'count(*)' } },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('data-commons'),
+    toolSpan('data-commons'),
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+    toolSpan('boston-opencontext'),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 3);
+  const socrata = entries.find((s) => s.sourceId === 'socrata');
+  const dc = entries.find((s) => s.sourceId === 'data-commons');
+  const boston = entries.find((s) => s.sourceId === 'boston-opencontext');
+  assert.ok(socrata, 'missing socrata dataSource entry');
+  assert.ok(dc, 'missing data-commons dataSource entry');
+  assert.ok(boston, 'missing boston-opencontext dataSource entry');
+  assert.equal(socrata!.datasetId, 'erm2-nwe9');
+  assert.equal(dc!.portalUrl, 'https://api.datacommons.org/mcp');
+  assert.equal(boston!.catalogType, 'ckan');
+  assert.equal(boston!.portalUrl, 'https://data.boston.gov');
+});
+
+test('Empty trace falls back to tool-name mapping (Boston OpenContext)', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'ckan__search_datasets', args: { query: 'permits' } },
+  ];
+  const trace = { resourceSpans: [] };
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'boston-opencontext');
+});
+
 test('Regression: Socrata-only entry shape is backward-compatible (new sourceId is additive)', () => {
   // The shape must contain every field the pre-M9.3 code produced, plus the
   // new additive `sourceId`. Downstream consumers that ignore unknown fields
@@ -214,6 +295,7 @@ test('Unknown tool with no trace span defaults to socrata (pre-M9.1 backward com
 test('displayNameForSource maps known source ids to friendly names', () => {
   assert.equal(displayNameForSource('socrata'), 'Socrata');
   assert.equal(displayNameForSource('data-commons'), 'Data Commons');
+  assert.equal(displayNameForSource('boston-opencontext'), 'Boston OpenContext');
 });
 
 test('displayNameForSource capitalises unknown ids so new sources render sensibly', () => {
@@ -267,6 +349,53 @@ test('formatDataSourcesSummary dedupes multiple Socrata dataset entries into one
     },
   ];
   assert.equal(formatDataSourcesSummary(entries), 'Socrata');
+});
+
+test('formatDataSourcesSummary renders a three-source analysis in active-source order', () => {
+  const entries: DataSourceEntry[] = [
+    {
+      sourceId: 'socrata',
+      catalogType: 'socrata',
+      portalUrl: 'https://data.cityofnewyork.us',
+      datasetId: 'erm2-nwe9',
+      datasetUrl: 'https://data.cityofnewyork.us/d/erm2-nwe9',
+      accessTimestamp: NOW,
+    },
+    {
+      sourceId: 'data-commons',
+      catalogType: 'data-commons',
+      portalUrl: 'https://api.datacommons.org/mcp',
+      accessTimestamp: NOW,
+    },
+    {
+      sourceId: 'boston-opencontext',
+      catalogType: 'ckan',
+      portalUrl: 'https://data.boston.gov',
+      accessTimestamp: NOW,
+    },
+  ];
+  const result = formatDataSourcesSummary(entries);
+  assert.ok(result !== null && result.includes('Socrata'));
+  assert.ok(result !== null && result.includes('Data Commons'));
+  assert.ok(result !== null && result.includes('Boston OpenContext'));
+  assert.ok(
+    result !== null &&
+      result.indexOf('Socrata') < result.indexOf('Data Commons') &&
+      result.indexOf('Data Commons') < result.indexOf('Boston OpenContext'),
+    'three-source summary should render in active-source order',
+  );
+});
+
+test('formatDataSourcesSummary renders a Boston-only package without Socrata leakage', () => {
+  const entries: DataSourceEntry[] = [
+    {
+      sourceId: 'boston-opencontext',
+      catalogType: 'ckan',
+      portalUrl: 'https://data.boston.gov',
+      accessTimestamp: NOW,
+    },
+  ];
+  assert.equal(formatDataSourcesSummary(entries), 'Boston OpenContext');
 });
 
 test('formatDataSourcesSummary joins multi-source entries with a middle-dot separator', () => {

--- a/src/lib/evidence/data-sources.ts
+++ b/src/lib/evidence/data-sources.ts
@@ -8,10 +8,12 @@
 
 import { sourceIdForToolName } from '../mcp/operation-types.ts';
 
-// Endpoint URL used to tag Data Commons data-source entries. Kept as a
-// module-scoped constant (not read from process.env) so the function stays
-// pure. Overriding the hosted endpoint via env is out of scope for M9.3.
+// Endpoint URLs used to tag data-source entries for sources whose query
+// surface isn't dataset-keyed. Kept as module-scoped constants (not read from
+// process.env) so the function stays pure. Overriding the hosted endpoints
+// via env is out of scope.
 const DATA_COMMONS_ENDPOINT = 'https://api.datacommons.org/mcp';
+const BOSTON_OPENCONTEXT_PORTAL = 'https://data.boston.gov';
 
 export interface ToolCallSummary {
   name: string;
@@ -39,6 +41,7 @@ export interface DataSourceEntry {
 const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   socrata: 'Socrata',
   'data-commons': 'Data Commons',
+  'boston-opencontext': 'Boston OpenContext',
 };
 
 export function displayNameForSource(sourceId: string | undefined | null): string {
@@ -118,8 +121,11 @@ export function resolveToolSource(
  *
  * Socrata contributes one entry per unique `dataset_id` observed across tool
  * calls. Data Commons contributes a single aggregate entry when any DC tool
- * call was made (its knowledge graph isn't dataset-keyed). Each entry is
- * tagged with `sourceId` so downstream consumers can distinguish provenance.
+ * call was made (its knowledge graph isn't dataset-keyed). Boston OpenContext
+ * contributes a single aggregate entry tagged with the data.boston.gov portal
+ * — per-dataset CKAN resource UUIDs are surfaced via the PROV-O graph's tool
+ * call activities rather than rolled up here. Each entry is tagged with
+ * `sourceId` so downstream consumers can distinguish provenance.
  */
 export function buildDataSources(
   toolCalls: ToolCallSummary[],
@@ -130,6 +136,7 @@ export function buildDataSources(
   const toolSpans = getToolSpans(trace);
   const socrataByDataset = new Map<string, { portalUrl: string; datasetId: string }>();
   let dataCommonsAccessed = false;
+  let bostonOpencontextAccessed = false;
 
   for (let i = 0; i < toolCalls.length; i++) {
     const tc = toolCalls[i];
@@ -142,6 +149,8 @@ export function buildDataSources(
       }
     } else if (source === 'data-commons') {
       dataCommonsAccessed = true;
+    } else if (source === 'boston-opencontext') {
+      bostonOpencontextAccessed = true;
     }
   }
 
@@ -161,6 +170,14 @@ export function buildDataSources(
       sourceId: 'data-commons',
       catalogType: 'data-commons',
       portalUrl: DATA_COMMONS_ENDPOINT,
+      accessTimestamp: now,
+    });
+  }
+  if (bostonOpencontextAccessed) {
+    entries.push({
+      sourceId: 'boston-opencontext',
+      catalogType: 'ckan',
+      portalUrl: BOSTON_OPENCONTEXT_PORTAL,
       accessTimestamp: now,
     });
   }

--- a/src/lib/evidence/provenance.test.ts
+++ b/src/lib/evidence/provenance.test.ts
@@ -99,6 +99,36 @@ test('Multi-source analysis emits both MCP agents', () => {
   assert.ok(agents.includes('urn:civic-evidence:mcp-server:data-commons'));
 });
 
+test('Boston OpenContext only analysis emits only the boston-opencontext MCP agent with correct title', () => {
+  const trace = traceOf([skillSpan('skill-hash'), toolSpan('boston-opencontext', 'ckan__search_datasets', 'span-1')]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const agents = mcpAgents(graph['@graph']);
+  assert.deepEqual(agents, ['urn:civic-evidence:mcp-server:boston-opencontext']);
+
+  const bostonAgentNode = graph['@graph'].find(
+    (n) => n['@id'] === 'urn:civic-evidence:mcp-server:boston-opencontext',
+  );
+  assert.ok(bostonAgentNode, 'expected Boston OpenContext agent node in graph');
+  assert.equal(bostonAgentNode!['dcterms:title'], 'Boston OpenContext MCP Server');
+  assert.equal(bostonAgentNode!['civic:serverUrl'], 'https://data-mcp.boston.gov/mcp');
+  assert.equal(bostonAgentNode!['civic:sourceId'], 'boston-opencontext');
+});
+
+test('Three-source analysis emits all three MCP agents, no stray sources', () => {
+  const trace = traceOf([
+    skillSpan('skill-hash'),
+    toolSpan('socrata', 'get_data', 'span-1'),
+    toolSpan('data-commons', 'get_observations', 'span-2'),
+    toolSpan('boston-opencontext', 'ckan__aggregate_data', 'span-3'),
+  ]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const agents = mcpAgents(graph['@graph']);
+  assert.equal(agents.length, 3);
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:socrata'));
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:data-commons'));
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:boston-opencontext'));
+});
+
 test('Skill fetched but no tool calls emits no MCP agent', () => {
   // Regression: pre-M9.3 behaviour always added a socrata agent here even
   // though nothing was ever queried. New rule: no tool calls → no MCP agent.

--- a/src/lib/evidence/provenance.ts
+++ b/src/lib/evidence/provenance.ts
@@ -140,6 +140,11 @@ export function buildProvenanceGraph(
       title: 'Google Data Commons MCP Server',
       serverUrl: 'https://api.datacommons.org/mcp',
     },
+    'boston-opencontext': {
+      urn: `urn:civic-evidence:mcp-server:boston-opencontext`,
+      title: 'Boston OpenContext MCP Server',
+      serverUrl: 'https://data-mcp.boston.gov/mcp',
+    },
   };
 
   const sourcesInTrace = new Set<string>();
@@ -261,7 +266,8 @@ export function buildProvenanceGraph(
       dataResponseUrns.push(dataUrn);
 
       // Description varies by source — Socrata has a portal domain, Data
-      // Commons calls run against a knowledge graph keyed by DCIDs.
+      // Commons calls run against a knowledge graph keyed by DCIDs, and
+      // Boston OpenContext calls hit the CKAN DataStore at data.boston.gov.
       const description = toolSource === 'socrata'
         ? `Data response from ${portalDomain}`
         : `Data response from ${sourceAgentMap[toolSource]?.title || toolSource}`;

--- a/src/lib/mcp/boston-skill.ts
+++ b/src/lib/mcp/boston-skill.ts
@@ -1,0 +1,73 @@
+// Boston OpenContext MCP Skill — Domain knowledge for querying Boston
+// civic open data via the CKAN-native OpenContext MCP server at
+// data-mcp.boston.gov/mcp.
+//
+// Source of truth: civic-ai-tools/docs/skills/boston.md
+// Manually embedded here (multi-MCP skill guidance). Inline code spans from
+// the markdown source are stripped so the content can live in a plain
+// template literal without backtick escaping — matches the approach used by
+// DATA_COMMONS_SKILL in ./data-commons-skill.ts and SOCRATA_SKILL_FALLBACK
+// in ./socrata-skill.ts.
+//
+// If you change the guidance: update civic-ai-tools/docs/skills/boston.md
+// first (source of truth), then re-sync this constant by hand. A sync script
+// is planned as post-M9 cleanup.
+
+export const BOSTON_OPENCONTEXT_SKILL = `
+# Boston OpenContext Companion Skill — Base Guidance
+
+Guidance for querying Boston civic open data through the OpenContext MCP server at data-mcp.boston.gov/mcp. OpenContext is a CKAN-native MCP framework maintained by the City of Boston; it fronts the CKAN DataStore powering Analyze Boston (data.boston.gov).
+
+## Purpose and when to use
+
+- **Use Boston OpenContext** for Boston civic data on data.boston.gov — 311 requests, permits, crime, inspections, property records, elections, schools, parcels, parking, neighborhoods.
+- **Use Socrata** for other cities (NYC, Chicago, SF, Seattle, LA). Boston is not on Socrata.
+- **Use Data Commons for Boston demographics** — ACS / Census / BLS figures for Boston, Suffolk County (geoId/25025), Boston city (geoId/2507000), or tracts. Don't go hunting for demographic tables on Analyze Boston.
+
+When a question mixes operational and demographic data ("311 noise per capita by neighborhood"), plan a multi-source analysis: operational counts from OpenContext, population denominator from Data Commons at tract level. State the geography caveat — neighborhoods and council districts are not standard census geographies.
+
+## CKAN vs Socrata — the one-screen summary
+
+Boston runs CKAN, not Socrata:
+
+| Concern | Socrata | CKAN / OpenContext |
+|---------|---------|--------------------|
+| Query language | SoQL (SQL-like but dialectal) | PostgreSQL SELECT |
+| Dataset identity | 4x4 code (erm2-nwe9) | UUID resource id (8048697b-ad64-4bfc-b090-ee00169f2323) |
+| Identifier quoting in SQL | not required | UUIDs MUST be double-quoted: FROM "uuid-here" |
+| Schema discovery | get_data with LIMIT 1 | ckan__get_schema (explicit) |
+| Aggregation | SELECT ... GROUP BY via get_data | ckan__aggregate_data or ckan__execute_sql |
+| Writes | Not exposed | Blocked server-side — only SELECT passes |
+
+## Typical workflow chain
+
+1. **ckan__search_datasets** — natural-language discovery. Returns candidate datasets with their UUID resource ids.
+2. **ckan__get_dataset** — inspect a dataset's full metadata; pick the right resource when a dataset bundles several.
+3. **ckan__get_schema** — fetch field names/types. Run this before querying unfamiliar data — Boston uses CKAN field conventions, not the NYC/Chicago conventions a model may have memorized.
+4. **ckan__query_data** — simple equality-filter queries. Good for "rows where field = value" patterns.
+5. **ckan__aggregate_data** — structured GROUP BY + metrics. Prefer this over raw SQL for countable/summable questions; the server compiles safe SQL from a JSON spec (group_by, metrics, filters, having, order_by).
+6. **ckan__execute_sql** — raw SELECT for CTEs, window functions, JOINs, percentile aggregates.
+
+Don't skip steps 1-3 on an unfamiliar dataset — guessing a field name against a 500-column CKAN resource silently returns zero rows or a SQL error.
+
+## Boston-specific geographies
+
+- **Neighborhoods** — not Census tracts. ~20 city-maintained names (Dorchester, Roxbury, Jamaica Plain, South Boston, ...).
+- **BPD districts** — 12 police districts (A1, A7, B2, B3, C6, C11, D4, D14, E5, E13, E18). Different from neighborhoods.
+- **BPS school zones** — Boston Public Schools has its own geography; present on school datasets only.
+- **Parcel IDs** — 10-digit strings. Assessor data is keyed on parcel, not address; to go address to parcel, query the parcels dataset first.
+- **ZIP codes** — 021xx range. Boston crosses multiple ZIPs; treat carefully when comparing against ACS ZCTAs.
+
+Neighborhoods do NOT map cleanly to Census tracts. When joining Boston operational data with Data Commons tract-level demographics, state the geography mismatch rather than silently imputing.
+
+## Caveats
+
+- **Update cadence varies.** 311 daily, assessor annually, crime weekly. Surface metadata_updated or last_modified when the question is time-sensitive.
+- **Coverage gaps.** Some city agencies (BPD, BPS, BPL) publish partial data. If a natural query returns empty, the data genuinely may not be there — say so rather than fishing.
+- **Resource UUIDs change** when a dataset gets a v2 resource. Re-run search/get_dataset for current IDs each session; don't cache UUIDs across runs.
+- **Hot-spotting risk.** Crime and 311 point-level data can be re-identifying when filtered narrowly. Honor aggregation thresholds — don't report a single address.
+
+## Attribution
+
+Cite Boston OpenContext analyses with: dataset title, resource UUID, data.boston.gov portal URL, and the SQL / aggregation spec that produced the number. The evidence-package layer captures tool calls and args automatically; your job in the text output is to make the citation human-readable.
+`;

--- a/src/lib/mcp/operation-types.test.ts
+++ b/src/lib/mcp/operation-types.test.ts
@@ -58,6 +58,28 @@ test('sourceIdForToolName: Data Commons tools', () => {
   assert.equal(sourceIdForToolName('get_observations'), 'data-commons');
 });
 
+test('sourceIdForToolName: Boston OpenContext tools', () => {
+  for (const toolName of [
+    'ckan__search_datasets',
+    'ckan__get_dataset',
+    'ckan__query_data',
+    'ckan__get_schema',
+    'ckan__execute_sql',
+    'ckan__aggregate_data',
+  ]) {
+    assert.equal(sourceIdForToolName(toolName), 'boston-opencontext', `expected "${toolName}" to route to boston-opencontext`);
+  }
+});
+
+test('Boston OpenContext: operation types map per tool', () => {
+  assert.equal(deriveOperationType('ckan__search_datasets', { query: '311' }), 'search');
+  assert.equal(deriveOperationType('ckan__get_dataset', { dataset_id: 'x' }), 'metadata');
+  assert.equal(deriveOperationType('ckan__get_schema', { resource_id: 'x' }), 'metadata');
+  assert.equal(deriveOperationType('ckan__query_data', { resource_id: 'x' }), 'query');
+  assert.equal(deriveOperationType('ckan__execute_sql', { sql: 'SELECT 1' }), 'query');
+  assert.equal(deriveOperationType('ckan__aggregate_data', { resource_id: 'x', metrics: {} }), 'query');
+});
+
 test('sourceIdForToolName: unknown tool returns undefined', () => {
   assert.equal(sourceIdForToolName('mystery_tool'), undefined);
   assert.equal(sourceIdForToolName(''), undefined);

--- a/src/lib/mcp/operation-types.ts
+++ b/src/lib/mcp/operation-types.ts
@@ -10,6 +10,12 @@
 const TOOL_OPERATION_TYPES: Record<string, string> = {
   search_indicators: 'search',
   get_observations: 'query',
+  ckan__search_datasets: 'search',
+  ckan__get_dataset: 'metadata',
+  ckan__get_schema: 'metadata',
+  ckan__query_data: 'query',
+  ckan__execute_sql: 'query',
+  ckan__aggregate_data: 'query',
 };
 
 const SOURCE_BY_TOOL_NAME: Record<string, string> = {
@@ -18,6 +24,12 @@ const SOURCE_BY_TOOL_NAME: Record<string, string> = {
   fetch: 'socrata',
   search_indicators: 'data-commons',
   get_observations: 'data-commons',
+  ckan__search_datasets: 'boston-opencontext',
+  ckan__get_dataset: 'boston-opencontext',
+  ckan__query_data: 'boston-opencontext',
+  ckan__get_schema: 'boston-opencontext',
+  ckan__execute_sql: 'boston-opencontext',
+  ckan__aggregate_data: 'boston-opencontext',
 };
 
 /**

--- a/src/lib/mcp/registry.test.ts
+++ b/src/lib/mcp/registry.test.ts
@@ -20,6 +20,7 @@ const TEST_ENV = {
   socrataUrl: 'https://socrata-mcp.example.org',
   dataCommonsUrl: 'https://api.datacommons.org/mcp',
   dataCommonsApiKey: 'test-key-abc',
+  bostonOpencontextUrl: 'https://data-mcp.boston.example.org/mcp',
 };
 
 test('Socrata tool names route to the Socrata endpoint', () => {
@@ -44,6 +45,25 @@ test('Data Commons tool names route to the Data Commons endpoint with X-API-Key'
   }
 });
 
+test('Boston OpenContext tool names route to the OpenContext endpoint with no auth header', () => {
+  const registry = buildMcpRegistry(TEST_ENV);
+  const expected = [
+    'ckan__search_datasets',
+    'ckan__get_dataset',
+    'ckan__query_data',
+    'ckan__get_schema',
+    'ckan__execute_sql',
+    'ckan__aggregate_data',
+  ];
+  for (const toolName of expected) {
+    const server = resolveServerForTool(registry, toolName);
+    assert.ok(server, `expected server for tool "${toolName}"`);
+    assert.equal(server!.sourceId, 'boston-opencontext');
+    assert.equal(server!.endpointUrl, 'https://data-mcp.boston.example.org/mcp');
+    assert.equal(server!.headers, undefined, 'OpenContext is unauthenticated; no auth headers expected');
+  }
+});
+
 test('Unknown tool names do not resolve to any server', () => {
   const registry = buildMcpRegistry(TEST_ENV);
   assert.equal(resolveServerForTool(registry, 'get_observation_typo'), undefined);
@@ -51,28 +71,33 @@ test('Unknown tool names do not resolve to any server', () => {
   assert.equal(resolveServerForTool(registry, ''), undefined);
 });
 
-test('Bare Socrata URL gets /mcp appended; Data Commons URL is not double-appended', () => {
+test('Bare Socrata URL gets /mcp appended; DC + OpenContext URLs are not double-appended', () => {
   const registry = buildMcpRegistry({
     socrataUrl: 'https://socrata-mcp.example.org',
     dataCommonsUrl: 'https://api.datacommons.org/mcp',
+    bostonOpencontextUrl: 'https://data-mcp.boston.example.org/mcp',
   });
   assert.equal(registry.servers.socrata.endpointUrl, 'https://socrata-mcp.example.org/mcp');
   assert.equal(registry.servers['data-commons'].endpointUrl, 'https://api.datacommons.org/mcp');
+  assert.equal(registry.servers['boston-opencontext'].endpointUrl, 'https://data-mcp.boston.example.org/mcp');
 });
 
-test('Trailing slash on either env var is normalized', () => {
+test('Trailing slash on any env var is normalized', () => {
   const registry = buildMcpRegistry({
     socrataUrl: 'https://socrata-mcp.example.org/',
     dataCommonsUrl: 'https://api.datacommons.org/mcp/',
+    bostonOpencontextUrl: 'https://data-mcp.boston.example.org/mcp/',
   });
   assert.equal(registry.servers.socrata.endpointUrl, 'https://socrata-mcp.example.org/mcp');
   assert.equal(registry.servers['data-commons'].endpointUrl, 'https://api.datacommons.org/mcp');
+  assert.equal(registry.servers['boston-opencontext'].endpointUrl, 'https://data-mcp.boston.example.org/mcp');
 });
 
 test('Missing Data Commons API key omits the auth header entirely', () => {
   const registry = buildMcpRegistry({
     socrataUrl: 'https://socrata-mcp.example.org',
     dataCommonsUrl: 'https://api.datacommons.org/mcp',
+    bostonOpencontextUrl: 'https://data-mcp.boston.example.org/mcp',
     // no dataCommonsApiKey
   });
   assert.equal(registry.servers['data-commons'].headers, undefined);
@@ -82,18 +107,22 @@ test('readMcpEnvFromProcess falls back to defaults when env vars are unset', () 
   const originalSocrata = process.env.SOCRATA_MCP_URL;
   const originalDc = process.env.DATA_COMMONS_MCP_URL;
   const originalKey = process.env.DATA_COMMONS_API_KEY;
+  const originalBoston = process.env.BOSTON_OPENCONTEXT_MCP_URL;
   delete process.env.SOCRATA_MCP_URL;
   delete process.env.DATA_COMMONS_MCP_URL;
   delete process.env.DATA_COMMONS_API_KEY;
+  delete process.env.BOSTON_OPENCONTEXT_MCP_URL;
   try {
     const env = readMcpEnvFromProcess();
     assert.equal(env.socrataUrl, 'https://socrata-mcp.civicaitools.org');
     assert.equal(env.dataCommonsUrl, 'https://api.datacommons.org/mcp');
     assert.equal(env.dataCommonsApiKey, undefined);
+    assert.equal(env.bostonOpencontextUrl, 'https://data-mcp.boston.gov/mcp');
   } finally {
     if (originalSocrata !== undefined) process.env.SOCRATA_MCP_URL = originalSocrata;
     if (originalDc !== undefined) process.env.DATA_COMMONS_MCP_URL = originalDc;
     if (originalKey !== undefined) process.env.DATA_COMMONS_API_KEY = originalKey;
+    if (originalBoston !== undefined) process.env.BOSTON_OPENCONTEXT_MCP_URL = originalBoston;
   }
 });
 
@@ -135,5 +164,6 @@ test('Every tool appears in exactly one server (no accidental overlap)', () => {
       allTools.set(tool, sourceId);
     }
   }
-  assert.equal(allTools.size, 5, 'registry should host exactly 5 tools in M9.1');
+  // 3 Socrata + 2 Data Commons + 6 Boston OpenContext = 11
+  assert.equal(allTools.size, 11, 'registry should host exactly 11 tools across three sources');
 });

--- a/src/lib/mcp/registry.ts
+++ b/src/lib/mcp/registry.ts
@@ -27,10 +27,19 @@ export interface McpRegistryEnv {
   socrataUrl: string;
   dataCommonsUrl: string;
   dataCommonsApiKey?: string;
+  bostonOpencontextUrl: string;
 }
 
 const SOCRATA_TOOLS = ['get_data', 'search', 'fetch'];
 const DATA_COMMONS_TOOLS = ['search_indicators', 'get_observations'];
+const BOSTON_OPENCONTEXT_TOOLS = [
+  'ckan__search_datasets',
+  'ckan__get_dataset',
+  'ckan__query_data',
+  'ckan__get_schema',
+  'ckan__execute_sql',
+  'ckan__aggregate_data',
+];
 
 /**
  * Normalize a base URL to a POST-able MCP endpoint. The Socrata env var is
@@ -63,6 +72,12 @@ export function buildMcpRegistry(env: McpRegistryEnv): McpRegistry {
       headers: env.dataCommonsApiKey ? { 'X-API-Key': env.dataCommonsApiKey } : undefined,
       tools: DATA_COMMONS_TOOLS,
     },
+    'boston-opencontext': {
+      sourceId: 'boston-opencontext',
+      label: 'Boston OpenContext MCP Server',
+      endpointUrl: normalizeMcpEndpoint(env.bostonOpencontextUrl),
+      tools: BOSTON_OPENCONTEXT_TOOLS,
+    },
   };
 
   const toolIndex: Record<string, string> = {};
@@ -91,5 +106,7 @@ export function readMcpEnvFromProcess(): McpRegistryEnv {
     socrataUrl: process.env.SOCRATA_MCP_URL || 'https://socrata-mcp.civicaitools.org',
     dataCommonsUrl: process.env.DATA_COMMONS_MCP_URL || 'https://api.datacommons.org/mcp',
     dataCommonsApiKey: process.env.DATA_COMMONS_API_KEY || undefined,
+    bostonOpencontextUrl:
+      process.env.BOSTON_OPENCONTEXT_MCP_URL || 'https://data-mcp.boston.gov/mcp',
   };
 }

--- a/src/lib/mcp/skill-composition.test.ts
+++ b/src/lib/mcp/skill-composition.test.ts
@@ -19,7 +19,7 @@ const TODAY = '2026-04-15';
 const PREAMBLE = 'PREAMBLE_BODY';
 const INTRO_LINE = 'You are a helpful assistant with access to civic and statistical data via MCP tools.';
 const TODAY_LINE = `Today's date is ${TODAY}. Always use this as the current date for interpreting relative time expressions like "last year" or "past two months."`;
-const OUTRO = 'When you get results, summarize clearly and cite the dataset ID (for Socrata) or the variable DCID + source dataset (for Data Commons).';
+const OUTRO = 'When you get results, summarize clearly and cite the dataset ID (for Socrata), the variable DCID + source dataset (for Data Commons), or the resource UUID + dataset title (for Boston OpenContext).';
 
 function makeStubEntry(sourceId: SourceId, text: string): SkillEntry {
   return {
@@ -51,6 +51,12 @@ function makeFailingEntry(sourceId: SourceId, message: string): SkillEntry {
 const TWO_SOURCE_REGISTRY: SkillRegistry = {
   socrata: makeStubEntry('socrata', 'SOCRATA_BLOCK'),
   'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+};
+
+const THREE_SOURCE_REGISTRY: SkillRegistry = {
+  socrata: makeStubEntry('socrata', 'SOCRATA_BLOCK'),
+  'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+  'boston-opencontext': makeStubEntry('boston-opencontext', 'BOSTON_BLOCK'),
 };
 
 test('Both sources, typical context: intro+preamble, both source blocks in order, outro — joined by \\n\\n---\\n\\n', async () => {
@@ -251,6 +257,88 @@ test('SkillContext is threaded through to fetchText (portal + today visible)', a
 
   assert.ok(result.includes('SOCRATA_(portal=data.cityofchicago.org, today=2026-04-15)'));
   assert.ok(result.includes('DC_(portal=data.cityofchicago.org, today=2026-04-15)'));
+});
+
+test('All three sources: socrata + data-commons + boston-opencontext render in active order with ---  separators', async () => {
+  const result = await composeSkillPrompt(
+    ['socrata', 'data-commons', 'boston-opencontext'],
+    { today: TODAY, preamble: PREAMBLE, portal: 'data.cityofnewyork.us' },
+    THREE_SOURCE_REGISTRY,
+  );
+
+  const expected = [
+    `${INTRO_LINE}\n\n${TODAY_LINE}\n\n${PREAMBLE}`,
+    'SOCRATA_BLOCK',
+    'DATA_COMMONS_BLOCK',
+    'BOSTON_BLOCK',
+    OUTRO,
+  ].join('\n\n---\n\n');
+
+  assert.equal(result, expected);
+});
+
+test('Boston-only: no Socrata or Data Commons blocks in output', async () => {
+  const result = await composeSkillPrompt(
+    ['boston-opencontext'],
+    { today: TODAY, preamble: PREAMBLE },
+    THREE_SOURCE_REGISTRY,
+  );
+
+  assert.ok(result.includes('BOSTON_BLOCK'), 'Boston block should be present');
+  assert.ok(!result.includes('SOCRATA_BLOCK'), 'Socrata block should be absent');
+  assert.ok(!result.includes('DATA_COMMONS_BLOCK'), 'Data Commons block should be absent');
+});
+
+test('Three-source activeSources order is preserved regardless of registry insertion order', async () => {
+  const reorderedRegistry: SkillRegistry = {
+    'boston-opencontext': makeStubEntry('boston-opencontext', 'BOSTON_BLOCK'),
+    socrata: makeStubEntry('socrata', 'SOCRATA_BLOCK'),
+    'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+  };
+
+  const result = await composeSkillPrompt(
+    ['boston-opencontext', 'data-commons', 'socrata'],
+    { today: TODAY, preamble: PREAMBLE },
+    reorderedRegistry,
+  );
+
+  const bostonIndex = result.indexOf('BOSTON_BLOCK');
+  const dcIndex = result.indexOf('DATA_COMMONS_BLOCK');
+  const socrataIndex = result.indexOf('SOCRATA_BLOCK');
+  assert.ok(bostonIndex >= 0 && dcIndex >= 0 && socrataIndex >= 0, 'all three source blocks should appear');
+  assert.ok(bostonIndex < dcIndex, 'boston should render before data-commons when listed first');
+  assert.ok(dcIndex < socrataIndex, 'data-commons should render before socrata when listed second');
+});
+
+test('Three-source composition survives one failing source: boston throws, socrata + data-commons still render', async () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+
+  try {
+    const registry: SkillRegistry = {
+      socrata: makeStubEntry('socrata', 'SOCRATA_BLOCK'),
+      'data-commons': makeStubEntry('data-commons', 'DATA_COMMONS_BLOCK'),
+      'boston-opencontext': makeFailingEntry('boston-opencontext', 'simulated boston outage'),
+    };
+    const result = await composeSkillPrompt(
+      ['socrata', 'data-commons', 'boston-opencontext'],
+      { today: TODAY, preamble: PREAMBLE },
+      registry,
+    );
+
+    assert.ok(result.includes('SOCRATA_BLOCK'), 'surviving Socrata source renders');
+    assert.ok(result.includes('DATA_COMMONS_BLOCK'), 'surviving Data Commons source renders');
+    assert.ok(!result.includes('BOSTON_BLOCK'), 'failed Boston source is omitted');
+    assert.ok(
+      warnings.some((w) => w.includes('boston-opencontext') && w.includes('simulated boston outage')),
+      'a warning was logged about the failed Boston source',
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
 });
 
 test('No-preamble + empty sources: intro joins directly to outro by separator (preamble omitted, no double separator)', async () => {

--- a/src/lib/mcp/socrata-skill.ts
+++ b/src/lib/mcp/socrata-skill.ts
@@ -1,7 +1,8 @@
 // Multi-source MCP skill composition for the civic-ai-tools website.
 //
 // Despite the filename (historical — Socrata was the only source pre-M9.1),
-// `buildSystemPrompt` now composes the full multi-source system prompt:
+// `buildSystemPrompt` now composes the full multi-source system prompt
+// spanning Socrata, Google Data Commons, and Boston OpenContext:
 //
 //   1. Cross-source preamble  — "you have access to two data sources..."
 //   2. Socrata skill          — fetched from the Socrata MCP server's

--- a/src/lib/mcp/socrata-skill.ts
+++ b/src/lib/mcp/socrata-skill.ts
@@ -18,6 +18,7 @@
 
 import { callMcpPrompt, getServerInstructions } from './client.ts';
 import { DATA_COMMONS_SKILL } from './data-commons-skill.ts';
+import { BOSTON_OPENCONTEXT_SKILL } from './boston-skill.ts';
 
 // Fallback constant used when the MCP server is unreachable.
 // NOTE: This may be stale — it was last synced at PR #19 and may be missing
@@ -436,11 +437,11 @@ async function fetchSkillGuidance(): Promise<string> {
 
 /**
  * Identifier for an MCP data source. Mirrors the keys in `./registry.ts` so a
- * source's skill text is keyed the same way as its tool routing. Adding a
- * third source means widening this union and adding one entry to
+ * source's skill text is keyed the same way as its tool routing. Adding
+ * another source means widening this union and adding one entry to
  * `SKILL_REGISTRY` below — no changes to `composeSkillPrompt` itself.
  */
-export type SourceId = 'socrata' | 'data-commons';
+export type SourceId = 'socrata' | 'data-commons' | 'boston-opencontext';
 
 /**
  * Inputs handed to every `SkillEntry.fetchText` call. Sources are free to
@@ -474,12 +475,19 @@ export interface SkillEntry {
  */
 export type SkillRegistry = Partial<Record<SourceId, SkillEntry>>;
 
-const CROSS_SOURCE_PREAMBLE = `You have access to TWO MCP data sources through the tools below.
+const CROSS_SOURCE_PREAMBLE = `You have access to THREE MCP data sources through the tools below.
 
-1. **Socrata open data portals** — city operational data such as 311 requests, building permits, inspections, crime, housing violations, payroll, and licenses. Tools: get_data, search, fetch.
+1. **Socrata open data portals** — city operational data such as 311 requests, building permits, inspections, crime, housing violations, payroll, and licenses. Covers NYC, Chicago, SF, Seattle, LA, and hundreds of other portals — but not Boston. Tools: get_data, search, fetch.
 2. **Google Data Commons** — authoritative federal and international statistical data from the U.S. Census Bureau (ACS, Decennial), BLS, CDC, Department of Education, EPA, and other official agencies. Tools: search_indicators, get_observations.
+3. **Boston OpenContext** — the City of Boston's CKAN-native open-data MCP, fronting data.boston.gov. 311, permits, crime, inspections, property, elections, schools, parcels, and neighborhoods for Boston specifically. Tools: ckan__search_datasets, ckan__get_dataset, ckan__query_data, ckan__get_schema, ckan__execute_sql, ckan__aggregate_data.
 
-When a question is about demographics, poverty, income, education, health, labor, or environment for a defined geography, prefer Data Commons. When a question is about city operations or anything that changes daily, prefer Socrata. When a question needs both — equity analyses that join city operations against demographic context — plan a multi-step analysis and attribute each figure to its source. See the Cross-source decision logic section in the Data Commons guidance below for the join pattern.`;
+Source selection rules:
+- **Boston civic questions** → Boston OpenContext. Boston is not on Socrata.
+- **Other-city civic questions** (NYC, Chicago, SF, Seattle, LA, ...) → Socrata.
+- **Demographics, poverty, income, education, health, labor, environment** for any geography → Data Commons.
+- **Multi-source equity questions** that join operational data against demographic context → plan a multi-step analysis, attribute each figure to its source, and mind geography alignment (Boston neighborhoods and city council districts are not standard census geographies — state the mismatch rather than silently imputing).
+
+See the Cross-source decision logic section in the Data Commons guidance below for the join pattern.`;
 
 const INTRO_TEMPLATE = (today: string) =>
   `You are a helpful assistant with access to civic and statistical data via MCP tools.
@@ -487,7 +495,7 @@ const INTRO_TEMPLATE = (today: string) =>
 Today's date is ${today}. Always use this as the current date for interpreting relative time expressions like "last year" or "past two months."`;
 
 const OUTRO =
-  'When you get results, summarize clearly and cite the dataset ID (for Socrata) or the variable DCID + source dataset (for Data Commons).';
+  'When you get results, summarize clearly and cite the dataset ID (for Socrata), the variable DCID + source dataset (for Data Commons), or the resource UUID + dataset title (for Boston OpenContext).';
 
 /**
  * Default registry. One entry per source the website talks to. Each entry's
@@ -515,6 +523,16 @@ const SKILL_REGISTRY: SkillRegistry = {
         ? `# Data Commons server instructions (from initialize response)\n\n${instructions}`
         : '# Data Commons server instructions\n\n(The Data Commons MCP server did not advertise per-server instructions on initialize — composing with the embedded Data Commons skill only.)';
       return `${instructionsBlock}\n\n---\n\n${DATA_COMMONS_SKILL}`;
+    },
+  },
+  'boston-opencontext': {
+    sourceId: 'boston-opencontext',
+    async fetchText() {
+      const instructions = await getServerInstructions('boston-opencontext');
+      const instructionsBlock = instructions
+        ? `# Boston OpenContext server instructions (from initialize response)\n\n${instructions}`
+        : '# Boston OpenContext server instructions\n\n(The OpenContext MCP server did not advertise per-server instructions on initialize — composing with the embedded Boston skill only; per-tool guidance is carried inline on each ckan__* tool description.)';
+      return `${instructionsBlock}\n\n---\n\n${BOSTON_OPENCONTEXT_SKILL}`;
     },
   },
 };
@@ -575,10 +593,11 @@ export async function composeSkillPrompt(
 /**
  * Thin wrapper kept for backward compatibility with the existing route
  * handlers. Delegates to `composeSkillPrompt` with the default active source
- * list (`['socrata', 'data-commons']`) and the cross-source preamble.
+ * list (`['socrata', 'data-commons', 'boston-opencontext']`) and the
+ * cross-source preamble.
  */
 export const buildSystemPrompt = async (portal: string): Promise<string> => {
-  return composeSkillPrompt(['socrata', 'data-commons'], {
+  return composeSkillPrompt(['socrata', 'data-commons', 'boston-opencontext'], {
     portal,
     today: new Date().toISOString().split('T')[0],
     preamble: CROSS_SOURCE_PREAMBLE,

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -195,10 +195,194 @@ Examples:
   },
 ];
 
+// --- Boston OpenContext MCP (CKAN-native, data.boston.gov) ---
+// Six-tool surface routed to the production OpenContext endpoint at
+// https://data-mcp.boston.gov/mcp. OpenContext is the City of Boston's
+// open-source MCP framework fronting the CKAN DataStore; full CKAN vs Socrata
+// workflow and Boston-specific geography guidance lives in the skill prompt
+// (see `./boston-skill.ts`). Tool names preserve the `ckan__` prefix used by
+// the upstream server so the registry-layer tool-name → source routing works
+// without a rename layer.
+const bostonOpencontextMcpTools: ChatCompletionTool[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'ckan__search_datasets',
+      description: `Natural-language dataset discovery against Boston's CKAN portal (data.boston.gov). Returns candidate datasets with their CKAN UUID resource ids, titles, and descriptions.
+
+Use this first when the user asks about Boston civic data and you don't already know the resource UUID. Pair with ckan__get_dataset to inspect a specific candidate or ckan__get_schema to fetch field names for querying.
+
+Examples:
+- { "query": "311 pothole requests", "limit": 5 }
+- { "query": "building permits" }`,
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Free-text search query (e.g., "311 pothole requests", "building permits", "assessing values")',
+          },
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of results (default: 20)',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'ckan__get_dataset',
+      description: `Fetch detailed metadata for a specific Boston dataset — title, publisher, update cadence, description, and the list of CKAN resources attached to it. Use after ckan__search_datasets when you need to pick the right resource within a dataset that bundles several.
+
+Example:
+- { "dataset_id": "311-service-requests" }
+- { "dataset_id": "8048697b-ad64-4bfc-b090-ee00169f2323" }`,
+      parameters: {
+        type: 'object',
+        properties: {
+          dataset_id: {
+            type: 'string',
+            description: 'CKAN dataset ID or slug (UUID or human-readable name)',
+          },
+        },
+        required: ['dataset_id'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'ckan__get_schema',
+      description: `Fetch the field names and types for a specific Boston CKAN resource. Always run this before querying an unfamiliar resource — Boston follows CKAN field-naming conventions that differ from Socrata portals (NYC, Chicago, etc.), and guessing a field name can silently return zero rows.
+
+Example:
+- { "resource_id": "8048697b-ad64-4bfc-b090-ee00169f2323" }`,
+      parameters: {
+        type: 'object',
+        properties: {
+          resource_id: {
+            type: 'string',
+            description: 'CKAN resource UUID (e.g., "8048697b-ad64-4bfc-b090-ee00169f2323")',
+          },
+        },
+        required: ['resource_id'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'ckan__query_data',
+      description: `Simple equality-filter query against a Boston CKAN resource. Supports exact-match filtering on one or more fields. For GROUP BY / aggregation, use ckan__aggregate_data. For complex SQL (CTEs, window functions, JOINs), use ckan__execute_sql.
+
+Example:
+- { "resource_id": "8048697b-ad64-4bfc-b090-ee00169f2323", "filters": { "neighborhood": "Dorchester" }, "limit": 100 }`,
+      parameters: {
+        type: 'object',
+        properties: {
+          resource_id: {
+            type: 'string',
+            description: 'CKAN resource UUID to query',
+          },
+          filters: {
+            type: 'object',
+            description: 'Optional exact-match filters as field: value pairs (e.g., { "neighborhood": "Dorchester" })',
+          },
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of records (default: 100)',
+          },
+        },
+        required: ['resource_id'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'ckan__aggregate_data',
+      description: `Structured GROUP BY + aggregation against a Boston CKAN resource. The server compiles a safe SQL query from a JSON spec — prefer this over ckan__execute_sql whenever the question is countable / summable / averageable. Supports count(*), sum(), avg(), min(), max(), stddev().
+
+Run ckan__get_schema first to confirm field names.
+
+Examples:
+- Count 311 requests by neighborhood:
+  { "resource_id": "8048697b-ad64-4bfc-b090-ee00169f2323", "group_by": ["neighborhood"], "metrics": { "count": "count(*)" }, "order_by": "count DESC", "limit": 25 }
+- Requests matching a specific case type grouped by year:
+  { "resource_id": "...", "group_by": ["year"], "metrics": { "total": "count(*)" }, "filters": { "case_title": "Request for Pothole Repair" } }`,
+      parameters: {
+        type: 'object',
+        properties: {
+          resource_id: {
+            type: 'string',
+            description: 'CKAN resource UUID',
+          },
+          group_by: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Fields to group by',
+          },
+          metrics: {
+            type: 'object',
+            description: 'Aggregation metrics as alias: expression pairs (e.g., { "count": "count(*)", "avg_val": "avg(amount)" })',
+          },
+          filters: {
+            type: 'object',
+            description: 'Optional exact-match filters before aggregation',
+          },
+          having: {
+            type: 'object',
+            description: 'Optional post-aggregation filters',
+          },
+          order_by: {
+            type: 'string',
+            description: 'Optional ORDER BY clause (e.g., "count DESC")',
+          },
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of groups to return (default: 100)',
+          },
+        },
+        required: ['resource_id', 'metrics'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'ckan__execute_sql',
+      description: `Execute a raw PostgreSQL SELECT against a Boston CKAN resource. For complex queries only — prefer ckan__query_data or ckan__aggregate_data first.
+
+CRITICAL:
+- Only SELECT is allowed. INSERT / UPDATE / DELETE / DDL are rejected server-side.
+- Resource UUIDs MUST be double-quoted in the FROM clause: FROM "8048697b-ad64-4bfc-b090-ee00169f2323"
+
+Supports CTEs (WITH ...), window functions (RANK() OVER (...)), percentile aggregates (PERCENTILE_CONT), and JOINs across resources.
+
+Example:
+- { "sql": "SELECT neighborhood, count(*) AS requests FROM \\"8048697b-ad64-4bfc-b090-ee00169f2323\\" WHERE open_dt >= '2024-01-01' GROUP BY neighborhood ORDER BY requests DESC LIMIT 10" }`,
+      parameters: {
+        type: 'object',
+        properties: {
+          sql: {
+            type: 'string',
+            description: 'PostgreSQL SELECT statement. Resource UUIDs must be double-quoted in FROM.',
+          },
+        },
+        required: ['sql'],
+      },
+    },
+  },
+];
+
 /** Unified tool schema exposed to OpenRouter. The client in ./client.ts routes each call to the correct MCP server by tool name. */
 export const mcpTools: ChatCompletionTool[] = [
   ...socrataMcpTools,
   ...dataCommonsMcpTools,
+  ...bostonOpencontextMcpTools,
 ];
 
 // Model definitions for the model selector


### PR DESCRIPTION
## Summary

Closes #81. Wires the City of Boston's OpenContext MCP server at `data-mcp.boston.gov/mcp` as the third data source alongside Socrata (multi-city civic) and Google Data Commons (federal statistical). First real validation of the M9.2 *"new source = one registry entry + `SourceId` union widening, zero composer edits"* design claim — the composer in `socrata-skill.ts` required only a `SKILL_REGISTRY` addition and a preamble rewrite, no structural changes.

- **SourceId chosen:** `boston-opencontext` — matches the #81 acceptance criteria; leaves room for future forks like `other-city-opencontext` as cities deploy their own OpenContext instances (OpenContext is template-first and MIT-licensed).
- **6 tools routed:** `ckan__search_datasets`, `ckan__get_dataset`, `ckan__query_data`, `ckan__get_schema`, `ckan__execute_sql`, `ckan__aggregate_data`.
- **Env var:** `BOSTON_OPENCONTEXT_MCP_URL` (defaults to `https://data-mcp.boston.gov/mcp`; no auth required, 5 req/s sustained / 1000/day quota upstream).
- **Skill doc:** `civic-ai-tools/docs/skills/boston.md` (source of truth, 676 words — within the ~500-800 target set by the issue); embedded copy at `src/lib/mcp/boston-skill.ts`.

## Sibling PR (skill-doc source of truth)

npstorey/civic-ai-tools#47 ships `civic-ai-tools/docs/skills/boston.md` on a same-named `feat/opencontext-integration` branch. Opted for a sibling PR rather than a direct commit to main so the paired changes are reviewable together. Merge website PR first, then the skill-doc PR.

## Files touched

| File | Change |
|------|--------|
| `src/lib/mcp/registry.ts` | Widens `McpRegistryEnv` with `bostonOpencontextUrl`; adds `boston-opencontext` server entry with 6 `ckan__*` tools |
| `src/lib/mcp/operation-types.ts` | Maps the 6 `ckan__*` tools to `(source, operationType)` — search/metadata/query buckets per OpenContext semantics |
| `src/lib/mcp/tools.ts` | OpenRouter function-calling schemas for the 6 tools — concise, defers workflow guidance to the skill prompt |
| `src/lib/mcp/boston-skill.ts` | New — embedded copy of `civic-ai-tools/docs/skills/boston.md`, backtick-stripped per `data-commons-skill.ts` pattern |
| `src/lib/mcp/socrata-skill.ts` | `SourceId` union widened to include `'boston-opencontext'`; `SKILL_REGISTRY` gets a Boston entry; cross-source preamble rewritten from TWO → THREE sources with explicit source-selection rules |
| `src/lib/evidence/data-sources.ts` | `boston-opencontext` display name + Boston branch in `buildDataSources` (one aggregate entry, `catalogType: 'ckan'`, portal `https://data.boston.gov`) |
| `src/lib/evidence/provenance.ts` | `sourceAgentMap` gains the Boston OpenContext agent with correct title + server URL |

## Test counts

**Before (origin/main):** 122 tests passing
**After:** 136 tests passing (+14 net)

Added coverage:
- `registry.test.ts` (+1): Boston OpenContext routing with no auth header; URL normalization; `readMcpEnvFromProcess` default fallback; updated "every tool in exactly one server" count from 5 → 11
- `operation-types.test.ts` (+2): Boston OpenContext source mapping for all 6 tools; per-tool operation type derivation
- `data-sources.test.ts` (+5): Boston-only `buildDataSources`, three-source `buildDataSources`, empty-trace Boston fallback, three-source `formatDataSourcesSummary`, Boston-only `formatDataSourcesSummary`, Boston display name
- `provenance.test.ts` (+2): Boston-only PROV-O graph, three-source PROV-O graph
- `skill-composition.test.ts` (+4): three-source composition with `---` separators, Boston-only, order-preservation-with-reordered-registry, failing-Boston-source

## Pre-merge E2E verification (against Vercel preview)

Target Vercel preview deploy of this branch.

E2E query: *"How many 311 pothole requests were filed in Dorchester in 2024?"*

Attribution checks on the published evidence package:

- [ ] `dataSources[]` includes `{ sourceId: "boston-opencontext", catalogType: "ckan", portalUrl: "https://data.boston.gov", ... }`
- [ ] `queries[]` includes at least one `ckan__*` tool call with the correct `operationType` (`search` / `metadata` / `query`) — not `"unknown"`
- [ ] PROV-O graph emits `urn:civic-evidence:mcp-server:boston-opencontext` agent with title "Boston OpenContext MCP Server"
- [ ] Data entities tagged `civic:sourceId: "boston-opencontext"`
- [ ] Detail page renders "Data sources: Boston OpenContext"
- [ ] No regressions on Socrata-only or Data Commons-only queries

## Coordination hold — DO NOT MERGE

Per roadmap, coordinate with upstream maintainers before pointing production traffic at the endpoint. This PR stops at a green preview deploy + passing E2E.

## Related

- #81 — this integration
- #82 — evaluate per-tool descriptions vs centralized skill composition (informed by this integration)
- civic-ai-tools#35, civic-ai-tools#46 — directory entries (boston-core-mcp v1 prototype + OpenContext v2 framework)
- socrata-mcp-server#40 — evaluate `aggregate_data`-style helper for Socrata (inspired by `ckan__aggregate_data`)

## Pre-existing issues noted

Lint + tsc surface 11 + 2 warnings/errors respectively against files I did not touch (`TraceControls.tsx`, `ComparisonDisplay.tsx`, `LiveResponsePanel.tsx`, `expert-attestation.test.ts`, etc.). These exist on `origin/main` today — filing them is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)