### PR TITLE
feat(evidence): enforce ADR-0003 captureMethod end-to-end on /api/evidence

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records (civic-ai-tools-website)
+
+This directory is a stub. ADRs governing the **evidence system** live in the canonical hub-repo location: [`civic-ai-tools/docs/adr/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/adr).
+
+## Current ADRs (canonical location)
+
+| # | Title | Status |
+|---|-------|--------|
+| 0001 | Public-roadmap governance | Accepted |
+| 0002 | Trust commitments vs. operational targets | Accepted |
+| 0003 | Capture-method differentiation for evidence packages | Accepted |
+
+## Policy
+
+ADRs in this repo cover decisions that govern **web-specific concerns** — Vercel deployment configuration, Next.js routing/rendering choices, browser-only code, the marketing site, third-party site integrations. Decisions that govern the broader evidence system (package format, signing, publishing protocol, identity model, capture-method vocabulary, attestation types) live in the canonical hub-repo location regardless of which repo holds the implementation.
+
+When in doubt, prefer the hub-repo location and cross-link from here when a hub-repo ADR has substantial site-side consequences.
+
+This README is itself a stub and should be replaced with real ADRs as web-specific decisions accumulate.

--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -88,6 +88,7 @@ Send exactly one auth header — when both are present, the `Authorization` head
 | `promptVisibility`      | string             | yes      | `"full_text"` to include the prompt text in the package and database record, or `"hash_only"` to include only the SHA-256 hash.                         |
 | `title`                 | string             | yes      | Display title for the evidence record. Used to derive the URL slug.                                                                                     |
 | `summary`               | string             | yes      | A 2–4 sentence description for non-technical readers.                                                                                                   |
+| `captureMethod`         | string             | yes      | Capture-method label per [ADR-0003](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0003-evidence-capture-method.md). One of `"chat-flow-stream"`, `"claude-code-jsonl-readback"`, `"claude-code-self-report"`. Included in the signed envelope and persisted to the database. Missing or invalid values return `400`. |
 | `duration_ms`           | number             | no       | End-to-end analysis duration in milliseconds.                                                                                                           |
 | `skillMetadataOverride` | object             | no       | Override for the skill metadata normally extracted from the trace. Required when `trace` is a BlobRef. See [Blob references](#blob-references-phase-b6). |
 | `extensions`            | object             | no       | Implementation-specific artifacts keyed by reverse-DNS identifiers (e.g., `"org.civicaitools.notebook"`). Extensions are included in the canonical JSON and therefore covered by the package hash. |
@@ -107,6 +108,7 @@ Send exactly one auth header — when both are present, the `Authorization` head
 - **`trace`** — The trace is embedded verbatim in the package and used to extract PROV-O provenance at publish time. External clients that don't run OpenTelemetry internally can ship an empty trace (`{ "resourceSpans": [] }`); per-tool provenance will use the static tool-name → source map. Including a trace with `mcp_tool_call` spans and `mcp.source` attributes produces richer attribution.
 - **`portal`** — Primarily meaningful for Socrata analyses. For Data Commons-only or mixed analyses, this field is still required by the current schema but a placeholder such as `"n/a"` works without breaking provenance. See [known chat-flow assumptions](#known-chat-flow-assumptions).
 - **`extensions`** — The `"org.civicaitools.notebook"` extension (a Jupyter-style cell list) is emitted by the website's chat flow as a content-format marker, not a publish-surface marker. External clients are not required to include any extensions.
+- **`captureMethod`** — Required since 2026-04-29. Three vocabulary values per ADR-0003: `chat-flow-stream` (website server captured bytes streaming to the browser; verbatim by construction at the wire layer), `claude-code-jsonl-readback` (Claude Code skill read each turn from the session JSONL, filtering to text-typed content blocks; verbatim by construction at the JSONL layer), `claude-code-self-report` (legacy: the publishing model paraphrased from in-context memory; deprecated 2026-04-28, retained so pre-ADR records can be labeled with their actual capture method rather than silently re-described). The label is included in `metadata.captureMethod` of the canonical package JSON, so it is covered by the package hash and the platform Ed25519ph signature — the capture method itself is tamper-evident. Pre-ADR packages without the field render as "Unknown (pre-ADR-0003)" on the detail page.
 
 ---
 
@@ -230,6 +232,7 @@ await fetch('https://civicaitools.org/api/evidence', {
     promptVisibility: 'full_text',
     title,
     summary,
+    captureMethod: 'claude-code-jsonl-readback',
   }),
 });
 ```
@@ -362,7 +365,8 @@ curl -sS -X POST https://civicaitools.org/api/evidence \
     "duration_ms": 4200,
     "promptVisibility": "full_text",
     "title": "Manhattan 311 noise complaints, 2025",
-    "summary": "A count of 311 noise complaints filed in Manhattan during 2025 against the NYC Open Data 311 Service Requests dataset."
+    "summary": "A count of 311 noise complaints filed in Manhattan during 2025 against the NYC Open Data 311 Service Requests dataset.",
+    "captureMethod": "claude-code-jsonl-readback"
   }'
 ```
 
@@ -392,6 +396,7 @@ Returns the database row (truncated here for readability):
   "model": "openai/gpt-4o",
   "promptHash": "1f2e3d4c...",
   "promptVisibility": "full_text",
+  "captureMethod": "claude-code-jsonl-readback",
   "verificationStatus": "unverified",
   "consistencyClassification": null,
   "jurisdiction": null,
@@ -434,6 +439,7 @@ const res = await fetch('https://civicaitools.org/api/evidence', {
     promptVisibility: 'full_text',
     title,
     summary,
+    captureMethod: 'claude-code-jsonl-readback',
   }),
 });
 
@@ -461,6 +467,7 @@ These are implementation details that may surprise an external client. None of t
 
 ## Change log
 
+- **2026-04-29** — Added required `captureMethod` field on `POST /api/evidence` per [ADR-0003](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0003-evidence-capture-method.md). Values: `chat-flow-stream` | `claude-code-jsonl-readback` | `claude-code-self-report`. The field is part of `metadata.captureMethod` in the canonical package JSON (covered by the package hash and platform signature) and is persisted to the new `evidence_records.capture_method` column. Requests that omit or misvalue the field return `400`. The detail page surfaces a "Captured via:" label next to the verification status; pre-ADR records render as "Unknown (pre-ADR-0003)". Backwards-compatible at the verify path — legacy packages without the field continue to recompute their hash and verify identically.
 - **2026-04-21** — Added OAuth 2.0 device-flow bearer-token authentication (closes [#73](https://github.com/npstorey/civic-ai-tools-website/issues/73)). New endpoints: `POST /api/auth/device/code` (start), `POST /api/auth/device/token` (poll), `POST /api/auth/device/approve` (user-facing), `GET /api/auth/device/lookup` (user-facing prefill), `GET /api/auth/tokens` (list), `DELETE /api/auth/tokens/:id` (revoke). Clients send `Authorization: Bearer <token>` on `POST /api/evidence` and `POST /api/blob/upload-token`; scope `evidence:publish` is required. Tokens live 90 days by default, are stored server-side as SHA-256 hashes, and can be revoked from the Dashboard **Tokens** tab. Session-cookie auth remains working indefinitely but now emits `X-Auth-Deprecated: cookie` on each cookie-authed response. Backwards-compatible — existing cookie-based clients continue working without changes.
 - **2026-04-18** — Added the [Blob references (Phase B.6)](#blob-references-phase-b6) section. The `output`, `trace`, and `skillMetadataOverride.skillText` request fields now accept either inline content or a BlobRef `{ ref, url, contentType, size }` object; the verify endpoint returns per-reference `blobRefs[]` entries alongside the existing verdicts. A new `POST /api/blob/upload-token` endpoint mints presigned tokens for direct client uploads to `evidence-refs/<sha256>[.ext]`, gated by the same NextAuth session as `/api/evidence`. Orphan blobs are swept by a daily cron (`/api/cron/blob-gc`). Backwards-compatible — existing inline-content packages remain valid and the verify response adds fields rather than renaming any.
 - **2026-04-18** — Added the [Signing and trust registry](#signing-and-trust-registry) section. Documents the `metadata.signingKeyId` field now included in the canonical package hash, the `/.well-known/evidence-public-keys.json` registry endpoint, the `keyTrust` verdicts returned by `GET /api/evidence/<slug>/verify` (including the new `legacy_embedded` state for pre-registry packages), and the signing-side env vars (`EVIDENCE_SIGNING_KEY`, `EVIDENCE_KEY_ID`, `EVIDENCE_PUBLIC_KEY`, `EVIDENCE_TRUST_REGISTRY_URL`). Backwards-compatible at the publish path — clients do not need any changes.

--- a/drizzle/0007_capture_method.sql
+++ b/drizzle/0007_capture_method.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."capture_method" AS ENUM('chat-flow-stream', 'claude-code-jsonl-readback', 'claude-code-self-report');--> statement-breakpoint
+ALTER TABLE "evidence_records" ADD COLUMN "capture_method" "capture_method";

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,661 @@
+{
+  "id": "24304b13-a2b5-4f39-9076-37c2511d8f0e",
+  "prevId": "67d689ab-8037-40d3-bd33-20ec7c1d9d24",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_packages": {
+      "name": "attestation_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evidence_record_id": {
+          "name": "evidence_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attestation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_hash": {
+          "name": "package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references_base_hash": {
+          "name": "references_base_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_packages_evidence_record_id_evidence_records_id_fk": {
+          "name": "attestation_packages_evidence_record_id_evidence_records_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "evidence_records",
+          "columnsFrom": [
+            "evidence_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attestation_packages_creator_id_users_id_fk": {
+          "name": "attestation_packages_creator_id_users_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_approved_user_id_users_id_fk": {
+          "name": "device_codes_approved_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_records": {
+      "name": "evidence_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_visibility": {
+          "name": "prompt_visibility",
+          "type": "prompt_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_text'"
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_server": {
+          "name": "mcp_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civic_context": {
+          "name": "civic_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_hash": {
+          "name": "base_package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_storage_key": {
+          "name": "base_package_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_signature": {
+          "name": "base_package_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rfc3161_timestamp": {
+          "name": "base_package_rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_id": {
+          "name": "base_package_rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_inclusion_proof": {
+          "name": "base_package_rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_method": {
+          "name": "capture_method",
+          "type": "capture_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "consistency_classification": {
+          "name": "consistency_classification",
+          "type": "consistency_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_reason": {
+          "name": "withdrawn_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_signature": {
+          "name": "withdrawal_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_timestamp": {
+          "name": "withdrawal_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_reason": {
+          "name": "reinstated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_signature": {
+          "name": "reinstatement_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_timestamp": {
+          "name": "reinstatement_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evidence_records_creator_id_users_id_fk": {
+          "name": "evidence_records_creator_id_users_id_fk",
+          "tableFrom": "evidence_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evidence_records_slug_unique": {
+          "name": "evidence_records_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attestation_type": {
+      "name": "attestation_type",
+      "schema": "public",
+      "values": [
+        "consistency",
+        "evaluation",
+        "re_evaluation",
+        "correction",
+        "expert_attestation"
+      ]
+    },
+    "public.capture_method": {
+      "name": "capture_method",
+      "schema": "public",
+      "values": [
+        "chat-flow-stream",
+        "claude-code-jsonl-readback",
+        "claude-code-self-report"
+      ]
+    },
+    "public.consistency_classification": {
+      "name": "consistency_classification",
+      "schema": "public",
+      "values": [
+        "highly_reproducible",
+        "moderately_stable",
+        "inconsistent"
+      ]
+    },
+    "public.prompt_visibility": {
+      "name": "prompt_visibility",
+      "schema": "public",
+      "values": [
+        "full_text",
+        "hash_only"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "consistency_tested",
+        "evaluated",
+        "fully_attested"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776731843403,
       "tag": "0006_mixed_sabra",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777479752642,
+      "tag": "0007_capture_method",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -3,7 +3,7 @@ import { db } from '@/lib/db';
 import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { putPackage } from '@/lib/storage';
-import { buildEvidencePackage, type PackageInput } from '@/lib/evidence/packager';
+import { buildEvidencePackage, type PackageInput, type CaptureMethod } from '@/lib/evidence/packager';
 import { hash } from '@/lib/evidence/trace';
 import { signPackage, getRfc3161Timestamp, publishToRekor } from '@/lib/evidence/signing';
 import { type BlobRef } from '@/lib/evidence/blob-ref';
@@ -45,6 +45,12 @@ async function resolveSlug(title: string, packageHash: string): Promise<string> 
   return buildSlug(title, packageHash, 64);
 }
 
+const VALID_CAPTURE_METHODS: readonly CaptureMethod[] = [
+  'chat-flow-stream',
+  'claude-code-jsonl-readback',
+  'claude-code-self-report',
+] as const;
+
 interface PublishRequest {
   /** OTel trace OR a BlobRef. See `docs/api/evidence-publish.md` for the
    *  blob-reference contract. */
@@ -66,6 +72,9 @@ interface PublishRequest {
   promptVisibility: 'full_text' | 'hash_only';
   title: string;
   summary: string;
+  /** Capture-method label per ADR-0003. Required for all publishes; the
+   *  route rejects requests that omit or misvalue this field. */
+  captureMethod: CaptureMethod;
   /** Optional override for the skill metadata that would otherwise be
    *  extracted from the trace. Required when `trace` is a BlobRef. */
   skillMetadataOverride?: {
@@ -92,6 +101,18 @@ export async function POST(request: NextRequest) {
 
     const body: PublishRequest = await request.json();
 
+    // Validate captureMethod (ADR-0003). Required for all publishes;
+    // resolve once here, never re-derive downstream.
+    if (!body.captureMethod || !VALID_CAPTURE_METHODS.includes(body.captureMethod)) {
+      return NextResponse.json(
+        {
+          error:
+            'captureMethod is required and must be one of: chat-flow-stream, claude-code-jsonl-readback, claude-code-self-report',
+        },
+        { status: 400 },
+      );
+    }
+
     // Build evidence package
     const packageInput: PackageInput = {
       trace: body.trace,
@@ -105,6 +126,7 @@ export async function POST(request: NextRequest) {
       promptVisibility: body.promptVisibility,
       title: body.title,
       summary: body.summary,
+      captureMethod: body.captureMethod,
       skillMetadataOverride: body.skillMetadataOverride,
       extensions: body.extensions,
     };
@@ -157,6 +179,7 @@ export async function POST(request: NextRequest) {
       basePackageRfc3161Timestamp: rfc3161Token,
       basePackageRekorEntryId: rekorResult?.entryId || null,
       basePackageRekorInclusionProof: rekorResult?.inclusionProof || null,
+      captureMethod: body.captureMethod,
     });
 
     const response = NextResponse.json({

--- a/src/app/evidence/[slug]/page.tsx
+++ b/src/app/evidence/[slug]/page.tsx
@@ -163,6 +163,22 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
+// Human-readable label for the ADR-0003 captureMethod field. Pre-ADR
+// records (column null) render as "Unknown (pre-ADR-0003)" rather than
+// inferring a method from indirect signals — see ADR-0003 §1 amendment.
+function captureMethodLabel(method: string | null | undefined): string {
+  switch (method) {
+    case 'chat-flow-stream':
+      return 'Chat flow (verbatim stream)';
+    case 'claude-code-jsonl-readback':
+      return 'Claude Code (verbatim JSONL)';
+    case 'claude-code-self-report':
+      return 'Claude Code (self-report, deprecated)';
+    default:
+      return 'Unknown (pre-ADR-0003)';
+  }
+}
+
 export default async function EvidencePage({ params }: PageProps) {
   const { slug } = await params;
   const data = await getEvidenceData(slug);
@@ -269,6 +285,9 @@ export default async function EvidencePage({ params }: PageProps) {
                 Consistency: {record.consistencyClassification.replace(/_/g, ' ')}
               </span>
             )}
+            <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
+              Captured via: {captureMethodLabel(record.captureMethod)}
+            </span>
           </div>
         </Section>
 

--- a/src/components/PublishEvidenceDialog.tsx
+++ b/src/components/PublishEvidenceDialog.tsx
@@ -112,6 +112,8 @@ export default function PublishEvidenceDialog({
           promptVisibility,
           title,
           summary,
+          // ADR-0003: chat flow captures bytes streaming to the browser.
+          captureMethod: 'chat-flow-stream',
           extensions: {
             'org.civicaitools.notebook': notebook,
           },

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -42,6 +42,20 @@ export const attestationTypeEnum = pgEnum('attestation_type', [
   'expert_attestation',
 ]);
 
+// captureMethod labels how the package contents were captured (ADR-0003).
+// `chat-flow-stream` — server captured bytes streaming to the browser.
+// `claude-code-jsonl-readback` — Claude Code skill read each turn from
+// the session JSONL, filtering to text-typed content blocks.
+// `claude-code-self-report` — legacy: the publishing model paraphrased
+// from in-context memory. Deprecated 2026-04-28; retained so pre-ADR
+// records can be labeled with their actual capture method rather than
+// silently re-described.
+export const captureMethodEnum = pgEnum('capture_method', [
+  'chat-flow-stream',
+  'claude-code-jsonl-readback',
+  'claude-code-self-report',
+]);
+
 // --- Tables ---
 
 export const users = pgTable('users', {
@@ -78,6 +92,7 @@ export const evidenceRecords = pgTable('evidence_records', {
   basePackageRfc3161Timestamp: text('base_package_rfc3161_timestamp'),
   basePackageRekorEntryId: text('base_package_rekor_entry_id'),
   basePackageRekorInclusionProof: text('base_package_rekor_inclusion_proof'),
+  captureMethod: captureMethodEnum('capture_method'),
   verificationStatus: verificationStatusEnum('verification_status')
     .notNull()
     .default('unverified'),

--- a/src/lib/evidence/packager.test.ts
+++ b/src/lib/evidence/packager.test.ts
@@ -146,3 +146,60 @@ test('buildEvidencePackage: empty-string output is hashed, not undefined-skipped
     `sha256:${sha256Hex('')}`,
   );
 });
+
+// --- ADR-0003: captureMethod is part of the canonical hash ---
+//
+// The label is what differentiates structurally distinct publish paths
+// (chat-flow streaming vs. Claude Code JSONL readback). For the label to
+// be tamper-evident, two packages identical except for `captureMethod`
+// MUST produce different package hashes — otherwise the field could be
+// flipped in storage without invalidating the signature.
+//
+// `packageId` and `metadata.createdAt` are random/time-dependent, so we
+// strip them before re-hashing for a deterministic comparison.
+
+function normalizedHash(pkg: ReturnType<typeof buildEvidencePackage>['pkg']): string {
+  // Clone the metadata without the non-deterministic fields, leaving the
+  // rest of the package shape (and ordering) intact.
+  const stripped = {
+    ...pkg,
+    metadata: {
+      schemaVersion: pkg.metadata.schemaVersion,
+      signingKeyId: pkg.metadata.signingKeyId,
+      ...(pkg.metadata.captureMethod ? { captureMethod: pkg.metadata.captureMethod } : {}),
+    },
+  };
+  return sha256Hex(JSON.stringify(stripped));
+}
+
+test('buildEvidencePackage: captureMethod is covered by the package hash (ADR-0003)', () => {
+  const a = buildEvidencePackage(baseInput({ captureMethod: 'chat-flow-stream' }));
+  const b = buildEvidencePackage(baseInput({ captureMethod: 'claude-code-jsonl-readback' }));
+  assert.notEqual(
+    normalizedHash(a.pkg),
+    normalizedHash(b.pkg),
+    'two packages identical except for captureMethod must hash differently',
+  );
+});
+
+test('buildEvidencePackage: omitting captureMethod produces canonical JSON without the metadata key', () => {
+  // Backwards compat: callers that don't supply captureMethod (legacy
+  // tests, internal call sites that pre-date the route enforcement) get
+  // a metadata block with no captureMethod key — so legacy verify, which
+  // recomputes the package hash from stored canonical JSON, continues to
+  // produce identical hashes.
+  const { pkg } = buildEvidencePackage(baseInput());
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(pkg.metadata, 'captureMethod'),
+    false,
+  );
+  // And the corresponding JSON.stringify output has no captureMethod key.
+  assert.equal(JSON.stringify(pkg.metadata).includes('captureMethod'), false);
+});
+
+test('buildEvidencePackage: with captureMethod, metadata.captureMethod matches input', () => {
+  const { pkg } = buildEvidencePackage(
+    baseInput({ captureMethod: 'claude-code-jsonl-readback' }),
+  );
+  assert.equal(pkg.metadata.captureMethod, 'claude-code-jsonl-readback');
+});

--- a/src/lib/evidence/packager.ts
+++ b/src/lib/evidence/packager.ts
@@ -7,6 +7,24 @@ import { deriveOperationType } from '../mcp/operation-types.ts';
 
 const PACKAGE_SCHEMA_VERSION = '0.1.0';
 
+/**
+ * Capture method for the package contents (ADR-0003).
+ *
+ * - `chat-flow-stream` — website server captured bytes as the model
+ *   streamed to the browser. Verbatim by construction at the wire layer.
+ * - `claude-code-jsonl-readback` — Claude Code publish skill read each
+ *   turn's `content` and per-invocation `usage` directly from the session
+ *   JSONL, filtering to `text`-typed content blocks. Verbatim by
+ *   construction at the JSONL layer.
+ * - `claude-code-self-report` — legacy: the publishing model paraphrased
+ *   from in-context memory. Deprecated 2026-04-28; retained so packages
+ *   predating that date can be labeled with their actual capture method.
+ */
+export type CaptureMethod =
+  | 'chat-flow-stream'
+  | 'claude-code-jsonl-readback'
+  | 'claude-code-self-report';
+
 export interface ToolCallInput {
   name: string;
   args: Record<string, unknown>;
@@ -35,6 +53,14 @@ export interface PackageInput {
   promptVisibility: 'full_text' | 'hash_only';
   title: string;
   summary: string;
+  /**
+   * Capture method label per ADR-0003. Optional at the packager layer so
+   * existing tests and any internal call sites that don't supply it still
+   * produce canonical JSON identical to pre-ADR shape. Required at the
+   * route layer (`POST /api/evidence` rejects requests that omit it) so
+   * every published package has an explicit, signed label.
+   */
+  captureMethod?: CaptureMethod;
   /**
    * Override the skill metadata that the packager would otherwise extract
    * from the trace. Required when `trace` is a BlobRef (the packager can't
@@ -65,6 +91,12 @@ export interface EvidencePackage {
      *  post-hoc trust-registry relabeling). Verifiers cross-check this
      *  against the `kid` embedded in the signature blob. */
     signingKeyId: string;
+    /** Capture-method label (ADR-0003). Present on packages built after
+     *  the ADR's enforcement landed; absent on legacy packages, which the
+     *  detail page surfaces as "Unknown (pre-ADR-0003)". When set, the
+     *  field is part of canonical JSON and therefore covered by the
+     *  package hash and signature. */
+    captureMethod?: CaptureMethod;
   };
   prompt: {
     hash: string;
@@ -206,6 +238,11 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
       packageId,
       createdAt: now,
       signingKeyId: getActiveKeyId(),
+      // Conditional spread so legacy/test inputs without captureMethod
+      // produce canonical JSON identical to pre-ADR-0003 shape (and
+      // therefore identical hashes). The route layer enforces presence
+      // for production publishes.
+      ...(input.captureMethod ? { captureMethod: input.captureMethod } : {}),
     },
     prompt: {
       hash: promptHash,


### PR DESCRIPTION
This PR closes the gap that motivated the broader ADR-hygiene exercise: an Accepted ADR whose decision was not enforced in production. Until today, ADR-0003 said the `captureMethod` label was "preserved in the signed envelope so the capture method is itself tamper-evident," but the website's `POST /api/evidence` silently dropped the field, the packager omitted it from `EvidencePackage`, and the database had no column for it. With this PR, ADR-0003's decision is actually enforced in code — and is verified by a passing test that fails if the field's tamper-evidence guarantee regresses. **This is the moment the ADR system becomes trustworthy in this repo:** going forward, an Accepted ADR governing this codebase means the code enforces it, full stop.

## Summary

The capture-method label is now (a) required at the publish endpoint, (b) covered by the canonical-JSON package hash and the platform Ed25519ph signature, (c) persisted to the database, and (d) surfaced on the evidence detail page next to the verification status. Two structurally different package paths (chat-flow streaming vs. Claude Code JSONL readback) are no longer indistinguishable to readers — which was the user-visible problem ADR-0003 was filed to solve.

## What shipped

**Schema + migration**
- `src/lib/db/schema.ts` — `captureMethodEnum` + nullable `capture_method` column on `evidence_records`.
- `drizzle/0007_capture_method.sql` — `CREATE TYPE` + `ALTER TABLE ... ADD COLUMN`.
- `drizzle/meta/_journal.json` + `drizzle/meta/0007_snapshot.json` — drizzle-kit bookkeeping.

**Packager**
- `src/lib/evidence/packager.ts` — `CaptureMethod` type; optional `captureMethod` on `PackageInput`; conditional `metadata.captureMethod` in `EvidencePackage` (legacy/test callers without the field produce canonical JSON byte-identical to the pre-ADR shape, so legacy verify continues to recompute identical hashes).

**Route**
- `src/app/api/evidence/route.ts` — `VALID_CAPTURE_METHODS` constant, `captureMethod` required on `PublishRequest`, validation returning `400` on missing or invalid, threaded into `PackageInput`, persisted to the new column.

**Browser caller**
- `src/components/PublishEvidenceDialog.tsx` — chat-flow publish sends `captureMethod: 'chat-flow-stream'` explicitly.

**Detail-page UI**
- `src/app/evidence/[slug]/page.tsx` — `captureMethodLabel` helper + a "Captured via:" muted-text element in the Verification Status section. Pre-ADR packages render as `Unknown (pre-ADR-0003)` per the §1 amendment.

**External docs**
- `docs/api/evidence-publish.md` — new `captureMethod` row in the request body schema, notes-on-specific-fields entry, three example payloads updated, 2026-04-29 change log entry.

**Tests**
- `src/lib/evidence/packager.test.ts` — three new tests, including the load-bearing hash-sensitivity assertion that two packages identical except for `captureMethod` produce different normalized hashes. Full suite: 139/139 passing.

**ADR pointer**
- `docs/adr/README.md` — new pointer stub explaining ADRs governing the evidence system live in `civic-ai-tools/docs/adr/`. Lists the three current ADRs with statuses; ADR-0003 reflects today's re-Accept.

The companion ADR change (Status promotion + §1 in-place amendment + dated status note quoting before/after clauses with rationale) shipped to `civic-ai-tools` main as commit `7d230ff`. Reference: [`civic-ai-tools/docs/adr/0003-evidence-capture-method.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0003-evidence-capture-method.md).

## Deliberately left for separate work

These items appear in ADR-0003 Consequences but are out of scope here per the ADR's own implementation timeline:

- **Replacing the 2,000-char `output` truncation in `ProvenanceChain.tsx:173` and rendering multi-turn transcripts from `turns[]`** — tracked at #96.
- **Bronx package `a9e428…` retroactive human-expert attestation** — tracked at npstorey/civic-ai-tools#61.
- **Re-signing pre-ADR packages** — explicitly out forever per ADR-0003. Pre-ADR records render as `Unknown (pre-ADR-0003)`; their database `capture_method` column remains null.
- **Future capture-method enum extensions** (e.g., sandbox-attested) — tracked at #98.

## A note on the deleted `001-enforce-capture-method.md`

A proposed-issue file at `docs/proposed-issues/001-enforce-capture-method.md` was created in an earlier planning session as a tracking artifact when ADR-0003 was downgraded to Proposed. It was never committed to git — it lived only as a local working file — and was removed today once this PR became the canonical record of the work. **This PR is the canonical record going forward; the proposed-issue file is obsolete.**

## Post-merge action

- [ ] After merge, run the Drizzle migration against the shared Neon DB:

  ```bash
  cd civic-ai-tools-website && export $(grep DATABASE_URL .env.local) && npx drizzle-kit migrate
  ```

  Migration `0007_capture_method.sql` is additive (`CREATE TYPE` + `ALTER TABLE ... ADD COLUMN`) and the new column is nullable — safe to run at any time relative to the Vercel deploy. Preview and production share the same Neon database, so this only runs once.

## Test plan

- [ ] Verify the migration applies cleanly: `npx drizzle-kit migrate` against the shared Neon DB succeeds and the new `capture_method` column is present on `evidence_records` (nullable, no default).
- [ ] After deploy, publish a fresh chat-flow analysis end-to-end and confirm: the resulting evidence record's `capture_method` column is `chat-flow-stream`; the package JSON in Vercel Blob has `metadata.captureMethod: "chat-flow-stream"`; the detail page shows `Captured via: Chat flow (verbatim stream)`; the verify endpoint still returns `signatureValid: true`.
- [ ] Confirm a Claude Code skill publish (already sends `captureMethod: 'claude-code-jsonl-readback'`) writes the column and renders correctly.
- [ ] Confirm a legacy package detail page (e.g. `255b8e…` or `a9e428…`) renders `Captured via: Unknown (pre-ADR-0003)` and verify still passes.
- [ ] Confirm a `POST /api/evidence` request without `captureMethod` returns `400`.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)