### PR TITLE
docs(proposed-issues): vision-doc TKs, infrastructure label, Path B cross-ref, CCV rename, three new drafts (005/006/007)

### DIFF
--- a/docs/proposed-issues/002-extend-agent-receipts-response-capture.md
+++ b/docs/proposed-issues/002-extend-agent-receipts-response-capture.md
@@ -1,0 +1,66 @@
+# Contribute response-capture extension to Agent Receipts (upstream)
+
+**Repo:** `agent-receipts/ar` (primary, upstream contribution); civic-ai-tools (planning + coordination only — no civic-ai-tools code change)
+**Labels:** future-work, upstream-contribution, trace-layer, infrastructure, low-priority
+**Estimated effort:** M (bounded technical work; gated on upstream-coordination handshake)
+**Blocks:** post-M8 evaluation of `org.agentreceipts.chain` evidence-package extension (`civic-ai-tools-website#59`); future resolution of `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #4 — trace capture
+
+## Problem
+
+Agent Receipts (`agent-receipts/ar`) is a draft-v0.1 open protocol for capturing per-call receipts of MCP tool invocations as W3C Verifiable Credentials, with Ed25519 per-receipt signatures and an inter-call hash chain. Per `civic-ai-tools/docs/research/agent-receipts-evaluation.md` (April 2026), the current v0.1 capture path stores `action.parameters_hash` (SHA-256 of RFC 8785 canonical parameters) but explicitly **does not store the response body or any response hash**. An open upstream proposal — [agent-receipts/ar#153](https://github.com/agent-receipts/ar/issues/153) — proposes adding a response hash as an optional field; the issue has zero comments and is unshipped as of the eval.
+
+That gap is what currently keeps Agent Receipts from being a viable replacement for the project's OTel-shaped trace layer (`civic-ai-tools-website/src/lib/evidence/trace.ts`). The OTel layer captures both parameters and response bodies and feeds the PROV-O graph and the per-tool-call rendering on the evidence detail page. Without response-content capture, an Agent Receipts receipt records *that a tool call happened* but not *what the tool call returned* — which means a downstream verifier can confirm the chain's structure but cannot recompute or audit the analysis from receipts alone.
+
+The Open Evidence Standard's trace-capture layer (per `civic-ai-tools/docs/architecture/end-state-vision.md` §1 L2 and §2) currently uses hand-rolled OTel-shaped JSON. It is good enough for the prototype and near-term adopters, but it is not a real OTel SDK and does not survive adopters who bring their own OTel infrastructure. Agent Receipts with response capture would be a strong candidate to replace or augment it. Contributing the response-capture extension upstream changes the project's relationship with Agent Receipts from consumer to contributor and gives the standard a clean answer to "what's your trace layer?"
+
+## Proposed approach
+
+A draft PR or formal design proposal posted to `agent-receipts/ar` that addresses:
+
+1. **Response-stream interception in `mcp-proxy`.** The reference proxy at `agent-receipts/ar/mcp-proxy/` wraps an MCP server child process's stdin/stdout. Add response-capture at the same wire layer where parameters are intercepted today, before the response is forwarded back to the calling client.
+2. **Canonical response hashing.** Apply RFC 8785 canonicalization (already used for `parameters_hash`) to the response payload, then SHA-256. The canonical form must handle MCP `tools/call` response shapes (text content blocks, structured content, error envelopes) in a deterministic way.
+3. **VC schema extension.** Add an optional `action.response_hash` field to the Verifiable Credential, mirroring the existing `action.parameters_hash` shape. Optionality preserves backward compatibility with v0.1 receipts.
+4. **Optional content-addressable storage of the response body.** A separate optional field — for example `action.response_storage` — pointing to a CAS-resolvable URI (or BlobRef-style structure) so verifiers can fetch the raw bytes when selective disclosure is acceptable. Hash-only-vs-hash-plus-body should be a publisher choice, not a protocol requirement.
+5. **Coordination with upstream maintainers.** A 30-minute conversation with `ojongerius` (effective sole substantive maintainer per the eval) about roadmap, review capacity, and whether this scope fits the v0.1 → v0.2 increment they have in mind. This conversation is a prerequisite to opening the PR; without it, the work risks duplicating something already in flight or landing against an unwilling upstream.
+
+The work is technically bounded — the protocol primitives already exist for parameters; this extends them to responses. The unbounded part is the human coordination, which is why the prerequisite step matters.
+
+## Scope
+
+**In:**
+- Conversation with Agent Receipts maintainers about roadmap and scope alignment.
+- Design proposal or draft PR in `agent-receipts/ar` covering response-stream interception, canonical response hashing, VC schema extension, and optional CAS-storage reference.
+- Reference implementation in `mcp-proxy` if maintainers prefer a code-first proposal.
+- Coordination of how `agent-receipts/ar#153` resolves relative to this contribution.
+
+**Out:**
+- Switching the civic-ai-tools trace layer from OTel-shaped JSON to Agent Receipts. That is a separate downstream decision (see `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #4 — trace capture) which depends on this work being shipped first.
+- Implementing the `org.civicaitools.agentreceipts-chain` (or equivalent) evidence-package extension. Tracked separately in `civic-ai-tools-website#59`.
+- Resolving [agent-receipts/ar#124](https://github.com/agent-receipts/ar/issues/124) (remote-hosted `mcp-proxy` for HTTPS MCP servers). That is independently blocking civic-ai-tools' use of Agent Receipts, but is not the gap this issue addresses. Worth explicitly mentioning in the upstream conversation as adjacent context.
+- Replacing the OTel-shaped JSON in the same PR. Civic-side adoption is downstream and is gated separately on the Xanadu test.
+
+## Acceptance criteria
+
+- A 30-minute conversation has happened with the Agent Receipts maintainers, with notes captured in `civic-ai-tools/docs/research/agent-receipts-evaluation.md` (or a follow-up doc).
+- A draft PR or design proposal is posted to `agent-receipts/ar` covering response-stream interception, canonical response hashing, and the VC schema extension. The optional CAS-storage reference is included as either a sketch or a follow-up.
+- Maintainers have publicly acknowledged the approach is acceptable in principle, even if review and merge happen on their timeline.
+- `agent-receipts/ar#153` is resolved (closed by this work, superseded, or explicitly merged into the new design).
+
+## Dependencies
+
+- Conversation with Agent Receipts maintainers about their roadmap and review capacity.
+- This work is **not** gated on resolution of `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #4 — trace capture. It is valuable independently — a contribution to a standard the project already depends on conceptually.
+- The Xanadu test still applies to *adopting* the contributed extension downstream: do not switch the civic-ai-tools trace infrastructure until at least one external adopter (Boston OpenContext, datHere, an academic partner, etc.) explicitly asks for Agent Receipts integration. The eval doc's revisit conditions (`agent-receipts/ar#124` closed, `agent-receipts/ar#153` shipped, governance maturation, or explicit adopter ask) remain authoritative for the *adoption* decision; this issue only commits to the *contribution* path.
+
+## Risk
+
+- The upstream maintainer conversation reveals incompatible scope or roadmap, and the work cannot land cleanly. Mitigation: keep the design proposal as a public artifact regardless of merge outcome — it is a reference for the eventual `org.civicaitools.agentreceipts-chain` extension either way.
+- Cross-SDK correctness bugs documented in the eval (`agent-receipts/ar#82`, `#83`, `#84`, `#86`, `#118`) may complicate the canonical-hashing work — adding response hashing on top of an unstable parameters-hash baseline could re-litigate canonicalization decisions. Mitigation: scope the response-hash design to use the same canonicalization rules as parameters and explicitly defer cross-SDK conformance to upstream.
+
+## Reproducible at
+
+- Eval doc: `civic-ai-tools/docs/research/agent-receipts-evaluation.md` (last updated April 2026).
+- Trace-layer baseline: `civic-ai-tools-website/src/lib/evidence/trace.ts`.
+- Existing extension architecture: `civic-ai-tools-website` packager (`src/lib/evidence/packager.ts`) and the reverse-DNS extensions pattern shipped via `civic-ai-tools-website#54`.
+- Downstream consumer issue: `civic-ai-tools-website#59` (Agent Receipts interop evidence-package extension).
+- Upstream issues referenced: [agent-receipts/ar#124](https://github.com/agent-receipts/ar/issues/124) (remote-proxy support), [agent-receipts/ar#153](https://github.com/agent-receipts/ar/issues/153) (response-hash proposal).

--- a/docs/proposed-issues/003-caco-domain-extensions-portfolio.md
+++ b/docs/proposed-issues/003-caco-domain-extensions-portfolio.md
@@ -1,0 +1,92 @@
+# Design CACO domain-extensions portfolio + governance model
+
+**Repo:** civic-ai-tools (where CACO source-of-truth docs live; the portfolio doc lands in `docs/architecture/`)
+**Labels:** future-work, caco, extensions, design, infrastructure, low-priority
+**Estimated effort:** S (design/scoping document; not implementation)
+**Blocks:** any specific CACO domain-extension implementation; any cross-package corpus operation that relies on typed domain claims
+
+## Problem
+
+CACO (Civic Analysis Core Ontology) is the project-specific minimal vocabulary for typed claims in evidence packages. The architectural design — captured in the v0.1 draft spec at `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` and shown as a node in `civic-ai-tools/docs/architecture/end-state-vision.md` §5 (claims ontology family) — is that CACO core stays small and stable, and **domain extensions** (per use case) are governed separately and can evolve at their own pace. A claim conforms to CACO core + zero or more domain extensions. The spec's §6 sketches an extension mechanism (subclassing `caco:Claim`, declaring a namespace, publishing SHACL shapes, optional inclusion in a registry at `civicaitools.org/ontology-registry`) but **no domain extensions exist today** — the entire extension layer is speculative.
+
+Several public standards are candidates for the first extensions, but the project has not articulated:
+
+1. The criteria a candidate must meet before promotion from "research" to "designed."
+2. The relative priority and rationale across candidates.
+3. The relationship between domain extensions and cross-cutting controlled vocabularies (notably the ISO 37120 / 37122 / 37123 / 30182 Smart Cities portfolio, which is paywalled but whose indicator names are public).
+4. The governance model — how extensions are proposed, reviewed, versioned, retired.
+
+Without this scaffolding, the first time a real package needs a typed domain claim, the project has no surface against which to make a defensible call about which standard to align with, what the extension should look like, or who else should see the proposal before it lands.
+
+## Proposed approach
+
+A short design document at `civic-ai-tools/docs/architecture/caco-extensions-portfolio.md` covering four sections:
+
+1. **Promotion criteria.** What a candidate must satisfy to move from "candidate" to "designed":
+   - A real evidence package needs it (Xanadu test).
+   - The reference standard is mature (≥1 stable major version, broad adoption, public schema).
+   - Cross-city or cross-publisher comparability is a concrete benefit, not a hypothetical.
+   - At least one external collaborator or stakeholder has expressed interest (or filed a `guidance-quality` issue surfacing the need).
+
+2. **Ranked candidate list with rationale.** Initial set, drawn from the most-queried civic data types and the most-referenced public standards:
+   - **Open311** — open standard for service-request data, widely adopted across US and international cities. Free, well-documented, immediate cross-city comparability. Aligns with the most-queried civic data type. Strongest candidate for the first domain extension.
+   - **GFOA standards / Open Fiscal Data Package (OFDP)** — structured fiscal data standards. Useful because budget claims are the highest-stakes civic claim type and structured comparability is most needed there.
+   - **GTFS / GTFS-Realtime** — global transit standard. Easy adoption, immediate cross-city comparability.
+   - **OpenAQ** — global air-quality data aggregator with stable schema.
+   - **HUD / NYC PLUTO / Boston parcel data** — housing and land-use, but no single dominant cross-city standard. Defer until a canonical alignment target emerges.
+   - **HL7 FHIR** — clinical data standard; environmental and population health are messier. Probably defer.
+
+3. **Cross-cutting vocabularies (ISO 37120 portfolio).** ISO 37120 (city services indicators), 37122 (smart city indicators), 37123 (resilient cities), and ISO/IEC 30182 (reference architecture) are paywalled (~$200/copy for ISO 37120), but the indicator names and concepts are public. **Recommended approach: treat the ISO 37120 portfolio as a cross-cutting controlled vocabulary that domain extensions reference, not as a domain extension itself.** A CACO domain extension can reference indicator names without redistributing the protected text. This unlocks international comparability without licensing risk and without inflating the extension portfolio.
+
+4. **Governance model.** How extensions are proposed, reviewed, versioned, and retired:
+   - Proposal as a `roadmap-change` issue or a dedicated `caco-extension` template, with the promotion criteria as required fields.
+   - Lightweight review by maintainer plus any named domain stakeholders.
+   - Versioning per the spec's §6.3 governance model (minor: 30-day public-comment, major: 90-day plus migration guide).
+   - All extension versions remain resolvable at versioned URIs forever — explicit in the spec.
+   - Inclusion in the registry at `civicaitools.org/ontology-registry` is informational and does not confer endorsement.
+   - Retirement: deprecation path (no removal, only marking as superseded), with the new extension or core change carrying the migration burden.
+
+The design document is the deliverable. Implementation of any specific extension happens later, one at a time, each with its own ADR + acceptance criteria.
+
+## Scope
+
+**In:**
+- Design document at `civic-ai-tools/docs/architecture/caco-extensions-portfolio.md`.
+- Promotion criteria + ranked candidate list with rationale.
+- Recommended approach for the ISO 37120 portfolio as cross-cutting controlled vocabulary.
+- Governance model (proposal, review, versioning, retirement, registry).
+- Public discussion threads on the top 1–2 candidate extensions (Open311, fiscal) so external collaborators can weigh in before any implementation.
+- A pointer in the ROADMAP §5 Later (or successor section) to this portfolio doc as the canonical scope answer for typed-claims domain coverage.
+
+**Out:**
+- Actually implementing any domain extension. That happens later, one extension at a time, gated on the promotion criteria.
+- Authoring the registry web surface at `civicaitools.org/ontology-registry`. The spec provides for it; a separate website-side issue tracks the build-out when the first extension is real.
+- Adopting any framework that re-fragments CACO core (FHIR, DCAT-AP, etc.) as the project's identity. The portfolio is additive; the core stays stable.
+- Resolving the underlying spec questions in the draft (`civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` §9) — those are core-level questions and are upstream of this work.
+
+## Acceptance criteria
+
+- Design document committed at `civic-ai-tools/docs/architecture/caco-extensions-portfolio.md`.
+- Promotion criteria are concrete and falsifiable (a candidate either meets them or does not).
+- Ranked list includes at minimum the candidates above with rationale, and explicitly names which would be the first one promoted to "designed" status when conditions are met.
+- ISO 37120 portfolio approach is documented including the public-naming-vs-paywalled-text distinction.
+- Governance model integrates with existing project governance (`ROADMAP.md` §8, `.github/ISSUE_TEMPLATE/roadmap-change.md`, ADR log).
+- Public discussion threads opened for Open311 and one other candidate (fiscal or transit) inviting external feedback. Threads remain open until a real package needs that extension.
+
+## Dependencies
+
+- **Resolution of `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #5 — claims.jsonld implementation timing.** If `claims.jsonld` is deferred entirely, the extension portfolio is also deferred. If it ships in any form, this portfolio doc becomes the scoping surface for downstream extension work.
+- **A stable v1.0 of CACO core.** The current `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` is v0.1 draft and explicitly not normative. Extensions presuppose a stable core. This document can be drafted against the v0.1 surface but should not be merged until the core has at least passed initial review.
+
+## Risk
+
+- **Speculative spec growth.** Domain extensions are exactly the kind of forward-design that the Xanadu test is meant to prevent. Mitigation: this issue commits to *design-only*. No extension is implemented before a real package needs it. The promotion criteria are the gating mechanism.
+- **Vocabulary lock-in.** Choosing Open311 as the first extension implicitly privileges the Open311 conceptualization of service requests. Mitigation: reuse the spec's principle (Section 2.1 — "Build on existing standards, do not replace them"). Extension authors who want to use a different standard in a domain Open311 covers must explain why; the registry can list multiple extensions per domain with `owl:sameAs` cross-references (per spec §8.3).
+- **Governance overhead.** A heavy proposal-review-version process discourages the first extension from being filed at all. Mitigation: keep the governance model lightweight; `roadmap-change` and an ADR are the maximum process for v1, and are themselves lightweight.
+
+## Reproducible at
+
+- Draft spec: `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` (v0.1 draft, April 2026; promoted from `civic-ai-tools-project/temp/` to a tracked location 2026-05-01).
+- Existing project governance: `ROADMAP.md` §8, `civic-ai-tools/.github/ISSUE_TEMPLATE/roadmap-change.md`, `civic-ai-tools/docs/adr/`.
+- Cross-package context: `civic-ai-tools/docs/research-agenda.md` Question 8 (modular research objects from evidence artifacts) and Question 9 (discoverability across accumulated evidence) both depend on typed claims existing.
+- Related issue: this portfolio doc + a future first-extension implementation together resolve `civic-ai-tools/docs/architecture/end-state-vision.md` §5 (claims ontology family) from research to designed.

--- a/docs/proposed-issues/003-civic-claim-vocabulary-domain-extensions-portfolio.md
+++ b/docs/proposed-issues/003-civic-claim-vocabulary-domain-extensions-portfolio.md
@@ -1,13 +1,13 @@
-# Design CACO domain-extensions portfolio + governance model
+# Explore and define Civic Claim Vocabulary domain extensions portfolio
 
-**Repo:** civic-ai-tools (where CACO source-of-truth docs live; the portfolio doc lands in `docs/architecture/`)
-**Labels:** future-work, caco, extensions, design, infrastructure, low-priority
+**Repo:** civic-ai-tools (where Civic Claim Vocabulary source-of-truth docs live; the portfolio doc lands in `docs/architecture/`)
+**Labels:** future-work, civic-claim-vocabulary, extensions, design, infrastructure, low-priority
 **Estimated effort:** S (design/scoping document; not implementation)
-**Blocks:** any specific CACO domain-extension implementation; any cross-package corpus operation that relies on typed domain claims
+**Blocks:** any specific Civic Claim Vocabulary domain-extension implementation; any cross-package corpus operation that relies on typed domain claims
 
 ## Problem
 
-CACO (Civic Analysis Core Ontology) is the project-specific minimal vocabulary for typed claims in evidence packages. The architectural design — captured in the v0.1 draft spec at `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` and shown as a node in `civic-ai-tools/docs/architecture/end-state-vision.md` §5 (claims ontology family) — is that CACO core stays small and stable, and **domain extensions** (per use case) are governed separately and can evolve at their own pace. A claim conforms to CACO core + zero or more domain extensions. The spec's §6 sketches an extension mechanism (subclassing `caco:Claim`, declaring a namespace, publishing SHACL shapes, optional inclusion in a registry at `civicaitools.org/ontology-registry`) but **no domain extensions exist today** — the entire extension layer is speculative.
+The Civic Claim Vocabulary is the project-specific controlled vocabulary of typed claim shapes for evidence packages. The architectural design — captured in the v0.1 draft spec at `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` and shown as a node in `civic-ai-tools/docs/architecture/end-state-vision.md` §5 (claims vocabulary family) — is that the core stays small and stable, and **domain extensions** (per use case) are governed separately and can evolve at their own pace. A claim conforms to the Civic Claim Vocabulary + zero or more domain extensions. The spec's §6 sketches an extension mechanism (subclassing `ccv:Claim`, declaring a namespace, publishing SHACL shapes, optional inclusion in a registry at `civicaitools.org/vocabulary-registry`) but **no domain extensions exist today** — the entire extension layer is speculative.
 
 Several public standards are candidates for the first extensions, but the project has not articulated:
 
@@ -20,7 +20,7 @@ Without this scaffolding, the first time a real package needs a typed domain cla
 
 ## Proposed approach
 
-A short design document at `civic-ai-tools/docs/architecture/caco-extensions-portfolio.md` covering four sections:
+A short design document at `civic-ai-tools/docs/architecture/civic-claim-vocabulary-extensions-portfolio.md` covering four sections:
 
 1. **Promotion criteria.** What a candidate must satisfy to move from "candidate" to "designed":
    - A real evidence package needs it (Xanadu test).
@@ -36,14 +36,14 @@ A short design document at `civic-ai-tools/docs/architecture/caco-extensions-por
    - **HUD / NYC PLUTO / Boston parcel data** — housing and land-use, but no single dominant cross-city standard. Defer until a canonical alignment target emerges.
    - **HL7 FHIR** — clinical data standard; environmental and population health are messier. Probably defer.
 
-3. **Cross-cutting vocabularies (ISO 37120 portfolio).** ISO 37120 (city services indicators), 37122 (smart city indicators), 37123 (resilient cities), and ISO/IEC 30182 (reference architecture) are paywalled (~$200/copy for ISO 37120), but the indicator names and concepts are public. **Recommended approach: treat the ISO 37120 portfolio as a cross-cutting controlled vocabulary that domain extensions reference, not as a domain extension itself.** A CACO domain extension can reference indicator names without redistributing the protected text. This unlocks international comparability without licensing risk and without inflating the extension portfolio.
+3. **Cross-cutting vocabularies (ISO 37120 portfolio).** ISO 37120 (city services indicators), 37122 (smart city indicators), 37123 (resilient cities), and ISO/IEC 30182 (reference architecture) are paywalled (~$200/copy for ISO 37120), but the indicator names and concepts are public. **Recommended approach: treat the ISO 37120 portfolio as a cross-cutting controlled vocabulary that domain extensions reference, not as a domain extension itself.** A Civic Claim Vocabulary domain extension can reference indicator names without redistributing the protected text. This unlocks international comparability without licensing risk and without inflating the extension portfolio.
 
 4. **Governance model.** How extensions are proposed, reviewed, versioned, and retired:
-   - Proposal as a `roadmap-change` issue or a dedicated `caco-extension` template, with the promotion criteria as required fields.
+   - Proposal as a `roadmap-change` issue or a dedicated `civic-claim-vocabulary-extension` template, with the promotion criteria as required fields.
    - Lightweight review by maintainer plus any named domain stakeholders.
    - Versioning per the spec's §6.3 governance model (minor: 30-day public-comment, major: 90-day plus migration guide).
    - All extension versions remain resolvable at versioned URIs forever — explicit in the spec.
-   - Inclusion in the registry at `civicaitools.org/ontology-registry` is informational and does not confer endorsement.
+   - Inclusion in the registry at `civicaitools.org/vocabulary-registry` is informational and does not confer endorsement.
    - Retirement: deprecation path (no removal, only marking as superseded), with the new extension or core change carrying the migration burden.
 
 The design document is the deliverable. Implementation of any specific extension happens later, one at a time, each with its own ADR + acceptance criteria.
@@ -51,7 +51,7 @@ The design document is the deliverable. Implementation of any specific extension
 ## Scope
 
 **In:**
-- Design document at `civic-ai-tools/docs/architecture/caco-extensions-portfolio.md`.
+- Design document at `civic-ai-tools/docs/architecture/civic-claim-vocabulary-extensions-portfolio.md`.
 - Promotion criteria + ranked candidate list with rationale.
 - Recommended approach for the ISO 37120 portfolio as cross-cutting controlled vocabulary.
 - Governance model (proposal, review, versioning, retirement, registry).
@@ -60,13 +60,13 @@ The design document is the deliverable. Implementation of any specific extension
 
 **Out:**
 - Actually implementing any domain extension. That happens later, one extension at a time, gated on the promotion criteria.
-- Authoring the registry web surface at `civicaitools.org/ontology-registry`. The spec provides for it; a separate website-side issue tracks the build-out when the first extension is real.
-- Adopting any framework that re-fragments CACO core (FHIR, DCAT-AP, etc.) as the project's identity. The portfolio is additive; the core stays stable.
-- Resolving the underlying spec questions in the draft (`civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` §9) — those are core-level questions and are upstream of this work.
+- Authoring the registry web surface at `civicaitools.org/vocabulary-registry`. The spec provides for it; a separate website-side issue tracks the build-out when the first extension is real.
+- Adopting any framework that re-fragments the Civic Claim Vocabulary core (FHIR, DCAT-AP, etc.) as the project's identity. The portfolio is additive; the core stays stable.
+- Resolving the underlying spec questions in the draft (`civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` §9) — those are core-level questions and are upstream of this work.
 
 ## Acceptance criteria
 
-- Design document committed at `civic-ai-tools/docs/architecture/caco-extensions-portfolio.md`.
+- Design document committed at `civic-ai-tools/docs/architecture/civic-claim-vocabulary-extensions-portfolio.md`.
 - Promotion criteria are concrete and falsifiable (a candidate either meets them or does not).
 - Ranked list includes at minimum the candidates above with rationale, and explicitly names which would be the first one promoted to "designed" status when conditions are met.
 - ISO 37120 portfolio approach is documented including the public-naming-vs-paywalled-text distinction.
@@ -76,7 +76,7 @@ The design document is the deliverable. Implementation of any specific extension
 ## Dependencies
 
 - **Resolution of `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #5 — claims.jsonld implementation timing.** If `claims.jsonld` is deferred entirely, the extension portfolio is also deferred. If it ships in any form, this portfolio doc becomes the scoping surface for downstream extension work.
-- **A stable v1.0 of CACO core.** The current `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` is v0.1 draft and explicitly not normative. Extensions presuppose a stable core. This document can be drafted against the v0.1 surface but should not be merged until the core has at least passed initial review.
+- **A stable v1.0 of the Civic Claim Vocabulary core.** The current `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` is v0.1 draft and explicitly not normative. Extensions presuppose a stable core. This document can be drafted against the v0.1 surface but should not be merged until the core has at least passed initial review.
 
 ## Risk
 
@@ -86,7 +86,7 @@ The design document is the deliverable. Implementation of any specific extension
 
 ## Reproducible at
 
-- Draft spec: `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` (v0.1 draft, April 2026; promoted from `civic-ai-tools-project/temp/` to a tracked location 2026-05-01).
+- Draft spec: `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` (v0.1 draft, April 2026; promoted from `civic-ai-tools-project/temp/` to a tracked location 2026-05-01).
 - Existing project governance: `ROADMAP.md` §8, `civic-ai-tools/.github/ISSUE_TEMPLATE/roadmap-change.md`, `civic-ai-tools/docs/adr/`.
 - Cross-package context: `civic-ai-tools/docs/research-agenda.md` Question 8 (modular research objects from evidence artifacts) and Question 9 (discoverability across accumulated evidence) both depend on typed claims existing.
-- Related issue: this portfolio doc + a future first-extension implementation together resolve `civic-ai-tools/docs/architecture/end-state-vision.md` §5 (claims ontology family) from research to designed.
+- Related issue: this portfolio doc + a future first-extension implementation together resolve `civic-ai-tools/docs/architecture/end-state-vision.md` §5 (claims vocabulary family) from research to designed.

--- a/docs/proposed-issues/003-civic-claim-vocabulary-domain-extensions-portfolio.md
+++ b/docs/proposed-issues/003-civic-claim-vocabulary-domain-extensions-portfolio.md
@@ -20,7 +20,7 @@ Without this scaffolding, the first time a real package needs a typed domain cla
 
 ## Proposed approach
 
-A short design document at `civic-ai-tools/docs/architecture/civic-claim-vocabulary-extensions-portfolio.md` covering four sections:
+A short design document at `civic-ai-tools/docs/architecture/civic-claim-vocab-extensions.md` covering four sections:
 
 1. **Promotion criteria.** What a candidate must satisfy to move from "candidate" to "designed":
    - A real evidence package needs it (Xanadu test).
@@ -51,7 +51,7 @@ The design document is the deliverable. Implementation of any specific extension
 ## Scope
 
 **In:**
-- Design document at `civic-ai-tools/docs/architecture/civic-claim-vocabulary-extensions-portfolio.md`.
+- Design document at `civic-ai-tools/docs/architecture/civic-claim-vocab-extensions.md`.
 - Promotion criteria + ranked candidate list with rationale.
 - Recommended approach for the ISO 37120 portfolio as cross-cutting controlled vocabulary.
 - Governance model (proposal, review, versioning, retirement, registry).
@@ -66,7 +66,7 @@ The design document is the deliverable. Implementation of any specific extension
 
 ## Acceptance criteria
 
-- Design document committed at `civic-ai-tools/docs/architecture/civic-claim-vocabulary-extensions-portfolio.md`.
+- Design document committed at `civic-ai-tools/docs/architecture/civic-claim-vocab-extensions.md`.
 - Promotion criteria are concrete and falsifiable (a candidate either meets them or does not).
 - Ranked list includes at minimum the candidates above with rationale, and explicitly names which would be the first one promoted to "designed" status when conditions are met.
 - ISO 37120 portfolio approach is documented including the public-naming-vs-paywalled-text distinction.

--- a/docs/proposed-issues/004-croissant-outbound-metadata.md
+++ b/docs/proposed-issues/004-croissant-outbound-metadata.md
@@ -1,0 +1,88 @@
+# Publish outbound Croissant metadata on every evidence page
+
+**Repo:** civic-ai-tools-website (primary — evidence pages are served here)
+**Labels:** future-work, croissant, discoverability, network-effect, infrastructure, medium-priority
+**Estimated effort:** M (design + reference implementation + crawler-discovery validation)
+**Blocks:** evidence-package discoverability through external dataset crawlers; soft-de-facto-standard adoption by other publishers (Boston, datHere, third parties)
+
+## Problem
+
+Croissant (MLCommons, currently v1.1) plays one role in the project's architecture today: characterizing **inbound** datasets — the package's `data-sources.json` references or embeds Croissant 1.1 metadata for whatever was queried (M2 PROV-O Croissant 1.1 hooks shipped per `ROADMAP.md` Day 2 / 2026-04-13). This makes the package's data-source provenance machine-readable.
+
+A second role is now under consideration: **outbound** metadata, where every published evidence page carries a Croissant metadata file at a well-known location, making the package itself discoverable through dataset crawlers (Hugging Face, Kaggle, CKAN, Schema.org-aware search engines). See `civic-ai-tools/docs/architecture/end-state-vision.md` §1 L3 ("Note on Croissant's dual role in L3") and §Open questions item #8 — Croissant outbound metadata.
+
+ROADMAP.md §5 Later already names Croissant as a potential **emitter-side extension** (per `civic-ai-tools/docs/research/landscape-analysis.md` §7). This issue makes that line of work concrete.
+
+The two roles are independent. Adopting outbound Croissant requires no change to the inbound use, and works whether the package format stays single-blob (today) or moves to multi-file (post-resolution of `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #1 — package format).
+
+The strategic case: discoverability through existing dataset crawlers without building any custom indexing infrastructure. A soft de-facto standard for "published as evidence" that adjacent projects (Boston OpenContext, datHere, anyone publishing their own evidence packages) can adopt to become discoverable in the same surfaces. A real network effect — the metadata pattern propagates without centralized coordination. Strategically, this positions evidence packages as first-class members of the open-data ecosystem rather than a parallel publishing format.
+
+The "soft de-facto standard" framing here overlaps with the broader question of external-publisher adoption posture (see `civic-ai-tools/docs/evidence-protocol-fork.md` Path B and `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #7 — producer-type scope). This issue does not resolve that question; it makes one concrete contribution that's compatible with whichever way the broader question lands.
+
+## Proposed approach
+
+A design document plus reference implementation, in three deliverables:
+
+1. **Schema mapping.** A document at `civic-ai-tools-website/docs/api/croissant-outbound.md` covering the field mapping from evidence-package metadata to Croissant. Outbound use leans on Croissant's general Schema.org-inherited fields rather than the dataset-specific structural fields:
+   - `name`, `description`, `citation`, `license`, `creator`, `dateCreated`, `distribution`, `sameAs`, `keywords`, `url`
+   - The published evidence page URL is the canonical `url`.
+   - The package SHA-256 is included in `sameAs` (or a similar identity field) as a content-addressable identifier.
+   - Skill-guidance hash and signing-key id (`kid`) are included as `keywords` or as Schema.org-style additional properties — to be decided in the design doc.
+   - **Honesty about the dataset-shape mismatch.** Croissant 1.1's data model assumes the entity is a dataset (with `recordSet`, `distribution`, column-level schemas). An evidence package isn't quite that shape. Document this as an explicit "shape gap" section: which Croissant fields are populated meaningfully, which are populated minimally (or omitted), and why. This honesty is itself part of the standard the project would want other publishers to adopt.
+
+2. **Well-known location.** Decide and document the URL pattern. Candidates:
+   - `<package-url>/croissant.json` — clean, content-adjacent. Requires routing on the website.
+   - `<package-url>.croissant.json` — sibling-file pattern, may be friendlier to dumb crawlers.
+   - `<package-url>` itself with a `<link rel="alternate" type="application/ld+json+croissant">` or a `<script type="application/ld+json">` block embedding Croissant inline, and a separate `.json` URL for the same payload — covers both crawler styles.
+   The well-known-location decision is **loosely** dependent on `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #1 — package format: if the package becomes multi-file, the location may live alongside other package artifacts; if it stays single-blob, the location is purely a website concern. Scoping can proceed today against the current single-blob format with a documented migration path.
+
+3. **Crawler-discovery validation.** Test that real dataset crawlers index pages via the published metadata. At minimum:
+   - Submit one published package to Hugging Face's dataset index using the Croissant metadata.
+   - Verify that Schema.org-aware search engines (Google Dataset Search) pick up the metadata on the public page.
+   - If feasible, test Kaggle and CKAN-aware crawlers.
+   - Document what worked, what didn't, and what the next-step refinements are.
+
+4. **Adoption guidance for other publishers.** A short section in the design doc covering how Boston OpenContext, datHere, or other publishers of evidence-style packages could adopt the same outbound-metadata pattern to become discoverable in the same surfaces. This is what gives the work network-effect leverage rather than just civicaitools.org-specific gain.
+
+## Scope
+
+**In:**
+- Design document at `civic-ai-tools-website/docs/api/croissant-outbound.md` covering the field-mapping, well-known-location decision, dataset-shape-mismatch honesty section, and adoption guidance for external publishers.
+- Reference implementation that emits Croissant outbound metadata for every published package.
+- Crawler-discovery validation against at minimum Hugging Face and Google Dataset Search.
+- Documentation updates linking the new metadata surface from `civic-ai-tools-website/docs/api/evidence-publish.md` and the README.
+
+**Out:**
+- Changing the **inbound** use of Croissant (data-sources.json characterization). That's already partially built, governed by the M2 PROV-O work, and unaffected by this issue.
+- Building a custom indexer or search surface on civicaitools.org. The whole point of this work is to use existing crawler infrastructure rather than build new infrastructure.
+- Migrating to a multi-file package format. That depends on `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #1 — package format and is a separate decision.
+- Schema.org `Claim` / `ClaimReview` integration. That intersects with the typed-claims layer (CACO) and is governed by `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` §9 Open Question 5; it does not belong in this issue.
+
+## Acceptance criteria
+
+- Design document committed at `civic-ai-tools-website/docs/api/croissant-outbound.md`.
+- Reference implementation deployed for at least one published evidence page.
+- The package's outbound Croissant metadata validates against the Croissant 1.1 schema (using MLCommons' validator).
+- Confirmation that at least one external dataset crawler (Hugging Face Dataset Search OR Google Dataset Search) indexes the page via the Croissant metadata. If both fail despite valid metadata, the design doc documents what the crawler-side gap was and what the next experiment is.
+- Adoption guidance for external publishers is included in the design doc (≤2 pages, with a worked example).
+- README and `evidence-publish.md` reference the outbound-Croissant surface.
+
+## Dependencies
+
+- `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #1 — package format resolved enough to determine the well-known URL pattern. Loose dependency: scoping can proceed today; the well-known-location decision can be revisited if the package format moves to multi-file.
+- The existing inbound-Croissant work (M2 PROV-O Croissant 1.1 hooks) is preserved and not changed by this issue.
+- No external service contracts change. Signing, RFC-3161, Rekor, trust-registry paths are unaffected.
+
+## Risk
+
+- **Dataset-shape mismatch.** Croissant 1.1 assumes the entity is a dataset; evidence packages are closer to `schema:CreativeWork` or `schema:SoftwareApplication`-output. Mitigation: lean on Schema.org-inherited fields, document the gap honestly in the design doc, and propose the gap as a Croissant-side issue if and when MLCommons takes input on the next version.
+- **Crawler indexing turns out to be non-deterministic or slow.** Hugging Face and Google Dataset Search may take days to weeks to index, or may require specific submission flows. Mitigation: include crawler-discovery validation in the acceptance criteria but allow for "documented next experiment" as an alternative if first-pass indexing fails — the design doc captures the loop.
+- **Outbound Croissant becomes a publisher's burden.** If every external publisher must hand-craft Croissant metadata, adoption stalls. Mitigation: emit metadata mechanically from the existing package fields. Adoption guidance points at the reference implementation as a template, not at hand-crafted metadata.
+
+## Reproducible at
+
+- Inbound Croissant precedent: M2 PROV-O work shipped per `ROADMAP.md` Day 2 / 2026-04-13 (`civic-ai-tools-website` packager + PROV-O builder).
+- Existing evidence-package extension architecture: `civic-ai-tools-website#54` (reverse-DNS keys `org.civicaitools.*`).
+- Croissant context in landscape: `civic-ai-tools/docs/research/landscape-analysis.md` §7 (Croissant two-sided framing) and §0 component 1 (discoverability of data to AI systems).
+- Strategic context: `civic-ai-tools/docs/research-agenda.md` Question 9 (discoverability across accumulated evidence).
+- Public-facing API doc to update: `civic-ai-tools-website/docs/api/evidence-publish.md`.

--- a/docs/proposed-issues/004-croissant-outbound-metadata.md
+++ b/docs/proposed-issues/004-croissant-outbound-metadata.md
@@ -56,7 +56,7 @@ A design document plus reference implementation, in three deliverables:
 - Changing the **inbound** use of Croissant (data-sources.json characterization). That's already partially built, governed by the M2 PROV-O work, and unaffected by this issue.
 - Building a custom indexer or search surface on civicaitools.org. The whole point of this work is to use existing crawler infrastructure rather than build new infrastructure.
 - Migrating to a multi-file package format. That depends on `civic-ai-tools/docs/architecture/end-state-vision.md` §Open questions item #1 — package format and is a separate decision.
-- Schema.org `Claim` / `ClaimReview` integration. That intersects with the typed-claims layer (CACO) and is governed by `civic-ai-tools/docs/architecture/claims-ontology-draft-spec.md` §9 Open Question 5; it does not belong in this issue.
+- Schema.org `Claim` / `ClaimReview` integration. That intersects with the typed-claims layer (the Civic Claim Vocabulary) and is governed by `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` §9 Open Question 5; it does not belong in this issue.
 
 ## Acceptance criteria
 

--- a/docs/proposed-issues/005-promote-civic-claim-vocabulary-to-ontology.md
+++ b/docs/proposed-issues/005-promote-civic-claim-vocabulary-to-ontology.md
@@ -1,0 +1,101 @@
+# Promote Civic Claim Vocabulary from controlled vocabulary to full OWL ontology
+
+**Repo:** civic-ai-tools (CCV draft spec + alignment with adjacent ontologies live here)
+**Labels:** future-work, civic-claim-vocabulary, ontology, infrastructure, medium-priority
+**Estimated effort:** L (multi-step: axiomatization of core shapes, alignment with adjacent ontologies, reasoner test corpus, ADR, v0.2 spec)
+**Blocks:** any work that depends on richer downstream tooling (SPARQL queries over claim graphs, OWL reasoners checking class hierarchies, automated alignment with PROV-O / Data Cube)
+**Tracks:** [Open Question #10](../../../../civic-ai-tools/docs/architecture/open-questions.md) — Civic Claim Vocabulary as a full ontology
+
+## Problem
+
+The Civic Claim Vocabulary is currently framed as a controlled vocabulary of typed claim shapes expressed in JSON-LD, intentionally lighter-weight than a full OWL ontology with rich axioms (see `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` §4 — "controlled set of typed claim shapes expressed in JSON-LD"). The current draft references W3C ontologies (PROV-O, OWL-Time, RDF Data Cube) and Schema.org for concepts those vocabularies already cover, but it does not itself author OWL axioms or define class hierarchies that a reasoner could use.
+
+This was the right framing for v0.1 — small, stable, easy to author against, no heavy semantic-web machinery required. The cost is that the vocabulary lacks:
+
+- **Axiomatic class definitions.** A reasoner cannot infer that `ccv:TrendClaim` is a subclass of `ccv:Claim` without explicit `rdfs:subClassOf` axioms; the spec describes this in prose but doesn't formalize it.
+- **Disjoint-class declarations.** Whether `ccv:ObservationClaim` and `ccv:TrendClaim` can both apply to the same instance is left implicit.
+- **Property cardinality and domain/range constraints in OWL form.** SHACL shapes are mentioned but not yet authored; OWL property restrictions would let reasoners check well-formedness independently of SHACL.
+- **Explicit alignment with adjacent ontologies.** A `ccv:ObservationClaim` is structurally close to `qb:Observation` (W3C Data Cube), but no `owl:equivalentClass` or `rdfs:subClassOf` declaration links them. Same for `ccv:TrendClaim` and any analogous SDMX-RDF concept; same for `ccv:RelationshipClaim` and statistical-inference vocabularies elsewhere.
+- **Reasoner compatibility.** The spec cannot today be loaded into a standard OWL reasoner (HermiT, Pellet, ELK) for consistency checks, classification, or query answering against a claim corpus.
+
+The project intends to address all of this. This issue scopes the promotion.
+
+## Proposed approach
+
+Three phases. Each phase produces a publishable artifact; the spec stays usable throughout.
+
+**Phase 1 — Axiomatize the core in OWL.** Author `civic-claim-vocabulary.owl` (Turtle or RDF/XML, hosted at `https://civicaitools.org/ns/civic-claim-vocabulary/v1`) with:
+
+- Class hierarchy: `ccv:Claim` as the root; `ccv:TrendClaim`, `ccv:ComparisonClaim`, `ccv:ObservationClaim`, `ccv:CompositionClaim`, `ccv:RelationshipClaim`, `ccv:QualitativeClaim` as subclasses.
+- Property declarations for every required and optional property in §4.3 with explicit `rdfs:domain`, `rdfs:range`, and cardinality restrictions.
+- The `ccv:Scope`, `ccv:ConfidenceStatement`, `ccv:AnalyticalDerivation` patterns as named OWL classes.
+- The `ccv:GeographicScope` taxonomy from §4.4 with `rdfs:subClassOf` from each named subtype to `ccv:GeographicScope`.
+
+**Phase 2 — Alignment with adjacent ontologies.** Add explicit `owl:equivalentClass` / `rdfs:subClassOf` / `skos:exactMatch` / `skos:closeMatch` declarations linking:
+
+- `ccv:ObservationClaim` ↔ `qb:Observation` (W3C Data Cube — likely `rdfs:subClassOf qb:Observation` since CCV adds claim-specific properties).
+- `ccv:Scope` and its geographic subtypes ↔ relevant TIGER/Line and OGC GeoSPARQL classes (where they exist).
+- `ccv:AnalyticalDerivation` ↔ relevant `prov:Derivation` subtypes; `ccv:translationModel` ↔ `prov:wasAssociatedWith` patterns.
+- `ccv:Claim` ↔ Schema.org `schema:Claim` (subject to the §9 open question 5 about fact-check tooling interop — alignment may be `skos:closeMatch` rather than `owl:equivalentClass` to avoid the fact-check connotation).
+- `ccv:ConfidenceStatement` confidence-method enums ↔ relevant statistical-inference vocabularies (search for existing ontologies; no obvious candidate yet).
+
+**Phase 3 — Reasoner test corpus.** Build a small corpus of test claims (JSON-LD) plus a SPARQL test suite (or an OWL test suite using one of the standard reasoners) that demonstrates:
+
+- Subclass inference works (a `ccv:TrendClaim` instance is also a `ccv:Claim`).
+- Property domain/range constraints fire when violated.
+- Cross-ontology alignment fires (an instance of `ccv:ObservationClaim` is recognized as a `qb:Observation`).
+- SHACL validation produces the same results as the OWL constraints for the cases where they overlap.
+
+The reasoner-test corpus is the "is this actually working" check. Without it, the OWL axioms could be subtly wrong and no one would notice until a downstream consumer hits the bug.
+
+## Spec changes the work produces
+
+- `civic-claim-vocabulary.owl` (new file, hosted at the namespace URL).
+- `civic-claim-vocabulary-draft-spec.md` v0.2: framing changes from "controlled vocabulary" back to "ontology"; §4 gains a "Class hierarchy" subsection describing the OWL axioms; §6 governance section gets revised once a v1.0 process exists; `claims-vocabulary` references rename to `claims-ontology` where appropriate (no mass rename — the term "Civic Claim Vocabulary" stays as the project name; just the framing inside the spec changes).
+- `end-state-vision.md` glossary entries for OWL, RDF, and Civic Claim Vocabulary updated to reflect the promotion.
+- `end-state-vision.md` §5 heading reverts from "claims vocabulary family" to "claims ontology family" to match the OWL framing once the promotion lands.
+- A new ADR (`docs/adr/0004-civic-claim-vocabulary-as-ontology.md` or similar) records the decision and the phasing.
+
+## Scope
+
+**In:**
+- ADR recording the decision and phasing.
+- OWL axiomatization (Phase 1).
+- Alignment declarations with adjacent ontologies (Phase 2).
+- Reasoner test corpus (Phase 3).
+- Spec rewrites in CCV draft + end-state-vision + open-questions registry to reflect the promotion.
+- Hosting plan for `civic-claim-vocabulary.owl` at the namespace URL (likely just adding it to the website's `/.well-known/` or `/ns/` path — straightforward).
+
+**Out:**
+- Building OWL reasoners or SPARQL endpoints for downstream consumption. Adopters use existing reasoners (HermiT, Pellet, ELK) and existing SPARQL stores against the published ontology.
+- Domain extensions. Each extension is its own work, gated on a real package needing it (per the Civic Claim Vocabulary domain-extensions portfolio in `003-civic-claim-vocabulary-domain-extensions-portfolio.md`).
+- Implementing `claims.jsonld` generation. That depends on Open Question #5 resolving — separate work.
+- Q11 (typed claims as attestation reframe) — separate issue 006.
+
+## Acceptance criteria
+
+- ADR drafted and Accepted.
+- `civic-claim-vocabulary.owl` published at the namespace URL and validates against W3C OWL 2 DL profile (verifiable via the [OWL 2 Validator](https://www.w3.org/2012/pyRdfa/extract?validate=yes&format=html&warnings=yes)).
+- Alignment declarations land for at minimum Data Cube + PROV-O + Schema.org.
+- Reasoner test corpus demonstrates the four checks above; tests pass against at least one of HermiT, Pellet, or ELK.
+- CCV draft spec v0.2 is committed with the framing changes; pointers in `end-state-vision.md` and the open-questions registry are updated.
+- `civic-claim-vocabulary.owl` is referenced from the trust-registry-style `.well-known` location or equivalent so adopters can discover it.
+
+## Dependencies
+
+- **Soft dependency on Open Question #5** (claims.jsonld implementation timing) — promoting the vocabulary to an ontology before any package uses it is permitted under the Xanadu doctrine (research / spec authoring is exempt from the gate), but actually generating `claims.jsonld` is downstream and gated separately.
+- **No hard dependency on Open Question #1** (package format) — the ontology is independent of how the package is structured.
+- **Open Question #11 may interact** — if typed claims get reframed as a kind of attestation, the OWL axioms may need to express the attestation relationship differently. Coordinate timing.
+
+## Risk
+
+- **OWL is hard to write correctly.** Subtle axiomatization errors (wrong domain/range, missing disjointness, accidentally-too-broad subclass declarations) produce reasoner outputs that look fine but are wrong. Mitigation: Phase 3's reasoner test corpus is designed exactly for this.
+- **Alignment declarations may force naming changes.** If `qb:Observation` semantics differ from `ccv:ObservationClaim` more than expected, the alignment may need to be `skos:closeMatch` rather than `owl:equivalentClass` (or even just informative prose). Don't force alignment that doesn't actually hold.
+- **Reasoner choice has consequences.** OWL 2 DL profiles vary in expressivity and reasoner support. Pick a profile that works with at least two reasoners.
+
+## Reproducible at
+
+- CCV draft spec: `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` (v0.1 draft, internal working draft pre-v0.1 status).
+- Vision doc framing: `civic-ai-tools/docs/architecture/end-state-vision.md` §5 (claims vocabulary family) and Glossary entries for OWL, RDF, Civic Claim Vocabulary.
+- Open-questions registry: `civic-ai-tools/docs/architecture/open-questions.md` Q10.
+- Related issues: 003 (domain-extensions portfolio — depends on a stable v1.0 ontology); 006 (typed claims as attestation reframe — may interact); 007 (attestation as upstream-evidence — may interact).

--- a/docs/proposed-issues/006-typed-claims-as-attestation-reframe.md
+++ b/docs/proposed-issues/006-typed-claims-as-attestation-reframe.md
@@ -1,0 +1,105 @@
+# Reframe typed claims as a kind of attestation
+
+**Repo:** civic-ai-tools (Open Evidence Standard + Civic Claim Vocabulary spec drafts); civic-ai-tools-website (attestation infrastructure code lives here)
+**Labels:** future-work, evidence-system, attestations, civic-claim-vocabulary, infrastructure, medium-priority
+**Estimated effort:** M (architectural reframe + ADR + spec restructure; no implementation rewrite required for v0.1 since typed claims aren't built yet)
+**Blocks:** Civic Claim Vocabulary v1.0 — the framing decision affects how `claims.jsonld` integrates with the rest of the package
+**Tracks:** [Open Question #11](../../../../civic-ai-tools/docs/architecture/open-questions.md) — Typed claims as a kind of attestation. May subsume [Open Question #12](../../../../civic-ai-tools/docs/architecture/open-questions.md) (issue 007) — see "Relationship to issue 007" below.
+
+## Problem
+
+The Open Evidence Standard currently treats typed claims (`claims.jsonld`, the Civic Claim Vocabulary layer) and attestations (`consistency`, `evaluation`, `expert_attestation`) as architecturally separate concepts:
+
+- **Typed claims** (Open Evidence Standard §11) are an optional companion file that asserts structured statements derived from the analysis, conforming to the Civic Claim Vocabulary. The `caco:AnalyticalDerivation` requirement (CCV draft spec §4.6) requires every typed claim to link back to the analytical step that produced it (which prompt, which model, which span of the source output).
+- **Attestations** (Open Evidence Standard §15) are signed artifacts that comment on a previously-published package without modifying it. Attestation kinds in current use: `consistency` (repeat-publish runs), `evaluation` (LLM-as-judge), `expert_attestation` (named human reviewer).
+
+Looked at structurally, these are the same shape. A typed claim is:
+- A signed assertion *about* a package's content.
+- Carrying metadata about *how the assertion was made* (the translation model, the translation prompt, the source span).
+- Linked to the package by hash.
+
+An attestation is:
+- A signed assertion *about* a package's correctness or replication.
+- Carrying metadata about *how the assertion was made* (the reviewer identity, the rubric, the consistency-test inputs).
+- Linked to the package by hash.
+
+The framing difference is mostly historical — the typed-claims layer was conceived as part of the package; attestations were conceived as commentary on the package. Restructuring both as instances of "attestation" — signed structured assertions about evidence packages, with translation/review metadata — could collapse the two surfaces into one infrastructure.
+
+This issue scopes that reframe.
+
+## Proposed approach
+
+Three deliverables:
+
+1. **Assessment.** Walk through every property of every Civic Claim Vocabulary claim type and ask: is this property a feature of the underlying analysis (which must come from the analysis itself) or a feature of the attestation about the analysis (which the attester provides)? Examples:
+   - `ccv:metric`, `ccv:value`, `ccv:scope`, `ccv:magnitude` — features of the analysis.
+   - `caco:translationModel`, `caco:translationPrompt`, `caco:sourceOutputSpan` — features of the attestation (the LLM that did the translation, the prompt that asked for the translation, the source span the translation references).
+   - The signed-by-the-platform-at-publish-time property — features of the attestation (when the attestation was made, by whom).
+   The output is a property-by-property map showing which side of the typed-claim-as-attestation reframe each property lives on. If the map is clean, the reframe works. If it's confused, the reframe has friction.
+
+2. **ADR + spec restructure.** If the assessment confirms the reframe, produce:
+   - An ADR (`docs/adr/0005-typed-claims-as-attestation.md` or similar) recording the decision.
+   - A revised Open Evidence Standard §11 that describes typed claims as a structured-assertion attestation kind, alongside `consistency`, `evaluation`, `expert_attestation` — possibly named `typed_claim` or `semantic_translation` in the attestation enum.
+   - A revised §15 that includes `typed_claim` (or whatever name lands) in the canonical attestation kinds.
+   - Civic Claim Vocabulary draft spec changes: `caco:AnalyticalDerivation` becomes the attestation-metadata pattern, possibly aligned with adjacent ontologies (PROV-O `prov:Activity` for the translation step, etc.).
+   - Pointers from the open-questions registry Q11 entry to the Resolution log.
+
+3. **Implementation guidance.** The reframe doesn't require the attestation infrastructure code to change today — typed claims aren't generated yet (Open Question #5). What it does require: when typed claims do get implemented (downstream of Open Question #5), the implementation should follow the attestation pattern (separate signed artifact, linked to the original package by hash) rather than embedding into the package's signed envelope. Document this in the ADR so the implementation team picks it up.
+
+## Spec changes the work produces
+
+- `docs/adr/000N-typed-claims-as-attestation.md` (new ADR).
+- Open Evidence Standard §11 (typed claims) — restructured.
+- Open Evidence Standard §15 (attestations) — gains the typed-claim attestation kind.
+- Civic Claim Vocabulary draft spec §4.6 (`caco:AnalyticalDerivation`) — reframed as the attestation-metadata pattern.
+- Open-questions registry Q11 — moved to Resolution log; Q12 may follow if the reframe also subsumes it (see issue 007).
+
+## Relationship to issue 007 (attestation as upstream-evidence)
+
+Issue 007 (`007-attestation-as-upstream-evidence.md`) tracks Open Question #12: whether `upstream-evidence.json` is also a kind of attestation. The two issues share the underlying insight (attestations are the unifying frame for "things you can say *about* a package"), but they target different artifacts:
+
+- 006 (this issue): typed claims as attestation. The attestation says *this is what the analysis claims*.
+- 007: upstream-evidence as attestation. The attestation says *this package is in relationship R with package X*.
+
+Both could be in scope for a single ADR. **The drafter of 007 should check this issue's status before starting; if 006 has already produced an ADR that covers both, 007 folds and the registry Q12 entry gets updated to point at 006's resolution.** As of filing, the two are kept separate so each can be scoped independently; folding is a decision made during the work, not preemptively.
+
+## Scope
+
+**In:**
+- Property-by-property assessment (§Proposed approach step 1).
+- ADR + spec restructure if the assessment confirms the reframe.
+- Implementation guidance for the eventual typed-claims build-out (downstream of Open Question #5).
+
+**Out:**
+- Implementing typed claims. That's downstream of Open Question #5 (claims.jsonld implementation timing).
+- The Civic Claim Vocabulary domain-extensions portfolio. That work proceeds independently per issue 003.
+- The promotion of CCV to a full OWL ontology. That's issue 005.
+- The upstream-evidence-as-attestation reframe. That's issue 007 (or this issue, if folded).
+
+## Acceptance criteria
+
+- The property-by-property assessment is committed (as a section in the ADR or as a working note in the open-questions registry).
+- ADR drafted and Accepted (or explicitly Rejected with rationale, if the assessment finds the reframe doesn't work).
+- If Accepted: Open Evidence Standard §11 + §15 + Civic Claim Vocabulary draft spec §4.6 are all revised to reflect the reframe.
+- Open-questions registry Q11 moved to Resolution log.
+- Decision documented on whether issue 007 is folded into this work or remains separate; registry Q12 entry updated accordingly.
+
+## Dependencies
+
+- **No hard dependency on Open Question #5** — the reframe is a spec / framing change that can land before typed claims are built. It actually strengthens the argument that typed-claims implementation should wait until the framing is settled.
+- **Soft interaction with issue 005** (CCV as full OWL ontology) — the ontology axioms for `caco:AnalyticalDerivation` will look different if the reframe lands; coordinate timing.
+- **Soft interaction with issue 007** — see above. Both issues may share an ADR.
+
+## Risk
+
+- **Property-by-property assessment may surface a property that doesn't fit either side cleanly.** If found, the assessment should document the friction and propose a resolution (either move the property, or articulate why typed claims have a feature attestations don't). Don't force-fit.
+- **The reframe changes how typed claims interact with the package signature.** Today the Civic Claim Vocabulary draft spec §3.2 says "The package signature in `signature.json` covers `claims.jsonld` along with all other package contents — claims are immutable once signed." Under the reframe, typed claims are separately-signed attestations, not part of the package's own signature. The spec needs to update this.
+- **Attestation infrastructure may not perfectly fit the typed-claim semantics.** Today's attestations are simpler shapes than typed claims; making attestations general enough to accommodate typed claims may complicate the attestation infrastructure. Mitigation: ADR explicitly weighs this and either accepts the complexity or notes that a typed-claim-specific attestation kind is fine even within the unified frame.
+
+## Reproducible at
+
+- Open Evidence Standard: `civic-ai-tools/docs/architecture/open-evidence-standard.md` §11, §12, §15.
+- Civic Claim Vocabulary draft spec: `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md` §3.2, §4.6.
+- Open-questions registry: `civic-ai-tools/docs/architecture/open-questions.md` Q11, Q12.
+- Existing attestation infrastructure: `civic-ai-tools-website/src/lib/evidence/expert-attestation.test.ts` and adjacent (consistency / evaluation kinds).
+- Related issues: 005 (CCV as ontology — coordinates on `caco:AnalyticalDerivation` axiomatization); 007 (attestation as upstream-evidence — may fold here).

--- a/docs/proposed-issues/007-attestation-as-upstream-evidence.md
+++ b/docs/proposed-issues/007-attestation-as-upstream-evidence.md
@@ -1,0 +1,86 @@
+# Use attestations as the implementation path for upstream-evidence references
+
+**Repo:** civic-ai-tools (Open Evidence Standard spec); civic-ai-tools-website (attestation infrastructure)
+**Labels:** future-work, evidence-system, attestations, infrastructure, medium-priority
+**Estimated effort:** M (architectural reframe + ADR + spec restructure; may fold into 006)
+**Blocks:** any cross-package corroboration or citation-graph work
+**Tracks:** [Open Question #12](../../../../civic-ai-tools/docs/architecture/open-questions.md) — Attestations as the implementation path for upstream-evidence references. **May fold into [issue 006](006-typed-claims-as-attestation-reframe.md)** if the typed-claims-as-attestation work produces an ADR general enough to cover this case too.
+
+## Problem
+
+The Open Evidence Standard currently has a §12 reserving space for `upstream-evidence.json` — an optional companion file declaring relationships between evidence packages: `derived_from`, `compares_to`, `extends`, `replicates`, `contradicts`, `evaluates`. Cross-package citation graphs, meta-analysis, and adversarial-evaluation chains all depend on this layer.
+
+The attestation infrastructure (Open Evidence Standard §15) already supports signed artifacts that comment on a previously-published package, including `evaluation` (an attestation that says "I evaluated this package against rubric R and got result X"). Extending that to "I evaluate this package against the package at hash Y, with relationship R" is a small step.
+
+The insight: **upstream-evidence references may not need a separate file format — they may be a kind of attestation.** Specifically, an attestation kind that carries a relationship vocabulary (`derived_from`, `compares_to`, `extends`, `replicates`, `contradicts`, `evaluates`) and a target-package hash. The attestation infrastructure already handles signing, linkage by hash, lifecycle, and rendering; reusing it avoids duplicating that infrastructure for upstream-evidence.
+
+If the reframe works, it eliminates `upstream-evidence.json` as a planned package companion file and replaces it with extending the attestation-kind enum to include relationship attestations.
+
+## Proposed approach
+
+Three deliverables, parallel in shape to issue 006.
+
+1. **Assessment.** Compare the upstream-evidence relationship vocabulary against the attestation infrastructure:
+   - Does each relationship kind (`derived_from`, `compares_to`, `extends`, `replicates`, `contradicts`, `evaluates`) fit cleanly as a signed-attestation-with-target-package?
+   - Is the directionality the same? (Attestations point from attester to package; upstream-evidence references point from one package to another.)
+   - Are there relationships that need bidirectional or multi-target shape that single-target attestations don't support?
+   - Does the attestation rendering surface (the detail page) accommodate displaying the relationship structurally?
+
+2. **ADR + spec restructure.** If the assessment confirms the reframe:
+   - An ADR (or a section in the ADR from issue 006 if folded) recording the decision.
+   - Open Evidence Standard §12 collapses or becomes a forward to §15 (attestations).
+   - Open Evidence Standard §15 gains relationship attestation kinds. The vocabulary may be the existing six (`derived_from`, etc.) or a refined set if the assessment surfaces issues.
+   - Open-questions registry Q12 moves to Resolution log.
+
+3. **Implementation guidance.** Whether the new relationship attestation kinds get implemented now or deferred per Open Question #5 — the reframe doesn't require implementation; it just changes the planned shape.
+
+## Relationship to issue 006
+
+Issue 006 (`006-typed-claims-as-attestation-reframe.md`) tracks the parallel question for typed claims. Both issues share the insight that attestations are the unifying frame for "things you can say *about* a package":
+
+- **Issue 006:** typed claims as attestations. The attestation says *this is what the analysis claims*.
+- **Issue 007 (this):** upstream-evidence references as attestations. The attestation says *this package is in relationship R with package X*.
+
+The two could share a single ADR. The decision on whether to fold is left to the drafter of 006 (or whoever picks up both):
+
+- **If folded:** 007's content moves into 006's ADR scope; 006's title and acceptance criteria expand; this file gets a closing note pointing at 006 and stays in the directory as a record of the question; the open-questions registry Q12 entry points at 006's resolution.
+- **If not folded:** 007 proceeds independently with its own ADR. The two ADRs cross-reference each other.
+
+The folding decision should be made during the assessment phase. If the property-by-property work in 006 turns up that typed claims and upstream-evidence are structurally identical attestations, fold. If they're structurally different (e.g. typed claims need translation-method metadata that upstream-evidence references don't), keep separate.
+
+## Scope
+
+**In:**
+- Assessment (per §Proposed approach step 1).
+- ADR + spec restructure (separately or folded into 006).
+- Implementation guidance.
+
+**Out:**
+- Implementing relationship attestations (downstream of Open Question #5 + the reframe).
+- The typed-claims-as-attestation reframe (issue 006).
+- Building cross-package citation-graph or meta-analysis surfaces (downstream of implementation).
+
+## Acceptance criteria
+
+- Assessment committed (as a section in the ADR, or as a working note).
+- ADR drafted and Accepted (or explicitly Rejected with rationale).
+- If folded: 006's ADR covers both reframes; this issue's resolution points at that ADR.
+- If not folded: a standalone ADR + Open Evidence Standard §12/§15 revisions land in this issue.
+- Open-questions registry Q12 moved to Resolution log.
+
+## Dependencies
+
+- **No hard dependency on Open Question #5** — the reframe is a spec / framing change.
+- **Tight coupling with issue 006** — see above. The drafter should read 006 first.
+
+## Risk
+
+- **Relationship vocabulary may need refinement.** The current six (`derived_from`, `compares_to`, `extends`, `replicates`, `contradicts`, `evaluates`) were named without a structural review. The assessment may surface that some are actually the same relationship from different directions, or that some need decomposition.
+- **Bidirectional / multi-target relationships.** If a relationship needs to be expressed bidirectionally (package A extends package B and package B is extended by package A), single-target attestations may not support that natively. Mitigation: most relationships are inherently directional (A `derived_from` B means A is the derivative); for symmetric relationships, two attestations can capture both directions.
+- **Conflict with Open Question #1** (package format) — `upstream-evidence.json` was conceived as a multi-file companion. If Open Question #1 resolves toward multi-file, the file format conflict goes away (attestations could live alongside the package). If it stays single-blob, upstream-evidence-as-attestation is the simpler option (no second file).
+
+## Reproducible at
+
+- Open Evidence Standard: `civic-ai-tools/docs/architecture/open-evidence-standard.md` §12 (upstream-evidence references) and §15 (attestations).
+- Open-questions registry: `civic-ai-tools/docs/architecture/open-questions.md` Q12. Cross-references Q11.
+- Related issues: 006 (typed claims as attestation — possible fold).


### PR DESCRIPTION
## Summary

Companion to [`npstorey/civic-ai-tools#66`](https://github.com/npstorey/civic-ai-tools/pull/66) (architecture-foundation). Resolves vision-doc references in 002/003/004, applies two triage-discipline tightenings, propagates the CACO → Civic Claim Vocabulary rename, and adds three new issue drafts surfaced during the architecture-doc cleanup.

## Three commits

- **0428cc4** — Original bundle: backfill `[TK: vision-doc §...]` references in 002/003/004 against the vision doc landing in #66, add `infrastructure` label to all three, add Path B cross-reference to 004 under the strategic-case paragraph.
- **1912607** — CACO → Civic Claim Vocabulary rename: 003 file renamed, title rewritten to *Explore and define Civic Claim Vocabulary domain extensions portfolio*, body substitutes CACO → Civic Claim Vocabulary throughout. 004 gets the `(CACO)` parenthetical and CCV-spec path reference updated.
- **74b0e76** — Three new drafts:
  - `005-promote-civic-claim-vocabulary-to-ontology.md` — promote CCV from controlled vocabulary to full OWL ontology with axioms, alignment, and reasoner test corpus. Tracks Open Question #10. Decision: yes, do this.
  - `006-typed-claims-as-attestation-reframe.md` — reframe typed claims as a kind of attestation (semantic translation of a package, signed with translation-method metadata). Tracks Open Questions #11 and #12. Decision: yes, do this.
  - `007-attestation-as-upstream-evidence.md` — use the attestation infrastructure as the implementation path for upstream-evidence references. Kept separate from 006 per the structural distinction documented in 006's *Relationship to issue 007* section. Folding decision left to the drafter when work starts. Tracks Open Question #12.
  - All three carry the `infrastructure` label.
  - Filename follow-up in 003: `civic-claim-vocabulary-extensions-portfolio.md` → `civic-claim-vocab-extensions.md` (50-char filename trimmed).

## What's not in this PR

- `001-enforce-capture-method.md` is still untracked locally — out of scope per the original bundled-tasks request.

## Test plan

- [ ] Zero CACO / Civic Analysis Core Ontology / `caco:` prefix / old-filename references across all five drafts.
- [ ] All five drafts (002, 003, 004, 005, 006, 007) carry the `infrastructure` label.
- [ ] 003's title and filename match the renamed convention.
- [ ] 005, 006, 007 cross-reference `open-questions.md` by Q-number — those references resolve once #66 merges.
- [ ] Cross-references to `civic-ai-tools/docs/architecture/end-state-vision.md`, `civic-ai-tools/docs/architecture/civic-claim-vocabulary-draft-spec.md`, and `civic-ai-tools/docs/architecture/open-questions.md` resolve correctly once #66 merges. Per the task brief, this PR should merge **after** #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)