### PR TITLE
feat(evidence): PR1 — taxonomy & profile-label envelope fields

### DIFF
--- a/public/.well-known/evidence-public-keys.json
+++ b/public/.well-known/evidence-public-keys.json
@@ -9,6 +9,11 @@
     {
       "kid": "platform:evidence-2026-04",
       "publicKey": "MCowBQYDK2VwAyEAqd/MVdHJFPLi8nxxwmqWsDdgz8yssU76unJMHW3xaAE=",
+      "signerIdentity": {
+        "bindingTier": "platform",
+        "identifier": "platform:civic-ai-tools",
+        "displayName": "Civic AI Tools Platform"
+      },
       "status": "active",
       "activatedAt": "2026-04-15T00:00:00.000Z",
       "deprecatedAt": null,

--- a/src/app/.well-known/typed-publisher.json/route.ts
+++ b/src/app/.well-known/typed-publisher.json/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import registry from '../../../../public/.well-known/evidence-public-keys.json' with { type: 'json' };
+
+// Canonical trust-registry path (spec §8.3.3, ADR-0012 §3 parallel-serve).
+// Serves the same content as the legacy static file at
+// /.well-known/evidence-public-keys.json. Single-source: this route returns
+// the same bundled registry JSON, so the two paths never diverge. The new
+// path is canonical going forward; the legacy path is served indefinitely
+// (no forced cutover). New external clients SHOULD fetch this path.
+export const dynamic = 'force-static';
+
+export function GET() {
+  return NextResponse.json(registry);
+}

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -11,8 +11,14 @@ import {
   loadTrustRegistry,
   legacyEmbeddedKeyTrust,
   verifyPackageBlobRefs,
+  resolvePackageType,
+  checkSignerIdentity,
+  checkCaptureMethodVocab,
   type KeyTrustResult,
   type BlobRefVerification,
+  type TypeResolution,
+  type SignerIdentityCheck,
+  type CaptureMethodVocabCheck,
 } from '@/lib/evidence/verify';
 
 export async function GET(
@@ -106,12 +112,35 @@ export async function GET(
   //     registry cannot vouch for it. The UI renders this as neutral rather
   //     than failed so older packages aren't visually penalized.
   //   - No signature at all → keep `keyTrust: null`.
+  // Load the trust registry once — used by both key-trust (step 4) and the
+  // signer-identity cross-check (#14 below). Cached; falls back to the
+  // build-time embedded copy.
+  const registry = await loadTrustRegistry();
+
   let keyTrust: KeyTrustResult | null = null;
   if (sigPublicKey && sigKid) {
-    const registry = await loadTrustRegistry();
     keyTrust = verifyKeyTrust(sigPublicKey, sigKid, rekorIntegratedTime, registry);
   } else if (sigPublicKey) {
     keyTrust = legacyEmbeddedKeyTrust();
+  }
+
+  // Step 5: Typed-standards envelope checks (spec §9.2). These run against
+  // the canonical package JSON when available; each degrades gracefully for
+  // pre-v0.1 packages that omit the corresponding field.
+  //   #12 type resolution      — non-fatal (unknown_type renders, doesn't fail)
+  //   #13 nodeId               — the recomputed envelope hash (current
+  //                              JSON.stringify canonicalization; PR2 switches
+  //                              this to JCS alongside the hash change)
+  //   #14 signer ↔ registry    — fatal on mismatch; skipped when no signer
+  //   #15 captureMethod vocab  — captureMethod_unknown rejects; bundle-
+  //                              unresolved degrades gracefully
+  let typeResolution: TypeResolution | null = null;
+  let signerIdentity: SignerIdentityCheck | null = null;
+  let captureMethodVocab: CaptureMethodVocabCheck | null = null;
+  if (pkgJson) {
+    typeResolution = resolvePackageType(pkgJson);
+    signerIdentity = checkSignerIdentity(pkgJson, sigKid, registry);
+    captureMethodVocab = checkCaptureMethodVocab(pkgJson);
   }
 
   return NextResponse.json({
@@ -122,6 +151,11 @@ export async function GET(
     keyTrust,
     blobRefsVerified,
     blobRefs,
+    // Typed-standards envelope checks (spec §9.2 checks #12-#15).
+    nodeId: recomputedHash,
+    typeResolution,
+    signerIdentity,
+    captureMethodVocab,
     details: {
       storedHash: record.basePackageHash,
       recomputedHash,

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -3,9 +3,10 @@ import { db } from '@/lib/db';
 import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { putPackage } from '@/lib/storage';
-import { buildEvidencePackage, type PackageInput, type CaptureMethod, type ContentProfile } from '@/lib/evidence/packager';
+import { buildEvidencePackage, type PackageInput, type CaptureMethod, type ContentProfile, DEFAULT_CONTENT_TYPE } from '@/lib/evidence/packager';
 import { hash } from '@/lib/evidence/trace';
-import { signPackage, getRfc3161Timestamp, publishToRekor } from '@/lib/evidence/signing';
+import { signPackage, getRfc3161Timestamp, publishToRekor, getActiveSigner, type SignerIdentity } from '@/lib/evidence/signing';
+import { captureVocabForProfile } from '@/lib/evidence/profiles';
 import { type BlobRef } from '@/lib/evidence/blob-ref';
 import { resolveRequestUser, hasScope } from '@/lib/api-auth';
 
@@ -45,12 +46,6 @@ async function resolveSlug(title: string, packageHash: string): Promise<string> 
   return buildSlug(title, packageHash, 64);
 }
 
-const VALID_CAPTURE_METHODS: readonly CaptureMethod[] = [
-  'chat-flow-stream',
-  'claude-code-jsonl-readback',
-  'claude-code-self-report',
-] as const;
-
 // ADR-0004: contentProfile values. Orthogonal to captureMethod. Optional
 // at the route layer; absence is equivalent to `'default'`.
 const VALID_CONTENT_PROFILES: readonly ContentProfile[] = [
@@ -88,6 +83,17 @@ interface PublishRequest {
    *  packager promotes `summary` into canonical JSON + auto-emits the
    *  `org.civicaitools.environment` extension. */
   contentProfile?: ContentProfile;
+  /** Producer Profile label per ADR-0006 (spec §8.1.1). Optional; when
+   *  omitted the packager auto-derives it for the datHere content profile.
+   *  Must stay consistent with contentProfile (validated below). */
+  producerProfile?: string;
+  /** Node type per ADR-0009 (spec §8.1.1, §8.12). Optional; defaults to
+   *  `content/analysis/v1`. This endpoint accepts only that value — other
+   *  sub-types are emitted by their own routes / reserved. */
+  type?: string;
+  /** Envelope-side identity claim per ADR-0009 (spec §8.1.1, §8.5).
+   *  Optional; the route default-fills it from the active signing key. */
+  signer?: SignerIdentity;
   /** Optional override for the skill metadata that would otherwise be
    *  extracted from the trace. Required when `trace` is a BlobRef. */
   skillMetadataOverride?: {
@@ -114,18 +120,6 @@ export async function POST(request: NextRequest) {
 
     const body: PublishRequest = await request.json();
 
-    // Validate captureMethod (ADR-0003). Required for all publishes;
-    // resolve once here, never re-derive downstream.
-    if (!body.captureMethod || !VALID_CAPTURE_METHODS.includes(body.captureMethod)) {
-      return NextResponse.json(
-        {
-          error:
-            'captureMethod is required and must be one of: chat-flow-stream, claude-code-jsonl-readback, claude-code-self-report',
-        },
-        { status: 400 },
-      );
-    }
-
     // Validate contentProfile (ADR-0004). Optional; absence is equivalent
     // to `'default'`. When set, must be a recognized value.
     if (body.contentProfile && !VALID_CONTENT_PROFILES.includes(body.contentProfile)) {
@@ -133,6 +127,51 @@ export async function POST(request: NextRequest) {
         {
           error:
             'contentProfile, when provided, must be one of: default, datHere',
+        },
+        { status: 400 },
+      );
+    }
+
+    // Validate producerProfile consistency (ADR-0006, spec §8.1.1). When a
+    // producerProfile is supplied it MUST agree with contentProfile:
+    // contentProfile === 'datHere' iff producerProfile begins with
+    // 'ai-assisted-analysis/datHere'. When omitted, the packager
+    // auto-derives a consistent value for the datHere profile.
+    if (body.producerProfile) {
+      const ppIsDatHere = body.producerProfile.startsWith('ai-assisted-analysis/datHere');
+      const cpIsDatHere = body.contentProfile === 'datHere';
+      if (ppIsDatHere !== cpIsDatHere) {
+        return NextResponse.json(
+          {
+            error:
+              'producerProfile and contentProfile are inconsistent: contentProfile "datHere" iff producerProfile begins with "ai-assisted-analysis/datHere".',
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Validate type (ADR-0009). The standard publish path produces
+    // content/analysis/v1; attestation/* sub-types are emitted by their own
+    // routes and typed-content sub-types are reserved (out of scope here).
+    if (body.type && body.type !== DEFAULT_CONTENT_TYPE) {
+      return NextResponse.json(
+        { error: `type, when provided to this endpoint, must be "${DEFAULT_CONTENT_TYPE}".` },
+        { status: 400 },
+      );
+    }
+
+    // Validate captureMethod (ADR-0003/0011). Required for all publishes;
+    // must be in the captureMethod vocabulary declared by the package's
+    // Producer Profile (spec §8.6), resolved via the shared hardcoded
+    // PROFILE_CAPTURE_VOCAB table. Resolve once here, never re-derive
+    // downstream.
+    const captureVocab = captureVocabForProfile(body.producerProfile, body.contentProfile);
+    if (!body.captureMethod || !captureVocab || !captureVocab.includes(body.captureMethod)) {
+      return NextResponse.json(
+        {
+          error:
+            'captureMethod is required and must be one of the values declared by the producerProfile vocabulary (ai-assisted-analysis: chat-flow-stream, claude-code-jsonl-readback, claude-code-self-report).',
         },
         { status: 400 },
       );
@@ -180,6 +219,12 @@ export async function POST(request: NextRequest) {
       summary: body.summary,
       captureMethod: body.captureMethod,
       contentProfile: body.contentProfile,
+      // ADR-0006: pass through; the packager auto-derives for datHere when omitted.
+      producerProfile: body.producerProfile,
+      // ADR-0009: default-fill the standard content type + the envelope-side
+      // signer identity (the active platform signing key) for every publish.
+      type: body.type ?? DEFAULT_CONTENT_TYPE,
+      signer: body.signer ?? getActiveSigner(),
       skillMetadataOverride: body.skillMetadataOverride,
       extensions: body.extensions,
     };

--- a/src/app/evidence/[slug]/page.tsx
+++ b/src/app/evidence/[slug]/page.tsx
@@ -531,6 +531,19 @@ export default async function EvidencePage({ params }: PageProps) {
               <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
                 Captured via: {captureMethodLabel(record.captureMethod)}
               </span>
+              {/* Typed-standards envelope labels (ADR-0006/0009). Read from
+                  the canonical package object — not a DB column. Absent on
+                  pre-v0.1 packages, which simply omit these. */}
+              {renderPkg?.producerProfile && (
+                <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
+                  Producer profile: {renderPkg.producerProfile}
+                </span>
+              )}
+              {renderPkg?.type && (
+                <span style={{ fontSize: '13px', color: 'var(--text-muted)', fontFamily: 'monospace' }}>
+                  {renderPkg.type}
+                </span>
+              )}
             </div>
           </Section>
         )}
@@ -750,6 +763,19 @@ export default async function EvidencePage({ params }: PageProps) {
               <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
                 Captured via: {captureMethodLabel(record.captureMethod)}
               </span>
+              {/* Typed-standards envelope labels (ADR-0006/0009). Read from
+                  the canonical package object — not a DB column. Absent on
+                  pre-v0.1 packages, which simply omit these. */}
+              {renderPkg?.producerProfile && (
+                <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
+                  Producer profile: {renderPkg.producerProfile}
+                </span>
+              )}
+              {renderPkg?.type && (
+                <span style={{ fontSize: '13px', color: 'var(--text-muted)', fontFamily: 'monospace' }}>
+                  {renderPkg.type}
+                </span>
+              )}
             </div>
           </Section>
         )}

--- a/src/lib/evidence/packager.test.ts
+++ b/src/lib/evidence/packager.test.ts
@@ -356,3 +356,64 @@ test('buildEvidencePackage: datHere content profile preserves caller-supplied ex
     'environment extension must be auto-emitted alongside the caller-supplied notebook extension',
   );
 });
+
+// --- PR1: producerProfile / type / signer top-level envelope fields ---
+//
+// ADR-0006/0009 (spec §8.1.1). The load-bearing property is that
+// existing-shape inputs (none of the three fields) produce byte-identical
+// canonical JSON to before — so legacy verify, which recomputes the hash
+// from stored canonical JSON, still matches. The fields are top-level
+// (parallel to metadata.contentProfile, which stays nested).
+
+test('buildEvidencePackage: existing-shape input emits NO producerProfile/type/signer (byte-identical)', () => {
+  const { pkg } = buildEvidencePackage(baseInput());
+  // Top-level keys must be absent so legacy verify (which recomputes the hash
+  // from stored canonical JSON) still matches. (A substring scan of the JSON
+  // would false-positive on nested keys like a tool call's `args.type`, so
+  // assert on the top-level object's own properties.)
+  assert.equal(Object.prototype.hasOwnProperty.call(pkg, 'producerProfile'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(pkg, 'type'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(pkg, 'signer'), false);
+});
+
+test('buildEvidencePackage: datHere auto-derives producerProfile = ai-assisted-analysis/datHere', () => {
+  const { pkg } = buildEvidencePackage(baseInput({ contentProfile: 'datHere' }));
+  assert.equal(pkg.producerProfile, 'ai-assisted-analysis/datHere');
+});
+
+test('buildEvidencePackage: explicit producerProfile is preserved (not overridden by auto-derive)', () => {
+  const { pkg } = buildEvidencePackage(
+    baseInput({ contentProfile: 'datHere', producerProfile: 'ai-assisted-analysis/datHere' }),
+  );
+  assert.equal(pkg.producerProfile, 'ai-assisted-analysis/datHere');
+  // And a non-datHere input with an explicit producerProfile keeps it.
+  const { pkg: pkg2 } = buildEvidencePackage(
+    baseInput({ producerProfile: 'ai-assisted-analysis/civicaitools-default' }),
+  );
+  assert.equal(pkg2.producerProfile, 'ai-assisted-analysis/civicaitools-default');
+});
+
+test('buildEvidencePackage: type is emitted at top level when supplied', () => {
+  const { pkg } = buildEvidencePackage(baseInput({ type: 'content/analysis/v1' }));
+  assert.equal(pkg.type, 'content/analysis/v1');
+});
+
+test('buildEvidencePackage: signer is emitted at top level when supplied', () => {
+  const signer = {
+    bindingTier: 'platform',
+    identifier: 'platform:civic-ai-tools',
+    displayName: 'Civic AI Tools Platform',
+  };
+  const { pkg } = buildEvidencePackage(baseInput({ signer }));
+  assert.deepEqual(pkg.signer, signer);
+});
+
+test('buildEvidencePackage: type is covered by the package hash (tamper-evidence)', () => {
+  const a = buildEvidencePackage(baseInput({ type: 'content/analysis/v1' }));
+  const b = buildEvidencePackage(baseInput({ type: 'content/other/v1' }));
+  assert.notEqual(
+    normalizedHash(a.pkg),
+    normalizedHash(b.pkg),
+    'two packages identical except for type must hash differently',
+  );
+});

--- a/src/lib/evidence/packager.ts
+++ b/src/lib/evidence/packager.ts
@@ -1,11 +1,23 @@
 import crypto from 'crypto';
 import { buildProvenanceGraph, type ProvGraph } from './provenance.ts';
 import { buildDataSources, type DataSourceEntry } from './data-sources.ts';
-import { getActiveKeyId } from './signing.ts';
+import { getActiveKeyId, type SignerIdentity } from './signing.ts';
 import { isBlobRef, parseBlobRef, type BlobRef } from './blob-ref.ts';
 import { deriveOperationType } from '../mcp/operation-types.ts';
 
 const PACKAGE_SCHEMA_VERSION = '0.1.0';
+
+// Two-family node type taxonomy (spec §8.1.1, §8.12, ADR-0009): every node
+// carries `type` of the form `content/<noun>/v<N>` or `attestation/<verb>/v<N>`.
+// AI-Assisted Analysis output defaults to `content/analysis/v1`; pre-v0.1
+// packages omit the field and are interpreted as this value.
+export const DEFAULT_CONTENT_TYPE = 'content/analysis/v1';
+
+// Producer Profile (spec §8.1.1, §8.6, ADR-0006): compound
+// `<profile-type>/<profile-subtype>`. The v0.1 value auto-derived for the
+// datHere content profile — the legacy `contentProfile` field is retained as
+// a backwards-compatible alias, and the two MUST stay consistent.
+const DATHERE_PRODUCER_PROFILE = 'ai-assisted-analysis/datHere';
 
 /**
  * Capture method for the package contents (ADR-0003).
@@ -99,6 +111,29 @@ export interface PackageInput {
    */
   contentProfile?: ContentProfile;
   /**
+   * Producer Profile label per ADR-0006 (spec §8.1.1, §8.6). Compound
+   * `<profile-type>/<profile-subtype>` string. Optional at the packager
+   * layer (conditional-spread keeps existing-shape inputs byte-identical);
+   * when omitted but `contentProfile === 'datHere'`, the packager
+   * auto-derives `'ai-assisted-analysis/datHere'`. The route default-fills
+   * and validates the consistency invariant.
+   */
+  producerProfile?: string;
+  /**
+   * Node type per the two-family taxonomy (ADR-0009, spec §8.1.1, §8.12).
+   * Optional at the packager layer so existing-shape inputs stay
+   * byte-identical; the route default-fills `'content/analysis/v1'` for the
+   * standard publish path. Absence is interpreted as `content/analysis/v1`.
+   */
+  type?: string;
+  /**
+   * Envelope-side identity claim per ADR-0009 (spec §8.1.1, §8.5).
+   * "Recommended": the route default-fills it from the active signing key.
+   * Optional at the packager layer (conditional-spread); pre-v0.1 packages
+   * have no signer and verifiers derive it from the trust registry instead.
+   */
+  signer?: SignerIdentity;
+  /**
    * Override the skill metadata that the packager would otherwise extract
    * from the trace. Required when `trace` is a BlobRef (the packager can't
    * inspect trace spans in that case). Also accepts a BlobRef for
@@ -141,6 +176,21 @@ export interface EvidencePackage {
      *  package hash and signature. */
     contentProfile?: ContentProfile;
   };
+  /** Producer Profile label (ADR-0006, spec §8.1.1). Top-level envelope
+   *  field (parallel axis to `metadata.contentProfile`, which stays nested
+   *  as the grandfathered legacy alias). Present when supplied or
+   *  auto-derived for the datHere content profile; covered by the package
+   *  hash and signature when present. */
+  producerProfile?: string;
+  /** Node type per the two-family taxonomy (ADR-0009, spec §8.1.1, §8.12).
+   *  Top-level. Present on packages built via the publish route (default
+   *  `content/analysis/v1`); absence is interpreted as `content/analysis/v1`. */
+  type?: string;
+  /** Envelope-side identity claim (ADR-0009, spec §8.1.1, §8.5). Top-level.
+   *  Distinct from the signature envelope (`kid`/publicKey); verifiers
+   *  cross-check the two via the trust registry (check #14). Absent on
+   *  pre-v0.1 packages. */
+  signer?: SignerIdentity;
   prompt: {
     hash: string;
     visibility: 'full_text' | 'hash_only';
@@ -315,6 +365,15 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
     portal: input.portal,
   });
 
+  // Producer Profile (ADR-0006): emit when explicitly supplied, else
+  // auto-derive from the datHere content profile. Left undefined (and thus
+  // unspread below) for default/legacy inputs so their canonical JSON — and
+  // package hash — stays byte-identical to pre-ADR-0006 shape. The route
+  // enforces the contentProfile↔producerProfile consistency invariant.
+  const producerProfile =
+    input.producerProfile ??
+    (input.contentProfile === 'datHere' ? DATHERE_PRODUCER_PROFILE : undefined);
+
   const pkg: EvidencePackage = {
     metadata: {
       schemaVersion: PACKAGE_SCHEMA_VERSION,
@@ -332,6 +391,13 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
       // canonical JSON to before.
       ...(input.contentProfile ? { contentProfile: input.contentProfile } : {}),
     },
+    // Top-level envelope fields (ADR-0006/0009, spec §8.1.1). Conditional
+    // spread so existing-shape inputs (no producerProfile/type/signer) emit
+    // byte-identical canonical JSON to before; the route default-fills `type`
+    // and `signer` for the production publish path.
+    ...(producerProfile ? { producerProfile } : {}),
+    ...(input.type ? { type: input.type } : {}),
+    ...(input.signer ? { signer: input.signer } : {}),
     prompt: {
       hash: promptHash,
       visibility: input.promptVisibility,

--- a/src/lib/evidence/profiles.ts
+++ b/src/lib/evidence/profiles.ts
@@ -1,0 +1,55 @@
+// Producer Profile → captureMethod vocabulary (spec §8.6, ADR-0011).
+//
+// captureMethod's valid value space is declared per Producer Profile rather
+// than as a single flat core enum. v0.1 ships one Producer Profile type —
+// `ai-assisted-analysis` — whose vocabulary is the three capture methods
+// relocated from the former core enum. The bundle-distribution mechanism
+// (versioned, content-addressed guidance bundles) is deferred to Q32; v0.1
+// verifiers and the publish route resolve the vocabulary via this hardcoded
+// fallback table, used by BOTH `route.ts` (publish-time validation) and
+// `verify.ts` (verification check #15).
+
+import type { CaptureMethod } from './packager.ts';
+
+/** Hardcoded per-profile-type captureMethod vocabulary (Q32 fallback). */
+export const PROFILE_CAPTURE_VOCAB: Record<string, readonly CaptureMethod[]> = {
+  'ai-assisted-analysis': [
+    'chat-flow-stream',
+    'claude-code-jsonl-readback',
+    'claude-code-self-report',
+  ],
+};
+
+/**
+ * Resolve a package's Producer Profile *type* (the segment before the first
+ * `/` of the compound `<profile-type>/<profile-subtype>` value) from its
+ * `producerProfile`, applying the spec §8.6 step-1 fallbacks:
+ *   - `producerProfile` present        → its profile-type segment.
+ *   - absent + contentProfile==='datHere' → legacy alias
+ *     `ai-assisted-analysis/datHere` → `ai-assisted-analysis`.
+ *   - both absent (pre-v0.1)           → implicit `ai-assisted-analysis`
+ *     (every pre-existing package was AI-mediated by construction).
+ */
+export function resolveProfileType(
+  producerProfile?: string | null,
+  contentProfile?: string | null,
+): string {
+  const profile =
+    producerProfile ??
+    (contentProfile === 'datHere'
+      ? 'ai-assisted-analysis/datHere'
+      : 'ai-assisted-analysis');
+  return profile.split('/')[0];
+}
+
+/**
+ * The captureMethod vocabulary declared by a package's Producer Profile, or
+ * `undefined` when the profile type has no resolvable bundle (verify check
+ * #15's `producerProfile_bundle_unresolved` degraded case).
+ */
+export function captureVocabForProfile(
+  producerProfile?: string | null,
+  contentProfile?: string | null,
+): readonly CaptureMethod[] | undefined {
+  return PROFILE_CAPTURE_VOCAB[resolveProfileType(producerProfile, contentProfile)];
+}

--- a/src/lib/evidence/signing.ts
+++ b/src/lib/evidence/signing.ts
@@ -17,6 +17,33 @@ const ALGORITHM = 'Ed25519ph';
 // see Phase 5 of the security hardening plan.
 const DEFAULT_KEY_ID = 'platform:evidence-2026-04';
 
+/**
+ * Envelope-side identity claim for the party that signed a node (spec
+ * §8.1.1 `signer`, §8.5). Distinct from the `sig` envelope (publicKey +
+ * algorithm + kid): `sig` answers *what was signed and by what key*;
+ * `signer` answers *who claims to have signed it*. A verifier cross-checks
+ * the two via the trust registry's `signerIdentity` (verify check #14).
+ */
+export interface SignerIdentity {
+  bindingTier: string;
+  identifier: string;
+  displayName: string;
+  verifiedAt?: string;
+}
+
+// Identity bound to the active platform signing key. The platform holds the
+// key and signs on behalf of authors (spec §8.5 — users do not yet sign
+// their own packages), so the envelope `signer` reflects the platform. These
+// values MUST match the `signerIdentity` recorded for the active `kid` in the
+// trust registry (`public/.well-known/evidence-public-keys.json`) so verify
+// check #14 resolves — the kid and its identity are kept together here the
+// same way `DEFAULT_KEY_ID` mirrors the registry's `kid`.
+const PLATFORM_SIGNER_IDENTITY: SignerIdentity = {
+  bindingTier: 'platform',
+  identifier: 'platform:civic-ai-tools',
+  displayName: 'Civic AI Tools Platform',
+};
+
 export interface SignResult {
   signature: string;   // base64
   publicKey: string;   // base64 (DER-encoded public key)
@@ -33,6 +60,17 @@ export interface SignResult {
  */
 export function getActiveKeyId(): string {
   return process.env.EVIDENCE_KEY_ID || DEFAULT_KEY_ID;
+}
+
+/**
+ * Identity bound to the active signing key, for emission as the envelope-side
+ * `signer` claim (spec §8.1.1). Returns the platform identity since the
+ * platform key signs all packages today; mirrors the active key's
+ * `signerIdentity` in the trust registry so verify check #14 cross-checks
+ * cleanly.
+ */
+export function getActiveSigner(): SignerIdentity {
+  return { ...PLATFORM_SIGNER_IDENTITY };
 }
 
 interface RekorResult {

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -13,6 +13,9 @@ import {
   clearTrustRegistryCache,
   legacyEmbeddedKeyTrust,
   verifyPackageBlobRefs,
+  resolvePackageType,
+  checkSignerIdentity,
+  checkCaptureMethodVocab,
   type TrustRegistry,
 } from './verify.ts';
 import type { BlobRef } from './blob-ref.ts';
@@ -435,4 +438,124 @@ test('verifyPackageBlobRefs: ignores non-BlobRef objects in the field paths', as
   };
   const refs = await verifyPackageBlobRefs(pkg);
   assert.deepEqual(refs, []);
+});
+
+// --- PR1: check #12 — type resolution ---
+
+test('resolvePackageType: known content type → ok', () => {
+  assert.deepEqual(resolvePackageType({ type: 'content/analysis/v1' }), {
+    status: 'ok',
+    type: 'content/analysis/v1',
+  });
+});
+
+test('resolvePackageType: known attestation sub-type → ok', () => {
+  assert.deepEqual(resolvePackageType({ type: 'attestation/withdraws/v1' }), {
+    status: 'ok',
+    type: 'attestation/withdraws/v1',
+  });
+});
+
+test('resolvePackageType: absent → implicit content/analysis/v1 (pre-v0.1)', () => {
+  assert.deepEqual(resolvePackageType({}), {
+    status: 'implicit',
+    type: 'content/analysis/v1',
+  });
+});
+
+test('resolvePackageType: unrecognized URI → unknown_type (non-fatal)', () => {
+  assert.deepEqual(resolvePackageType({ type: 'content/madeup/v9' }), {
+    status: 'unknown_type',
+    type: 'content/madeup/v9',
+  });
+});
+
+// --- PR1: check #14 — signer.identifier ↔ registry signerIdentity ---
+
+const SIGNER_REGISTRY: TrustRegistry = registryWith([
+  {
+    kid: KID,
+    publicKey: PUB,
+    status: 'active',
+    activatedAt: '2026-04-15T00:00:00.000Z',
+    deprecatedAt: null,
+    revokedAt: null,
+    signerIdentity: {
+      bindingTier: 'platform',
+      identifier: 'platform:civic-ai-tools',
+      displayName: 'Civic AI Tools Platform',
+    },
+  },
+]);
+
+test('checkSignerIdentity: matching identifier → ok', () => {
+  const pkg = { signer: { bindingTier: 'platform', identifier: 'platform:civic-ai-tools', displayName: 'Civic AI Tools Platform' } };
+  assert.deepEqual(checkSignerIdentity(pkg, KID, SIGNER_REGISTRY), {
+    status: 'ok',
+    claimed: 'platform:civic-ai-tools',
+    registered: 'platform:civic-ai-tools',
+  });
+});
+
+test('checkSignerIdentity: mismatched identifier → signer_identity_mismatch (fatal)', () => {
+  const pkg = { signer: { bindingTier: 'platform', identifier: 'platform:impostor', displayName: 'x' } };
+  const result = checkSignerIdentity(pkg, KID, SIGNER_REGISTRY);
+  assert.equal(result.status, 'signer_identity_mismatch');
+  assert.equal(result.claimed, 'platform:impostor');
+  assert.equal(result.registered, 'platform:civic-ai-tools');
+});
+
+test('checkSignerIdentity: no envelope signer (pre-v0.1) → no_signer, skip', () => {
+  assert.deepEqual(checkSignerIdentity({}, KID, SIGNER_REGISTRY), { status: 'no_signer' });
+});
+
+test('checkSignerIdentity: registry entry without signerIdentity → no_registry_identity', () => {
+  const legacyRegistry = registryWith([
+    { kid: KID, publicKey: PUB, status: 'active', activatedAt: '2026-04-15T00:00:00.000Z', deprecatedAt: null, revokedAt: null },
+  ]);
+  const pkg = { signer: { bindingTier: 'platform', identifier: 'platform:civic-ai-tools', displayName: 'x' } };
+  assert.deepEqual(checkSignerIdentity(pkg, KID, legacyRegistry), {
+    status: 'no_registry_identity',
+    claimed: 'platform:civic-ai-tools',
+  });
+});
+
+// --- PR1: check #15 — captureMethod per-profile vocabulary ---
+
+test('checkCaptureMethodVocab: value in vocab → ok', () => {
+  const pkg = {
+    metadata: { captureMethod: 'chat-flow-stream' },
+    producerProfile: 'ai-assisted-analysis/datHere',
+  };
+  const r = checkCaptureMethodVocab(pkg);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.profileType, 'ai-assisted-analysis');
+});
+
+test('checkCaptureMethodVocab: value not in vocab → captureMethod_unknown (rejects)', () => {
+  const pkg = { metadata: { captureMethod: 'totally-bogus' }, producerProfile: 'ai-assisted-analysis/datHere' };
+  assert.equal(checkCaptureMethodVocab(pkg).status, 'captureMethod_unknown');
+});
+
+test('checkCaptureMethodVocab: null captureMethod (pre-v0.1) → no_capture_method (neutral)', () => {
+  assert.equal(checkCaptureMethodVocab({ metadata: {} }).status, 'no_capture_method');
+});
+
+test('checkCaptureMethodVocab: unresolvable profile bundle → producerProfile_bundle_unresolved (degrade)', () => {
+  const pkg = { metadata: { captureMethod: 'chat-flow-stream' }, producerProfile: 'human/expert-review' };
+  const r = checkCaptureMethodVocab(pkg);
+  assert.equal(r.status, 'producerProfile_bundle_unresolved');
+  assert.equal(r.profileType, 'human');
+});
+
+test('checkCaptureMethodVocab: resolves via contentProfile legacy alias when producerProfile absent', () => {
+  const pkg = { metadata: { captureMethod: 'claude-code-jsonl-readback', contentProfile: 'datHere' } };
+  assert.equal(checkCaptureMethodVocab(pkg).status, 'ok');
+});
+
+test('checkCaptureMethodVocab: pre-v0.1 (no producerProfile/contentProfile) resolves to ai-assisted-analysis', () => {
+  const pkg = { metadata: { captureMethod: 'chat-flow-stream' } };
+  const r = checkCaptureMethodVocab(pkg);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.profileType, 'ai-assisted-analysis');
 });

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -2,7 +2,9 @@ import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { ed25519ph } from '@noble/curves/ed25519.js';
-import { rekorHashForPackage } from './signing.ts';
+import { rekorHashForPackage, type SignerIdentity } from './signing.ts';
+import { captureVocabForProfile, resolveProfileType } from './profiles.ts';
+import type { CaptureMethod } from './packager.ts';
 import {
   isBlobRef,
   verifyBlobRef,
@@ -213,6 +215,11 @@ export interface TrustRegistryKey {
   activatedAt: string;
   deprecatedAt: string | null;
   revokedAt: string | null;
+  /** Identity the `kid` is bound to (spec §8.3.3). Verify check #14
+   *  cross-checks a package's envelope-side `signer.identifier` against this.
+   *  Optional: legacy registries omit it, and verifiers then skip the
+   *  cross-check (treating the binding as `legacy_embedded`). */
+  signerIdentity?: SignerIdentity;
 }
 
 export interface TrustRegistry {
@@ -338,6 +345,156 @@ export function verifyKeyTrust(
     verified: true,
     kid,
     activatedAt: match.activatedAt,
+  };
+}
+
+// --- Typed-standards envelope checks (spec §9.2 checks #12, #14, #15) ---
+//
+// These read the consolidated-spec envelope fields (`type`, `signer`,
+// `producerProfile`) added by the publish path. They run alongside the
+// existing hash/signature/Rekor/key-trust checks. Each degrades gracefully
+// for pre-v0.1 packages that omit the field, per the per-field
+// backwards-compatibility rules.
+
+// v0.1 ratified node type URIs (spec §8.12.1). Recognized so check #12
+// resolves them; only `content/analysis/v1` (+ the withdraws/reinstates
+// lifecycle sub-types in PR3) are operationalized today, but the full
+// ratified set is registered so conformant packages don't render as
+// `unknown_type`.
+const KNOWN_TYPE_URIS: readonly string[] = [
+  'content/analysis/v1',
+  'attestation/withdraws/v1',
+  'attestation/reinstates/v1',
+  'attestation/supersedes/v1',
+  'attestation/publishes/v1',
+  'attestation/locatedAt/v1',
+  'attestation/corroborates/v1',
+  'attestation/contradicts/v1',
+  'attestation/endorses/v1',
+  'attestation/wasDerivedFrom/v1',
+  'attestation/answersQuestion/v1',
+  'attestation/supportedBy/v1',
+  'attestation/opposedBy/v1',
+  'attestation/certifies/v1',
+  'attestation/evaluates/v1',
+  'attestation/conforms/v1',
+];
+
+export type TypeResolutionStatus = 'ok' | 'implicit' | 'unknown_type';
+
+export interface TypeResolution {
+  status: TypeResolutionStatus;
+  /** The resolved type URI (the implicit `content/analysis/v1` when omitted). */
+  type: string;
+}
+
+/**
+ * Check #12 — `type` resolution. Reads the node's family + sub-type so
+ * per-sub-type rules can apply. An absent field resolves to the implicit
+ * `content/analysis/v1` (pre-v0.1). An unrecognized URI reports
+ * `unknown_type` and renders as such — it does NOT fail verification.
+ */
+export function resolvePackageType(pkg: Record<string, unknown>): TypeResolution {
+  const raw = pkg['type'];
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return { status: 'implicit', type: 'content/analysis/v1' };
+  }
+  if (KNOWN_TYPE_URIS.includes(raw)) {
+    return { status: 'ok', type: raw };
+  }
+  return { status: 'unknown_type', type: raw };
+}
+
+export type SignerIdentityCheckStatus =
+  | 'ok'
+  | 'signer_identity_mismatch'
+  | 'no_signer'
+  | 'no_registry_identity';
+
+export interface SignerIdentityCheck {
+  status: SignerIdentityCheckStatus;
+  /** The `signer.identifier` claimed in the envelope, when present. */
+  claimed?: string;
+  /** The identifier the registry records for the signing `kid`, when present. */
+  registered?: string;
+}
+
+/**
+ * Check #14 — `signer.identifier` ↔ trust-registry `signerIdentity`
+ * cross-check (rules out a kid-swap-with-mismatched-identity attack).
+ * `signer_identity_mismatch` is fatal. Pre-v0.1 packages carry no
+ * envelope-side `signer` (`no_signer`) — the verifier derives the signer
+ * from the registry and skips the cross-check. A registry entry without a
+ * `signerIdentity` (legacy registry) yields `no_registry_identity`.
+ */
+export function checkSignerIdentity(
+  pkg: Record<string, unknown>,
+  kid: string | undefined,
+  registry: TrustRegistry | undefined,
+): SignerIdentityCheck {
+  const signer = pkg['signer'] as SignerIdentity | undefined;
+  if (!signer || typeof signer !== 'object' || typeof signer.identifier !== 'string') {
+    return { status: 'no_signer' };
+  }
+  const entry = kid && registry ? registry.keys.find((k) => k.kid === kid) : undefined;
+  const registered = entry?.signerIdentity?.identifier;
+  if (!registered) {
+    return { status: 'no_registry_identity', claimed: signer.identifier };
+  }
+  if (registered !== signer.identifier) {
+    return { status: 'signer_identity_mismatch', claimed: signer.identifier, registered };
+  }
+  return { status: 'ok', claimed: signer.identifier, registered };
+}
+
+export type CaptureMethodVocabStatus =
+  | 'ok'
+  | 'captureMethod_unknown'
+  | 'producerProfile_bundle_unresolved'
+  | 'no_capture_method';
+
+export interface CaptureMethodVocabCheck {
+  status: CaptureMethodVocabStatus;
+  captureMethod?: string;
+  /** The resolved Producer Profile type whose vocabulary was consulted. */
+  profileType: string;
+}
+
+/**
+ * Check #15 — `captureMethod` per-profile vocabulary conformance. Resolves
+ * the package's Producer Profile (or its legacy-alias / pre-v0.1 fallback)
+ * and confirms `metadata.captureMethod` is in the declared vocabulary.
+ * A value not in the vocabulary reports `captureMethod_unknown` (rejects).
+ * An unresolvable profile bundle reports `producerProfile_bundle_unresolved`
+ * and degrades gracefully — the value is preserved, structural checks still
+ * pass, only the vocabulary-conformance assertion is unverified. A null
+ * captureMethod (pre-v0.1) is neutral (`no_capture_method`).
+ */
+export function checkCaptureMethodVocab(pkg: Record<string, unknown>): CaptureMethodVocabCheck {
+  const metadata = pkg['metadata'] as Record<string, unknown> | undefined;
+  const captureMethod =
+    typeof metadata?.['captureMethod'] === 'string'
+      ? (metadata['captureMethod'] as string)
+      : undefined;
+  const producerProfile =
+    typeof pkg['producerProfile'] === 'string' ? (pkg['producerProfile'] as string) : undefined;
+  const contentProfile =
+    typeof metadata?.['contentProfile'] === 'string'
+      ? (metadata['contentProfile'] as string)
+      : undefined;
+  const profileType = resolveProfileType(producerProfile, contentProfile);
+
+  if (!captureMethod) {
+    return { status: 'no_capture_method', profileType };
+  }
+  const vocab = captureVocabForProfile(producerProfile, contentProfile);
+  if (!vocab) {
+    return { status: 'producerProfile_bundle_unresolved', captureMethod, profileType };
+  }
+  return {
+    status: vocab.includes(captureMethod as CaptureMethod) ? 'ok' : 'captureMethod_unknown',
+    captureMethod,
+    profileType,
   };
 }
 


### PR DESCRIPTION
## Summary

PR1 of the Phase 3 work bringing the website reference implementation up to the consolidated Typed Standards Specification (v0.1.2). This PR lands the **taxonomy & profile-label** envelope fields — the low-risk, no-migration cohort.

- **packager** — emits three new **top-level** envelope fields (`producerProfile`, `type`, `signer`) via the existing conditional-spread pattern, so existing-shape inputs produce **byte-identical** canonical JSON (and hashes) as before. `producerProfile` is auto-derived as `ai-assisted-analysis/datHere` for the datHere content profile. `contentProfile` stays nested under `metadata` as the grandfathered legacy alias (moving it would break existing datHere hashes — per Q2 decision).
- **publish route** — accepts + default-fills the three (`type` → `content/analysis/v1`, `signer` → the active platform identity); enforces the `contentProfile` ↔ `producerProfile` consistency invariant; validates `captureMethod` through a shared per-profile vocabulary table (`PROFILE_CAPTURE_VOCAB`) instead of the old flat list.
- **verify** — adds spec §9.2 checks **#12** (`type` → `unknown_type`, non-fatal), **#13** (`nodeId` = recomputed envelope hash), **#14** (`signer.identifier` ↔ trust-registry `signerIdentity` cross-check, fatal on mismatch), **#15** (`captureMethod` per-profile vocabulary; `producerProfile_bundle_unresolved` degrades gracefully). Adds `signerIdentity` to the trust-registry key type.
- **trust registry** — adds `signerIdentity` to the platform key; serves the canonical `/.well-known/typed-publisher.json` alongside the legacy `/.well-known/evidence-public-keys.json` (single-source, no forced cutover).
- **detail page** — surfaces `producerProfile` + `type` near the existing capture-method label (read from the package object; no DB change).

### Backwards compatibility
Pre-v0.1 packages (none of the new fields) verify unchanged: implicit `content/analysis/v1`, signer derived from the registry (check #14 skipped), `ai-assisted-analysis` vocabulary for #15. No DB migration — every field is canonical-JSON-only.

### Notes for review
- **No migration.** All five fields live only in canonical JSON; the only Phase 3 migration is PR3's lifecycle storage.
- **JCS switch deferred to PR2.** Check #13 recomputes the envelope hash with the **current** `JSON.stringify` method. The `JSON.stringify` → RFC 8785 JCS switch (plus `contentHash`/`contentCanonicalization`) is PR2, held on the §8.2 Q1 clarification.
- **`type` default placement.** The packager emits `type` only when supplied (conditional-spread, to keep existing-shape inputs byte-identical); the `content/analysis/v1` default is applied at the publish route. Flagging in case the orchestrator intended the packager itself to always default-emit.
- **`signer` reflects the platform.** Because the platform key signs all packages today (spec §8.5), `signer` carries the platform identity (matching the registry's `signerIdentity` for the active kid) so check #14 resolves. The GitHub author identity remains separate (creator/author).

## Test plan

- [x] `npm test` — 188/188 pass (new packager emission + byte-identical tests; new verify tests for checks #12/#14/#15)
- [x] `npm run build` — succeeds; `/.well-known/typed-publisher.json` prerenders as static and serves the registry with `signerIdentity`
- [x] `npx tsc --noEmit` — no type errors in touched files (only pre-existing errors in an untouched test file)
- [x] `npm run lint` — no new lint problems in touched files
- [ ] Orchestrator spot-check of phasing + scope before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
