### PR TITLE
fix(evidence): PR1.1 — byte-identical well-known trust-registry paths

### DIFF
--- a/src/app/.well-known/typed-publisher.json/route.ts
+++ b/src/app/.well-known/typed-publisher.json/route.ts
@@ -1,14 +1,27 @@
+import { promises as fs } from 'fs';
+import path from 'path';
 import { NextResponse } from 'next/server';
-import registry from '../../../../public/.well-known/evidence-public-keys.json' with { type: 'json' };
 
 // Canonical trust-registry path (spec §8.3.3, ADR-0012 §3 parallel-serve).
-// Serves the same content as the legacy static file at
-// /.well-known/evidence-public-keys.json. Single-source: this route returns
-// the same bundled registry JSON, so the two paths never diverge. The new
+// Returns the legacy static file at /.well-known/evidence-public-keys.json
+// VERBATIM — the same bytes, not a re-serialization of the parsed JSON
+// (which would compact whitespace and diverge byte-wise). ADR-0012 §3
+// requires the two paths emit byte-identical content; reading the one
+// source file guarantees that.
+//
+// The route is force-static, so the read runs at build time where
+// process.cwd() resolves to the project root and the file is present —
+// reliable, and the prerendered response is the file's exact bytes. The new
 // path is canonical going forward; the legacy path is served indefinitely
 // (no forced cutover). New external clients SHOULD fetch this path.
 export const dynamic = 'force-static';
 
-export function GET() {
-  return NextResponse.json(registry);
+export async function GET() {
+  const body = await fs.readFile(
+    path.join(process.cwd(), 'public', '.well-known', 'evidence-public-keys.json'),
+    'utf-8',
+  );
+  return new NextResponse(body, {
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  });
 }


### PR DESCRIPTION
## Summary

Follow-up to PR1 (#106). ADR-0012 §3 requires the canonical `/.well-known/typed-publisher.json` and the legacy `/.well-known/evidence-public-keys.json` emit **byte-identical** content. PR1's route re-serialized the parsed JSON via `NextResponse.json` (compact), which diverged byte-wise from the pretty-printed static file (semantically identical, but not byte-identical).

This route now reads the legacy file and returns its bytes **verbatim**. The route stays `force-static`, so the read runs at build time (where `process.cwd()` is the project root and the file is present) — reliable, and the prerendered response is the file's exact bytes.

Single file, orthogonal to PR2 (no canonicalization interaction).

## Test plan

- [x] `npm run build` — succeeds; route still prerenders as static (○)
- [x] Build artifact `…/typed-publisher.json.body` is **byte-identical** to `public/.well-known/evidence-public-keys.json` (verified with `diff`)
- [x] `eslint` clean on the file
- [ ] Post-merge: `curl` both production paths and `diff` — expect zero difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
