### PR TITLE
feat(evidence): PR2 — RFC 8785 JCS canonicalization + multihash contentHash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vercel/kv": "^3.0.0",
         "@vercel/sandbox": "^1.10.2",
         "bpmn-js": "^18.12.0",
+        "canonicalize": "^3.0.0",
         "drizzle-orm": "^0.45.2",
         "next": "16.1.1",
         "next-auth": "^4.24.13",
@@ -3763,6 +3764,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/kv": "^3.0.0",
     "@vercel/sandbox": "^1.10.2",
     "bpmn-js": "^18.12.0",
+    "canonicalize": "^3.0.0",
     "drizzle-orm": "^0.45.2",
     "next": "16.1.1",
     "next-auth": "^4.24.13",

--- a/src/app/api/evidence/[slug]/bundle/route.ts
+++ b/src/app/api/evidence/[slug]/bundle/route.ts
@@ -45,6 +45,7 @@ type UserRecord = typeof users.$inferSelect;
 function buildCommitmentView(
   record: EvidenceRecord,
   creator: UserRecord | null,
+  pkg: EvidencePackage,
 ): Record<string, unknown> {
   let signature: Record<string, unknown> | null = null;
   if (record.basePackageSignature) {
@@ -70,6 +71,20 @@ function buildCommitmentView(
     packageUrl: record.basePackageStorageKey,
     captureMethod: record.captureMethod ?? null,
     contentProfile: 'datHere',
+    // Envelope fields sourced from the signed package JSON (spec §8.1.1).
+    // Conditionally spread so packages predating these fields omit them
+    // rather than emitting nulls. `producerProfile` / `type` / `signer` are
+    // the PR1 taxonomy fields; `contentHash` / `contentCanonicalization` are
+    // the PR2 §8.2 canonicalization fields. All are covered by the package
+    // signature, so surfacing them in the commitment view lets a cross-host
+    // reader resolve the same envelope the signature commits to.
+    ...(pkg.producerProfile ? { producerProfile: pkg.producerProfile } : {}),
+    ...(pkg.type ? { type: pkg.type } : {}),
+    ...(pkg.signer ? { signer: pkg.signer } : {}),
+    ...(pkg.contentHash ? { contentHash: pkg.contentHash } : {}),
+    ...(pkg.contentCanonicalization
+      ? { contentCanonicalization: pkg.contentCanonicalization }
+      : {}),
     ...(signature ? { signature } : {}),
     ...(signerIdentity ? { signerIdentity } : {}),
     ...(record.basePackageRfc3161Timestamp
@@ -212,7 +227,7 @@ export async function GET(
 
   // Inject commitment view at notebook root metadata (OES §9.2.2)
   const metadata = (notebook.metadata as Record<string, unknown>) ?? {};
-  metadata[EVIDENCE_NAMESPACE_KEY] = buildCommitmentView(record, creator);
+  metadata[EVIDENCE_NAMESPACE_KEY] = buildCommitmentView(record, creator, pkg);
   notebook.metadata = metadata;
 
   // Prepend cell-0 reader-affordance table (OES §9.2.4)

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -14,11 +14,15 @@ import {
   resolvePackageType,
   checkSignerIdentity,
   checkCaptureMethodVocab,
+  resolveContentCanonicalization,
+  verifyContentHash,
   type KeyTrustResult,
   type BlobRefVerification,
   type TypeResolution,
   type SignerIdentityCheck,
   type CaptureMethodVocabCheck,
+  type ContentCanonicalizationResolution,
+  type ContentHashCheck,
 } from '@/lib/evidence/verify';
 
 export async function GET(
@@ -124,20 +128,37 @@ export async function GET(
     keyTrust = legacyEmbeddedKeyTrust();
   }
 
-  // Step 5: Typed-standards envelope checks (spec §9.2). These run against
-  // the canonical package JSON when available; each degrades gracefully for
-  // pre-v0.1 packages that omit the corresponding field.
+  // Step 5: Canonicalization, content-hash, and typed-standards envelope
+  // checks (spec §9.2). These run against the canonical package JSON when
+  // available; each degrades gracefully for pre-v0.1 packages that omit the
+  // corresponding field.
+  //   #3  contentCanonicalization — known URI resolves; unknown renders as
+  //                              unknown_canonicalization_rule; absent infers
+  //                              the rule from the content profile
+  //   #4  contentHash          — recompute off-log digest under the resolved
+  //                              rule and confirm at least one algorithm
+  //                              matches; pre-v0.1 relabels the slug hash
   //   #12 type resolution      — non-fatal (unknown_type renders, doesn't fail)
-  //   #13 nodeId               — the recomputed envelope hash (current
-  //                              JSON.stringify canonicalization; PR2 switches
-  //                              this to JCS alongside the hash change)
+  //   #13 nodeId               — the recomputed envelope hash; dual-chain via
+  //                              recomputePackageHash (JCS for v0.1 packages,
+  //                              legacy JSON.stringify for pre-v0.1)
   //   #14 signer ↔ registry    — fatal on mismatch; skipped when no signer
   //   #15 captureMethod vocab  — captureMethod_unknown rejects; bundle-
   //                              unresolved degrades gracefully
+  let contentCanonicalization: ContentCanonicalizationResolution | null = null;
+  let contentHashCheck: ContentHashCheck | null = null;
   let typeResolution: TypeResolution | null = null;
   let signerIdentity: SignerIdentityCheck | null = null;
   let captureMethodVocab: CaptureMethodVocabCheck | null = null;
   if (pkgJson) {
+    contentCanonicalization = resolveContentCanonicalization(pkgJson);
+    // The legacy external single-SHA-256 (relabeled for pre-v0.1 packages) is
+    // the package's stored slug hash — pass it so check #4 can surface it.
+    contentHashCheck = verifyContentHash(
+      pkgJson,
+      contentCanonicalization,
+      record.basePackageHash ?? undefined,
+    );
     typeResolution = resolvePackageType(pkgJson);
     signerIdentity = checkSignerIdentity(pkgJson, sigKid, registry);
     captureMethodVocab = checkCaptureMethodVocab(pkgJson);
@@ -151,6 +172,9 @@ export async function GET(
     keyTrust,
     blobRefsVerified,
     blobRefs,
+    // Canonicalization & content-hash checks (spec §9.2 checks #3-#4).
+    contentCanonicalization,
+    contentHash: contentHashCheck,
     // Typed-standards envelope checks (spec §9.2 checks #12-#15).
     nodeId: recomputedHash,
     typeResolution,

--- a/src/lib/evidence/canonicalization.test.ts
+++ b/src/lib/evidence/canonicalization.test.ts
@@ -1,0 +1,131 @@
+// Unit tests for the PR2 canonicalization & hashing core (spec §8.2).
+// Exercises the JCS wrapper, the multihash-contentHash detection rule that
+// routes packages to the JCS vs legacy chain, the dual-chain envelope hash,
+// and the per-rule off-log content hash.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'crypto';
+import canonicalize from 'canonicalize';
+import {
+  jcs,
+  isMultihashContentHash,
+  computeEnvelopeHash,
+  computeContentHashSha256,
+  LEGACY_JSON_CANONICALIZATION,
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+  KNOWN_CANONICALIZATION_RULES,
+} from './canonicalization.ts';
+
+function sha256Hex(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+// --- jcs() RFC 8785 wrapper ---
+
+test('jcs: sorts object keys lexicographically, no whitespace', () => {
+  assert.equal(jcs({ b: 1, a: 2 }), '{"a":2,"b":1}');
+});
+
+test('jcs: preserves array order (arrays are order-significant)', () => {
+  assert.equal(jcs({ x: [3, 1, 2] }), '{"x":[3,1,2]}');
+});
+
+test('jcs: deeply sorts nested objects', () => {
+  assert.equal(jcs({ z: { d: 1, c: 2 }, a: 3 }), '{"a":3,"z":{"c":2,"d":1}}');
+});
+
+test('jcs: throws on a non-JSON-canonicalizable value (undefined)', () => {
+  assert.throws(() => jcs(undefined), /no output/);
+});
+
+// --- isMultihashContentHash() detection rule (§8.2) ---
+
+test('isMultihashContentHash: object of string digests → true', () => {
+  assert.equal(isMultihashContentHash({ sha256: 'abc' }), true);
+  assert.equal(isMultihashContentHash({ sha256: 'a', 'sha3-256': 'b' }), true);
+});
+
+test('isMultihashContentHash: external single hex string → false (pre-v0.1)', () => {
+  assert.equal(isMultihashContentHash('deadbeef'), false);
+});
+
+test('isMultihashContentHash: absent / null / array / empty / non-string values → false', () => {
+  assert.equal(isMultihashContentHash(undefined), false);
+  assert.equal(isMultihashContentHash(null), false);
+  assert.equal(isMultihashContentHash([]), false);
+  assert.equal(isMultihashContentHash({}), false);
+  assert.equal(isMultihashContentHash({ sha256: 123 }), false);
+});
+
+// --- computeEnvelopeHash() dual-chain (§8.2) ---
+
+test('computeEnvelopeHash: multihash contentHash present → JCS chain', () => {
+  const pkg = { b: 1, a: 2, contentHash: { sha256: 'x' } };
+  assert.equal(computeEnvelopeHash(pkg), sha256Hex(canonicalize(pkg) as string));
+});
+
+test('computeEnvelopeHash: no contentHash → legacy JSON.stringify chain', () => {
+  const pkg = { b: 1, a: 2 };
+  assert.equal(computeEnvelopeHash(pkg), sha256Hex(JSON.stringify(pkg)));
+});
+
+test('computeEnvelopeHash: v0.1 chain is key-order-independent (JCS property)', () => {
+  const a = { a: 1, b: 2, contentHash: { sha256: 'x' } };
+  const b = { contentHash: { sha256: 'x' }, b: 2, a: 1 };
+  assert.equal(computeEnvelopeHash(a), computeEnvelopeHash(b));
+});
+
+test('computeEnvelopeHash: legacy chain is key-order-DEPENDENT (JSON.stringify property)', () => {
+  // This is the property that forces the storage round-trip to preserve
+  // insertion order for pre-v0.1 packages — and why the detection rule keeps
+  // them on the legacy chain rather than re-canonicalizing.
+  const a = { a: 1, b: 2 };
+  const b = { b: 2, a: 1 };
+  assert.notEqual(computeEnvelopeHash(a), computeEnvelopeHash(b));
+});
+
+// --- computeContentHashSha256() per-rule off-log content (§8.2) ---
+
+test('computeContentHashSha256: legacy-json/v1 fingerprints the package minus contentHash', () => {
+  const pkg = { a: 1, b: 2, contentHash: { sha256: 'should-be-excluded' } };
+  const expected = sha256Hex(canonicalize({ a: 1, b: 2 }) as string);
+  assert.equal(computeContentHashSha256(pkg, LEGACY_JSON_CANONICALIZATION), expected);
+});
+
+test('computeContentHashSha256: legacy-json/v1 is identical whether contentHash is present or not (produce/verify symmetry)', () => {
+  // The packager calls this on the base object (no contentHash yet); verify
+  // calls it on the stored object (contentHash present). Both must agree.
+  const base = { a: 1, b: 2 };
+  const withHash = { a: 1, b: 2, contentHash: { sha256: 'x' } };
+  assert.equal(
+    computeContentHashSha256(base, LEGACY_JSON_CANONICALIZATION),
+    computeContentHashSha256(withHash, LEGACY_JSON_CANONICALIZATION),
+  );
+});
+
+test('computeContentHashSha256: dathere-ag-jupyter/v1 fingerprints the notebook extension', () => {
+  const notebook = { nbformat: 4, nbformat_minor: 5, cells: [], metadata: {} };
+  const pkg = { extensions: { 'org.civicaitools.notebook': notebook } };
+  const expected = sha256Hex(canonicalize(notebook) as string);
+  assert.equal(
+    computeContentHashSha256(pkg, DATHERE_AG_JUPYTER_CANONICALIZATION),
+    expected,
+  );
+});
+
+test('computeContentHashSha256: dathere-ag-jupyter/v1 throws when the notebook extension is missing', () => {
+  assert.throws(
+    () => computeContentHashSha256({ extensions: {} }, DATHERE_AG_JUPYTER_CANONICALIZATION),
+    /notebook/,
+  );
+});
+
+// --- Rule registry ---
+
+test('KNOWN_CANONICALIZATION_RULES contains both v0.1 reserved URIs', () => {
+  assert.ok(KNOWN_CANONICALIZATION_RULES.includes(LEGACY_JSON_CANONICALIZATION));
+  assert.ok(KNOWN_CANONICALIZATION_RULES.includes(DATHERE_AG_JUPYTER_CANONICALIZATION));
+});

--- a/src/lib/evidence/canonicalization.ts
+++ b/src/lib/evidence/canonicalization.ts
@@ -1,0 +1,128 @@
+// Canonicalization + hashing core (spec §8.2, §8.3.1, §12.3).
+//
+// PR2 of the Phase 3 typed-standards work introduces RFC 8785 JSON
+// Canonicalization (JCS) for the envelope hash and a multihash content hash.
+// This module is the single source of truth for both, shared by the packager
+// (which PRODUCES the hashes) and verify.ts (which RECOMPUTES them). Keeping
+// the two on identical code is what guarantees a package re-verifies to the
+// hash it was published under.
+//
+// Backwards-compatibility is structural, via the §8.2 detection rule: a
+// package whose `contentHash` is a multihash object is a v0.1 package on the
+// JCS chain; absence of that field marks a pre-v0.1 package on the legacy
+// `JSON.stringify` chain. Both regimes coexist because every package routes
+// to its own chain — pre-v0.1 packages published before the JCS switch stay
+// byte-identical.
+
+import crypto from 'crypto';
+import canonicalize from 'canonicalize';
+
+// Content-canonicalization rule URIs (spec §8.2, §12.3). Identifiers, not
+// fetch targets — verifiers resolve them via the local registry below rather
+// than dereferencing them.
+export const LEGACY_JSON_CANONICALIZATION =
+  'https://typedstandards.org/canonicalization/legacy-json/v1';
+export const DATHERE_AG_JUPYTER_CANONICALIZATION =
+  'https://typedstandards.org/canonicalization/dathere-ag-jupyter/v1';
+
+/** Canonicalization-rule URIs this implementation knows how to apply. An
+ *  unknown URI fails verify check #3 (`unknown_canonicalization_rule`). */
+export const KNOWN_CANONICALIZATION_RULES: readonly string[] = [
+  LEGACY_JSON_CANONICALIZATION,
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+];
+
+/** Notebook extension whose object the dathere-ag-jupyter/v1 rule fingerprints
+ *  (spec §8.2, §8.7.2). */
+const NOTEBOOK_EXTENSION_KEY = 'org.civicaitools.notebook';
+
+function sha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * RFC 8785 JSON Canonicalization Scheme. Wraps the `canonicalize` reference
+ * implementation (by the RFC 8785 author); its return type is
+ * `string | undefined`, undefined when the input isn't JSON-canonicalizable
+ * (e.g. `undefined`). We throw in that case so a malformed package fails
+ * loudly rather than silently producing a wrong hash.
+ */
+export function jcs(value: unknown): string {
+  const out = canonicalize(value);
+  if (typeof out !== 'string') {
+    throw new Error('JCS canonicalization produced no output (non-JSON value)');
+  }
+  return out;
+}
+
+/**
+ * §8.2 detection rule: a package whose `contentHash` is embedded as a
+ * multihash OBJECT (keyed by lowercase algorithm name, hex-string values) is
+ * a v0.1 package on the JCS chain. Absence — or an external single-SHA-256
+ * hex string carried out of band on the DB row — marks a pre-v0.1 package on
+ * the legacy `JSON.stringify` chain.
+ */
+export function isMultihashContentHash(
+  value: unknown,
+): value is Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  return entries.length > 0 && entries.every(([, v]) => typeof v === 'string');
+}
+
+/**
+ * The envelope hash for a package, routed by the §8.2 detection rule:
+ *   - v0.1 (multihash `contentHash` present) → SHA-256 of the RFC 8785 JCS
+ *     canonicalization of the unsigned envelope.
+ *   - pre-v0.1 (no multihash `contentHash`) → SHA-256 of the legacy
+ *     insertion-order `JSON.stringify`, preserving byte-identical
+ *     verification of every package published before the JCS switch.
+ *
+ * The signature envelope is persisted on the database row, not inside the
+ * package object, so the package object already IS the unsigned envelope —
+ * there is no `sig` field to strip here.
+ *
+ * Used by BOTH the packager and the verifier so producer and verifier agree.
+ */
+export function computeEnvelopeHash(pkg: Record<string, unknown>): string {
+  if (isMultihashContentHash(pkg['contentHash'])) {
+    return sha256Hex(jcs(pkg));
+  }
+  return sha256Hex(JSON.stringify(pkg));
+}
+
+/**
+ * SHA-256 of a package's off-log content, canonicalized per the named rule
+ * (spec §8.2). Symmetric across produce/verify: `contentHash` is stripped
+ * before hashing, so the result is identical whether the package already
+ * carries `contentHash` (verify) or does not yet (packager).
+ *
+ *   - legacy-json/v1        → the canonical-JSON package with `contentHash`
+ *     (and the sig envelope, which lives off-package here) omitted. For a
+ *     fully-inline package this nearly coincides with the envelope hash,
+ *     differing only by the absent `contentHash` field; it becomes
+ *     load-bearing only when content is supplied by reference (BlobRef).
+ *   - dathere-ag-jupyter/v1 → the executed notebook object
+ *     (`extensions["org.civicaitools.notebook"]` and its rendered outputs).
+ */
+export function computeContentHashSha256(
+  pkg: Record<string, unknown>,
+  rule: string,
+): string {
+  if (rule === DATHERE_AG_JUPYTER_CANONICALIZATION) {
+    const extensions = pkg['extensions'] as Record<string, unknown> | undefined;
+    const notebook = extensions?.[NOTEBOOK_EXTENSION_KEY];
+    if (notebook === undefined) {
+      throw new Error(
+        `dathere-ag-jupyter/v1 content hash requires the ${NOTEBOOK_EXTENSION_KEY} extension`,
+      );
+    }
+    return sha256Hex(jcs(notebook));
+  }
+  // legacy-json/v1 (default): fingerprint the package minus contentHash.
+  const rest: Record<string, unknown> = { ...pkg };
+  delete rest['contentHash'];
+  return sha256Hex(jcs(rest));
+}

--- a/src/lib/evidence/packager.test.ts
+++ b/src/lib/evidence/packager.test.ts
@@ -8,7 +8,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'crypto';
+import canonicalize from 'canonicalize';
 import { buildEvidencePackage, type PackageInput } from './packager.ts';
+import { recomputePackageHash } from './verify.ts';
+import {
+  LEGACY_JSON_CANONICALIZATION,
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+} from './canonicalization.ts';
 import type { BlobRef } from './blob-ref.ts';
 
 function sha256Hex(content: string): string {
@@ -416,4 +422,135 @@ test('buildEvidencePackage: type is covered by the package hash (tamper-evidence
     normalizedHash(b.pkg),
     'two packages identical except for type must hash differently',
   );
+});
+
+// --- PR2: contentCanonicalization + contentHash + JCS envelope hash ---
+//
+// The v0.1 envelope is gated on `type` presence (the spec's required v0.1
+// discriminator, which the route always default-fills). Legacy / internal
+// callers that don't supply `type` keep the pre-PR2 shape — no contentHash,
+// JSON.stringify hashing — so their canonical JSON stays byte-identical and
+// re-verifies on the legacy detection chain.
+
+/** Simulate the production storage round-trip: putPackage stores
+ *  JSON.stringify(pkg); getPackage returns response.json() (a parsed object). */
+function storageRoundTrip(pkg: unknown): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(pkg)) as Record<string, unknown>;
+}
+
+test('buildEvidencePackage: legacy input (no type) emits NO contentHash/contentCanonicalization and hashes via JSON.stringify (byte-identical)', () => {
+  const { pkg, hash } = buildEvidencePackage(baseInput());
+  assert.equal(Object.prototype.hasOwnProperty.call(pkg, 'contentHash'), false);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(pkg, 'contentCanonicalization'),
+    false,
+  );
+  // Byte-identical legacy chain: the envelope hash is SHA-256(JSON.stringify).
+  assert.equal(
+    hash,
+    crypto.createHash('sha256').update(JSON.stringify(pkg)).digest('hex'),
+  );
+});
+
+test('buildEvidencePackage: v0.1 input (type present) emits legacy-json/v1 rule + multihash contentHash, hashes via JCS', () => {
+  const { pkg, hash } = buildEvidencePackage(
+    baseInput({ type: 'content/analysis/v1' }),
+  );
+  assert.equal(pkg.contentCanonicalization, LEGACY_JSON_CANONICALIZATION);
+  assert.ok(pkg.contentHash, 'contentHash should be present on a v0.1 package');
+  assert.equal(typeof pkg.contentHash!.sha256, 'string');
+  assert.equal(pkg.contentHash!.sha256.length, 64);
+  // JCS chain: the envelope hash is SHA-256(JCS(pkg)).
+  assert.equal(
+    hash,
+    crypto.createHash('sha256').update(canonicalize(pkg) as string).digest('hex'),
+  );
+});
+
+test('buildEvidencePackage: v0.1 default contentHash fingerprints the package minus contentHash (legacy-json/v1)', () => {
+  const { pkg } = buildEvidencePackage(baseInput({ type: 'content/analysis/v1' }));
+  const rest: Record<string, unknown> = { ...pkg };
+  delete rest.contentHash;
+  const expected = crypto
+    .createHash('sha256')
+    .update(canonicalize(rest) as string)
+    .digest('hex');
+  assert.equal(pkg.contentHash!.sha256, expected);
+});
+
+test('buildEvidencePackage: v0.1 datHere emits dathere-ag-jupyter/v1 rule + fingerprints the executed notebook', () => {
+  const notebook = { nbformat: 4, nbformat_minor: 5, cells: [], metadata: {} };
+  const { pkg } = buildEvidencePackage(
+    baseInput({
+      type: 'content/analysis/v1',
+      contentProfile: 'datHere',
+      extensions: { 'org.civicaitools.notebook': notebook },
+    }),
+  );
+  assert.equal(pkg.contentCanonicalization, DATHERE_AG_JUPYTER_CANONICALIZATION);
+  // datHere off-log content is the notebook, NOT the whole package; the
+  // auto-emitted environment extension is a sibling and is excluded.
+  const expected = crypto
+    .createHash('sha256')
+    .update(canonicalize(notebook) as string)
+    .digest('hex');
+  assert.equal(pkg.contentHash!.sha256, expected);
+});
+
+test('buildEvidencePackage: v0.1 contentHash changes when off-log content changes (tamper-evidence)', () => {
+  const a = buildEvidencePackage(
+    baseInput({ type: 'content/analysis/v1', output: 'AAAA' }),
+  );
+  const b = buildEvidencePackage(
+    baseInput({ type: 'content/analysis/v1', output: 'BBBB' }),
+  );
+  assert.notEqual(a.pkg.contentHash!.sha256, b.pkg.contentHash!.sha256);
+});
+
+// --- PR2: build → store → verify round-trip (the regression-guard property) ---
+//
+// A freshly-built package must recompute to the exact hash it was published
+// under after the production storage round-trip (JSON.stringify → JSON.parse).
+// This is the unit-level analog of the production regression guard.
+
+test('round-trip: legacy package re-verifies byte-identical (legacy detection chain)', () => {
+  const { pkg, hash } = buildEvidencePackage(baseInput());
+  assert.equal(recomputePackageHash(storageRoundTrip(pkg)), hash);
+});
+
+test('round-trip: v0.1 default package re-verifies (JCS detection chain)', () => {
+  const { pkg, hash } = buildEvidencePackage(
+    baseInput({ type: 'content/analysis/v1' }),
+  );
+  assert.equal(recomputePackageHash(storageRoundTrip(pkg)), hash);
+});
+
+test('round-trip: v0.1 datHere package re-verifies (JCS detection chain)', () => {
+  const notebook = {
+    nbformat: 4,
+    nbformat_minor: 5,
+    cells: [
+      { cell_type: 'code', source: ['print(1)'], outputs: [], metadata: {} },
+    ],
+    metadata: {},
+  };
+  const { pkg, hash } = buildEvidencePackage(
+    baseInput({
+      type: 'content/analysis/v1',
+      contentProfile: 'datHere',
+      extensions: { 'org.civicaitools.notebook': notebook },
+    }),
+  );
+  assert.equal(recomputePackageHash(storageRoundTrip(pkg)), hash);
+});
+
+test('round-trip: v0.1 package re-verifies even if storage reorders top-level keys (JCS order-independence)', () => {
+  const { pkg, hash } = buildEvidencePackage(
+    baseInput({ type: 'content/analysis/v1' }),
+  );
+  const reordered: Record<string, unknown> = {};
+  for (const k of Object.keys(pkg).reverse()) {
+    reordered[k] = (pkg as unknown as Record<string, unknown>)[k];
+  }
+  assert.equal(recomputePackageHash(reordered), hash);
 });

--- a/src/lib/evidence/packager.ts
+++ b/src/lib/evidence/packager.ts
@@ -4,6 +4,12 @@ import { buildDataSources, type DataSourceEntry } from './data-sources.ts';
 import { getActiveKeyId, type SignerIdentity } from './signing.ts';
 import { isBlobRef, parseBlobRef, type BlobRef } from './blob-ref.ts';
 import { deriveOperationType } from '../mcp/operation-types.ts';
+import {
+  LEGACY_JSON_CANONICALIZATION,
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+  computeEnvelopeHash,
+  computeContentHashSha256,
+} from './canonicalization.ts';
 
 const PACKAGE_SCHEMA_VERSION = '0.1.0';
 
@@ -191,6 +197,20 @@ export interface EvidencePackage {
    *  cross-check the two via the trust registry (check #14). Absent on
    *  pre-v0.1 packages. */
   signer?: SignerIdentity;
+  /** Content-canonicalization rule URI (spec §8.1.1, §8.2). Names how the
+   *  off-log content reduces to the bytes `contentHash` fingerprints. Emitted
+   *  on v0.1 packages: `…/legacy-json/v1` by default, `…/dathere-ag-jupyter/v1`
+   *  for the datHere content profile. Absent on pre-v0.1 packages (verifiers
+   *  infer the rule from contentProfile). Covered by the envelope hash. */
+  contentCanonicalization?: string;
+  /** Multihash content-hash digest set (spec §8.1.1, §8.2). Object keyed by
+   *  lowercase algorithm name (`sha256` required default) with hex digest
+   *  values, fingerprinting the off-log content canonicalized per
+   *  `contentCanonicalization`. Its presence as a multihash object is the
+   *  §8.2 detection signal routing a package to the JCS chain; pre-v0.1
+   *  packages omit it and stay on the legacy `JSON.stringify` chain. Covered
+   *  by the envelope hash. */
+  contentHash?: Record<string, string>;
   prompt: {
     hash: string;
     visibility: 'full_text' | 'hash_only';
@@ -374,7 +394,22 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
     input.producerProfile ??
     (input.contentProfile === 'datHere' ? DATHERE_PRODUCER_PROFILE : undefined);
 
-  const pkg: EvidencePackage = {
+  // v0.1 canonicalization & hashing (PR2, spec §8.2). `type` is the spec's
+  // required v0.1 discriminator ("pre-v0.1 packages omit the field") and the
+  // route default-fills it for every publish, so its presence is the signal
+  // to emit `contentCanonicalization` + `contentHash` and hash via RFC 8785
+  // JCS. Legacy/internal callers that don't supply `type` keep the pre-PR2
+  // shape — no contentHash, JSON.stringify hashing — so their canonical JSON
+  // (and hash) stays byte-identical. The off-log content's canonicalization
+  // rule follows the content profile: datHere fingerprints its executed
+  // notebook, everything else uses the legacy-json/v1 whole-package rule.
+  const isV01Envelope = input.type !== undefined;
+  const contentCanonicalization =
+    input.contentProfile === 'datHere'
+      ? DATHERE_AG_JUPYTER_CANONICALIZATION
+      : LEGACY_JSON_CANONICALIZATION;
+
+  const pkgBase: EvidencePackage = {
     metadata: {
       schemaVersion: PACKAGE_SCHEMA_VERSION,
       packageId,
@@ -398,6 +433,12 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
     ...(producerProfile ? { producerProfile } : {}),
     ...(input.type ? { type: input.type } : {}),
     ...(input.signer ? { signer: input.signer } : {}),
+    // v0.1 content-canonicalization rule URI (spec §8.2). Conditional spread
+    // gated on the v0.1 discriminator so pre-PR2 callers stay byte-identical.
+    // `contentHash` is computed from this base object below and spread on
+    // last — it cannot be in this literal because legacy-json/v1 fingerprints
+    // the package minus contentHash (a hash cannot include itself).
+    ...(isV01Envelope ? { contentCanonicalization } : {}),
     prompt: {
       hash: promptHash,
       visibility: input.promptVisibility,
@@ -443,9 +484,27 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
     })(),
   };
 
-  // Compute package hash from canonical JSON (covers provenance + extensions)
-  const canonical = JSON.stringify(pkg);
-  const hash = sha256(canonical);
+  // v0.1 packages embed the multihash `contentHash` fingerprinting the
+  // off-log content (spec §8.2). It is computed from `pkgBase` (which already
+  // carries `contentCanonicalization` but not yet `contentHash`) and spread
+  // on last; legacy callers leave `pkgBase` untouched so their canonical JSON
+  // is byte-identical to the pre-PR2 shape.
+  const pkg: EvidencePackage = isV01Envelope
+    ? {
+        ...pkgBase,
+        contentHash: {
+          sha256: computeContentHashSha256(
+            pkgBase as unknown as Record<string, unknown>,
+            contentCanonicalization,
+          ),
+        },
+      }
+    : pkgBase;
+
+  // Envelope hash routes by the §8.2 detection rule: SHA-256(JCS) for v0.1
+  // packages (multihash contentHash present), legacy SHA-256(JSON.stringify)
+  // for pre-v0.1. Shared with verify.ts so producer and verifier agree.
+  const hash = computeEnvelopeHash(pkg as unknown as Record<string, unknown>);
 
   return { pkg, hash };
 }

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -7,6 +7,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'crypto';
+import canonicalize from 'canonicalize';
 import {
   verifyKeyTrust,
   loadTrustRegistry,
@@ -16,8 +17,15 @@ import {
   resolvePackageType,
   checkSignerIdentity,
   checkCaptureMethodVocab,
+  recomputePackageHash,
+  resolveContentCanonicalization,
+  verifyContentHash,
   type TrustRegistry,
 } from './verify.ts';
+import {
+  LEGACY_JSON_CANONICALIZATION,
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+} from './canonicalization.ts';
 import type { BlobRef } from './blob-ref.ts';
 
 const KID = 'platform:evidence-2026-04';
@@ -558,4 +566,146 @@ test('checkCaptureMethodVocab: pre-v0.1 (no producerProfile/contentProfile) reso
   const r = checkCaptureMethodVocab(pkg);
   assert.equal(r.status, 'ok');
   assert.equal(r.profileType, 'ai-assisted-analysis');
+});
+
+// --- PR2: recomputePackageHash dual-chain (checks #1 + #13) ---
+
+test('recomputePackageHash: multihash contentHash present → JCS chain', () => {
+  const pkg = { b: 1, a: 2, contentHash: { sha256: 'x' } };
+  assert.equal(
+    recomputePackageHash(pkg),
+    sha256Hex(canonicalize(pkg) as string),
+  );
+});
+
+test('recomputePackageHash: no contentHash (pre-v0.1) → legacy JSON.stringify chain', () => {
+  const pkg = { b: 1, a: 2 };
+  assert.equal(recomputePackageHash(pkg), sha256Hex(JSON.stringify(pkg)));
+});
+
+// --- PR2: check #3 — contentCanonicalization rule resolution ---
+
+test('resolveContentCanonicalization: known legacy-json/v1 URI → ok', () => {
+  assert.deepEqual(
+    resolveContentCanonicalization({
+      contentCanonicalization: LEGACY_JSON_CANONICALIZATION,
+    }),
+    { status: 'ok', rule: LEGACY_JSON_CANONICALIZATION },
+  );
+});
+
+test('resolveContentCanonicalization: known dathere-ag-jupyter/v1 URI → ok', () => {
+  assert.deepEqual(
+    resolveContentCanonicalization({
+      contentCanonicalization: DATHERE_AG_JUPYTER_CANONICALIZATION,
+    }),
+    { status: 'ok', rule: DATHERE_AG_JUPYTER_CANONICALIZATION },
+  );
+});
+
+test('resolveContentCanonicalization: unrecognized URI → unknown_canonicalization_rule', () => {
+  const r = resolveContentCanonicalization({
+    contentCanonicalization: 'https://example.org/canon/madeup/v9',
+  });
+  assert.equal(r.status, 'unknown_canonicalization_rule');
+  assert.equal(r.rule, 'https://example.org/canon/madeup/v9');
+});
+
+test('resolveContentCanonicalization: absent + contentProfile datHere → implicit dathere rule (pre-v0.1)', () => {
+  assert.deepEqual(
+    resolveContentCanonicalization({ metadata: { contentProfile: 'datHere' } }),
+    { status: 'implicit', rule: DATHERE_AG_JUPYTER_CANONICALIZATION },
+  );
+});
+
+test('resolveContentCanonicalization: absent + default/legacy → implicit legacy rule (pre-v0.1)', () => {
+  assert.deepEqual(resolveContentCanonicalization({ metadata: {} }), {
+    status: 'implicit',
+    rule: LEGACY_JSON_CANONICALIZATION,
+  });
+});
+
+test('resolveContentCanonicalization: absent + producerProfile datHere alias → implicit dathere rule', () => {
+  assert.deepEqual(
+    resolveContentCanonicalization({
+      producerProfile: 'ai-assisted-analysis/datHere',
+    }),
+    { status: 'implicit', rule: DATHERE_AG_JUPYTER_CANONICALIZATION },
+  );
+});
+
+// --- PR2: check #4 — content-hash verification ---
+
+/** Build a v0.1 legacy-json/v1 package with a correct contentHash. */
+function v01LegacyPkg(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    type: 'content/analysis/v1',
+    contentCanonicalization: LEGACY_JSON_CANONICALIZATION,
+    output: 'hello',
+    ...overrides,
+  };
+  const sha256 = sha256Hex(canonicalize(base) as string);
+  return { ...base, contentHash: { sha256 } };
+}
+
+const OK_RULE = { status: 'ok' as const, rule: LEGACY_JSON_CANONICALIZATION };
+const OK_DATHERE_RULE = {
+  status: 'ok' as const,
+  rule: DATHERE_AG_JUPYTER_CANONICALIZATION,
+};
+
+test('verifyContentHash: v0.1 legacy-json/v1 with a correct hash → ok (sha256 matched)', () => {
+  const pkg = v01LegacyPkg();
+  const r = verifyContentHash(pkg, OK_RULE);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.matched, 'sha256');
+  assert.deepEqual(r.algorithms, ['sha256']);
+});
+
+test('verifyContentHash: v0.1 tampered off-log content → content_hash_mismatch', () => {
+  // Keep the stored (now-stale) contentHash but mutate covered content.
+  const pkg = { ...v01LegacyPkg(), output: 'tampered after signing' };
+  assert.equal(verifyContentHash(pkg, OK_RULE).status, 'content_hash_mismatch');
+});
+
+test('verifyContentHash: v0.1 dathere-ag-jupyter/v1 over the notebook → ok', () => {
+  const notebook = { nbformat: 4, nbformat_minor: 5, cells: [], metadata: {} };
+  const sha256 = sha256Hex(canonicalize(notebook) as string);
+  const pkg = {
+    type: 'content/analysis/v1',
+    contentCanonicalization: DATHERE_AG_JUPYTER_CANONICALIZATION,
+    extensions: { 'org.civicaitools.notebook': notebook },
+    contentHash: { sha256 },
+  };
+  assert.equal(verifyContentHash(pkg, OK_DATHERE_RULE).status, 'ok');
+});
+
+test('verifyContentHash: only an unsupported algorithm listed → contentHash_no_supported_algorithm', () => {
+  const pkg = {
+    contentCanonicalization: LEGACY_JSON_CANONICALIZATION,
+    contentHash: { 'sha3-256': 'deadbeef' },
+  };
+  assert.equal(
+    verifyContentHash(pkg, OK_RULE).status,
+    'contentHash_no_supported_algorithm',
+  );
+});
+
+test('verifyContentHash: unknown canonicalization rule → unresolved_rule', () => {
+  const pkg = {
+    contentCanonicalization: 'https://example.org/canon/madeup/v9',
+    contentHash: { sha256: 'x' },
+  };
+  const resolution = resolveContentCanonicalization(pkg);
+  assert.equal(verifyContentHash(pkg, resolution).status, 'unresolved_rule');
+});
+
+test('verifyContentHash: pre-v0.1 (no multihash contentHash) → legacy_relabeled with the slug hash', () => {
+  const pkg = { output: 'hi' };
+  const resolution = resolveContentCanonicalization(pkg);
+  const r = verifyContentHash(pkg, resolution, 'abc123def456');
+  assert.equal(r.status, 'legacy_relabeled');
+  assert.deepEqual(r.contentHash, { sha256: 'abc123def456' });
 });

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -6,6 +6,14 @@ import { rekorHashForPackage, type SignerIdentity } from './signing.ts';
 import { captureVocabForProfile, resolveProfileType } from './profiles.ts';
 import type { CaptureMethod } from './packager.ts';
 import {
+  computeEnvelopeHash,
+  computeContentHashSha256,
+  isMultihashContentHash,
+  KNOWN_CANONICALIZATION_RULES,
+  LEGACY_JSON_CANONICALIZATION,
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+} from './canonicalization.ts';
+import {
   isBlobRef,
   verifyBlobRef,
   type BlobRef,
@@ -118,11 +126,171 @@ export async function verifyRekorEntry(
 }
 
 /**
- * Recompute the SHA-256 hash of a package object.
+ * Recompute a package's envelope hash, routed by the §8.2 detection rule:
+ * v0.1 packages (multihash `contentHash` present) hash via RFC 8785 JCS;
+ * pre-v0.1 packages hash via the legacy insertion-order `JSON.stringify`.
+ * Drives both check #1 (envelope integrity / `hashMatch`) and check #13
+ * (`nodeId`). Delegates to the shared `computeEnvelopeHash` so the recomputed
+ * value is guaranteed to match what the packager produced.
  */
 export function recomputePackageHash(pkg: Record<string, unknown>): string {
-  const canonical = JSON.stringify(pkg);
-  return crypto.createHash('sha256').update(canonical).digest('hex');
+  return computeEnvelopeHash(pkg);
+}
+
+// --- Content canonicalization & hashing checks (spec §9.2 checks #3, #4) ---
+//
+// These read the §8.2 `contentCanonicalization` + `contentHash` fields. Like
+// the envelope checks below, each degrades gracefully for pre-v0.1 packages
+// that omit the fields: check #3 infers the rule from the content profile,
+// and check #4 relabels the package's historical external single-SHA-256
+// rather than recomputing it under a v0.1 rule.
+
+export type ContentCanonicalizationStatus =
+  | 'ok'
+  | 'implicit'
+  | 'unknown_canonicalization_rule';
+
+export interface ContentCanonicalizationResolution {
+  status: ContentCanonicalizationStatus;
+  /** The resolved canonicalization-rule URI — the explicit field value, or
+   *  the rule inferred from the content profile for pre-v0.1 packages. */
+  rule: string;
+}
+
+/**
+ * Check #3 — content-canonicalization rule resolution (spec §9.2). Reads the
+ * package's `contentCanonicalization` URI and resolves it against the local
+ * rule registry. A known URI → `ok`. An unrecognized URI →
+ * `unknown_canonicalization_rule` (renders; check #4 then cannot recompute).
+ * An absent field on a pre-v0.1 package → `implicit`, inferring the rule from
+ * contentProfile / producerProfile (datHere → dathere-ag-jupyter/v1;
+ * otherwise legacy-json/v1).
+ */
+export function resolveContentCanonicalization(
+  pkg: Record<string, unknown>,
+): ContentCanonicalizationResolution {
+  const raw = pkg['contentCanonicalization'];
+  if (typeof raw === 'string' && raw.length > 0) {
+    if (KNOWN_CANONICALIZATION_RULES.includes(raw)) {
+      return { status: 'ok', rule: raw };
+    }
+    return { status: 'unknown_canonicalization_rule', rule: raw };
+  }
+  // Pre-v0.1: infer the rule from the content profile (the same datHere
+  // legacy-alias logic the captureMethod resolver uses).
+  const metadata = pkg['metadata'] as Record<string, unknown> | undefined;
+  const contentProfile =
+    typeof metadata?.['contentProfile'] === 'string'
+      ? (metadata['contentProfile'] as string)
+      : undefined;
+  const producerProfile =
+    typeof pkg['producerProfile'] === 'string'
+      ? (pkg['producerProfile'] as string)
+      : undefined;
+  const isDatHere =
+    contentProfile === 'datHere' ||
+    (producerProfile?.startsWith('ai-assisted-analysis/datHere') ?? false);
+  return {
+    status: 'implicit',
+    rule: isDatHere
+      ? DATHERE_AG_JUPYTER_CANONICALIZATION
+      : LEGACY_JSON_CANONICALIZATION,
+  };
+}
+
+export type ContentHashStatus =
+  | 'ok'
+  | 'content_hash_mismatch'
+  | 'contentHash_no_supported_algorithm'
+  | 'unresolved_rule'
+  | 'legacy_relabeled';
+
+export interface ContentHashCheck {
+  status: ContentHashStatus;
+  /** Algorithm names listed in the package's multihash `contentHash`. */
+  algorithms?: string[];
+  /** The algorithm whose recomputed digest matched (status === 'ok'). */
+  matched?: string;
+  /** The multihash digest set the verifier reports for the package. For
+   *  pre-v0.1 packages this is the legacy external single-SHA-256 relabeled
+   *  as `{ sha256: <hex> }` per §8.2. */
+  contentHash?: Record<string, string>;
+}
+
+/** Multihash algorithms this verifier can recompute today (spec §8.2 lists
+ *  sha256 required + sha3-256 / blake3 as registered alternates). */
+const SUPPORTED_CONTENT_HASH_ALGORITHMS: readonly string[] = ['sha256'];
+
+/**
+ * Check #4 — content-hash verification (spec §9.2, §8.2).
+ *
+ * v0.1 packages (multihash `contentHash` present): recompute the off-log
+ * content's digest under the resolved canonicalization rule for every listed
+ * algorithm this verifier supports, and confirm at least one matches.
+ *   - at least one supported algorithm matches → `ok`.
+ *   - a supported algorithm is present but none match → `content_hash_mismatch`
+ *     (the off-log content was altered).
+ *   - none of the listed algorithms are ones this verifier can compute →
+ *     `contentHash_no_supported_algorithm` (degrades; the value is preserved).
+ *   - the canonicalization rule could not be resolved (check #3 unknown) →
+ *     `unresolved_rule` (cannot recompute).
+ *
+ * pre-v0.1 packages (no multihash `contentHash`): the historical external
+ * single-SHA-256 (the package's slug / `basePackageHash`) is RELABELED as
+ * `{ sha256: <hex> }` per §8.2 rather than recomputed under legacy-json/v1.
+ * Its integrity is established by check #1 (the legacy envelope hash matches
+ * the slug), so check #4 reports `legacy_relabeled` rather than re-deriving it.
+ */
+export function verifyContentHash(
+  pkg: Record<string, unknown>,
+  resolution: ContentCanonicalizationResolution,
+  legacyExternalHash?: string,
+): ContentHashCheck {
+  const contentHash = pkg['contentHash'];
+  if (!isMultihashContentHash(contentHash)) {
+    return {
+      status: 'legacy_relabeled',
+      ...(legacyExternalHash ? { contentHash: { sha256: legacyExternalHash } } : {}),
+    };
+  }
+
+  const algorithms = Object.keys(contentHash);
+  if (resolution.status === 'unknown_canonicalization_rule') {
+    return { status: 'unresolved_rule', algorithms, contentHash };
+  }
+
+  const checkable = algorithms.filter((a) =>
+    SUPPORTED_CONTENT_HASH_ALGORITHMS.includes(a),
+  );
+  if (checkable.length === 0) {
+    return {
+      status: 'contentHash_no_supported_algorithm',
+      algorithms,
+      contentHash,
+    };
+  }
+
+  for (const algo of checkable) {
+    let recomputed: string | undefined;
+    try {
+      // sha256 is the only supported algorithm today; the off-log content is
+      // recomputed under the resolved rule (legacy-json/v1 → package minus
+      // contentHash; dathere-ag-jupyter/v1 → the executed notebook).
+      recomputed =
+        algo === 'sha256'
+          ? computeContentHashSha256(pkg, resolution.rule)
+          : undefined;
+    } catch {
+      // A structurally malformed package (e.g. a datHere package missing its
+      // notebook extension) can't be recomputed — treat as non-matching
+      // rather than throwing out of the whole verify pass.
+      recomputed = undefined;
+    }
+    if (recomputed !== undefined && recomputed === contentHash[algo]) {
+      return { status: 'ok', algorithms, matched: algo, contentHash };
+    }
+  }
+  return { status: 'content_hash_mismatch', algorithms, contentHash };
 }
 
 // --- Blob references (Phase B.6) ---


### PR DESCRIPTION
## Phase 3 PR2 — canonicalization & hashing (spec §8.2)

Wires the spec's envelope-hash + content-hash rules into the reference impl. **This is the high-risk PR** (the JCS switch must not break verification of anything published before it). Stacked on the merged PR1 + PR1.1; targets `main`.

⚠️ **Draft — awaiting orchestrator spot-check before merge.** Do not merge.

### What landed, per field

- **`contentCanonicalization`** (§8.1.1 field #2) — emitted on v0.1 packages: `…/legacy-json/v1` by default, `…/dathere-ag-jupyter/v1` for the datHere content profile.
- **`contentHash`** (§8.1.1 field #3) — multihash object keyed by lowercase algorithm name (`sha256` emitted by default; `sha3-256` / `blake3` are spec-registered alternates, not emitted yet). For legacy-json/v1 it fingerprints the package minus `contentHash`; for dathere-ag-jupyter/v1 it fingerprints the executed notebook (`extensions["org.civicaitools.notebook"]`).
- **Envelope hash** — switched `JSON.stringify` → SHA-256(RFC 8785 JCS(unsigned envelope)) for v0.1 packages; the Ed25519ph signature still covers that hex string. New dep: `canonicalize@^3.0.0` (RFC 8785 reference impl by the RFC author, Apache-2.0, zero-dep, ESM + typed).

### Dual-chain logic (the §8.2 detection rule)

A new shared module `src/lib/evidence/canonicalization.ts` is the single source of truth for both produce and verify, so they agree by construction:

- **Detection:** `contentHash` present as a *multihash object* ⟹ JCS chain; absent / external single hex ⟹ legacy `JSON.stringify` chain. `recomputePackageHash` routes on this (driving check #1 and the check #13 `nodeId`).
- **Packager gating:** v0.1 emission is gated on the `type` discriminator (the spec's required v0.1 field, which the route always default-fills). Legacy/internal callers that omit `type` keep the exact pre-PR2 shape — no `contentHash`, `JSON.stringify` hashing — so their canonical JSON and hash stay **byte-identical**.
- **verify check #3** (`resolveContentCanonicalization`) — known URI → `ok`; unknown → `unknown_canonicalization_rule`; absent (pre-v0.1) → `implicit`, rule inferred from the content profile.
- **verify check #4** (`verifyContentHash`) — recompute off-log digest under the resolved rule, confirm ≥1 supported algorithm matches (`ok` / `content_hash_mismatch` / `contentHash_no_supported_algorithm` / `unresolved_rule`); pre-v0.1 packages **relabel** the historical slug hash as `{sha256}` rather than recomputing it (`legacy_relabeled`).
- **bundle commitment-view** — now surfaces `contentHash` + `contentCanonicalization` plus the PR1 `producerProfile`/`type`/`signer` fields, sourced from the signed package JSON.

No migration (PR2 is canonical-JSON-only).

### Regression guard — both production fixtures re-verify byte-identical ✅

Fetched the two real published packages and re-verified under the dual-chain logic:

| fixture | slug | multihash contentHash? | PR2 recompute == slug | pre-PR2 `JSON.stringify` == slug | check #3 | check #4 |
|---|---|---|---|---|---|---|
| datHere | `noise-trends-in-nyc-last-week-d79dba` | false → legacy chain | ✅ true | ✅ true | `implicit` → dathere-ag-jupyter/v1 | `legacy_relabeled` |
| default | `pedestrian-…-f5f90d` | false → legacy chain | ✅ true | ✅ true | `implicit` → legacy-json/v1 | `legacy_relabeled` |

Both stay fully green; the JCS switch is a no-op for every pre-PR2 package.

### Test / build / lint

- **Tests:** 227 pass / 0 fail (`npm test`) — 188 prior + 39 new (canonicalization unit, packager v0.1 emission, build→store→verify round-trip on legacy + v0.1-default + v0.1-datHere, JCS order-independence, dual-chain `recomputePackageHash`, checks #3/#4).
- **Build:** `✓ Compiled successfully` — `canonicalize` bundles cleanly in all evidence routes.
- **Lint:** no new problems in any PR2-touched file (the repo's pre-existing warnings/errors live in untouched files).
- **tsc:** PR2 files type-clean (two pre-existing `expert-attestation.test.ts` errors are unrelated and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
