### PR TITLE
feat(evidence): PR3 — lifecycle attestation nodes (ADR-0010, §8.10/§8.12)

### DIFF
--- a/drizzle/0010_add_attestation_nodes.sql
+++ b/drizzle/0010_add_attestation_nodes.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "attestation_nodes" (
+	"node_id" text PRIMARY KEY NOT NULL,
+	"target_node_id" text NOT NULL,
+	"type" text NOT NULL,
+	"storage_key" text NOT NULL,
+	"signature" text,
+	"rfc3161_timestamp" text,
+	"rekor_entry_id" text,
+	"rekor_inclusion_proof" text,
+	"signer" jsonb,
+	"payload" jsonb,
+	"creator_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "attestation_nodes" ADD CONSTRAINT "attestation_nodes_creator_id_users_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,777 @@
+{
+  "id": "04e879b3-a049-442b-ae7e-5cfa88fea501",
+  "prevId": "f52e7bc4-96f3-4dd8-b91e-1ac791d7cc06",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_nodes": {
+      "name": "attestation_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rfc3161_timestamp": {
+          "name": "rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_entry_id": {
+          "name": "rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_inclusion_proof": {
+          "name": "rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer": {
+          "name": "signer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_nodes_creator_id_users_id_fk": {
+          "name": "attestation_nodes_creator_id_users_id_fk",
+          "tableFrom": "attestation_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_packages": {
+      "name": "attestation_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evidence_record_id": {
+          "name": "evidence_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attestation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_hash": {
+          "name": "package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references_base_hash": {
+          "name": "references_base_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_packages_evidence_record_id_evidence_records_id_fk": {
+          "name": "attestation_packages_evidence_record_id_evidence_records_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "evidence_records",
+          "columnsFrom": [
+            "evidence_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attestation_packages_creator_id_users_id_fk": {
+          "name": "attestation_packages_creator_id_users_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_approved_user_id_users_id_fk": {
+          "name": "device_codes_approved_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_records": {
+      "name": "evidence_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_visibility": {
+          "name": "prompt_visibility",
+          "type": "prompt_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_text'"
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_server": {
+          "name": "mcp_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civic_context": {
+          "name": "civic_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_hash": {
+          "name": "base_package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_storage_key": {
+          "name": "base_package_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_signature": {
+          "name": "base_package_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rfc3161_timestamp": {
+          "name": "base_package_rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_id": {
+          "name": "base_package_rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_inclusion_proof": {
+          "name": "base_package_rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_method": {
+          "name": "capture_method",
+          "type": "capture_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_profile": {
+          "name": "content_profile",
+          "type": "content_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "consistency_classification": {
+          "name": "consistency_classification",
+          "type": "consistency_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_reason": {
+          "name": "withdrawn_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_signature": {
+          "name": "withdrawal_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_timestamp": {
+          "name": "withdrawal_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_reason": {
+          "name": "reinstated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_signature": {
+          "name": "reinstatement_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_timestamp": {
+          "name": "reinstatement_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evidence_records_creator_id_users_id_fk": {
+          "name": "evidence_records_creator_id_users_id_fk",
+          "tableFrom": "evidence_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evidence_records_slug_unique": {
+          "name": "evidence_records_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attestation_type": {
+      "name": "attestation_type",
+      "schema": "public",
+      "values": [
+        "consistency",
+        "evaluation",
+        "re_evaluation",
+        "correction",
+        "expert_attestation"
+      ]
+    },
+    "public.capture_method": {
+      "name": "capture_method",
+      "schema": "public",
+      "values": [
+        "chat-flow-stream",
+        "claude-code-jsonl-readback",
+        "claude-code-self-report",
+        "datHere"
+      ]
+    },
+    "public.consistency_classification": {
+      "name": "consistency_classification",
+      "schema": "public",
+      "values": [
+        "highly_reproducible",
+        "moderately_stable",
+        "inconsistent"
+      ]
+    },
+    "public.content_profile": {
+      "name": "content_profile",
+      "schema": "public",
+      "values": [
+        "default",
+        "datHere"
+      ]
+    },
+    "public.prompt_visibility": {
+      "name": "prompt_visibility",
+      "schema": "public",
+      "values": [
+        "full_text",
+        "hash_only"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "consistency_tested",
+        "evaluated",
+        "fully_attested"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1779214284516,
       "tag": "0009_add_content_profile",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1780066435792,
+      "tag": "0010_add_attestation_nodes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/evidence/[slug]/reinstate/route.ts
+++ b/src/app/api/evidence/[slug]/reinstate/route.ts
@@ -1,21 +1,40 @@
-import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { evidenceRecords, users } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
-import { signPackage, getRfc3161Timestamp } from '@/lib/evidence/signing';
+import { evidenceRecords, attestationNodes, users } from '@/lib/db/schema';
+import { eq, and, desc } from 'drizzle-orm';
+import { putPackage } from '@/lib/storage';
+import {
+  signPackage,
+  getRfc3161Timestamp,
+  publishToRekor,
+  getActiveSigner,
+} from '@/lib/evidence/signing';
+import {
+  buildAttestationNode,
+  ATTESTATION_REINSTATES,
+  ATTESTATION_WITHDRAWS,
+} from '@/lib/evidence/attestation';
 
 /**
  * POST /api/evidence/[slug]/reinstate
  *
- * Reinstates a withdrawn evidence record. Only the creator can reinstate their own
- * evidence. The reinstatement is a signed, timestamped action — the withdrawal record
- * is preserved for transparency, and both withdrawal + reinstatement appear in the
- * status history.
+ * Reinstates a withdrawn evidence record (spec §8.10, ADR-0010; PR3).
  *
- * Body: { reason: string }
+ * When the prior withdrawal was itself a signed `attestation/withdraws/v1` node
+ * (the post-PR3 path), the reinstatement is a signed `attestation/reinstates/v1`
+ * node referencing the target by `targetNodeId` and the prior withdrawal by
+ * `priorWithdrawalNodeId`; the legacy `reinstated_at` column is also written as
+ * the status mirror.
+ *
+ * When the prior withdrawal was a pre-PR3 legacy column (no attestation node to
+ * reference), the reinstatement stays column-only — keeping that record's
+ * lifecycle in a single representation so the dual-read (verify check #10 /
+ * detail page) shows its full history from the legacy columns rather than a
+ * partial chain.
+ *
+ * Authorization is publisher-only (parity with pre-PR3). Body: { reason: string }
  */
 export async function POST(
   request: NextRequest,
@@ -51,12 +70,12 @@ export async function POST(
   }
   const record = records[0];
 
-  // Only the creator can reinstate
+  // Publisher-only: only the creator can reinstate (§8.12.3 authorization rule).
   if (record.creatorId !== userId) {
     return NextResponse.json({ error: 'Only the creator can reinstate evidence' }, { status: 403 });
   }
 
-  // Must be currently withdrawn (withdrawn and not already reinstated)
+  // Single-cycle parity: must be currently withdrawn and not already reinstated.
   if (!record.withdrawnAt) {
     return NextResponse.json({ error: 'Evidence is not withdrawn' }, { status: 400 });
   }
@@ -69,38 +88,101 @@ export async function POST(
   if (!reason || typeof reason !== 'string' || reason.trim().length === 0) {
     return NextResponse.json({ error: 'Reinstatement reason is required' }, { status: 400 });
   }
-
   const now = new Date();
 
-  // Sign the reinstatement action — hash binds the reinstatement to the prior withdrawal
-  const reinstatementContent = JSON.stringify({
-    action: 'reinstate',
-    slug,
-    reason: reason.trim(),
-    timestamp: now.toISOString(),
-    evidencePackageHash: record.basePackageHash,
-    priorWithdrawalSignature: record.withdrawalSignature,
-  });
-  const reinstatementHash = crypto.createHash('sha256').update(reinstatementContent).digest('hex');
+  // Find the prior withdrawal ATTESTATION node, if the withdrawal went through
+  // the post-PR3 path. Its presence decides whether this reinstatement is an
+  // attestation node or a legacy column-only update.
+  const priorWithdrawals = record.basePackageHash
+    ? await db
+        .select({ nodeId: attestationNodes.nodeId })
+        .from(attestationNodes)
+        .where(
+          and(
+            eq(attestationNodes.targetNodeId, record.basePackageHash),
+            eq(attestationNodes.type, ATTESTATION_WITHDRAWS),
+          ),
+        )
+        .orderBy(desc(attestationNodes.createdAt))
+        .limit(1)
+    : [];
+  const priorWithdrawalNodeId = priorWithdrawals[0]?.nodeId;
 
-  const signResult = signPackage(reinstatementHash);
-  const rfc3161Token = await getRfc3161Timestamp(reinstatementHash).catch(() => null);
+  let attestationNodeId: string | null = null;
 
-  await db
-    .update(evidenceRecords)
-    .set({
-      reinstatedAt: now,
-      reinstatedReason: reason.trim(),
-      reinstatementSignature: signResult
-        ? JSON.stringify({ hash: reinstatementHash, signature: signResult.signature, publicKey: signResult.publicKey, algorithm: signResult.algorithm })
-        : null,
-      reinstatementTimestamp: rfc3161Token,
-      updatedAt: now,
-    })
-    .where(eq(evidenceRecords.id, record.id));
+  if (priorWithdrawalNodeId && record.basePackageHash) {
+    // Post-PR3 path: emit a signed attestation/reinstates/v1 node referencing
+    // the target and the prior withdrawal node (§8.12.1).
+    const { node, nodeId } = buildAttestationNode({
+      type: ATTESTATION_REINSTATES,
+      targetNodeId: record.basePackageHash,
+      signer: getActiveSigner(),
+      reason: reason.trim(),
+      priorWithdrawalNodeId,
+    });
+    attestationNodeId = nodeId;
+
+    const signResult = signPackage(nodeId);
+    const [rfc3161Token, rekorResult] = await Promise.all([
+      getRfc3161Timestamp(nodeId).catch(() => null),
+      signResult
+        ? publishToRekor(nodeId, signResult.signature, signResult.publicKey).catch(() => null)
+        : Promise.resolve(null),
+    ]);
+
+    const blobUrl = await putPackage(nodeId, node as unknown as Record<string, unknown>);
+    const signatureJson = signResult
+      ? JSON.stringify({
+          nodeId,
+          signature: signResult.signature,
+          publicKey: signResult.publicKey,
+          algorithm: signResult.algorithm,
+          kid: signResult.kid,
+        })
+      : null;
+
+    await db.insert(attestationNodes).values({
+      nodeId,
+      targetNodeId: record.basePackageHash,
+      type: ATTESTATION_REINSTATES,
+      storageKey: blobUrl,
+      signature: signatureJson,
+      rfc3161Timestamp: rfc3161Token,
+      rekorEntryId: rekorResult?.entryId || null,
+      rekorInclusionProof: rekorResult?.inclusionProof || null,
+      signer: node.signer,
+      payload: { reason: reason.trim(), priorWithdrawalNodeId },
+      creatorId: userId,
+    });
+
+    await db
+      .update(evidenceRecords)
+      .set({
+        reinstatedAt: now,
+        reinstatedReason: reason.trim(),
+        reinstatementSignature: signatureJson,
+        reinstatementTimestamp: rfc3161Token,
+        updatedAt: now,
+      })
+      .where(eq(evidenceRecords.id, record.id));
+  } else {
+    // Legacy bridge: the withdrawal predates PR3 (column-only, no node to
+    // reference). Keep the reinstatement column-only so this record's lifecycle
+    // stays in one representation; the dual-read reads its full history from the
+    // legacy columns.
+    await db
+      .update(evidenceRecords)
+      .set({
+        reinstatedAt: now,
+        reinstatedReason: reason.trim(),
+        updatedAt: now,
+      })
+      .where(eq(evidenceRecords.id, record.id));
+  }
 
   return NextResponse.json({
     reinstated: true,
     reinstatedAt: now.toISOString(),
+    attestationNodeId,
   });
 }

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -24,6 +24,7 @@ import {
   type ContentCanonicalizationResolution,
   type ContentHashCheck,
 } from '@/lib/evidence/verify';
+import { resolveLifecycle } from '@/lib/evidence/lifecycle';
 
 export async function GET(
   _request: NextRequest,
@@ -164,6 +165,16 @@ export async function GET(
     captureMethodVocab = checkCaptureMethodVocab(pkgJson);
   }
 
+  // Step 6: Lifecycle (check #10, spec §8.10). Dual-read — derive status from
+  // the signer-matched, independently-verified chain of `attestation/*` nodes
+  // when present, else fall back to the legacy withdrawnAt/reinstatedAt columns
+  // (§8.10.4). The target signer is the content node's signer.identifier (the
+  // publisher-only signer-match), defaulting to the platform signer.
+  const lifecycle = await resolveLifecycle(
+    record,
+    (pkgJson?.['signer'] as { identifier?: string } | undefined)?.identifier,
+  );
+
   return NextResponse.json({
     hashMatch,
     signatureValid,
@@ -180,6 +191,9 @@ export async function GET(
     typeResolution,
     signerIdentity,
     captureMethodVocab,
+    // Lifecycle check (spec §9.2 check #10, §8.10) — attestation chain or
+    // legacy-column fallback.
+    lifecycle,
     details: {
       storedHash: record.basePackageHash,
       recomputedHash,

--- a/src/app/api/evidence/[slug]/withdraw/route.ts
+++ b/src/app/api/evidence/[slug]/withdraw/route.ts
@@ -1,18 +1,36 @@
-import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { evidenceRecords, users } from '@/lib/db/schema';
+import { evidenceRecords, attestationNodes, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
-import { signPackage, getRfc3161Timestamp } from '@/lib/evidence/signing';
+import { putPackage } from '@/lib/storage';
+import {
+  signPackage,
+  getRfc3161Timestamp,
+  publishToRekor,
+  getActiveSigner,
+} from '@/lib/evidence/signing';
+import { buildAttestationNode, ATTESTATION_WITHDRAWS } from '@/lib/evidence/attestation';
 
 /**
  * POST /api/evidence/[slug]/withdraw
  *
- * Withdraws an evidence record. Only the creator can withdraw their own evidence.
- * The withdrawal is a signed, timestamped action — the record and its cryptographic
- * proofs remain accessible but are flagged as withdrawn.
+ * Withdraws an evidence record (spec §8.10, ADR-0010; PR3). The withdrawal is a
+ * separately-signed `attestation/withdraws/v1` node — its own nodeId (envelope
+ * hash), signature, RFC 3161 timestamp, and Rekor inclusion — referencing the
+ * content node by `targetNodeId`. The content node's own signature is untouched.
+ *
+ * The legacy `withdrawn_at` / `withdrawn_reason` columns are ALSO written as a
+ * denormalized status mirror so the simple list / dashboard / index consumers
+ * (which filter + render on those columns) keep working unchanged. The signed
+ * attestation node is the canonical, conformant representation; verify check #10
+ * and the detail page read the chain first and fall back to the columns only for
+ * pre-PR3 records (§8.10.4 dual-read).
+ *
+ * Authorization is publisher-only: only the content node's creator may withdraw
+ * it (parity with the pre-PR3 behavior). The platform key signs the attestation
+ * on the author's behalf (§8.5), so its `signer` matches the content node's.
  *
  * Body: { reason: string }
  */
@@ -50,14 +68,26 @@ export async function POST(
   }
   const record = records[0];
 
-  // Only the creator can withdraw
+  // Publisher-only: only the creator can withdraw (§8.12.3 authorization rule).
   if (record.creatorId !== userId) {
     return NextResponse.json({ error: 'Only the creator can withdraw evidence' }, { status: 403 });
   }
 
-  // Already withdrawn
+  // Single-cycle parity: reject if already withdrawn. The current status is read
+  // from the legacy column mirror, which the dual-write keeps in sync with the
+  // attestation chain.
   if (record.withdrawnAt) {
     return NextResponse.json({ error: 'Evidence is already withdrawn' }, { status: 400 });
+  }
+
+  // An attestation MUST reference a content node by nodeId (§8.12.3). Published
+  // records always carry one; refuse otherwise rather than emit a non-conformant
+  // node.
+  if (!record.basePackageHash) {
+    return NextResponse.json(
+      { error: 'Cannot withdraw: record has no content node hash to reference' },
+      { status: 400 },
+    );
   }
 
   const body = await request.json();
@@ -66,30 +96,59 @@ export async function POST(
     return NextResponse.json({ error: 'Withdrawal reason is required' }, { status: 400 });
   }
 
-  const now = new Date();
-
-  // Sign the withdrawal action: hash of slug + reason + timestamp
-  const withdrawalContent = JSON.stringify({
-    action: 'withdraw',
-    slug,
+  // Build the signed attestation/withdraws/v1 node. nodeId = envelope hash via
+  // the shared PR2 canonicalization (RFC 8785 JCS).
+  const { node, nodeId } = buildAttestationNode({
+    type: ATTESTATION_WITHDRAWS,
+    targetNodeId: record.basePackageHash,
+    signer: getActiveSigner(),
     reason: reason.trim(),
-    timestamp: now.toISOString(),
-    evidencePackageHash: record.basePackageHash,
   });
-  const withdrawalHash = crypto.createHash('sha256').update(withdrawalContent).digest('hex');
 
-  const signResult = signPackage(withdrawalHash);
-  const rfc3161Token = await getRfc3161Timestamp(withdrawalHash).catch(() => null);
+  // Sign + timestamp + Rekor over the nodeId, exactly like a content package.
+  const signResult = signPackage(nodeId);
+  const [rfc3161Token, rekorResult] = await Promise.all([
+    getRfc3161Timestamp(nodeId).catch(() => null),
+    signResult
+      ? publishToRekor(nodeId, signResult.signature, signResult.publicKey).catch(() => null)
+      : Promise.resolve(null),
+  ]);
 
-  // Update the record
+  // Persist the canonical attestation node FIRST (blob + DB row), so a later
+  // column-mirror failure can't lose the signed artifact.
+  const blobUrl = await putPackage(nodeId, node as unknown as Record<string, unknown>);
+  const signatureJson = signResult
+    ? JSON.stringify({
+        nodeId,
+        signature: signResult.signature,
+        publicKey: signResult.publicKey,
+        algorithm: signResult.algorithm,
+        kid: signResult.kid,
+      })
+    : null;
+
+  await db.insert(attestationNodes).values({
+    nodeId,
+    targetNodeId: record.basePackageHash,
+    type: ATTESTATION_WITHDRAWS,
+    storageKey: blobUrl,
+    signature: signatureJson,
+    rfc3161Timestamp: rfc3161Token,
+    rekorEntryId: rekorResult?.entryId || null,
+    rekorInclusionProof: rekorResult?.inclusionProof || null,
+    signer: node.signer,
+    payload: { reason: reason.trim(), effectiveAt: node.effectiveAt },
+    creatorId: userId,
+  });
+
+  // Dual-write the legacy column mirror (keeps list/dashboard/index working).
+  const now = new Date();
   await db
     .update(evidenceRecords)
     .set({
       withdrawnAt: now,
       withdrawnReason: reason.trim(),
-      withdrawalSignature: signResult
-        ? JSON.stringify({ hash: withdrawalHash, signature: signResult.signature, publicKey: signResult.publicKey, algorithm: signResult.algorithm })
-        : null,
+      withdrawalSignature: signatureJson,
       withdrawalTimestamp: rfc3161Token,
       updatedAt: now,
     })
@@ -98,5 +157,6 @@ export async function POST(
   return NextResponse.json({
     withdrawn: true,
     withdrawnAt: now.toISOString(),
+    attestationNodeId: nodeId,
   });
 }

--- a/src/app/evidence/[slug]/page.tsx
+++ b/src/app/evidence/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { evidenceRecords, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
+import { resolveLifecycle } from '@/lib/evidence/lifecycle';
 import ProvenanceChain from '@/components/evidence/ProvenanceChain';
 import EvidenceActions from '@/components/evidence/EvidenceActions';
 import AttestationSection from '@/components/evidence/AttestationSection';
@@ -225,6 +226,15 @@ export default async function EvidencePage({ params }: PageProps) {
   // existing legacy layout renders unchanged.
   const isDatHere = record.contentProfile === 'datHere';
 
+  // Lifecycle (spec §8.10) — dual-read the signed attestation chain when
+  // present, else the legacy withdrawn/reinstated columns (§8.10.4). The banner
+  // and Status History below render from the resolved status + history rather
+  // than the raw columns, so post-PR3 records surface their signed chain while
+  // pre-PR3 records keep rendering from their columns.
+  const lifecycle = await resolveLifecycle(record, renderPkg?.signer?.identifier);
+  const fmtDate = (iso: string) =>
+    new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
   // Schema.org JSON-LD
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -243,8 +253,10 @@ export default async function EvidencePage({ params }: PageProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '40px 24px 64px' }}>
-        {/* Withdrawal banner — only shown when currently withdrawn (not reinstated) */}
-        {record.withdrawnAt && !record.reinstatedAt && (
+        {/* Withdrawal banner — shown when the resolved lifecycle status is
+            withdrawn (from the signed attestation chain, or the legacy columns
+            for pre-PR3 records). */}
+        {lifecycle.status === 'withdrawn' && lifecycle.withdrawnAt && (
           <div style={{
             padding: '16px 20px', marginBottom: '24px',
             backgroundColor: 'rgba(236, 19, 30, 0.06)',
@@ -253,15 +265,16 @@ export default async function EvidencePage({ params }: PageProps) {
           }}>
             <div style={{ fontSize: '15px', fontWeight: 600, color: 'var(--nyc-error)', marginBottom: '6px' }}>
               This evidence was withdrawn by the author on{' '}
-              {record.withdrawnAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+              {fmtDate(lifecycle.withdrawnAt)}
             </div>
-            {record.withdrawnReason && (
+            {lifecycle.withdrawnReason && (
               <div style={{ fontSize: '14px', color: 'var(--text-secondary)', marginBottom: '6px' }}>
-                <strong>Reason:</strong> {record.withdrawnReason}
+                <strong>Reason:</strong> {lifecycle.withdrawnReason}
               </div>
             )}
             <div style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
               The original content and cryptographic proofs are preserved below for transparency.
+              {lifecycle.source === 'attestation-chain' && ' This withdrawal is a separately-signed attestation node.'}
             </div>
           </div>
         )}
@@ -548,8 +561,10 @@ export default async function EvidencePage({ params }: PageProps) {
           </Section>
         )}
 
-        {/* Status History — shown when the record has a withdrawal/reinstatement cycle */}
-        {record.withdrawnAt && (
+        {/* Status History — shown when the record has a withdrawal/reinstatement
+            cycle. Sourced from the resolved lifecycle (signed attestation chain
+            when present, legacy columns otherwise). */}
+        {lifecycle.withdrawnAt && (
           <Section title="Status History">
             <div style={{
               padding: '16px 20px', border: '1px solid var(--border-color)',
@@ -564,19 +579,25 @@ export default async function EvidencePage({ params }: PageProps) {
               <div>
                 <strong style={{ color: 'var(--text-primary)' }}>Withdrawn</strong>
                 {' on '}
-                {record.withdrawnAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-                {record.withdrawnReason && (
-                  <span> — <em>{record.withdrawnReason}</em></span>
+                {fmtDate(lifecycle.withdrawnAt)}
+                {lifecycle.withdrawnReason && (
+                  <span> — <em>{lifecycle.withdrawnReason}</em></span>
                 )}
               </div>
-              {record.reinstatedAt && (
+              {lifecycle.reinstatedAt && (
                 <div>
                   <strong style={{ color: 'var(--text-primary)' }}>Reinstated</strong>
                   {' on '}
-                  {record.reinstatedAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-                  {record.reinstatedReason && (
-                    <span> — <em>{record.reinstatedReason}</em></span>
+                  {fmtDate(lifecycle.reinstatedAt)}
+                  {lifecycle.reinstatedReason && (
+                    <span> — <em>{lifecycle.reinstatedReason}</em></span>
                   )}
+                </div>
+              )}
+              {lifecycle.source === 'attestation-chain' && (
+                <div style={{ marginTop: '8px', fontSize: '12px', color: 'var(--text-muted)' }}>
+                  Lifecycle events above are separately-signed attestation nodes
+                  ({lifecycle.chain.length} in the chain).
                 </div>
               )}
             </div>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -5,6 +5,7 @@ import {
   timestamp,
   boolean,
   pgEnum,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 
 // --- Enums ---
@@ -153,6 +154,46 @@ export const attestationPackages = pgTable('attestation_packages', {
   packageHash: text('package_hash').notNull(),
   storageKey: text('storage_key').notNull(),
   referencesBaseHash: text('references_base_hash').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
+// Signed `attestation/*` nodes (spec §8.10, §8.12; ADR-0010). Each row is a
+// full signed envelope — its own nodeId (envelope hash), signature, timestamp,
+// and Rekor proof — referencing a content node by `target_node_id`. PR3
+// operationalizes the lifecycle sub-types (`attestation/withdraws/v1`,
+// `attestation/reinstates/v1`); the `type` column + `payload` jsonb keep the
+// table GENERAL so future sub-types (supersedes / publishes / locatedAt /
+// corroborates / endorses / evaluates / certifies …) land here with no further
+// migration (planning Q6). Distinct from `attestation_packages`, the pre-v0.1
+// "comment on a package" feature that has no signature/type-URI/targetNodeId
+// columns (see PR3 summary for the fold-in recommendation).
+export const attestationNodes = pgTable('attestation_nodes', {
+  // The attestation's own envelope hash (spec §8.2/§8.3.1) — its nodeId.
+  nodeId: text('node_id').primaryKey(),
+  // The content node this attestation references by nodeId (spec §8.12.1).
+  targetNodeId: text('target_node_id').notNull(),
+  // The attestation sub-type URI, e.g. `attestation/withdraws/v1`.
+  type: text('type').notNull(),
+  // Vercel Blob URL of the canonical attestation package JSON.
+  storageKey: text('storage_key').notNull(),
+  // Signature envelope JSON ({signature, publicKey, algorithm, kid}); null when
+  // signing was unavailable at emit time (best-effort, like content packages).
+  signature: text('signature'),
+  rfc3161Timestamp: text('rfc3161_timestamp'),
+  rekorEntryId: text('rekor_entry_id'),
+  rekorInclusionProof: text('rekor_inclusion_proof'),
+  // Envelope-side signer identity claim (spec §8.1.1 `signer`).
+  signer: jsonb('signer'),
+  // Sub-type-specific payload (lifecycle: reason / effectiveAt /
+  // priorWithdrawalNodeId; future sub-types: their own fields). jsonb keeps
+  // the table general across all attestation/* sub-types.
+  payload: jsonb('payload'),
+  // The human author who requested the attestation (route-level authz/audit).
+  creatorId: uuid('creator_id')
+    .notNull()
+    .references(() => users.id),
   createdAt: timestamp('created_at', { withTimezone: true })
     .defaultNow()
     .notNull(),

--- a/src/lib/evidence/attestation.test.ts
+++ b/src/lib/evidence/attestation.test.ts
@@ -1,0 +1,100 @@
+// Unit tests for the PR3 attestation node builder (spec §8.10, §8.12).
+// Confirms a conformant attestation envelope, the nodeId-as-JCS-envelope-hash
+// (re-verifying through a storage round-trip), the legacy-json/v1 content hash,
+// and tamper-evidence of the payload.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'crypto';
+import canonicalize from 'canonicalize';
+import {
+  buildAttestationNode,
+  ATTESTATION_WITHDRAWS,
+  ATTESTATION_REINSTATES,
+} from './attestation.ts';
+import {
+  computeEnvelopeHash,
+  LEGACY_JSON_CANONICALIZATION,
+} from './canonicalization.ts';
+
+const SIGNER = {
+  bindingTier: 'platform',
+  identifier: 'platform:civic-ai-tools',
+  displayName: 'Civic AI Tools Platform',
+};
+const TARGET = 'a'.repeat(64);
+
+test('buildAttestationNode: withdraws node carries the conformant envelope fields', () => {
+  const { node, nodeId } = buildAttestationNode({
+    type: ATTESTATION_WITHDRAWS,
+    targetNodeId: TARGET,
+    signer: SIGNER,
+    reason: 'data error in source dataset',
+  });
+  assert.equal(node.type, ATTESTATION_WITHDRAWS);
+  assert.equal(node.targetNodeId, TARGET);
+  assert.deepEqual(node.signer, SIGNER);
+  assert.equal(node.contentCanonicalization, LEGACY_JSON_CANONICALIZATION);
+  assert.ok(node.contentHash, 'contentHash should be present');
+  assert.equal(node.contentHash!.sha256.length, 64);
+  assert.equal(node.reason, 'data error in source dataset');
+  // effectiveAt defaults to the envelope timestamp (§8.12.1).
+  assert.equal(node.effectiveAt, node.metadata.createdAt);
+  assert.equal(nodeId.length, 64);
+});
+
+test('buildAttestationNode: nodeId is the JCS envelope hash and re-verifies after a storage round-trip', () => {
+  const { node, nodeId } = buildAttestationNode({
+    type: ATTESTATION_WITHDRAWS,
+    targetNodeId: TARGET,
+    signer: SIGNER,
+    reason: 'x',
+  });
+  const roundTripped = JSON.parse(JSON.stringify(node));
+  assert.equal(computeEnvelopeHash(roundTripped), nodeId);
+});
+
+test('buildAttestationNode: contentHash fingerprints the node minus contentHash (legacy-json/v1)', () => {
+  const { node } = buildAttestationNode({
+    type: ATTESTATION_WITHDRAWS,
+    targetNodeId: TARGET,
+    signer: SIGNER,
+    reason: 'x',
+  });
+  const rest: Record<string, unknown> = { ...node };
+  delete rest.contentHash;
+  const expected = crypto
+    .createHash('sha256')
+    .update(canonicalize(rest) as string)
+    .digest('hex');
+  assert.equal(node.contentHash!.sha256, expected);
+});
+
+test('buildAttestationNode: reinstates node carries priorWithdrawalNodeId and no effectiveAt', () => {
+  const prior = 'b'.repeat(64);
+  const { node } = buildAttestationNode({
+    type: ATTESTATION_REINSTATES,
+    targetNodeId: TARGET,
+    signer: SIGNER,
+    reason: 'source corrected',
+    priorWithdrawalNodeId: prior,
+  });
+  assert.equal(node.type, ATTESTATION_REINSTATES);
+  assert.equal(node.priorWithdrawalNodeId, prior);
+  // effectiveAt is a withdraws-only payload field.
+  assert.equal(node.effectiveAt, undefined);
+});
+
+test('buildAttestationNode: different reason → different nodeId (tamper-evidence)', () => {
+  const a = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: TARGET, signer: SIGNER, reason: 'reason A' });
+  const b = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: TARGET, signer: SIGNER, reason: 'reason B' });
+  assert.notEqual(a.nodeId, b.nodeId);
+});
+
+test('buildAttestationNode: different targetNodeId → different nodeId', () => {
+  const a = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: 'a'.repeat(64), signer: SIGNER, reason: 'x' });
+  const b = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: 'c'.repeat(64), signer: SIGNER, reason: 'x' });
+  assert.notEqual(a.nodeId, b.nodeId);
+});

--- a/src/lib/evidence/attestation.ts
+++ b/src/lib/evidence/attestation.ts
@@ -1,0 +1,133 @@
+// Attestation node builder (spec §8.10, §8.12; ADR-0010).
+//
+// An `attestation/*` node is a full signed envelope — its own nodeId (envelope
+// hash), signature, timestamp, and Rekor proof — that references a content node
+// by `targetNodeId` and asserts something about it WITHOUT modifying it. PR3
+// operationalizes the two lifecycle sub-types (`withdraws`, `reinstates`).
+//
+// This builder is the attestation analog of `buildEvidencePackage`: it produces
+// the unsigned envelope + its nodeId, REUSING the PR2 canonicalization module
+// (RFC 8785 JCS envelope hash + multihash contentHash). The signing /
+// timestamp / Rekor / storage steps run in the route via the existing signing
+// path, exactly as the content-publish route does — no new signing abstraction.
+
+import crypto from 'crypto';
+import { getActiveKeyId, type SignerIdentity } from './signing.ts';
+import {
+  LEGACY_JSON_CANONICALIZATION,
+  computeEnvelopeHash,
+  computeContentHashSha256,
+} from './canonicalization.ts';
+
+const PACKAGE_SCHEMA_VERSION = '0.1.0';
+
+// Lifecycle attestation sub-type URIs operationalized in PR3 (spec §8.12.1).
+// `supersedes` / `publishes` / `locatedAt` and the claim-to-claim sub-types are
+// reserved name-only per the Xanadu doctrine — the attestation_nodes table
+// holds them, but no route emits them until an adopter needs them.
+export const ATTESTATION_WITHDRAWS = 'attestation/withdraws/v1';
+export const ATTESTATION_REINSTATES = 'attestation/reinstates/v1';
+
+export type LifecycleAttestationType =
+  | typeof ATTESTATION_WITHDRAWS
+  | typeof ATTESTATION_REINSTATES;
+
+/** The lifecycle sub-type URIs PR3 resolves on the verify side. */
+export const LIFECYCLE_ATTESTATION_TYPES: readonly string[] = [
+  ATTESTATION_WITHDRAWS,
+  ATTESTATION_REINSTATES,
+];
+
+/**
+ * A conformant `attestation/*` envelope (spec §8.12.3). Structurally a
+ * content-like package: metadata + type + signer + contentCanonicalization +
+ * contentHash, plus the attestation-specific `targetNodeId` and the sub-type
+ * payload fields. `contentHash` is typed optional only so the builder can
+ * compute it from the base object (a hash cannot include itself); it is always
+ * present on a built node.
+ */
+export interface AttestationNode {
+  metadata: {
+    schemaVersion: string;
+    packageId: string;
+    createdAt: string;
+    signingKeyId: string;
+  };
+  /** Attestation sub-type URI, e.g. `attestation/withdraws/v1`. */
+  type: string;
+  /** Envelope-side identity claim (spec §8.1.1, §8.5). The platform signs on
+   *  behalf of authors today, so this carries the platform identity. */
+  signer?: SignerIdentity;
+  /** The content node this attestation references by nodeId (spec §8.12.1). */
+  targetNodeId: string;
+  /** Off-log canonicalization rule. Attestation content is JSON, so always
+   *  legacy-json/v1 (the whole-envelope-minus-contentHash rule). */
+  contentCanonicalization: string;
+  /** Multihash digest set fingerprinting the off-log content (spec §8.2). */
+  contentHash?: Record<string, string>;
+  // --- Sub-type payload (spec §8.12.1) ---
+  /** `withdraws` (required, non-empty) / `reinstates` (optional). */
+  reason?: string;
+  /** `withdraws`: when the withdrawal takes effect (defaults to envelope ts). */
+  effectiveAt?: string;
+  /** `reinstates`: the prior withdrawal this reinstatement reverses. */
+  priorWithdrawalNodeId?: string;
+}
+
+export interface AttestationInput {
+  type: LifecycleAttestationType;
+  targetNodeId: string;
+  signer: SignerIdentity;
+  reason?: string;
+  effectiveAt?: string;
+  priorWithdrawalNodeId?: string;
+}
+
+/**
+ * Build an unsigned attestation envelope and its nodeId.
+ *
+ * The nodeId is the RFC 8785 JCS envelope hash (spec §8.2/§8.3.1) — the same
+ * `computeEnvelopeHash` the content packager uses, so attestation nodes verify
+ * on the identical dual-chain logic. The off-log content hash is computed under
+ * legacy-json/v1 from the envelope minus `contentHash`, then spread on last.
+ */
+export function buildAttestationNode(
+  input: AttestationInput,
+): { node: AttestationNode; nodeId: string } {
+  const now = new Date().toISOString();
+
+  // Base envelope WITHOUT contentHash. The conditional spreads keep the
+  // payload minimal — only supplied sub-type fields are emitted, so the
+  // canonical JSON carries exactly the fields the sub-type defines.
+  const base: AttestationNode = {
+    metadata: {
+      schemaVersion: PACKAGE_SCHEMA_VERSION,
+      packageId: crypto.randomUUID(),
+      createdAt: now,
+      signingKeyId: getActiveKeyId(),
+    },
+    type: input.type,
+    signer: input.signer,
+    targetNodeId: input.targetNodeId,
+    contentCanonicalization: LEGACY_JSON_CANONICALIZATION,
+    ...(input.reason !== undefined ? { reason: input.reason } : {}),
+    // `effectiveAt` defaults to the envelope timestamp per §8.12.1.
+    ...(input.type === ATTESTATION_WITHDRAWS
+      ? { effectiveAt: input.effectiveAt ?? now }
+      : {}),
+    ...(input.priorWithdrawalNodeId !== undefined
+      ? { priorWithdrawalNodeId: input.priorWithdrawalNodeId }
+      : {}),
+  };
+
+  const contentHash = {
+    sha256: computeContentHashSha256(
+      base as unknown as Record<string, unknown>,
+      LEGACY_JSON_CANONICALIZATION,
+    ),
+  };
+  const node: AttestationNode = { ...base, contentHash };
+  const nodeId = computeEnvelopeHash(node as unknown as Record<string, unknown>);
+
+  return { node, nodeId };
+}

--- a/src/lib/evidence/lifecycle.ts
+++ b/src/lib/evidence/lifecycle.ts
@@ -1,0 +1,158 @@
+// Lifecycle dual-read orchestrator (spec §8.10, §8.10.4; ADR-0010).
+//
+// Resolves a content node's current lifecycle status (active / withdrawn) and
+// its history, preferring the signed `attestation/*` chain when present and
+// falling back to the legacy `withdrawnAt` / `reinstatedAt` DB columns for
+// pre-PR3 records — the same dual-read shape as PR2's dual-chain hashing.
+//
+// This is the async, DB + Blob orchestration layer. The pure ordering /
+// status-derivation / per-node verification logic lives in `verify.ts` so it is
+// unit-testable; this module fetches the rows, fetches + verifies each signed
+// attestation envelope, and hands the views to that pure logic. Shared by the
+// verify route (check #10) and the detail page so both read lifecycle the same
+// way.
+
+import { db } from '@/lib/db';
+import { attestationNodes } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { getPackage } from '@/lib/storage';
+import { getActiveSigner, type SignerIdentity } from './signing.ts';
+import {
+  verifyAttestationNode,
+  resolveLifecycleFromChain,
+  resolveLifecycleFromLegacyColumns,
+  type LifecycleResolution,
+  type LifecycleAttestationView,
+} from './verify.ts';
+
+/** The lifecycle-relevant columns this resolver reads from an evidence row. */
+export interface LifecycleRecordColumns {
+  basePackageHash: string | null;
+  withdrawnAt: Date | null;
+  withdrawnReason: string | null;
+  reinstatedAt: Date | null;
+  reinstatedReason: string | null;
+}
+
+type AttestationRow = typeof attestationNodes.$inferSelect;
+
+/**
+ * Resolve a content node's lifecycle.
+ *
+ * @param record the evidence row's lifecycle columns + `basePackageHash`
+ *   (the content node's nodeId, which attestations reference by `targetNodeId`).
+ * @param targetSignerIdentifier the content node's `signer.identifier`, used for
+ *   the publisher-only signer-match (§8.12.3). Defaults to the platform signer
+ *   identity — correct today since the platform signs every package (§8.5).
+ */
+export async function resolveLifecycle(
+  record: LifecycleRecordColumns,
+  targetSignerIdentifier?: string,
+): Promise<LifecycleResolution> {
+  const targetNodeId = record.basePackageHash;
+
+  if (targetNodeId) {
+    // Defensive: the attestation_nodes table is added by the PR3 migration,
+    // which is run (user-supervised) BEFORE this code deploys. Should the
+    // deploy-before-migration sequence ever be violated, this query would
+    // fail; we swallow that one error and fall through to the legacy columns
+    // so detail pages + verify keep working (degraded, not down) rather than
+    // 500 site-wide. Any other query failure surfaces the same way.
+    let rows: AttestationRow[] = [];
+    try {
+      rows = await db
+        .select()
+        .from(attestationNodes)
+        .where(eq(attestationNodes.targetNodeId, targetNodeId));
+    } catch (err) {
+      console.warn(
+        '[lifecycle] attestation_nodes query failed; falling back to legacy columns:',
+        err instanceof Error ? err.message : err,
+      );
+      rows = [];
+    }
+
+    if (rows.length > 0) {
+      const resolvedSigner =
+        targetSignerIdentifier ?? getActiveSigner().identifier;
+      const views = await Promise.all(
+        rows.map((row) => buildAttestationView(row, resolvedSigner)),
+      );
+      return resolveLifecycleFromChain(views);
+    }
+  }
+
+  // §8.10.4 backwards-compat: no attestation envelopes → legacy DB columns.
+  return resolveLifecycleFromLegacyColumns({
+    withdrawnAt: record.withdrawnAt?.toISOString() ?? null,
+    withdrawnReason: record.withdrawnReason,
+    reinstatedAt: record.reinstatedAt?.toISOString() ?? null,
+    reinstatedReason: record.reinstatedReason,
+  });
+}
+
+/**
+ * Fetch one attestation's signed envelope, verify it independently, and build
+ * the view. Rendered fields are sourced from the SIGNED node JSON when it can
+ * be fetched (the values the signature covers), falling back to the row's
+ * denormalized columns/payload if the blob is unavailable.
+ */
+async function buildAttestationView(
+  row: AttestationRow,
+  resolvedSigner: string,
+): Promise<LifecycleAttestationView> {
+  const node = (await getPackage(row.storageKey).catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+
+  let sigEnvelope: { signature?: string; publicKey?: string } | null = null;
+  if (row.signature) {
+    try {
+      sigEnvelope = JSON.parse(row.signature);
+    } catch {
+      sigEnvelope = null;
+    }
+  }
+
+  const verdict = node
+    ? verifyAttestationNode(node, row.nodeId, sigEnvelope)
+    : { nodeId: row.nodeId, nodeIdMatches: false, signatureValid: null };
+
+  const payload = (row.payload ?? {}) as Record<string, unknown>;
+  const metadata = (node?.metadata ?? {}) as Record<string, unknown>;
+  const signer = (node?.signer ?? row.signer ?? undefined) as
+    | SignerIdentity
+    | undefined;
+
+  // Prefer signed-node values; fall back to the denormalized row payload.
+  const reason =
+    pickString(node?.reason) ?? pickString(payload.reason) ?? undefined;
+  const effectiveAt =
+    pickString(node?.effectiveAt) ?? pickString(payload.effectiveAt) ?? undefined;
+  const priorWithdrawalNodeId =
+    pickString(node?.priorWithdrawalNodeId) ??
+    pickString(payload.priorWithdrawalNodeId) ??
+    undefined;
+  const createdAt =
+    pickString(metadata.createdAt) ?? row.createdAt.toISOString();
+
+  return {
+    nodeId: row.nodeId,
+    type: row.type,
+    signer,
+    createdAt,
+    reason,
+    effectiveAt,
+    priorWithdrawalNodeId,
+    signatureValid: verdict.signatureValid,
+    nodeIdMatches: verdict.nodeIdMatches,
+    hasTimestamp: !!row.rfc3161Timestamp,
+    hasRekor: !!row.rekorEntryId,
+    signerMatchesTarget: !!signer && signer.identifier === resolvedSigner,
+  };
+}
+
+function pickString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -20,12 +20,21 @@ import {
   recomputePackageHash,
   resolveContentCanonicalization,
   verifyContentHash,
+  verifyAttestationNode,
+  resolveLifecycleFromChain,
+  resolveLifecycleFromLegacyColumns,
   type TrustRegistry,
+  type LifecycleAttestationView,
 } from './verify.ts';
 import {
   LEGACY_JSON_CANONICALIZATION,
   DATHERE_AG_JUPYTER_CANONICALIZATION,
 } from './canonicalization.ts';
+import {
+  buildAttestationNode,
+  ATTESTATION_WITHDRAWS,
+  ATTESTATION_REINSTATES,
+} from './attestation.ts';
 import type { BlobRef } from './blob-ref.ts';
 
 const KID = 'platform:evidence-2026-04';
@@ -708,4 +717,165 @@ test('verifyContentHash: pre-v0.1 (no multihash contentHash) → legacy_relabele
   const r = verifyContentHash(pkg, resolution, 'abc123def456');
   assert.equal(r.status, 'legacy_relabeled');
   assert.deepEqual(r.contentHash, { sha256: 'abc123def456' });
+});
+
+// --- PR3: check #10 — lifecycle attestation chain (spec §8.10) ---
+
+const PLATFORM = 'platform:civic-ai-tools';
+const OTHER = 'platform:someone-else';
+
+function view(overrides: Partial<LifecycleAttestationView> = {}): LifecycleAttestationView {
+  return {
+    nodeId: 'n1',
+    type: ATTESTATION_WITHDRAWS,
+    signer: { bindingTier: 'platform', identifier: PLATFORM, displayName: 'P' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    signatureValid: true,
+    nodeIdMatches: true,
+    hasTimestamp: true,
+    hasRekor: true,
+    signerMatchesTarget: true,
+    ...overrides,
+  };
+}
+
+test('resolveLifecycleFromChain: empty chain → active', () => {
+  const r = resolveLifecycleFromChain([]);
+  assert.equal(r.status, 'active');
+  assert.equal(r.source, 'attestation-chain');
+  assert.deepEqual(r.chain, []);
+});
+
+test('resolveLifecycleFromChain: single signer-matched withdraws → withdrawn', () => {
+  const r = resolveLifecycleFromChain([
+    view({ type: ATTESTATION_WITHDRAWS, reason: 'bad data', createdAt: '2026-02-01T00:00:00.000Z', effectiveAt: '2026-02-01T00:00:00.000Z' }),
+  ]);
+  assert.equal(r.status, 'withdrawn');
+  assert.equal(r.withdrawnReason, 'bad data');
+  assert.equal(r.withdrawnAt, '2026-02-01T00:00:00.000Z');
+});
+
+test('resolveLifecycleFromChain: withdraws then reinstates → active, both convenience fields', () => {
+  const w = view({ nodeId: 'w', type: ATTESTATION_WITHDRAWS, reason: 'oops', createdAt: '2026-02-01T00:00:00.000Z', effectiveAt: '2026-02-01T00:00:00.000Z' });
+  const re = view({ nodeId: 'r', type: ATTESTATION_REINSTATES, reason: 'fixed', createdAt: '2026-03-01T00:00:00.000Z' });
+  const r = resolveLifecycleFromChain([w, re]);
+  assert.equal(r.status, 'active');
+  assert.equal(r.withdrawnAt, '2026-02-01T00:00:00.000Z');
+  assert.equal(r.reinstatedAt, '2026-03-01T00:00:00.000Z');
+  assert.equal(r.reinstatedReason, 'fixed');
+});
+
+test('resolveLifecycleFromChain: orders by envelope timestamp regardless of input order', () => {
+  const w = view({ nodeId: 'w', type: ATTESTATION_WITHDRAWS, createdAt: '2026-02-01T00:00:00.000Z' });
+  const re = view({ nodeId: 'r', type: ATTESTATION_REINSTATES, createdAt: '2026-03-01T00:00:00.000Z' });
+  const r = resolveLifecycleFromChain([re, w]); // reinstates passed first
+  assert.equal(r.status, 'active');             // but withdraws is earlier → latest is reinstates
+  assert.equal(r.chain[0].nodeId, 'w');         // sorted ascending
+  assert.equal(r.chain[1].nodeId, 'r');
+});
+
+test('resolveLifecycleFromChain: ties broken by nodeId lexicographic', () => {
+  const a = view({ nodeId: 'aaa', type: ATTESTATION_REINSTATES, createdAt: '2026-02-01T00:00:00.000Z' });
+  const b = view({ nodeId: 'bbb', type: ATTESTATION_WITHDRAWS, createdAt: '2026-02-01T00:00:00.000Z' });
+  const r = resolveLifecycleFromChain([b, a]); // same timestamp; 'aaa' < 'bbb'
+  assert.equal(r.chain[0].nodeId, 'aaa');
+  assert.equal(r.chain[1].nodeId, 'bbb');
+  assert.equal(r.status, 'withdrawn');          // latest (bbb) is withdraws
+});
+
+test('resolveLifecycleFromChain: non-signer-matched withdraws does NOT move status (retention asymmetry §8.10.3)', () => {
+  const foreign = view({
+    nodeId: 'f', type: ATTESTATION_WITHDRAWS, createdAt: '2026-02-01T00:00:00.000Z',
+    signer: { bindingTier: 'platform', identifier: OTHER, displayName: 'X' },
+    signerMatchesTarget: false,
+  });
+  const r = resolveLifecycleFromChain([foreign]);
+  assert.equal(r.status, 'active');  // foreign withdrawal ignored for status
+  assert.equal(r.chain.length, 1);   // but still surfaced in the chain
+});
+
+test('resolveLifecycleFromChain: re-withdrawn (multi-cycle) → withdrawn (latest wins)', () => {
+  const w1 = view({ nodeId: 'w1', type: ATTESTATION_WITHDRAWS, createdAt: '2026-01-01T00:00:00.000Z' });
+  const r1 = view({ nodeId: 'r1', type: ATTESTATION_REINSTATES, createdAt: '2026-02-01T00:00:00.000Z' });
+  const w2 = view({ nodeId: 'w2', type: ATTESTATION_WITHDRAWS, createdAt: '2026-03-01T00:00:00.000Z', reason: 'again' });
+  const r = resolveLifecycleFromChain([w1, r1, w2]);
+  assert.equal(r.status, 'withdrawn');
+  assert.equal(r.withdrawnReason, 'again');
+});
+
+// --- PR3: check #10 — legacy column fallback (spec §8.10.4) ---
+
+test('resolveLifecycleFromLegacyColumns: no withdrawnAt → active, source none', () => {
+  const r = resolveLifecycleFromLegacyColumns({});
+  assert.equal(r.status, 'active');
+  assert.equal(r.source, 'none');
+});
+
+test('resolveLifecycleFromLegacyColumns: withdrawnAt set → withdrawn (pre-PR3 fallback)', () => {
+  const r = resolveLifecycleFromLegacyColumns({ withdrawnAt: '2026-02-01T00:00:00.000Z', withdrawnReason: 'legacy' });
+  assert.equal(r.status, 'withdrawn');
+  assert.equal(r.source, 'legacy-columns');
+  assert.equal(r.withdrawnReason, 'legacy');
+});
+
+test('resolveLifecycleFromLegacyColumns: withdrawn + reinstated → active', () => {
+  const r = resolveLifecycleFromLegacyColumns({ withdrawnAt: '2026-02-01T00:00:00.000Z', reinstatedAt: '2026-03-01T00:00:00.000Z' });
+  assert.equal(r.status, 'active');
+  assert.equal(r.source, 'legacy-columns');
+});
+
+// --- PR3: verifyAttestationNode ---
+
+const ATT_SIGNER = { bindingTier: 'platform', identifier: PLATFORM, displayName: 'P' };
+
+test('verifyAttestationNode: built node recomputes its nodeId (integrity)', () => {
+  const { node, nodeId } = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: 'a'.repeat(64), signer: ATT_SIGNER, reason: 'x' });
+  const r = verifyAttestationNode(node as unknown as Record<string, unknown>, nodeId, null);
+  assert.equal(r.nodeIdMatches, true);
+  assert.equal(r.signatureValid, null); // no signature envelope supplied
+});
+
+test('verifyAttestationNode: wrong stored nodeId → nodeIdMatches false', () => {
+  const { node } = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: 'a'.repeat(64), signer: ATT_SIGNER, reason: 'x' });
+  const r = verifyAttestationNode(node as unknown as Record<string, unknown>, 'f'.repeat(64), null);
+  assert.equal(r.nodeIdMatches, false);
+});
+
+test('verifyAttestationNode: tampered node → nodeIdMatches false', () => {
+  const { node, nodeId } = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: 'a'.repeat(64), signer: ATT_SIGNER, reason: 'x' });
+  const tampered = { ...node, reason: 'tampered after signing' } as unknown as Record<string, unknown>;
+  assert.equal(verifyAttestationNode(tampered, nodeId, null).nodeIdMatches, false);
+});
+
+// --- PR3 regression guard: both lifecycle paths resolve correctly ---
+
+test('lifecycle regression: NEW withdrawal (built node → view → chain) resolves withdrawn', () => {
+  // The post-PR3 path end-to-end minus the DB: build a withdraws node, project
+  // it into a view as lifecycle.ts would, resolve the chain.
+  const { node, nodeId } = buildAttestationNode({ type: ATTESTATION_WITHDRAWS, targetNodeId: 'a'.repeat(64), signer: ATT_SIGNER, reason: 'data error' });
+  const v: LifecycleAttestationView = {
+    nodeId,
+    type: node.type,
+    signer: node.signer,
+    createdAt: node.metadata.createdAt,
+    reason: node.reason,
+    effectiveAt: node.effectiveAt,
+    signatureValid: null,
+    nodeIdMatches: verifyAttestationNode(node as unknown as Record<string, unknown>, nodeId, null).nodeIdMatches,
+    hasTimestamp: false,
+    hasRekor: false,
+    signerMatchesTarget: true,
+  };
+  assert.equal(v.nodeIdMatches, true);
+  const r = resolveLifecycleFromChain([v]);
+  assert.equal(r.status, 'withdrawn');
+  assert.equal(r.source, 'attestation-chain');
+  assert.equal(r.withdrawnReason, 'data error');
+});
+
+test('lifecycle regression: PRE-PR3 legacy withdrawnAt (no chain) resolves withdrawn via fallback', () => {
+  const r = resolveLifecycleFromLegacyColumns({ withdrawnAt: '2025-12-01T00:00:00.000Z', withdrawnReason: 'pre-PR3 withdrawal' });
+  assert.equal(r.status, 'withdrawn');
+  assert.equal(r.source, 'legacy-columns');
+  assert.equal(r.withdrawnReason, 'pre-PR3 withdrawal');
 });

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -14,6 +14,11 @@ import {
   DATHERE_AG_JUPYTER_CANONICALIZATION,
 } from './canonicalization.ts';
 import {
+  ATTESTATION_WITHDRAWS,
+  ATTESTATION_REINSTATES,
+  LIFECYCLE_ATTESTATION_TYPES,
+} from './attestation.ts';
+import {
   isBlobRef,
   verifyBlobRef,
   type BlobRef,
@@ -291,6 +296,180 @@ export function verifyContentHash(
     }
   }
   return { status: 'content_hash_mismatch', algorithms, contentHash };
+}
+
+// --- Lifecycle attestation checks (spec §9.2 check #10, §8.10) ---
+//
+// Lifecycle state (withdrawn / active) is derived from a chain of separately-
+// signed `attestation/*` nodes referencing the content node by `targetNodeId`,
+// each verified independently. Backwards-compat (§8.10.4): when no attestation
+// envelopes are present, the legacy `withdrawnAt` / `reinstatedAt` DB columns
+// are honored instead — the same dual-read shape as PR2's dual-chain hashing.
+// The DB + blob fetch + per-node crypto orchestration lives in
+// `lifecycle.ts`; the pure ordering / status-derivation logic lives here so it
+// is unit-testable.
+
+export type LifecycleStatus = 'active' | 'withdrawn';
+
+/** A single verified lifecycle attestation, as surfaced in the chain. */
+export interface LifecycleAttestationView {
+  nodeId: string;
+  type: string;
+  signer?: SignerIdentity;
+  /** Envelope timestamp (the node's `metadata.createdAt`) — the chain sort key. */
+  createdAt: string;
+  reason?: string;
+  effectiveAt?: string;
+  priorWithdrawalNodeId?: string;
+  /** Ed25519ph signature over the recomputed nodeId; null when unsigned. */
+  signatureValid: boolean | null;
+  /** Recomputed envelope hash equals the stored nodeId (integrity). */
+  nodeIdMatches: boolean;
+  /** RFC 3161 timestamp token present (presence surfaced; full TSA-chain
+   *  verification is the same out-of-scope item as for content nodes). */
+  hasTimestamp: boolean;
+  /** Rekor inclusion-proof entry present (presence only; per-attestation Rekor
+   *  cryptographic verification is a follow-up). */
+  hasRekor: boolean;
+  /** Publisher-only conformance (§8.12.3): the attestation's signer.identifier
+   *  matches the target content node's signer.identifier. */
+  signerMatchesTarget: boolean;
+}
+
+export interface LifecycleResolution {
+  status: LifecycleStatus;
+  /** Which representation determined the status. `none` = never withdrawn,
+   *  no attestations and no legacy columns. */
+  source: 'attestation-chain' | 'legacy-columns' | 'none';
+  /** The ordered lifecycle attestation chain (envelope-timestamp asc, ties by
+   *  nodeId lexicographic). Empty for the legacy-columns / none sources. */
+  chain: LifecycleAttestationView[];
+  // Convenience fields for rendering, populated from whichever source won.
+  withdrawnAt?: string;
+  withdrawnReason?: string;
+  reinstatedAt?: string;
+  reinstatedReason?: string;
+}
+
+export interface AttestationVerifyResult {
+  /** The recomputed envelope hash (= nodeId by construction). */
+  nodeId: string;
+  /** Recomputed envelope hash equals the stored nodeId. */
+  nodeIdMatches: boolean;
+  /** Ed25519ph signature verifies over the recomputed nodeId; null if unsigned. */
+  signatureValid: boolean | null;
+}
+
+/**
+ * Verify an attestation node independently (spec §8.10: "verify the
+ * corresponding lifecycle signatures … for each attestation independently").
+ * Recomputes the envelope hash via the shared dual-chain `computeEnvelopeHash`
+ * (attestation nodes carry a multihash `contentHash`, so this is the JCS chain)
+ * and verifies the Ed25519ph signature over it.
+ */
+export function verifyAttestationNode(
+  node: Record<string, unknown>,
+  storedNodeId: string,
+  sigEnvelope: { signature?: string; publicKey?: string } | null,
+): AttestationVerifyResult {
+  const recomputed = computeEnvelopeHash(node);
+  const nodeIdMatches = recomputed === storedNodeId;
+  let signatureValid: boolean | null = null;
+  if (sigEnvelope?.signature && sigEnvelope?.publicKey) {
+    signatureValid = verifySignature(
+      recomputed,
+      sigEnvelope.signature,
+      sigEnvelope.publicKey,
+    );
+  }
+  return { nodeId: recomputed, nodeIdMatches, signatureValid };
+}
+
+/** Envelope-timestamp ascending, ties broken by nodeId lexicographic (§8.10.1). */
+function compareLifecycleOrder(
+  a: LifecycleAttestationView,
+  b: LifecycleAttestationView,
+): number {
+  if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+  if (a.nodeId === b.nodeId) return 0;
+  return a.nodeId < b.nodeId ? -1 : 1;
+}
+
+/**
+ * Check #10 (chain path) — derive lifecycle status from a set of verified
+ * attestation views (spec §8.10.1, §8.10.3). The current status is the latest
+ * signer-matched lifecycle attestation by envelope timestamp: `withdraws` →
+ * withdrawn, `reinstates` → active. Non-signer-matched attestations are kept in
+ * the surfaced chain for transparency but do NOT move the status (retention
+ * asymmetry, §8.10.3 — a publisher's status label is bounded to their own
+ * signer).
+ */
+export function resolveLifecycleFromChain(
+  views: LifecycleAttestationView[],
+): LifecycleResolution {
+  const chain = views
+    .filter((v) => LIFECYCLE_ATTESTATION_TYPES.includes(v.type))
+    .slice()
+    .sort(compareLifecycleOrder);
+
+  const signerMatched = chain.filter((v) => v.signerMatchesTarget);
+  const latest = signerMatched[signerMatched.length - 1];
+  const status: LifecycleStatus =
+    latest && latest.type === ATTESTATION_WITHDRAWS ? 'withdrawn' : 'active';
+
+  const latestWithdraw = [...signerMatched]
+    .reverse()
+    .find((v) => v.type === ATTESTATION_WITHDRAWS);
+  const latestReinstate = [...signerMatched]
+    .reverse()
+    .find((v) => v.type === ATTESTATION_REINSTATES);
+
+  return {
+    status,
+    source: 'attestation-chain',
+    chain,
+    ...(latestWithdraw
+      ? {
+          withdrawnAt: latestWithdraw.effectiveAt ?? latestWithdraw.createdAt,
+          withdrawnReason: latestWithdraw.reason,
+        }
+      : {}),
+    ...(latestReinstate
+      ? {
+          reinstatedAt: latestReinstate.createdAt,
+          reinstatedReason: latestReinstate.reason,
+        }
+      : {}),
+  };
+}
+
+/**
+ * Check #10 (legacy fallback) — derive lifecycle status from the pre-PR3
+ * `withdrawnAt` / `reinstatedAt` DB columns (spec §8.10.4). Used when a content
+ * node has no attestation envelopes. Mirrors the legacy single-cycle semantics:
+ * withdrawn iff `withdrawnAt` is set and `reinstatedAt` is not.
+ */
+export function resolveLifecycleFromLegacyColumns(columns: {
+  withdrawnAt?: string | null;
+  withdrawnReason?: string | null;
+  reinstatedAt?: string | null;
+  reinstatedReason?: string | null;
+}): LifecycleResolution {
+  if (!columns.withdrawnAt) {
+    return { status: 'active', source: 'none', chain: [] };
+  }
+  const reinstated = !!columns.reinstatedAt;
+  return {
+    status: reinstated ? 'active' : 'withdrawn',
+    source: 'legacy-columns',
+    chain: [],
+    withdrawnAt: columns.withdrawnAt,
+    ...(columns.withdrawnReason ? { withdrawnReason: columns.withdrawnReason } : {}),
+    ...(columns.reinstatedAt ? { reinstatedAt: columns.reinstatedAt } : {}),
+    ...(columns.reinstatedReason
+      ? { reinstatedReason: columns.reinstatedReason }
+      : {}),
+  };
 }
 
 // --- Blob references (Phase B.6) ---


### PR DESCRIPTION
## Phase 3 PR3 — lifecycle attestation nodes (ADR-0010, spec §8.10 / §8.12)

Converts DB-column lifecycle (`withdrawnAt` / `reinstatedAt`) to separately-signed `attestation/*` nodes. The highest-stakes Phase 3 PR — carries the one migration. Targets `main` (PR2 merged).

⚠️ **Draft — awaiting orchestrator spot-check. The migration runs (user-supervised) BEFORE this code merges. See merge sequencing below.**

Ships **withdraws + reinstates only** (parity with today's lifecycle). `supersedes` / `publishes` / `locatedAt` and the claim-to-claim sub-types are reserved name-only (Xanadu) — the table holds them, no route emits them.

### What landed, per piece

- **`attestation_nodes` table** (general, planning Q6): `node_id` PK, `target_node_id`, `type`, `storage_key`, `signature`, `rfc3161_timestamp`, `rekor_entry_id`/`rekor_inclusion_proof`, `signer` jsonb, `payload` jsonb, `creator_id`, `created_at`. The `type` column + `payload` jsonb keep it general — future sub-types land here with no further migration.
- **`buildAttestationNode()`** (`src/lib/evidence/attestation.ts`): a conformant signed envelope (metadata / type / signer / targetNodeId / contentCanonicalization / contentHash + sub-type payload). `nodeId` = the **PR2 `computeEnvelopeHash`** (JCS chain); contentHash via `computeContentHashSha256` (legacy-json/v1). Reuses PR2 — no new hashing. Routes do sign/timestamp/Rekor via the existing signing path.
- **withdraw / reinstate routes**: emit + persist a signed attestation node (sign `nodeId`, RFC 3161, Rekor, blob, insert), and **dual-write the legacy columns** as a denormalized status mirror so the list/dashboard/index consumers keep working (the list API filters on the columns in SQL). Publisher-only authz (requesting user == content creator); single-cycle parity preserved.
- **verify check #10 + dual-read** (`verify.ts` pure logic + `lifecycle.ts` orchestration): resolve the signer-matched, independently-verified attestation chain (envelope-timestamp order, ties by nodeId; latest-wins per §8.10.3 retention asymmetry) when present; fall back to the legacy columns (§8.10.4) otherwise. Surfaced as `lifecycle` in the verify response.
- **Detail page**: banner + Status History render from the resolved lifecycle (chain when present, columns for pre-PR3 records).

### Key design decisions (flagging for review)

1. **Dual-write the legacy columns.** The list API filters withdrawn items in SQL (`or(isNull(withdrawnAt), isNotNull(reinstatedAt))`) and EvidenceIndex/DashboardTabs/dashboard render off the columns. Attestation-only writes would leak withdrawn items into the public list. So new lifecycle writes produce the **canonical signed attestation node** AND mirror status into the columns. The dual-read prefers the chain; the columns are a denormalized cache for simple consumers.
2. **Single-cycle parity** preserved (reject re-withdraw / double-reinstate), matching today's behavior. The table itself supports multi-cycle; only the routes enforce parity.
3. **Legacy-bridge reinstate.** A reinstate of a *pre-PR3* (column-only) withdrawal stays column-only — there's no prior withdrawal **node** to reference via `priorWithdrawalNodeId`, and keeping it column-only keeps each record's lifecycle in one representation (so the dual-read shows full history rather than a partial chain).
4. **Publisher-only under the platform-key model.** The platform signs all packages (§8.5), so every `signer.identifier` is `platform:civic-ai-tools`; the verify-side publisher-only check (attestation signer == target signer) is therefore structural (platform==platform). The meaningful human-author binding is enforced at the **route** (requesting user == content creator), which is parity with today.
5. **Defensive fallback.** `resolveLifecycle` swallows a failed `attestation_nodes` query and falls back to legacy columns, so a deploy-before-migration degrades to legacy reads rather than 500ing every detail page + verify call. The correct sequence is still migration-first (below).

### Merge sequencing (critical)

The new code both **writes** (`attestation_nodes` inserts) and **reads** (verify check #10 + detail page) the new table. The table must exist before this code deploys, or those reads error (the defensive fallback mitigates a site-wide outage, but the table is still required for correct behavior). Order:

1. Orchestrator spot-checks this PR (migration drafted-but-unrun).
2. **User runs the migration + verifies the table exists** with a direct query (`\d attestation_nodes` + a row count) — not the drizzle success report.
3. **Then** merge this PR (deploys).

### Migration (DRAFTED, NOT RUN) — `drizzle/0010_add_attestation_nodes.sql`

Purely additive (new table + its own FK; **no ALTER on any existing table** — the lower-risk class):

```sql
CREATE TABLE "attestation_nodes" (
	"node_id" text PRIMARY KEY NOT NULL,
	"target_node_id" text NOT NULL,
	"type" text NOT NULL,
	"storage_key" text NOT NULL,
	"signature" text,
	"rfc3161_timestamp" text,
	"rekor_entry_id" text,
	"rekor_inclusion_proof" text,
	"signer" jsonb,
	"payload" jsonb,
	"creator_id" uuid NOT NULL,
	"created_at" timestamp with time zone DEFAULT now() NOT NULL
);
--> statement-breakpoint
ALTER TABLE "attestation_nodes" ADD CONSTRAINT "attestation_nodes_creator_id_users_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
```

**Backfill deferred** (stated explicitly): the legacy `withdrawalSignature` signed an ad-hoc `JSON.stringify` message, not a conformant envelope, so it cannot be wrapped into an `attestation/withdraws/v1` without re-signing. Pre-PR3 rows are honored as-is via the dual-read fallback rather than backfilled.

### Regression guard — both lifecycle paths (tested explicitly)

- **Pre-PR3 (legacy fallback):** `resolveLifecycleFromLegacyColumns({withdrawnAt})` → status `withdrawn`, source `legacy-columns`; a record with no attestation envelopes renders/verifies as withdrawn via the fallback. ✅
- **New withdrawal (chain):** `buildAttestationNode` → view → `resolveLifecycleFromChain` → status `withdrawn`, source `attestation-chain`; `verifyAttestationNode` recomputes the nodeId (integrity) and the built node re-verifies after a storage round-trip. ✅
- Plus: chain ordering (timestamp + nodeId tie-break), retention-asymmetry (non-signer-matched withdrawal doesn't move status), multi-cycle latest-wins, withdraw→reinstate→active.

### attestation_packages — investigation + recommendation (NOT migrated here)

`attestation_packages` is the pre-v0.1 "comment on a package" feature (consistency / evaluation / expert_attestation). It is **structurally different** from `attestation_nodes`: keyed by `evidence_record_id` + `references_base_hash` (internal FK + content hash, not `target_node_id`/envelope nodeId); no `signature` / `rfc3161` / `rekor` / type-URI / `signer` columns; and its POST route **signs then discards the signature** (`signPackage(packageHash)` with the result dropped) — so those rows are not standalone-verifiable signed envelopes.

**Recommendation: keep it separate for now; fold into `attestation_nodes` later when an adopter forces it.** `attestation_nodes` is general enough to absorb it (the §8.12.2 mapping: consistency → `content/analysis/v1` + `corroborates`/`contradicts`; evaluation → `evaluates/v1`; expert_attestation → `evaluates`/`endorses/v1`). The fold-in is correctly deferred because it needs prerequisites PR3 doesn't build: (a) actually persisting signatures as conformant envelopes (a behavior fix to the attestations route); (b) the `specific-role-required` authorization + evaluator-methodology model, which the spec (§8.12.4) defers to a future ADR gated on Q25/Q26; (c) consistency's two-node remodel (content node + corroborates/contradicts attestation). The spec (§8.12.2) already scopes this rewrite as a separate future migration.

### Test / build / lint

- **Tests:** 248 pass / 0 fail (227 prior + 21 new across attestation builder, chain resolution, legacy fallback, verifyAttestationNode, and both regression paths).
- **Build:** `✓ Compiled successfully` — withdraw / reinstate / verify routes compile.
- **Lint:** no new problems in any PR3-touched file. **tsc:** PR3 files type-clean (the 2 pre-existing `expert-attestation.test.ts` errors are unrelated/untouched). No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
