### PR TITLE
Trust-signal vocabulary + calm-status taxonomy (#110)

### DIFF
--- a/docs/trust-signal-vocabulary.md
+++ b/docs/trust-signal-vocabulary.md
@@ -1,0 +1,250 @@
+<!-- v1 — 2026-06-02 — Trust-signal vocabulary + calm-status taxonomy (Evidence trust UX #110, Wave 0). Defines the four severity tiers and assigns one to EVERY verify-library status value plus notebookProvenance, resolves every judgment call, and records three deliberate deviations from the issue brief. Source of truth for src/lib/evidence/trust-signal.ts and src/components/evidence/TrustSignal.tsx. No verification-behavior change; not wired into any live panel (that is #111). -->
+
+# Trust-signal vocabulary + calm-status taxonomy
+
+**Scope:** The severity taxonomy that turns each evidence verify-library status into a calm, plain-language signal — `{ tier, icon, one-liner }` — defined once and reused across the trust-communication surfaces (the verify panel and the provenance surfaces). This note assigns a tier to **every** status the verify route emits, plus `notebookProvenance`, and resolves every judgment call.
+
+**Status:** Foundation (Evidence trust UX milestone, Wave 0 / issue #110). This note + `src/lib/evidence/trust-signal.ts` + `src/components/evidence/TrustSignal.tsx` ship together. **No verification behavior changes**, and the component is **not wired into any live panel** — that is #111.
+
+**Constraint docs (cited, not re-derived):** [`evidence-trust-ux-memo.md`](./evidence-trust-ux-memo.md) §3 (the trust-signal spine); [`design-principles.md`](./design-principles.md) P1 (disclosure ≠ validation), P3 (no false precision), P5 (narrative bridge), P7 (orthogonal axes), P9 (user language); the Typed Standards Specification [§9.2](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/typed-standards-specification.md) (the 15-check verification list).
+
+---
+
+## 1. What this is, and what it is not
+
+The reference verifier now runs many more checks than the detail-page verify panel surfaces, and several of those checks return statuses that are **"not `ok`" but entirely expected** — every pre-v0.1 (legacy) package produces a fistful of them. Rendered naively, a legacy package would look like a wall of failures. It is not: it is an older-format package that verifies exactly as it should.
+
+The fix is a shared **trust-signal vocabulary**: every verification status maps to one of four **severity tiers**, a controlled icon, and a plain-language one-liner. This note is the taxonomy; `trust-signal.ts` is its machine-readable form; `<TrustSignal>` is the presentational primitive. The keystone requirement (§3) is that **legacy packages read calm**.
+
+**In scope (#110):** the tier taxonomy, the mapping library, the coverage test, and the component. **Out of scope (→ #111):** wiring `<TrustSignal>` into `EvidenceActions.tsx`, changing any check logic, and removing the existing `✅ / ❌ / ➖` `VerifyCheck`.
+
+---
+
+## 2. The four tiers
+
+| Tier | Reads as | Color token | Icon | Meaning |
+|---|---|---|---|---|
+| **Verified** | green, affirmative | `--nyc-success` `#008A02` | check | An affirmative check passed. |
+| **Normal** | neutral, calm, informational | `--text-muted` `#757575` | info (`i`) | "Not `ok`" but **expected**. The home of every legacy/back-compat status. **Not a warning.** |
+| **Attention** | amber | `--nyc-warning` (→ `--nyc-caution` `#FFB320`) | warning (`!` triangle) | Something **unconfirmed / unrecognized** — not proven-bad. "Look closer." |
+| **Alarm** | red | `--nyc-error` `#EC131E` | error (`!` octagon) | A **genuine integrity failure** — altered content, a forged signature, a revoked key. |
+
+The line that matters most is **Normal vs Attention vs Alarm**. Normal is calm (an expected state). Attention is amber (we could not confirm something). Alarm is red (something is provably wrong). Getting a status into the right one of those three is the whole job.
+
+Per **P1 (disclosure ≠ validation)**, none of these tiers say anything about whether the *analysis is correct*. "Verified" means a cryptographic or structural check passed — it never means "the answer is right."
+
+---
+
+## 3. The load-bearing requirement: legacy packages read calm
+
+A pre-v0.1 (legacy) package must show **zero red and zero amber** on the default view. It legitimately produces these statuses, all of which are **Normal** or **Verified**:
+
+| Check | Legacy status | Tier |
+|---|---|---|
+| #1 envelope integrity | `hashMatch: true` | Verified |
+| #2 signature | `signatureValid: true` (embedded key) or `null` (unsigned) | Verified / Normal |
+| #3 canonicalization | `implicit` | Normal |
+| #4 content hash | `legacy_relabeled` | **Normal** |
+| #5 key trust | `legacy_embedded` (or `null`) | **Normal** |
+| #7 timestamp | `hasTimestamp: false` | Normal |
+| #8 Rekor | `rekorVerified: null` | Normal |
+| #9 BlobRefs | `blobRefsVerified: null` | Normal |
+| #10 lifecycle | `active` / source `none` | Normal |
+| #12 type | `implicit` | Normal |
+| #14 signer identity | `no_signer` | Normal |
+| #15 captureMethod vocab | `no_capture_method` | Normal |
+| notebookProvenance | `skeleton` | Normal |
+
+The hardest split is **content-hash (#4)**: `legacy_relabeled` (every pre-v0.1 package) is **Normal**, while `content_hash_mismatch` (off-log content altered after signing) is **Alarm** — the same check, opposite tiers. The coverage test (`trust-signal.test.ts`) asserts both this split and that the full synthetic-legacy status set above tiers all-calm.
+
+---
+
+## 4. Complete status → tier map
+
+Ordered by spec §9.2 check number. "Copy" is the glanceable one-liner; the library also carries a one-sentence `detail` (omitted here for brevity — see `trust-signal.ts`). User language throughout (P9); disclosure, never validation (P1); no invented precision (P3).
+
+### #1 Envelope integrity — `hashMatch: boolean`
+| Status | Tier | Copy |
+|---|---|---|
+| `true` | Verified | Contents unchanged since signing |
+| `false` | **Alarm** | Contents changed since signing |
+
+### #2 Signature mathematics — `signatureValid: boolean \| null`
+| Status | Tier | Copy |
+|---|---|---|
+| `true` | Verified | Valid cryptographic signature |
+| `false` | **Alarm** | Signature does not verify |
+| `null` | Normal | Not signed |
+
+### #3 Content canonicalization — `contentCanonicalization.status`
+| Status | Tier | Copy |
+|---|---|---|
+| `ok` | Verified | Canonicalization rule recognized |
+| `implicit` | Normal | Canonicalization inferred (earlier-format package) |
+| `unknown_canonicalization_rule` | Attention | Unrecognized canonicalization rule |
+
+### #4 Content hash — `contentHash.status` (the load-bearing split)
+| Status | Tier | Copy |
+|---|---|---|
+| `ok` | Verified | Content matches its fingerprint |
+| `legacy_relabeled` | **Normal** | Earlier-format content fingerprint |
+| `content_hash_mismatch` | **Alarm** | Content does not match its fingerprint |
+| `unresolved_rule` | Attention | Content hash not recomputed (unknown rule) |
+| `contentHash_no_supported_algorithm` | Attention | Content hash uses an unsupported algorithm |
+
+### #5 Trust-registry verdict — `keyTrust.status`
+| Status | Tier | Copy |
+|---|---|---|
+| `active` | Verified | Signed with an active registered key |
+| `deprecated_valid` | Normal | Signed before the key was rotated out |
+| `deprecated_invalid` | **Alarm** | Signed after the key was rotated out |
+| `revoked` | **Alarm** | Signed with a revoked key |
+| `unknown_key` | Attention | Signing key not in the trust registry |
+| `registry_unavailable` | Attention | Trust registry could not be reached |
+| `legacy_embedded` | Normal | Signed before the trust registry existed |
+
+### #7 Timestamp — `hasTimestamp: boolean`
+| Status | Tier | Copy |
+|---|---|---|
+| `true` | Verified | Timestamped |
+| `false` | Normal | No timestamp |
+
+### #8 Transparency log (Rekor) — `rekorVerified: boolean \| null`
+| Status | Tier | Copy |
+|---|---|---|
+| `true` | Verified | Recorded in a public transparency log |
+| `false` | Attention | Transparency-log entry not confirmed |
+| `null` | Normal | Not in a transparency log |
+
+### #9 BlobRef integrity — `blobRefsVerified: boolean \| null`
+| Status | Tier | Copy |
+|---|---|---|
+| `true` | Verified | Referenced content verified |
+| `false` | **Alarm** | Referenced content failed verification |
+| `null` | Normal | No referenced content |
+
+**#9 per-reference failure reasons** (`blobRefs[].reason`, from `BlobRefVerifyReason`) — each a sub-explanation of an Alarm:
+| Reason | Tier | Copy |
+|---|---|---|
+| `invalid_ref` | Alarm | Malformed content reference |
+| `fetch_failed` | Alarm | Referenced content could not be retrieved |
+| `size_mismatch` | Alarm | Referenced content is the wrong size |
+| `hash_mismatch` | Alarm | Referenced content does not match its fingerprint |
+
+### #10 Lifecycle — `lifecycle.status`, `lifecycle.source`, per-attestation
+| Status | Tier | Copy |
+|---|---|---|
+| `status: active` | Normal | Active |
+| `status: withdrawn` | Normal | Withdrawn by the publisher |
+| `source: attestation-chain` | Verified | Lifecycle confirmed from signed transitions |
+| `source: legacy-columns` | Normal | Lifecycle from earlier-format records |
+| `source: none` | Normal | No lifecycle changes |
+| per-attestation `signatureValid: false` | **Alarm** | Lifecycle event signature does not verify |
+| per-attestation `nodeIdMatches: false` | **Alarm** | Lifecycle event has been altered |
+| per-attestation `signerMatchesTarget: false` | Normal | Lifecycle event from a different signer |
+| per-attestation `hasTimestamp / hasRekor: false` | Normal | (supplementary) |
+
+Whether lifecycle is surfaced **in the verify panel at all** is left open for #111: it is a separate axis from cryptographic integrity (**P7**), and the detail-page withdrawal banner already gives it prominence. Tiered here for completeness.
+
+### #11 captureMethod LABEL — `metadata.captureMethod`
+**Not a tier.** A signature-covered *label* describing how the bytes were captured (spec §9.2 #11 — "signed ≠ verbatim"). Rendered as a neutral informational label adjacent to the signature verdict (#111). `trust-signal.ts` provides plain-language readings in `CAPTURE_METHOD_LABELS` (`chat-flow-stream`, `claude-code-jsonl-readback`, `claude-code-self-report`).
+
+### #12 Type resolution — `typeResolution.status`
+| Status | Tier | Copy |
+|---|---|---|
+| `ok` | Verified | Node type recognized |
+| `implicit` | Normal | Node type inferred (earlier-format package) |
+| `unknown_type` | Attention | Unrecognized node type |
+
+### #14 Signer identity — `signerIdentity.status`
+| Status | Tier | Copy |
+|---|---|---|
+| `ok` | Verified | Signer identity matches the registry |
+| `signer_identity_mismatch` | **Alarm** | Signer identity does not match the registry |
+| `no_signer` | Normal | No stated signer (earlier-format package) |
+| `no_registry_identity` | Normal | Registry has no identity for this key |
+
+### #15 captureMethod vocabulary — `captureMethodVocab.status`
+| Status | Tier | Copy |
+|---|---|---|
+| `ok` | Verified | Capture method recognized for this profile |
+| `captureMethod_unknown` | Attention | Capture method not recognized for this profile |
+| `producerProfile_bundle_unresolved` | Normal | Producer profile not resolved |
+| `no_capture_method` | Normal | No capture method (earlier-format package) |
+
+### notebookProvenance — `metadata.extensions["org.civicaitools.notebook"].provenance`
+| Value | Tier | Copy |
+|---|---|---|
+| `executed` | Normal | Executed in a signed sandbox |
+| `skeleton` | Normal | Skeleton notebook (not executed) |
+
+Both readings are honest and calm (per [open-questions Q31](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/open-questions.md)). `executed` is the only value emitted today; `skeleton` is reserved (no code path writes it yet).
+
+---
+
+## 5. Resolved judgment calls
+
+Each `⚖` from the issue brief, resolved with rationale. The guiding distinction: **Alarm** is reserved for a *positive assertion of badness* (content altered, signature forged, registry says "do not trust"); **Attention** is for the *absence of a confirmation* (an unrecognized identifier, an unreachable check); **Normal** is for an *expected back-compat state*.
+
+1. **`captureMethod_unknown` → Attention** *(the sharpest call).* Spec §9.2 #15 says this "rejects the node." But the tier governs how the **signal reads**, not whether the node passes conformance — and #110 changes no verification behavior. The captureMethod label is **signature-covered**, so an unrecognized value is not an *alteration* (an alteration trips #1/#4 → Alarm); it is an unrecognized identifier, structurally identical to `unknown_canonicalization_rule` (#3) and `unknown_type` (#12), both Attention. Amber correctly says "look closer" without crying Alarm over a vocabulary this verifier simply does not recognize.
+
+2. **`rekorVerified: false` → Attention** (not Alarm). The verify route collapses "Rekor unreachable" and "Rekor entry contradicts the package" into one boolean. The common cause is a transient outage, and Rekor is a *supplementary* transparency log, not the package's content. Amber, not red. *(If the route is later refined to distinguish an entry that contradicts the package, that case should escalate to Alarm.)*
+
+3. **`keyTrust.deprecated_valid` → Normal.** `verified: true` — the signature is valid under preventive rotation (signed before the key was deprecated). It is not a fresh active-key Verified, but it is not a concern; Normal carries the rotation context calmly (**P7** — don't hide the deprecation behind a green check).
+
+4. **`keyTrust.unknown_key` → Attention** (not Alarm). An unknown key is the *absence* of a trust assertion, not a positive distrust. Contrast `revoked` / `deprecated_invalid`, where the registry *positively asserts* the key should not be trusted → Alarm. Absence-of-trust = Attention; positive-distrust = Alarm.
+
+5. **`contentHash_no_supported_algorithm` → Attention.** The fingerprint lists only algorithms this verifier cannot compute, so it cannot be confirmed (paralleling `unresolved_rule`). Unconfirmed, not altered.
+
+6. **`signerIdentity.no_registry_identity` → Normal.** A legacy registry entry predating identity binding; the cross-check is skipped. A back-compat degradation, like `no_signer`.
+
+7. **`captureMethodVocab.no_capture_method` → Normal.** Pre-ADR-0003 packages carry no captureMethod. Neutral, like an absent timestamp.
+
+8. **Lifecycle per-attestation falses — split, not uniform.** `signatureValid: false` and `nodeIdMatches: false` are integrity of the *event itself* → a forged or altered transition → **Alarm**. But `signerMatchesTarget: false` is **Normal** — see deviation (b) below.
+
+9. **Lifecycle surfaced in the verify panel?** Open for #111 (see §4 #10). Tiered here for completeness.
+
+### Deviations from the issue brief (flagged)
+
+Three places where I diverged from the brief's leans, each with rationale:
+
+- **(a) `--nyc-warning` aliased to `--nyc-caution`, not added as a fresh amber.** The brief said *"NO amber token exists — ADD `--nyc-warning`."* In fact `globals.css` already ships `--nyc-caution: #FFB320` in the NYC palette. Rather than introduce a second amber hex, I added `--nyc-warning: var(--nyc-caution);` — a semantically-named token (what the brief wanted) sourced from the existing design-system amber, so the Attention tier stays in lockstep with the palette.
+
+- **(b) `signerMatchesTarget: false` → Normal, not Alarm.** The brief grouped this with the integrity falses (Alarm, marked `⚖`). But a non-signer-matched attestation is a **legitimately-surfaced third-party event**: per spec §8.10.3 (retention asymmetry) it is shown but does **not** move the publisher's status, and the existing `verify.ts` test (`resolveLifecycleFromChain: non-signer-matched withdraws does NOT move status`) confirms this is designed behavior, not tampering. Tiering it Alarm would cry foul over a feature. → Normal.
+
+- **(c) Icons are stroke-outline, not the suggested `fill="currentColor"` filled glyphs.** The brief suggested filled glyphs "per house convention (the download icon)." A *filled* set with the inner `i` / `!` marks that make tiers distinguishable **without relying on color** (an accessibility requirement) needs even-odd knock-out paths. Four **stroked silhouettes** — check / circle / triangle / octagon — are hand-authored, coherent, crisp at 16px, and give four distinct shapes. The accessibility win (shape + color + aria, never color alone) outweighs matching the one existing filled glyph.
+
+### Checks not tiered at runtime
+
+Spec checks **#6** (`metadata.signingKeyId` consistency) and **#13** (`nodeId` cross-check) are **not** emitted as discrete status fields by today's verify route (it returns `nodeId` only as a recomputed hash string). Their tiers are **reserved here** — a mismatch on either → **Alarm** — but they have no runtime entry in `trust-signal.ts`, and the coverage test asserts only the codes the route actually emits. When #6/#13 gain discrete statuses, add their maps and tests.
+
+---
+
+## 6. The icon set
+
+Four in-house, `aria-labeled`, inline-SVG glyphs — one per tier. No icon dependency, **no DTPR assets** (the memo's guardrail). Severity is conveyed three independent ways so it never depends on color alone:
+
+| Tier | Glyph (silhouette) | `aria-label` |
+|---|---|---|
+| Verified | checkmark | "Verified" |
+| Normal | circle + `i` (info) | "Informational" |
+| Attention | triangle + `!` (warning) | "Attention" |
+| Alarm | octagon + `!` (error) | "Alarm" |
+
+The four outer shapes (check / circle / triangle / octagon) are distinct without color, supporting colorblind and screen-reader users. The shapes follow convergent severity-icon prior art (the design principles say *novelty is not a goal* — follow convention). They live in `TrustSignal.tsx`; the tier → glyph/color/aria mapping is `TIER_META` in `trust-signal.ts`.
+
+---
+
+## 7. Implementation map
+
+| Artifact | Path | Role |
+|---|---|---|
+| This note | `docs/trust-signal-vocabulary.md` | The taxonomy + resolved judgment calls (source of truth). |
+| Vocabulary library | `src/lib/evidence/trust-signal.ts` | `TrustTier`, `TIER_META`, the per-check `*_SIGNALS` maps, resolver helpers (`resolveSignature`, `resolveRekor`, …), `CAPTURE_METHOD_LABELS`, `NOTEBOOK_PROVENANCE_SIGNALS`. Pure data — type-only upstream imports, so client-safe. |
+| Coverage test | `src/lib/evidence/trust-signal.test.ts` | Proves total coverage of the emitted status codes, the load-bearing splits, and the synthetic-legacy all-calm guarantee. |
+| Component | `src/components/evidence/TrustSignal.tsx` | Presentational `<TrustSignal tier label detail? icon? />`; the four glyphs; consumes `TIER_META`. |
+| Amber token | `src/app/globals.css` | `--nyc-warning` (→ `--nyc-caution`). |
+
+**How total coverage holds by construction.** Each verify-library status union was refactored (behavior-preservingly) into a source-of-truth const-array, e.g. `KEY_TRUST_STATUSES` with `type KeyTrustStatus = typeof KEY_TRUST_STATUSES[number]`. The signal maps are typed `Record<KeyTrustStatus, …>`, so a status added upstream fails the compile until it is tiered here; the coverage test iterates the same arrays at runtime as a belt-and-suspenders and to assert the load-bearing tier *values*. The array and the map cannot drift.
+
+**Downstream (#111).** The verify route already returns checks #3 / #4 / #10 / #12 / #14 / #15 / blobRefs, but the local `VerifyResult` interface in `EvidenceActions.tsx` declares only five of them. #111 widens that consumer type, swaps the `✅/❌/➖` `VerifyCheck` for `<TrustSignal>`, and decides what (lifecycle, captureMethod label) renders where.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,10 @@
   --nyc-success: #008A02;
   --nyc-caution: #FFB320;
   --nyc-error: #EC131E;
+  /* Trust-signal "Attention" tier (civic-ai-tools-website#110). Aliased to the
+     existing NYC caution amber rather than introducing a second amber token, so
+     the verify panel's amber stays in lockstep with the design-system palette. */
+  --nyc-warning: var(--nyc-caution);
 
   /* Spacing Scale */
   --space-xs: 8px;

--- a/src/components/evidence/TrustSignal.tsx
+++ b/src/components/evidence/TrustSignal.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { TIER_META, type TrustTier, type TrustIconName } from '@/lib/evidence/trust-signal';
+
+/**
+ * Presentational trust-signal row (civic-ai-tools-website#110, Wave 0).
+ *
+ * Renders one `{ tier, icon, plain-language one-liner }` signal — the shared
+ * primitive that the verify panel and provenance surfaces will consume (#111+).
+ * It is NOT yet imported by any live panel; this is the standalone foundation.
+ *
+ * Severity is conveyed three ways so it never depends on color alone (WCAG /
+ * design-principles accessibility): a distinct icon SILHOUETTE per tier, the
+ * tier color, and an `aria-label` on the glyph announcing the tier to screen
+ * readers. The four glyphs are in-house inline SVGs (no icon dependency, no DTPR
+ * assets). They are stroke-outline rather than the filled house download glyph:
+ * a filled set with inner i/! marks needs even-odd knock-out paths, whereas four
+ * stroked silhouettes (check / circle / triangle / octagon) are hand-authored,
+ * coherent, and distinct without color. See docs/trust-signal-vocabulary.md.
+ *
+ * Tier color, default glyph, and aria label come from `TIER_META` — the single
+ * source of truth in trust-signal.ts (a pure-data, client-safe module). Only the
+ * SVG path data lives here, because JSX cannot live cleanly in that .ts module.
+ */
+
+/**
+ * The four in-house glyphs. Each is a stroked silhouette (outer shape) plus an
+ * inner mark where applicable. `currentColor` carries the tier color, set via
+ * the wrapping `<svg>`'s `color`. Inner dots override to a solid fill.
+ */
+const ICON_GLYPHS: Record<TrustIconName, ReactNode> = {
+  // Bare checkmark.
+  check: <path d="M3.25 8.6 L6.4 11.75 L12.75 4.5" />,
+  // Circle + lowercase "i" (dot above a short stem).
+  info: (
+    <>
+      <circle cx="8" cy="8" r="6.25" />
+      <line x1="8" y1="7.5" x2="8" y2="11.25" />
+      <circle cx="8" cy="5" r="0.85" fill="currentColor" stroke="none" />
+    </>
+  ),
+  // Triangle + "!" (stem above a dot).
+  warning: (
+    <>
+      <path d="M8 2.25 L14 13 L2 13 Z" />
+      <line x1="8" y1="6.5" x2="8" y2="9.75" />
+      <circle cx="8" cy="11.4" r="0.85" fill="currentColor" stroke="none" />
+    </>
+  ),
+  // Octagon + "!" (stem above a dot).
+  error: (
+    <>
+      <path d="M5.4 1.75 L10.6 1.75 L14.25 5.4 L14.25 10.6 L10.6 14.25 L5.4 14.25 L1.75 10.6 L1.75 5.4 Z" />
+      <line x1="8" y1="4.75" x2="8" y2="8.75" />
+      <circle cx="8" cy="11" r="0.85" fill="currentColor" stroke="none" />
+    </>
+  ),
+};
+
+function TierIcon({
+  icon,
+  color,
+  ariaLabel,
+}: {
+  icon: TrustIconName;
+  color: string;
+  ariaLabel: string;
+}) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label={ariaLabel}
+      style={{ color, flexShrink: 0, marginTop: '1px' }}
+    >
+      {ICON_GLYPHS[icon]}
+    </svg>
+  );
+}
+
+export interface TrustSignalProps {
+  /** Severity tier — drives the color and the default glyph. */
+  tier: TrustTier;
+  /** Glanceable plain-language one-liner (the `label`/`copy` from the
+   *  vocabulary). */
+  label: string;
+  /** Optional expand-on-demand sentence rendered muted beside the label. */
+  detail?: string;
+  /** Override the tier's default glyph (rare; tier normally drives the icon). */
+  icon?: TrustIconName;
+}
+
+/**
+ * One trust-signal row: `<glyph>  Label  detail`. Matches the layout of the
+ * existing inline `VerifyCheck` (EvidenceActions.tsx) so #111 can swap it in.
+ */
+export default function TrustSignal({ tier, label, detail, icon }: TrustSignalProps) {
+  const meta = TIER_META[tier];
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '8px',
+        fontSize: '13px',
+        marginBottom: '6px',
+      }}
+    >
+      <TierIcon icon={icon ?? meta.icon} color={meta.colorVar} ariaLabel={meta.ariaLabel} />
+      <div>
+        <span style={{ color: 'var(--text-primary)' }}>{label}</span>
+        {detail && (
+          <span style={{ color: 'var(--text-muted)', marginLeft: '6px' }}>{detail}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/evidence/blob-ref.ts
+++ b/src/lib/evidence/blob-ref.ts
@@ -59,11 +59,18 @@ export function parseBlobRef(ref: string): ParsedBlobRef {
   return { algo: 'sha256', hash: match[1] };
 }
 
-export type BlobRefVerifyReason =
-  | 'invalid_ref'
-  | 'fetch_failed'
-  | 'size_mismatch'
-  | 'hash_mismatch';
+// Source-of-truth array (not just a type) so the trust-signal vocabulary
+// (civic-ai-tools-website#110) can enumerate every BlobRef failure reason at
+// runtime. Each reason is a sub-explanation of a failed (Alarm-tier) BlobRef
+// integrity check (#9). Behavior-preserving: the derived type is identical to
+// the prior hand-written union.
+export const BLOB_REF_VERIFY_REASONS = [
+  'invalid_ref',
+  'fetch_failed',
+  'size_mismatch',
+  'hash_mismatch',
+] as const;
+export type BlobRefVerifyReason = (typeof BLOB_REF_VERIFY_REASONS)[number];
 
 export interface BlobRefVerifyResult {
   ok: boolean;

--- a/src/lib/evidence/trust-signal.test.ts
+++ b/src/lib/evidence/trust-signal.test.ts
@@ -1,0 +1,236 @@
+// Coverage + tier-correctness tests for the trust-signal vocabulary
+// (civic-ai-tools-website#110). Two things are proven here:
+//   1. TOTAL coverage — every status the verify route actually emits maps to a
+//      valid tier, by enumerating the source-of-truth const-arrays. (Spec checks
+//      #6 / #13 are NOT emitted as discrete status fields today, so they are
+//      tiered in the design note only and intentionally not asserted here.)
+//   2. The load-bearing splits and resolved judgment calls hold — including the
+//      calm requirement: a synthetic pre-v0.1 legacy package tiers all-calm,
+//      with zero amber/red on the default view.
+//
+// Run with: npm test (Node 22+).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CONTENT_CANONICALIZATION_STATUSES,
+  CONTENT_HASH_STATUSES,
+  KEY_TRUST_STATUSES,
+  TYPE_RESOLUTION_STATUSES,
+  SIGNER_IDENTITY_CHECK_STATUSES,
+  CAPTURE_METHOD_VOCAB_STATUSES,
+  LIFECYCLE_STATUSES,
+  LIFECYCLE_SOURCES,
+} from './verify.ts';
+import { BLOB_REF_VERIFY_REASONS } from './blob-ref.ts';
+import {
+  TIER_META,
+  toResolvedSignal,
+  biKey,
+  triKey,
+  BI_STATE_KEYS,
+  TRI_STATE_KEYS,
+  ENVELOPE_INTEGRITY_SIGNALS,
+  SIGNATURE_SIGNALS,
+  CONTENT_CANONICALIZATION_SIGNALS,
+  CONTENT_HASH_SIGNALS,
+  KEY_TRUST_SIGNALS,
+  TIMESTAMP_SIGNALS,
+  REKOR_SIGNALS,
+  BLOB_REFS_SIGNALS,
+  BLOB_REF_REASON_SIGNALS,
+  LIFECYCLE_STATE_SIGNALS,
+  LIFECYCLE_SOURCE_SIGNALS,
+  LIFECYCLE_ATTESTATION_SIGNATURE_SIGNALS,
+  LIFECYCLE_ATTESTATION_NODE_ID_SIGNALS,
+  LIFECYCLE_ATTESTATION_SIGNER_MATCH_SIGNALS,
+  LIFECYCLE_ATTESTATION_TIMESTAMP_SIGNALS,
+  LIFECYCLE_ATTESTATION_REKOR_SIGNALS,
+  TYPE_RESOLUTION_SIGNALS,
+  SIGNER_IDENTITY_SIGNALS,
+  CAPTURE_METHOD_VOCAB_SIGNALS,
+  CAPTURE_METHOD_LABELS,
+  NOTEBOOK_PROVENANCE_VALUES,
+  NOTEBOOK_PROVENANCE_SIGNALS,
+  type TrustSignalDescriptor,
+} from './trust-signal.ts';
+
+// The valid tiers, derived from the source so the test cannot drift from it.
+const VALID_TIERS = new Set(Object.keys(TIER_META));
+
+/**
+ * Assert that a status→descriptor map EXACTLY covers a status space: every
+ * status has a descriptor with a valid tier + non-empty label, and the map has
+ * no extra keys. Driven by the const-array, so a status added upstream that
+ * isn't tiered here fails the test (and `Record<Status, …>` fails the compile).
+ */
+function assertExactCoverage<K extends string>(
+  name: string,
+  statuses: readonly K[],
+  map: Record<K, TrustSignalDescriptor>,
+) {
+  for (const status of statuses) {
+    const d = map[status];
+    assert.ok(d, `${name}: status "${String(status)}" has no descriptor`);
+    assert.ok(VALID_TIERS.has(d.tier), `${name}: status "${status}" → invalid tier "${d.tier}"`);
+    assert.ok(d.label.length > 0, `${name}: status "${status}" has an empty label`);
+  }
+  assert.deepEqual(
+    Object.keys(map).sort(),
+    [...statuses].sort(),
+    `${name}: map keys do not exactly match the emitted status space`,
+  );
+}
+
+// --- Total coverage of the string-union status spaces --------------------
+
+test('total coverage: every emitted string-union status maps to a valid tier', () => {
+  assertExactCoverage('contentCanonicalization', CONTENT_CANONICALIZATION_STATUSES, CONTENT_CANONICALIZATION_SIGNALS);
+  assertExactCoverage('contentHash', CONTENT_HASH_STATUSES, CONTENT_HASH_SIGNALS);
+  assertExactCoverage('keyTrust', KEY_TRUST_STATUSES, KEY_TRUST_SIGNALS);
+  assertExactCoverage('typeResolution', TYPE_RESOLUTION_STATUSES, TYPE_RESOLUTION_SIGNALS);
+  assertExactCoverage('signerIdentity', SIGNER_IDENTITY_CHECK_STATUSES, SIGNER_IDENTITY_SIGNALS);
+  assertExactCoverage('captureMethodVocab', CAPTURE_METHOD_VOCAB_STATUSES, CAPTURE_METHOD_VOCAB_SIGNALS);
+  assertExactCoverage('lifecycleState', LIFECYCLE_STATUSES, LIFECYCLE_STATE_SIGNALS);
+  assertExactCoverage('lifecycleSource', LIFECYCLE_SOURCES, LIFECYCLE_SOURCE_SIGNALS);
+  assertExactCoverage('blobRefReason', BLOB_REF_VERIFY_REASONS, BLOB_REF_REASON_SIGNALS);
+});
+
+// --- Total coverage of the boolean-state checks --------------------------
+
+test('total coverage: every boolean-state check covers its states with valid tiers', () => {
+  assertExactCoverage('envelopeIntegrity', BI_STATE_KEYS, ENVELOPE_INTEGRITY_SIGNALS);
+  assertExactCoverage('timestamp', BI_STATE_KEYS, TIMESTAMP_SIGNALS);
+  assertExactCoverage('signature', TRI_STATE_KEYS, SIGNATURE_SIGNALS);
+  assertExactCoverage('rekor', TRI_STATE_KEYS, REKOR_SIGNALS);
+  assertExactCoverage('blobRefs', TRI_STATE_KEYS, BLOB_REFS_SIGNALS);
+  // Lifecycle per-attestation signals.
+  assertExactCoverage('lifecycle.signature', TRI_STATE_KEYS, LIFECYCLE_ATTESTATION_SIGNATURE_SIGNALS);
+  assertExactCoverage('lifecycle.nodeId', BI_STATE_KEYS, LIFECYCLE_ATTESTATION_NODE_ID_SIGNALS);
+  assertExactCoverage('lifecycle.signerMatch', BI_STATE_KEYS, LIFECYCLE_ATTESTATION_SIGNER_MATCH_SIGNALS);
+  assertExactCoverage('lifecycle.timestamp', BI_STATE_KEYS, LIFECYCLE_ATTESTATION_TIMESTAMP_SIGNALS);
+  assertExactCoverage('lifecycle.rekor', BI_STATE_KEYS, LIFECYCLE_ATTESTATION_REKOR_SIGNALS);
+});
+
+test('notebookProvenance: both readings covered and calm', () => {
+  assertExactCoverage('notebookProvenance', NOTEBOOK_PROVENANCE_VALUES, NOTEBOOK_PROVENANCE_SIGNALS);
+  for (const v of NOTEBOOK_PROVENANCE_VALUES) {
+    assert.equal(NOTEBOOK_PROVENANCE_SIGNALS[v].tier, 'normal');
+  }
+});
+
+// --- The load-bearing splits ---------------------------------------------
+
+test('load-bearing split #4: legacy_relabeled=Normal vs content_hash_mismatch=Alarm (same check, opposite tiers)', () => {
+  assert.equal(CONTENT_HASH_SIGNALS.legacy_relabeled.tier, 'normal');
+  assert.equal(CONTENT_HASH_SIGNALS.content_hash_mismatch.tier, 'alarm');
+});
+
+test('load-bearing split #5: legacy_embedded=Normal vs revoked/deprecated_invalid=Alarm', () => {
+  assert.equal(KEY_TRUST_SIGNALS.legacy_embedded.tier, 'normal');
+  assert.equal(KEY_TRUST_SIGNALS.revoked.tier, 'alarm');
+  assert.equal(KEY_TRUST_SIGNALS.deprecated_invalid.tier, 'alarm');
+});
+
+// --- The calm requirement: a synthetic legacy package shows zero red/amber
+
+test('a synthetic pre-v0.1 legacy package tiers all-calm (zero attention/alarm)', () => {
+  // The status set a signed pre-v0.1 (legacy-embedded) package produces across
+  // every check. Each MUST resolve to verified or normal — never attention/alarm.
+  const legacySignals: TrustSignalDescriptor[] = [
+    ENVELOPE_INTEGRITY_SIGNALS[biKey(true)], //  #1 envelope intact
+    SIGNATURE_SIGNALS[triKey(true)], //          #2 legacy embedded key verifies
+    CONTENT_CANONICALIZATION_SIGNALS.implicit, //#3 rule inferred
+    CONTENT_HASH_SIGNALS.legacy_relabeled, //    #4 slug hash relabeled
+    KEY_TRUST_SIGNALS.legacy_embedded, //        #5 pre-registry signature
+    TIMESTAMP_SIGNALS[biKey(false)], //          #7 no timestamp
+    REKOR_SIGNALS[triKey(null)], //              #8 not logged
+    BLOB_REFS_SIGNALS[triKey(null)], //          #9 all fields inline
+    LIFECYCLE_STATE_SIGNALS.active, //          #10 not withdrawn
+    LIFECYCLE_SOURCE_SIGNALS.none, //           #10 no lifecycle events
+    TYPE_RESOLUTION_SIGNALS.implicit, //        #12 type inferred
+    SIGNER_IDENTITY_SIGNALS.no_signer, //       #14 no envelope signer
+    CAPTURE_METHOD_VOCAB_SIGNALS.no_capture_method, // #15 pre-ADR-0003
+    NOTEBOOK_PROVENANCE_SIGNALS.skeleton, //     skeleton notebook
+  ];
+  for (const s of legacySignals) {
+    assert.ok(
+      s.tier === 'verified' || s.tier === 'normal',
+      `legacy signal "${s.label}" tiered "${s.tier}" — a legacy package must read calm`,
+    );
+  }
+  // And a fully-unsigned ancient package (no signature at all) is calm too.
+  assert.ok(['verified', 'normal'].includes(SIGNATURE_SIGNALS[triKey(null)].tier));
+});
+
+// --- Resolved judgment calls (see docs/trust-signal-vocabulary.md §5) ----
+
+test('judgment calls resolve as documented', () => {
+  // Sharpest call: captureMethod_unknown is Attention (unrecognized signature-
+  // covered label), not Alarm, despite spec #15 "rejects the node".
+  assert.equal(CAPTURE_METHOD_VOCAB_SIGNALS.captureMethod_unknown.tier, 'attention');
+  // signer_identity_mismatch is the genuine fatal identity failure → Alarm.
+  assert.equal(SIGNER_IDENTITY_SIGNALS.signer_identity_mismatch.tier, 'alarm');
+  // The "unrecognized identifier" family all sits at Attention.
+  assert.equal(TYPE_RESOLUTION_SIGNALS.unknown_type.tier, 'attention');
+  assert.equal(CONTENT_CANONICALIZATION_SIGNALS.unknown_canonicalization_rule.tier, 'attention');
+  assert.equal(CONTENT_HASH_SIGNALS.unresolved_rule.tier, 'attention');
+  assert.equal(CONTENT_HASH_SIGNALS.contentHash_no_supported_algorithm.tier, 'attention');
+  assert.equal(KEY_TRUST_SIGNALS.unknown_key.tier, 'attention');
+  assert.equal(KEY_TRUST_SIGNALS.registry_unavailable.tier, 'attention');
+  // rekor=false is Attention (often transient / supplementary log), not Alarm.
+  assert.equal(REKOR_SIGNALS.false.tier, 'attention');
+  // Backwards-compat degradations stay calm (Normal).
+  assert.equal(KEY_TRUST_SIGNALS.deprecated_valid.tier, 'normal');
+  assert.equal(SIGNER_IDENTITY_SIGNALS.no_registry_identity.tier, 'normal');
+  assert.equal(CAPTURE_METHOD_VOCAB_SIGNALS.producerProfile_bundle_unresolved.tier, 'normal');
+});
+
+test('every BlobRef failure reason is an Alarm sub-explanation', () => {
+  for (const reason of BLOB_REF_VERIFY_REASONS) {
+    assert.equal(BLOB_REF_REASON_SIGNALS[reason].tier, 'alarm', `blobRef reason "${reason}"`);
+  }
+});
+
+test('lifecycle per-attestation: integrity falses are Alarm; signer-mismatch + supplementary are Normal', () => {
+  // Forged / altered transition → Alarm.
+  assert.equal(LIFECYCLE_ATTESTATION_SIGNATURE_SIGNALS.false.tier, 'alarm');
+  assert.equal(LIFECYCLE_ATTESTATION_NODE_ID_SIGNALS.false.tier, 'alarm');
+  // Deviation from the brief's grouping: a third-party (non-signer-matched)
+  // attestation is a legitimately-surfaced event per §8.10.3 retention
+  // asymmetry — it does not move the publisher's status → Normal, not Alarm.
+  assert.equal(LIFECYCLE_ATTESTATION_SIGNER_MATCH_SIGNALS.false.tier, 'normal');
+  // Supplementary checks → Normal when absent.
+  assert.equal(LIFECYCLE_ATTESTATION_TIMESTAMP_SIGNALS.false.tier, 'normal');
+  assert.equal(LIFECYCLE_ATTESTATION_REKOR_SIGNALS.false.tier, 'normal');
+});
+
+// --- Tier metadata + resolver plumbing -----------------------------------
+
+test('TIER_META covers all four tiers with valid icons, colors, and aria labels', () => {
+  assert.deepEqual(Object.keys(TIER_META).sort(), ['alarm', 'attention', 'normal', 'verified']);
+  const validIcons = new Set(['check', 'info', 'warning', 'error']);
+  for (const tier of Object.keys(TIER_META) as (keyof typeof TIER_META)[]) {
+    const meta = TIER_META[tier];
+    assert.ok(validIcons.has(meta.icon), `tier "${tier}" has invalid icon "${meta.icon}"`);
+    assert.ok(meta.colorVar.startsWith('var('), `tier "${tier}" color is not a CSS var`);
+    assert.ok(meta.ariaLabel.length > 0);
+  }
+});
+
+test('toResolvedSignal attaches the tier default icon', () => {
+  assert.equal(toResolvedSignal({ tier: 'verified', label: 'x' }).icon, 'check');
+  assert.equal(toResolvedSignal({ tier: 'normal', label: 'x' }).icon, 'info');
+  assert.equal(toResolvedSignal({ tier: 'attention', label: 'x' }).icon, 'warning');
+  assert.equal(toResolvedSignal({ tier: 'alarm', label: 'x' }).icon, 'error');
+});
+
+test('captureMethod labels are informational (no tier) and cover the known methods', () => {
+  // Mirrors the packager `CaptureMethod` union (not runtime-enumerable). Each is
+  // a signature-covered LABEL rendered adjacent to the signature verdict, not a
+  // tiered pass/fail signal (spec §9.2 #11).
+  for (const method of ['chat-flow-stream', 'claude-code-jsonl-readback', 'claude-code-self-report'] as const) {
+    assert.ok(CAPTURE_METHOD_LABELS[method].length > 0, `captureMethod label "${method}"`);
+  }
+});

--- a/src/lib/evidence/trust-signal.ts
+++ b/src/lib/evidence/trust-signal.ts
@@ -1,0 +1,578 @@
+// Trust-signal vocabulary — the severity taxonomy that turns each verify-library
+// status into a calm, plain-language signal (civic-ai-tools-website#110, Wave 0).
+//
+// One idea threads the evidence trust-communication surfaces: every verification
+// status renders as `{ tier, icon, plain-language one-liner }`, defined once here
+// and reused. The load-bearing requirement is that a pre-v0.1 (legacy) package —
+// which produces many "not ok but expected" statuses — reads CALM, never as a
+// string of failures. See docs/trust-signal-vocabulary.md for the full taxonomy
+// and the resolved judgment calls.
+//
+// Scope discipline (#110): this is presentational vocabulary only. It changes NO
+// verification behavior and is wired into NO live panel — that is #111.
+//
+// Total coverage holds *by construction*: each status space is keyed with
+// `Record<Status, ...>`, so a status added upstream grows the union type and the
+// compiler then demands a tier here. The status TYPES are the verify-library's
+// source-of-truth const-arrays' element types (e.g. `KEY_TRUST_STATUSES`), and
+// the coverage test iterates those same arrays at runtime — the array and this
+// map cannot drift. The imports below are TYPE-ONLY, so this module carries no
+// runtime dependency on the verify library (and thus no node:crypto): it is pure
+// data and safe to import from a client component (see `<TrustSignal>`).
+//
+// Design-principles cited by number (docs/design-principles.md): P1 disclosure ≠
+// validation, P3 no false precision, P5 narrative bridge, P9 user language.
+
+import type {
+  ContentCanonicalizationStatus,
+  ContentHashStatus,
+  KeyTrustStatus,
+  TypeResolutionStatus,
+  SignerIdentityCheckStatus,
+  CaptureMethodVocabStatus,
+  LifecycleStatus,
+  LifecycleSource,
+} from './verify.ts';
+import type { BlobRefVerifyReason } from './blob-ref.ts';
+import type { CaptureMethod } from './packager.ts';
+
+// --- Tiers ---------------------------------------------------------------
+
+/**
+ * The four severity tiers. "Not `ok`" does not mean "broken":
+ *   - `verified`  — green; an affirmative check passed.
+ *   - `normal`    — neutral/calm/informational. "Not ok" but EXPECTED (every
+ *                   pre-v0.1 legacy status lands here). NOT a warning.
+ *   - `attention` — amber; something UNCONFIRMED / unrecognized, not proven-bad.
+ *   - `alarm`     — red; a genuine integrity failure.
+ */
+export type TrustTier = 'verified' | 'normal' | 'attention' | 'alarm';
+
+/** The four in-house glyphs, one per tier. Names only — the SVGs live in the
+ *  presentational `<TrustSignal>` component (client-side). */
+export type TrustIconName = 'check' | 'info' | 'warning' | 'error';
+
+export interface TrustSignalDescriptor {
+  tier: TrustTier;
+  /** The glanceable plain-language one-liner (P5 glance layer, P9 user
+   *  language). Disclosure, never validation (P1). */
+  label: string;
+  /** Optional expand-on-demand sentence (P5 narrative bridge / P8). */
+  detail?: string;
+}
+
+export interface TierMeta {
+  /** The tier's default glyph (overridable per-instance in the component). */
+  icon: TrustIconName;
+  /** CSS custom-property reference for the tier color (globals.css). */
+  colorVar: string;
+  /** aria-label applied to the tier glyph. */
+  ariaLabel: string;
+}
+
+/**
+ * Canonical tier → { icon, color, aria } mapping. The single source of truth for
+ * tier visuals: the `<TrustSignal>` component consumes this directly (it is a
+ * client-safe value because this module is pure data). `--nyc-warning` is aliased
+ * to the existing `--nyc-caution` amber (added in globals.css for #110); the
+ * other three tokens predate this change.
+ */
+export const TIER_META: Record<TrustTier, TierMeta> = {
+  verified: { icon: 'check', colorVar: 'var(--nyc-success)', ariaLabel: 'Verified' },
+  normal: { icon: 'info', colorVar: 'var(--text-muted)', ariaLabel: 'Informational' },
+  attention: { icon: 'warning', colorVar: 'var(--nyc-warning)', ariaLabel: 'Attention' },
+  alarm: { icon: 'error', colorVar: 'var(--nyc-error)', ariaLabel: 'Alarm' },
+};
+
+/** A descriptor plus the icon its tier resolves to — the full `status →
+ *  { tier, icon, copy }` shape. */
+export interface ResolvedTrustSignal extends TrustSignalDescriptor {
+  icon: TrustIconName;
+}
+
+/** Attach the tier's default icon to a descriptor. */
+export function toResolvedSignal(d: TrustSignalDescriptor): ResolvedTrustSignal {
+  return { ...d, icon: TIER_META[d.tier].icon };
+}
+
+// --- Boolean-state normalizers -------------------------------------------
+//
+// Several verify checks are tri-state booleans (true / false / null) or
+// bi-state (true / false). We key their signal maps on string forms so the
+// maps stay plain data and the coverage test can enumerate them.
+
+export type BiStateKey = 'true' | 'false';
+export type TriStateKey = 'true' | 'false' | 'null';
+
+export const BI_STATE_KEYS: readonly BiStateKey[] = ['true', 'false'];
+export const TRI_STATE_KEYS: readonly TriStateKey[] = ['true', 'false', 'null'];
+
+export function biKey(v: boolean): BiStateKey {
+  return v ? 'true' : 'false';
+}
+export function triKey(v: boolean | null | undefined): TriStateKey {
+  return v === null || v === undefined ? 'null' : v ? 'true' : 'false';
+}
+
+// =========================================================================
+// Per-check status → descriptor maps, ordered by spec §9.2 check number.
+// =========================================================================
+
+// --- #1 Envelope integrity (hashMatch: boolean) --------------------------
+
+export const ENVELOPE_INTEGRITY_SIGNALS: Record<BiStateKey, TrustSignalDescriptor> = {
+  true: {
+    tier: 'verified',
+    label: 'Contents unchanged since signing',
+    detail: 'The bytes of this package match the hash that was signed.',
+  },
+  false: {
+    tier: 'alarm',
+    label: 'Contents changed since signing',
+    detail:
+      'The recomputed hash does not match the signed package — it may have been altered.',
+  },
+};
+export const resolveEnvelopeIntegrity = (hashMatch: boolean): TrustSignalDescriptor =>
+  ENVELOPE_INTEGRITY_SIGNALS[biKey(hashMatch)];
+
+// --- #2 Signature mathematics (signatureValid: boolean | null) -----------
+
+export const SIGNATURE_SIGNALS: Record<TriStateKey, TrustSignalDescriptor> = {
+  true: {
+    tier: 'verified',
+    label: 'Valid cryptographic signature',
+    detail: 'The signature verifies against the signing key.',
+  },
+  false: {
+    tier: 'alarm',
+    label: 'Signature does not verify',
+    detail: 'The signature could not be validated against the signing key.',
+  },
+  null: {
+    tier: 'normal',
+    label: 'Not signed',
+    detail: 'This package carries no cryptographic signature.',
+  },
+};
+export const resolveSignature = (v: boolean | null): TrustSignalDescriptor =>
+  SIGNATURE_SIGNALS[triKey(v)];
+
+// --- #3 Content canonicalization rule resolution -------------------------
+
+export const CONTENT_CANONICALIZATION_SIGNALS: Record<
+  ContentCanonicalizationStatus,
+  TrustSignalDescriptor
+> = {
+  ok: { tier: 'verified', label: 'Canonicalization rule recognized' },
+  implicit: {
+    tier: 'normal',
+    label: 'Canonicalization inferred (earlier-format package)',
+    detail:
+      'This package predates explicit canonicalization labeling; the rule was inferred from its content profile.',
+  },
+  unknown_canonicalization_rule: {
+    tier: 'attention',
+    label: 'Unrecognized canonicalization rule',
+    detail:
+      'This package names a canonicalization rule this verifier does not recognize, so its content hash cannot be recomputed.',
+  },
+};
+
+// --- #4 Content hash verification (THE load-bearing split) ---------------
+
+export const CONTENT_HASH_SIGNALS: Record<ContentHashStatus, TrustSignalDescriptor> = {
+  ok: {
+    tier: 'verified',
+    label: 'Content matches its fingerprint',
+    detail: 'The off-log content hashes to the value the signature covers.',
+  },
+  // Load-bearing: applies to EVERY pre-v0.1 package. Must read calm.
+  legacy_relabeled: {
+    tier: 'normal',
+    label: 'Earlier-format content fingerprint',
+    detail:
+      'This package predates multi-hash content fingerprints; its original single hash is shown as-is, and its integrity is established by the envelope check.',
+  },
+  // Load-bearing: the same check as legacy_relabeled, opposite tier — off-log
+  // content was altered after signing.
+  content_hash_mismatch: {
+    tier: 'alarm',
+    label: 'Content does not match its fingerprint',
+    detail:
+      'The off-log content does not hash to the signed value — it may have been altered.',
+  },
+  unresolved_rule: {
+    tier: 'attention',
+    label: 'Content hash not recomputed (unknown rule)',
+    detail:
+      'The canonicalization rule could not be resolved, so the content hash was not recomputed.',
+  },
+  contentHash_no_supported_algorithm: {
+    tier: 'attention',
+    label: 'Content hash uses an unsupported algorithm',
+    detail:
+      'The content fingerprint lists only hash algorithms this verifier cannot compute, so it could not be confirmed.',
+  },
+};
+
+// --- #5 Trust-registry verdict (keyTrust) --------------------------------
+
+export const KEY_TRUST_SIGNALS: Record<KeyTrustStatus, TrustSignalDescriptor> = {
+  active: {
+    tier: 'verified',
+    label: 'Signed with an active registered key',
+    detail: 'The signing key is listed and active in our published trust registry.',
+  },
+  deprecated_valid: {
+    tier: 'normal',
+    label: 'Signed before the key was rotated out',
+    detail:
+      'The signing key has since been rotated out, but this package was signed while it was still valid.',
+  },
+  deprecated_invalid: {
+    tier: 'alarm',
+    label: 'Signed after the key was rotated out',
+    detail: 'This package was signed after its key was deprecated — it is not trusted.',
+  },
+  revoked: {
+    tier: 'alarm',
+    label: 'Signed with a revoked key',
+    detail: 'The signing key has been revoked — this package is not trusted.',
+  },
+  unknown_key: {
+    tier: 'attention',
+    label: 'Signing key not in the trust registry',
+    detail:
+      'The signing key is not listed in our published trust registry, so we cannot vouch for it.',
+  },
+  registry_unavailable: {
+    tier: 'attention',
+    label: 'Trust registry could not be reached',
+    detail: 'The trust registry could not be loaded, so the key status was not checked.',
+  },
+  // Load-bearing: every pre-trust-registry package. Must read calm.
+  legacy_embedded: {
+    tier: 'normal',
+    label: 'Signed before the trust registry existed',
+    detail:
+      'This package predates the trust registry; its signature verified against its embedded key, but the registry cannot vouch for it.',
+  },
+};
+
+// --- #7 Timestamp validity (hasTimestamp: boolean) -----------------------
+
+export const TIMESTAMP_SIGNALS: Record<BiStateKey, TrustSignalDescriptor> = {
+  true: {
+    tier: 'verified',
+    label: 'Timestamped',
+    detail: 'Carries an RFC 3161 timestamp token.',
+  },
+  false: {
+    tier: 'normal',
+    label: 'No timestamp',
+    detail: 'This package carries no timestamp token (common for earlier-format packages).',
+  },
+};
+export const resolveTimestamp = (hasTimestamp: boolean): TrustSignalDescriptor =>
+  TIMESTAMP_SIGNALS[biKey(hasTimestamp)];
+
+// --- #8 Transparency-log inclusion (rekorVerified: boolean | null) -------
+
+export const REKOR_SIGNALS: Record<TriStateKey, TrustSignalDescriptor> = {
+  true: {
+    tier: 'verified',
+    label: 'Recorded in a public transparency log',
+    detail: 'A matching entry was confirmed in the Sigstore Rekor transparency log.',
+  },
+  // Attention, not Alarm: the most common cause is a transient Rekor outage, and
+  // the supplementary log is not the package's content. See the design note.
+  false: {
+    tier: 'attention',
+    label: 'Transparency-log entry not confirmed',
+    detail:
+      'This package references a transparency-log entry that could not be confirmed — the log may be unreachable.',
+  },
+  null: {
+    tier: 'normal',
+    label: 'Not in a transparency log',
+    detail: 'This package was not recorded in a public transparency log.',
+  },
+};
+export const resolveRekor = (v: boolean | null): TrustSignalDescriptor =>
+  REKOR_SIGNALS[triKey(v)];
+
+// --- #9 BlobRef integrity (blobRefsVerified: boolean | null) -------------
+
+export const BLOB_REFS_SIGNALS: Record<TriStateKey, TrustSignalDescriptor> = {
+  true: {
+    tier: 'verified',
+    label: 'Referenced content verified',
+    detail: 'Every externally-stored field matched its embedded fingerprint.',
+  },
+  false: {
+    tier: 'alarm',
+    label: 'Referenced content failed verification',
+    detail: 'At least one externally-stored field did not match its fingerprint.',
+  },
+  null: {
+    tier: 'normal',
+    label: 'No referenced content',
+    detail: 'This package stores all fields inline; there is nothing to fetch.',
+  },
+};
+export const resolveBlobRefs = (v: boolean | null): TrustSignalDescriptor =>
+  BLOB_REFS_SIGNALS[triKey(v)];
+
+/**
+ * #9 BlobRef per-reference failure reasons. Each is a sub-explanation of a
+ * failed (Alarm-tier) BlobRef check — surfaced beneath the summary signal when a
+ * reference fails. `fetch_failed` is the softest (a transient retrieval failure
+ * is possible, paralleling rekor=false); it is tiered Alarm here because a
+ * BlobRef is a PRIMARY content carrier whose unavailability breaks the package's
+ * content-integrity guarantee, unlike the supplementary Rekor log. See the note.
+ */
+export const BLOB_REF_REASON_SIGNALS: Record<BlobRefVerifyReason, TrustSignalDescriptor> = {
+  invalid_ref: {
+    tier: 'alarm',
+    label: 'Malformed content reference',
+    detail: 'A referenced field does not carry a valid blob reference.',
+  },
+  fetch_failed: {
+    tier: 'alarm',
+    label: 'Referenced content could not be retrieved',
+    detail: 'A referenced blob could not be fetched to confirm its integrity.',
+  },
+  size_mismatch: {
+    tier: 'alarm',
+    label: 'Referenced content is the wrong size',
+    detail: 'A referenced blob does not match the size the package commits to.',
+  },
+  hash_mismatch: {
+    tier: 'alarm',
+    label: 'Referenced content does not match its fingerprint',
+    detail: 'A referenced blob does not hash to the value the package commits to.',
+  },
+};
+
+// --- #10 Lifecycle state -------------------------------------------------
+//
+// Lifecycle is a separate axis from cryptographic integrity (P7). Neither state
+// is an integrity verdict, so both are calm. Whether lifecycle renders in the
+// verify panel at all is left to #111 (the note explains the reasoning).
+
+export const LIFECYCLE_STATE_SIGNALS: Record<LifecycleStatus, TrustSignalDescriptor> = {
+  active: {
+    tier: 'normal',
+    label: 'Active',
+    detail: 'This package has not been withdrawn.',
+  },
+  // NOT alarm — a withdrawal is a legitimate signed action. Prominence (a banner)
+  // is the detail page's job, not the tier's.
+  withdrawn: {
+    tier: 'normal',
+    label: 'Withdrawn by the publisher',
+    detail:
+      'The publisher has withdrawn this package — a legitimate signed action. The reason is shown with the package.',
+  },
+};
+
+export const LIFECYCLE_SOURCE_SIGNALS: Record<LifecycleSource, TrustSignalDescriptor> = {
+  'attestation-chain': {
+    tier: 'verified',
+    label: 'Lifecycle confirmed from signed transitions',
+    detail: 'Status was derived from independently-verified, signed lifecycle events.',
+  },
+  'legacy-columns': {
+    tier: 'normal',
+    label: 'Lifecycle from earlier-format records',
+    detail: 'Status was derived from pre-attestation lifecycle records.',
+  },
+  none: {
+    tier: 'normal',
+    label: 'No lifecycle changes',
+    detail: 'No withdrawal or reinstatement has been recorded.',
+  },
+};
+
+// #10 per-attestation signals. Integrity of a lifecycle event (signature,
+// node-id) alarms when false — a forged or altered transition. The signer-match,
+// timestamp, and Rekor checks are NOT failures when false: a non-signer-matched
+// attestation is a legitimately-surfaced third-party event (§8.10.3 retention
+// asymmetry — it is shown but does not move the publisher's status), and the
+// timestamp / Rekor checks are supplementary. (See the note's deviation log: the
+// brief grouped signer-match with the integrity checks; the retention-asymmetry
+// semantics and the existing verify.ts test place it at Normal.)
+export const LIFECYCLE_ATTESTATION_SIGNATURE_SIGNALS: Record<
+  TriStateKey,
+  TrustSignalDescriptor
+> = {
+  true: { tier: 'verified', label: 'Lifecycle event signature verifies' },
+  false: {
+    tier: 'alarm',
+    label: 'Lifecycle event signature does not verify',
+    detail:
+      'A withdrawal or reinstatement claims a signature that does not validate — a forged transition.',
+  },
+  null: { tier: 'normal', label: 'Lifecycle event unsigned' },
+};
+export const LIFECYCLE_ATTESTATION_NODE_ID_SIGNALS: Record<BiStateKey, TrustSignalDescriptor> = {
+  true: { tier: 'verified', label: 'Lifecycle event intact' },
+  false: {
+    tier: 'alarm',
+    label: 'Lifecycle event has been altered',
+    detail: 'A lifecycle event does not hash to its recorded id — it may have been tampered with.',
+  },
+};
+export const LIFECYCLE_ATTESTATION_SIGNER_MATCH_SIGNALS: Record<
+  BiStateKey,
+  TrustSignalDescriptor
+> = {
+  true: { tier: 'verified', label: 'Lifecycle event from the publisher' },
+  false: {
+    tier: 'normal',
+    label: 'Lifecycle event from a different signer',
+    detail:
+      'A third party attested this transition; per the standard it is shown but does not change the status the publisher sets.',
+  },
+};
+export const LIFECYCLE_ATTESTATION_TIMESTAMP_SIGNALS: Record<BiStateKey, TrustSignalDescriptor> = {
+  true: { tier: 'verified', label: 'Lifecycle event timestamped' },
+  false: {
+    tier: 'normal',
+    label: 'Lifecycle event not timestamped',
+    detail: 'A supplementary check; its absence does not affect the transition.',
+  },
+};
+export const LIFECYCLE_ATTESTATION_REKOR_SIGNALS: Record<BiStateKey, TrustSignalDescriptor> = {
+  true: { tier: 'verified', label: 'Lifecycle event in a transparency log' },
+  false: {
+    tier: 'normal',
+    label: 'Lifecycle event not in a transparency log',
+    detail: 'A supplementary check; its absence does not affect the transition.',
+  },
+};
+
+// --- #11 captureMethod LABEL (informational — NO tier) -------------------
+//
+// Check #11 is not a pass/fail signal: `metadata.captureMethod` is a
+// signature-covered LABEL describing HOW the bytes were captured (spec §8.6 /
+// §9.2 #11 — "signed ≠ verbatim"). It is rendered as a neutral informational
+// label adjacent to the signature verdict (#111's job), never assigned a tier.
+// These strings give each captureMethod value a plain-language reading (P9).
+export const CAPTURE_METHOD_LABELS: Record<CaptureMethod, string> = {
+  'chat-flow-stream': 'Captured from the live chat as the analysis was generated.',
+  'claude-code-jsonl-readback': 'Reconstructed from the Claude Code session transcript.',
+  'claude-code-self-report':
+    'Summarized by the AI from its own session memory (deprecated capture method).',
+};
+
+// --- #12 type resolution -------------------------------------------------
+
+export const TYPE_RESOLUTION_SIGNALS: Record<TypeResolutionStatus, TrustSignalDescriptor> = {
+  ok: { tier: 'verified', label: 'Node type recognized' },
+  implicit: {
+    tier: 'normal',
+    label: 'Node type inferred (earlier-format package)',
+    detail: 'This package predates explicit type labeling; it is read as a standard analysis.',
+  },
+  unknown_type: {
+    tier: 'attention',
+    label: 'Unrecognized node type',
+    detail: 'This package declares a type this verifier does not recognize. It is shown, not rejected.',
+  },
+};
+
+// --- #14 signer identity ↔ registry cross-check --------------------------
+
+export const SIGNER_IDENTITY_SIGNALS: Record<SignerIdentityCheckStatus, TrustSignalDescriptor> = {
+  ok: {
+    tier: 'verified',
+    label: 'Signer identity matches the registry',
+    detail:
+      'The stated signer matches the identity our registry records for the signing key.',
+  },
+  signer_identity_mismatch: {
+    tier: 'alarm',
+    label: 'Signer identity does not match the registry',
+    detail:
+      'The stated signer does not match the identity bound to the signing key — do not trust.',
+  },
+  no_signer: {
+    tier: 'normal',
+    label: 'No stated signer (earlier-format package)',
+    detail:
+      'This package predates identity binding; the signer is derived from the registry and the cross-check is skipped.',
+  },
+  no_registry_identity: {
+    tier: 'normal',
+    label: 'Registry has no identity for this key',
+    detail: 'The registry entry for this key predates identity binding, so the cross-check is skipped.',
+  },
+};
+
+// --- #15 captureMethod per-profile vocabulary conformance ----------------
+
+export const CAPTURE_METHOD_VOCAB_SIGNALS: Record<
+  CaptureMethodVocabStatus,
+  TrustSignalDescriptor
+> = {
+  ok: { tier: 'verified', label: 'Capture method recognized for this profile' },
+  // The sharpest call. The spec says #15 "rejects the node," but the tier governs
+  // how the SIGNAL reads, not conformance (#110 changes no behavior). The
+  // captureMethod label is signature-covered, so an unrecognized value is not an
+  // alteration — it is an unrecognized identifier, like #3 / #12. → Attention.
+  captureMethod_unknown: {
+    tier: 'attention',
+    label: 'Capture method not recognized for this profile',
+    detail:
+      'The capture-method label is not in the vocabulary that this profile declares. The label is signature-covered, so this is an unrecognized value, not an alteration.',
+  },
+  producerProfile_bundle_unresolved: {
+    tier: 'normal',
+    label: 'Producer profile not resolved',
+    detail:
+      'The producer profile could not be resolved, so its capture-method vocabulary was not checked. The label is preserved.',
+  },
+  no_capture_method: {
+    tier: 'normal',
+    label: 'No capture method (earlier-format package)',
+    detail: 'This package predates capture-method labeling.',
+  },
+};
+
+// --- notebookProvenance (honest execution label) -------------------------
+//
+// Not a verify-library status: `metadata.extensions["org.civicaitools.notebook"]
+// .provenance` distinguishes a notebook executed in a signed sandbox from a
+// skeleton that reproduces the steps without running them (per open-questions
+// Q31). Both readings are honest and calm — neither is a failure. `'executed'`
+// is the only value emitted today; `'skeleton'` is reserved (no code path writes
+// it yet). Canonical list kept here because the value is a notebook-author
+// concept, not a verify.ts type.
+export const NOTEBOOK_PROVENANCE_VALUES = ['executed', 'skeleton'] as const;
+export type NotebookProvenance = (typeof NOTEBOOK_PROVENANCE_VALUES)[number];
+
+export const NOTEBOOK_PROVENANCE_SIGNALS: Record<NotebookProvenance, TrustSignalDescriptor> = {
+  executed: {
+    tier: 'normal',
+    label: 'Executed in a signed sandbox',
+    detail:
+      'The notebook was run end-to-end in a signed sandbox; its outputs are the executed results.',
+  },
+  skeleton: {
+    tier: 'normal',
+    label: 'Skeleton notebook (not executed)',
+    detail:
+      'The notebook reproduces the steps but was not executed; its outputs were not regenerated.',
+  },
+};
+
+// --- Checks not emitted as discrete status fields today ------------------
+//
+// Spec checks #6 (metadata.signingKeyId consistency) and #13 (nodeId
+// cross-check) are NOT surfaced by today's verify route as discrete status
+// codes — it returns `nodeId` only as a recomputed hash string. Their tiers are
+// RESERVED in the design note (a mismatch on either → Alarm) but intentionally
+// have no runtime map here, and the coverage test asserts only the codes the
+// route actually emits. When #6/#13 gain discrete statuses, add their maps here.

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -150,10 +150,17 @@ export function recomputePackageHash(pkg: Record<string, unknown>): string {
 // and check #4 relabels the package's historical external single-SHA-256
 // rather than recomputing it under a v0.1 rule.
 
+// Source-of-truth array (not just a type) so consumers — the trust-signal
+// vocabulary (civic-ai-tools-website#110) and its coverage test — can enumerate
+// every status at runtime. Behavior-preserving: the derived type is identical
+// to the prior hand-written union.
+export const CONTENT_CANONICALIZATION_STATUSES = [
+  'ok',
+  'implicit',
+  'unknown_canonicalization_rule',
+] as const;
 export type ContentCanonicalizationStatus =
-  | 'ok'
-  | 'implicit'
-  | 'unknown_canonicalization_rule';
+  (typeof CONTENT_CANONICALIZATION_STATUSES)[number];
 
 export interface ContentCanonicalizationResolution {
   status: ContentCanonicalizationStatus;
@@ -203,12 +210,14 @@ export function resolveContentCanonicalization(
   };
 }
 
-export type ContentHashStatus =
-  | 'ok'
-  | 'content_hash_mismatch'
-  | 'contentHash_no_supported_algorithm'
-  | 'unresolved_rule'
-  | 'legacy_relabeled';
+export const CONTENT_HASH_STATUSES = [
+  'ok',
+  'content_hash_mismatch',
+  'contentHash_no_supported_algorithm',
+  'unresolved_rule',
+  'legacy_relabeled',
+] as const;
+export type ContentHashStatus = (typeof CONTENT_HASH_STATUSES)[number];
 
 export interface ContentHashCheck {
   status: ContentHashStatus;
@@ -309,7 +318,17 @@ export function verifyContentHash(
 // `lifecycle.ts`; the pure ordering / status-derivation logic lives here so it
 // is unit-testable.
 
-export type LifecycleStatus = 'active' | 'withdrawn';
+export const LIFECYCLE_STATUSES = ['active', 'withdrawn'] as const;
+export type LifecycleStatus = (typeof LIFECYCLE_STATUSES)[number];
+
+/** Which representation determined the lifecycle status. `none` = never
+ *  withdrawn, no attestations and no legacy columns. */
+export const LIFECYCLE_SOURCES = [
+  'attestation-chain',
+  'legacy-columns',
+  'none',
+] as const;
+export type LifecycleSource = (typeof LIFECYCLE_SOURCES)[number];
 
 /** A single verified lifecycle attestation, as surfaced in the chain. */
 export interface LifecycleAttestationView {
@@ -338,9 +357,8 @@ export interface LifecycleAttestationView {
 
 export interface LifecycleResolution {
   status: LifecycleStatus;
-  /** Which representation determined the status. `none` = never withdrawn,
-   *  no attestations and no legacy columns. */
-  source: 'attestation-chain' | 'legacy-columns' | 'none';
+  /** Which representation determined the status (see `LIFECYCLE_SOURCES`). */
+  source: LifecycleSource;
   /** The ordered lifecycle attestation chain (envelope-timestamp asc, ties by
    *  nodeId lexicographic). Empty for the legacy-columns / none sources. */
   chain: LifecycleAttestationView[];
@@ -573,14 +591,16 @@ export interface TrustRegistry {
   keys: TrustRegistryKey[];
 }
 
-export type KeyTrustStatus =
-  | 'active'                // active key — package is trusted
-  | 'deprecated_valid'      // deprecated key, but package was signed before deprecation
-  | 'deprecated_invalid'    // deprecated key, but package was signed after deprecation
-  | 'revoked'               // revoked key — package is never trusted
-  | 'unknown_key'           // (kid, publicKey) pair not found in registry
-  | 'registry_unavailable'  // registry could not be loaded
-  | 'legacy_embedded';      // signature predates the trust registry (no kid stored)
+export const KEY_TRUST_STATUSES = [
+  'active',                // active key — package is trusted
+  'deprecated_valid',      // deprecated key, but package was signed before deprecation
+  'deprecated_invalid',    // deprecated key, but package was signed after deprecation
+  'revoked',               // revoked key — package is never trusted
+  'unknown_key',           // (kid, publicKey) pair not found in registry
+  'registry_unavailable',  // registry could not be loaded
+  'legacy_embedded',       // signature predates the trust registry (no kid stored)
+] as const;
+export type KeyTrustStatus = (typeof KEY_TRUST_STATUSES)[number];
 
 export interface KeyTrustResult {
   status: KeyTrustStatus;
@@ -727,7 +747,8 @@ const KNOWN_TYPE_URIS: readonly string[] = [
   'attestation/conforms/v1',
 ];
 
-export type TypeResolutionStatus = 'ok' | 'implicit' | 'unknown_type';
+export const TYPE_RESOLUTION_STATUSES = ['ok', 'implicit', 'unknown_type'] as const;
+export type TypeResolutionStatus = (typeof TYPE_RESOLUTION_STATUSES)[number];
 
 export interface TypeResolution {
   status: TypeResolutionStatus;
@@ -752,11 +773,14 @@ export function resolvePackageType(pkg: Record<string, unknown>): TypeResolution
   return { status: 'unknown_type', type: raw };
 }
 
+export const SIGNER_IDENTITY_CHECK_STATUSES = [
+  'ok',
+  'signer_identity_mismatch',
+  'no_signer',
+  'no_registry_identity',
+] as const;
 export type SignerIdentityCheckStatus =
-  | 'ok'
-  | 'signer_identity_mismatch'
-  | 'no_signer'
-  | 'no_registry_identity';
+  (typeof SIGNER_IDENTITY_CHECK_STATUSES)[number];
 
 export interface SignerIdentityCheck {
   status: SignerIdentityCheckStatus;
@@ -794,11 +818,14 @@ export function checkSignerIdentity(
   return { status: 'ok', claimed: signer.identifier, registered };
 }
 
+export const CAPTURE_METHOD_VOCAB_STATUSES = [
+  'ok',
+  'captureMethod_unknown',
+  'producerProfile_bundle_unresolved',
+  'no_capture_method',
+] as const;
 export type CaptureMethodVocabStatus =
-  | 'ok'
-  | 'captureMethod_unknown'
-  | 'producerProfile_bundle_unresolved'
-  | 'no_capture_method';
+  (typeof CAPTURE_METHOD_VOCAB_STATUSES)[number];
 
 export interface CaptureMethodVocabCheck {
   status: CaptureMethodVocabStatus;


### PR DESCRIPTION
## Summary

Wave 0 foundation for the **Evidence trust UX** milestone. Introduces a shared **trust-signal vocabulary**: every verify-library status maps to one of four severity tiers — **Verified / Normal / Attention / Alarm** — so a legacy (pre-v0.1) package reads **calm** (zero red/amber on the default view) while genuine integrity failures stay unmistakable.

**No verification behavior changes. Not wired into any live panel** — that is #111. This is the standalone vocabulary + component + coverage test.

## Deliverables

| File | Role |
|---|---|
| `docs/trust-signal-vocabulary.md` | The taxonomy. Every status value + `notebookProvenance` tiered; every judgment call resolved with rationale. |
| `src/lib/evidence/trust-signal.ts` | `status → { tier, icon, copy }` maps + resolver helpers + `TIER_META`. Pure data (type-only upstream imports → client-safe). |
| `src/lib/evidence/trust-signal.test.ts` | Proves total coverage of the emitted status codes, the load-bearing splits, and the synthetic-legacy-all-calm guarantee. |
| `src/components/evidence/TrustSignal.tsx` | Presentational `<TrustSignal tier label detail? icon? />` with a 4-glyph in-house, aria-labeled, inline-SVG set. |

**Supporting:** behavior-preserving refactor of each verify status union into a source-of-truth const-array (so total coverage holds *by construction* — a status added upstream fails the compile until it is tiered); `--nyc-warning` added to `globals.css`.

## The load-bearing split

Content-hash check #4: `legacy_relabeled` (every pre-v0.1 package) → **Normal**; `content_hash_mismatch` (off-log content altered after signing) → **Alarm**. Same check, opposite tiers. The test asserts both, plus `legacy_embedded`=Normal vs `revoked`/`deprecated_invalid`=Alarm, plus a full synthetic-legacy package tiering all-calm.

## Three deviations from the brief (flagged)

1. **`--nyc-warning` aliased to the existing `--nyc-caution`.** The brief said "no amber token exists — add `--nyc-warning`." In fact `globals.css` already ships `--nyc-caution: #FFB320`. I added `--nyc-warning: var(--nyc-caution);` rather than introduce a second amber hex.
2. **`signerMatchesTarget: false` → Normal, not Alarm.** A non-signer-matched lifecycle attestation is a legitimately-surfaced third-party event (spec §8.10.3 retention asymmetry; confirmed by an existing `verify.ts` test), not a forged transition.
3. **Stroke-outline icons, not the suggested filled glyphs.** Filled glyphs with inner `i`/`!` marks need even-odd knock-out paths; four stroked silhouettes (check / circle / triangle / octagon) are hand-authorable and distinct without color (accessibility).

The sharpest judgment call — `captureMethod_unknown` → **Attention** (not Alarm, despite spec #15's "rejects the node," because the label is signature-covered so an unrecognized value is not an alteration) — and all other ⚖ calls are resolved in §5 of the design note.

## Verification

- `npm test` (Node 22): **260/260 pass** (12 new).
- `npx tsc --noEmit`: clean on all changed/new files.
- `npm run lint`: clean on all changed/new files.

> Heads-up: `tsc` reports 2 **pre-existing** errors in `src/lib/evidence/expert-attestation.test.ts` (a `rating: string` vs union literal mismatch). They are present on `main` before this branch and unrelated to #110 — left untouched to keep scope tight; flagging for separate cleanup.

## Out of scope (guardrails respected)

Not wiring `<TrustSignal>` into `EvidenceActions.tsx`; not changing any check logic; not removing the existing `✅/❌/➖` `VerifyCheck`. All → #111, which will also widen the local `VerifyResult` interface to consume the checks (#3/#4/#10/#12/#14/#15/blobRefs) the route already returns.

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
