### PR TITLE
feat(evidence): #111 verify panel — calm baseline + captureMethod adjacency

### DIFF
--- a/docs/trust-signal-vocabulary.md
+++ b/docs/trust-signal-vocabulary.md
@@ -1,4 +1,6 @@
 <!-- v1 — 2026-06-02 — Trust-signal vocabulary + calm-status taxonomy (Evidence trust UX #110, Wave 0). Defines the four severity tiers and assigns one to EVERY verify-library status value plus notebookProvenance, resolves every judgment call, and records three deliberate deviations from the issue brief. Source of truth for src/lib/evidence/trust-signal.ts and src/components/evidence/TrustSignal.tsx. No verification-behavior change; not wired into any live panel (that is #111). -->
+<!-- v2 — 2026-06-04 — legacy_embedded copy P7-decoupled to match code (PR #118, commit e032a01, pending merge): label → "Signed with an embedded key (not in the trust registry)"; the detail no longer asserts the signature verified (that is check #2's axis — the registry line speaks only to key trust). Motivated by a live contradiction on the withdrawn da9246 package, whose plain-Ed25519 signature hit a since-fixed Ed25519/Ed25519ph false negative in verify.ts (same PR). Docs-only sync; no tier or verification-behavior change. See §5 #10. -->
+
 
 # Trust-signal vocabulary + calm-status taxonomy
 
@@ -101,7 +103,7 @@ Ordered by spec §9.2 check number. "Copy" is the glanceable one-liner; the libr
 | `revoked` | **Alarm** | Signed with a revoked key |
 | `unknown_key` | Attention | Signing key not in the trust registry |
 | `registry_unavailable` | Attention | Trust registry could not be reached |
-| `legacy_embedded` | Normal | Signed before the trust registry existed |
+| `legacy_embedded` | Normal | Signed with an embedded key (not in the trust registry) |
 
 ### #7 Timestamp — `hasTimestamp: boolean`
 | Status | Tier | Copy |
@@ -203,6 +205,8 @@ Each `⚖` from the issue brief, resolved with rationale. The guiding distinctio
 8. **Lifecycle per-attestation falses — split, not uniform.** `signatureValid: false` and `nodeIdMatches: false` are integrity of the *event itself* → a forged or altered transition → **Alarm**. But `signerMatchesTarget: false` is **Normal** — see deviation (b) below.
 
 9. **Lifecycle surfaced in the verify panel?** Open for #111 (see §4 #10). Tiered here for completeness.
+
+10. **`keyTrust.legacy_embedded` is key-trust-only (P7) — it must not assert signature validity.** This line speaks solely to the registry dimension: an embedded signing key that is not listed in the trust registry, so the registry cannot vouch for it. It must **not** claim the signature verified — that is check #2's axis. `legacyEmbeddedKeyTrust()` returns its verdict *without re-verifying*, so the earlier copy ("its signature verified against its embedded key") created a live contradiction on a real package: the withdrawn `da9246`, whose plain-Ed25519 signature read as a #2 failure — a since-fixed Ed25519/Ed25519ph false negative in `verifySignature` (PR #118) — while #5 calmly asserted the signature had verified. Decoupling the copy keeps the two axes orthogonal and prevents the contradiction recurring on any future no-kid package whose signature genuinely fails. Shipped strings (`trust-signal.ts`, e032a01): label *"Signed with an embedded key (not in the trust registry)"*; detail *"The signature uses an embedded public key that is not listed in our published trust registry, so the registry cannot vouch for it."* (The label also drops "Signed before the trust registry existed", which misread as a temporal claim — `legacy_embedded` means "embedded key, no registry kid", which includes recent packages signed before kid storage, not only genuinely-old ones.)
 
 ### Deviations from the issue brief (flagged)
 

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -69,6 +69,7 @@ export async function GET(
         record.basePackageHash,
         sigData.signature,
         sigData.publicKey,
+        sigData.algorithm,
       );
     } catch {
       signatureValid = false;

--- a/src/app/evidence/[slug]/page.tsx
+++ b/src/app/evidence/[slug]/page.tsx
@@ -166,31 +166,6 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-// Human-readable label for the ADR-0003 captureMethod field. Pre-ADR
-// records (column null) render as "Unknown (pre-ADR-0003)" rather than
-// inferring a method from indirect signals — see ADR-0003 §1 amendment.
-// Friendly labels per the 2026-05-19 reframe: chat-flow-stream surfaces
-// as "Web chat" — short, non-technical, matches the user-facing pipeline.
-function captureMethodLabel(method: string | null | undefined): string {
-  switch (method) {
-    case 'chat-flow-stream':
-      return 'Web chat';
-    case 'claude-code-jsonl-readback':
-      return 'Claude Code (verbatim JSONL)';
-    case 'claude-code-self-report':
-      return 'Claude Code (self-report, deprecated)';
-    case 'datHere':
-      // Legacy: pre-reframe records may carry this value. The 2026-05-19
-      // reframe (ADR-0004) moved datHere from captureMethod to a separate
-      // contentProfile field. No new publishes write this value to
-      // captureMethod; if a record still has it, surface as "Unknown"
-      // with a brief annotation so readers know the cause.
-      return 'Unknown (pre-reframe datHere captureMethod, ADR-0004)';
-    default:
-      return 'Unknown (pre-ADR-0003)';
-  }
-}
-
 // Type-narrowing accessor for the org.civicaitools.environment extension
 // (OES §9.1.1 requirement 3). Returns null when absent or malformed so
 // callers can default-fallback for non-datHere packages.
@@ -323,18 +298,17 @@ export default async function EvidencePage({ params }: PageProps) {
           </Section>
         )}
 
-        {/* DatHere small label row — appears between header and content.
-            Per ADR-0004 + the 2026-05-19 reframe: captureMethod and
-            contentProfile are orthogonal axes; surface both inline near
-            the top, then render A-G as the page structure below. */}
+        {/* DatHere small label row — appears between header and content. Per
+            ADR-0004 + the 2026-05-19 reframe, captureMethod and contentProfile
+            are orthogonal axes; this row carries the contentProfile label (the
+            captureMethod label now sits beside the signature verdict in the
+            verify panel, #111), then renders A-G as the page structure below. */}
         {isDatHere && (
           <div style={{
             fontSize: '13px', color: 'var(--text-secondary)',
             marginBottom: '24px', marginTop: '12px',
             display: 'flex', flexWrap: 'wrap', gap: '0 8px', alignItems: 'center',
           }}>
-            <span>Captured via <strong>{captureMethodLabel(record.captureMethod)}</strong></span>
-            <span>{'·'}</span>
             <span>datHere content profile</span>
             <span>{'·'}</span>
             <a
@@ -541,9 +515,6 @@ export default async function EvidencePage({ params }: PageProps) {
                   Consistency: {record.consistencyClassification.replace(/_/g, ' ')}
                 </span>
               )}
-              <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
-                Captured via: {captureMethodLabel(record.captureMethod)}
-              </span>
               {/* Typed-standards envelope labels (ADR-0006/0009). Read from
                   the canonical package object — not a DB column. Absent on
                   pre-v0.1 packages, which simply omit these. */}
@@ -781,9 +752,6 @@ export default async function EvidencePage({ params }: PageProps) {
                   Consistency: {record.consistencyClassification.replace(/_/g, ' ')}
                 </span>
               )}
-              <span style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
-                Captured via: {captureMethodLabel(record.captureMethod)}
-              </span>
               {/* Typed-standards envelope labels (ADR-0006/0009). Read from
                   the canonical package object — not a DB column. Absent on
                   pre-v0.1 packages, which simply omit these. */}
@@ -809,7 +777,7 @@ export default async function EvidencePage({ params }: PageProps) {
             creatorName={creator?.displayName || 'Unknown'}
             createdAt={record.createdAt.toISOString()}
             packageUrl={record.basePackageStorageKey || ''}
-            verificationStatus={record.verificationStatus}
+            captureMethod={record.captureMethod}
           />
         </Section>
 

--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -1,6 +1,25 @@
 'use client';
 
 import { useState } from 'react';
+import TrustSignal from './TrustSignal';
+import {
+  resolveEnvelopeIntegrity,
+  resolveSignature,
+  resolveTimestamp,
+  resolveRekor,
+  resolveKeyTrust,
+  resolveCaptureMethodLabel,
+} from '@/lib/evidence/trust-signal';
+import type {
+  KeyTrustResult,
+  BlobRefVerification,
+  TypeResolution,
+  SignerIdentityCheck,
+  CaptureMethodVocabCheck,
+  ContentCanonicalizationResolution,
+  ContentHashCheck,
+  LifecycleResolution,
+} from '@/lib/evidence/verify';
 
 interface EvidenceActionsProps {
   slug: string;
@@ -8,7 +27,10 @@ interface EvidenceActionsProps {
   creatorName: string;
   createdAt: string;
   packageUrl: string;
-  verificationStatus: string;
+  /** ADR-0003 captureMethod DB column (enum string | null). Rendered as a
+   *  neutral informational label beside the signature verdict (#11,
+   *  "signed ≠ verbatim"). */
+  captureMethod: string | null;
 }
 
 function CitePopover({ title, creatorName, createdAt, slug, onClose }: {
@@ -80,32 +102,32 @@ function CitePopover({ title, creatorName, createdAt, slug, onClose }: {
   );
 }
 
-type KeyTrustStatus =
-  | 'active'
-  | 'deprecated_valid'
-  | 'deprecated_invalid'
-  | 'revoked'
-  | 'unknown_key'
-  | 'registry_unavailable'
-  | 'legacy_embedded';
-
-interface KeyTrust {
-  status: KeyTrustStatus;
-  verified: boolean;
-  /** Optional because `legacy_embedded` signatures predate the trust
-   *  registry and therefore have no kid. */
-  kid?: string;
-  deprecatedAt?: string | null;
-  revokedAt?: string | null;
-}
-
+/**
+ * The verify-route response shape. #111 renders only the five legacy checks
+ * (hashMatch, signatureValid, keyTrust, hasTimestamp, rekorVerified), but the
+ * type is aligned to the route's full emitted shape (spec §9.2 checks #3-#15 +
+ * lifecycle) as a clean base for the #113/#114 panel waves — those fields are
+ * typed here but intentionally NOT surfaced yet. The upstream interfaces are
+ * type-only imports, so this client component pulls in no node:crypto runtime.
+ */
 interface VerifyResult {
   hashMatch: boolean;
   signatureValid: boolean | null;
   rekorVerified: boolean | null;
   hasTimestamp: boolean;
-  keyTrust: KeyTrust | null;
+  keyTrust: KeyTrustResult | null;
+  blobRefsVerified: boolean | null;
+  blobRefs: BlobRefVerification[];
+  contentCanonicalization: ContentCanonicalizationResolution | null;
+  contentHash: ContentHashCheck | null;
+  nodeId: string | null;
+  typeResolution: TypeResolution | null;
+  signerIdentity: SignerIdentityCheck | null;
+  captureMethodVocab: CaptureMethodVocabCheck | null;
+  lifecycle: LifecycleResolution;
   details: {
+    storedHash?: string | null;
+    recomputedHash?: string | null;
     hasSigning: boolean;
     hasRekor: boolean;
     rekor?: { logIndex?: number; logEntryUrl?: string } | null;
@@ -113,57 +135,18 @@ interface VerifyResult {
   };
 }
 
-function keyTrustCopy(keyTrust: KeyTrust): string {
-  switch (keyTrust.status) {
-    case 'active':
-      return `Signed with active key (${keyTrust.kid})`;
-    case 'deprecated_valid':
-      return `Signed with deprecated key before rotation (${keyTrust.kid})`;
-    case 'deprecated_invalid':
-      return `Key deprecated before this signature — do not trust (${keyTrust.kid})`;
-    case 'revoked':
-      return `Key revoked — do not trust (${keyTrust.kid})`;
-    case 'unknown_key':
-      return `Key not in platform trust registry (${keyTrust.kid})`;
-    case 'registry_unavailable':
-      return 'Trust registry unavailable — could not verify key';
-    case 'legacy_embedded':
-      return 'Signed with legacy embedded key (pre-trust-registry package)';
-  }
-}
-
-/**
- * Map a key-trust result onto the icon state used by `VerifyCheck`:
- *   - `true`  → ✅ green (registry-validated)
- *   - `false` → ❌ red (registry says untrusted)
- *   - `null`  → ➖ neutral (no signing key, or pre-registry legacy package)
- */
-function keyTrustIconStatus(keyTrust: KeyTrust | null): boolean | null {
-  if (keyTrust === null) return null;
-  if (keyTrust.status === 'legacy_embedded') return null;
-  return keyTrust.verified;
-}
-
-function VerifyCheck({ label, status, detail }: { label: string; status: boolean | null; detail?: string }) {
-  const icon = status === true ? '\u2705' : status === false ? '\u274C' : '\u2796';
-  return (
-    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', fontSize: '13px', marginBottom: '6px' }}>
-      <span>{icon}</span>
-      <div>
-        <span style={{ color: 'var(--text-primary)' }}>{label}</span>
-        {detail && <span style={{ color: 'var(--text-muted)', marginLeft: '6px' }}>{detail}</span>}
-      </div>
-    </div>
-  );
-}
-
 export default function EvidenceActions({
-  slug, title, creatorName, createdAt, packageUrl, verificationStatus,
+  slug, title, creatorName, createdAt, packageUrl, captureMethod,
 }: EvidenceActionsProps) {
   const [linkCopied, setLinkCopied] = useState(false);
   const [showCite, setShowCite] = useState(false);
   const [verifyState, setVerifyState] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
   const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
+
+  // captureMethod LABEL (#11, "signed != verbatim"): a neutral, signature-covered
+  // reading of HOW the bytes were captured, shown beside the signature verdict.
+  // Pre-ADR-0003 packages have no captureMethod (null), so the line is omitted.
+  const captureMethodCaption = resolveCaptureMethodLabel(captureMethod);
 
   const handleCopyLink = async () => {
     const url = `${window.location.origin}/evidence/${slug}`;
@@ -239,47 +222,42 @@ export default function EvidenceActions({
           backgroundColor: 'white',
         }}>
           <div style={{ fontSize: '14px', fontWeight: 600, marginBottom: '10px' }}>Verification Results</div>
-          <VerifyCheck
-            label="Package integrity"
-            status={verifyResult.hashMatch}
-            detail={verifyResult.hashMatch ? 'Hash matches stored package' : 'Hash mismatch — package may have been altered'}
-          />
-          <VerifyCheck
-            label="Cryptographic signature"
-            status={verifyResult.signatureValid}
-            detail={
-              verifyResult.signatureValid === null
-                ? 'Not signed'
-                : verifyResult.signatureValid
-                  ? 'Valid Ed25519 signature'
-                  : 'Invalid signature'
-            }
-          />
-          <VerifyCheck
-            label="Key trust"
-            status={keyTrustIconStatus(verifyResult.keyTrust)}
-            detail={
-              verifyResult.keyTrust === null
-                ? 'No signing key recorded'
-                : keyTrustCopy(verifyResult.keyTrust)
-            }
-          />
-          <VerifyCheck
-            label="RFC 3161 timestamp"
-            status={verifyResult.hasTimestamp ? true : null}
-            detail={verifyResult.hasTimestamp ? 'Timestamp token present' : 'No timestamp'}
-          />
-          <VerifyCheck
-            label="Transparency log (Rekor)"
-            status={verifyResult.rekorVerified}
-            detail={
-              verifyResult.rekorVerified === null
-                ? 'Not published to Rekor'
-                : verifyResult.rekorVerified
-                  ? 'Entry verified on Sigstore Rekor'
-                  : 'Rekor verification failed'
-            }
-          />
+          {/* The five integrity checks, re-skinned onto <TrustSignal> and driven
+              entirely by the trust-signal vocabulary (#110). Legacy / back-compat
+              statuses resolve to Verified or Normal — never amber or red — so a
+              pre-v0.1 package reads calm (the #111 calm baseline). The label is
+              the verdict one-liner; the muted detail expands it (P5). */}
+
+          {/* #1 Envelope integrity */}
+          <TrustSignal {...resolveEnvelopeIntegrity(verifyResult.hashMatch)} />
+
+          {/* #2 Cryptographic signature, with the captureMethod label directly
+              beneath it — "signed ≠ verbatim" (spec §9.2 #11). A valid signature
+              proves the bytes are unchanged since signing, not that they are a
+              verbatim capture; the caption says how the signed bytes were obtained. */}
+          <TrustSignal {...resolveSignature(verifyResult.signatureValid)} />
+          {captureMethodCaption && (
+            <div
+              style={{
+                marginLeft: '24px',
+                marginBottom: '8px',
+                fontSize: '12px',
+                lineHeight: 1.45,
+                color: 'var(--text-muted)',
+              }}
+            >
+              {captureMethodCaption}
+            </div>
+          )}
+
+          {/* #5 Key trust (keyTrust:null = unsigned → calm Normal) */}
+          <TrustSignal {...resolveKeyTrust(verifyResult.keyTrust)} />
+
+          {/* #7 RFC 3161 timestamp */}
+          <TrustSignal {...resolveTimestamp(verifyResult.hasTimestamp)} />
+
+          {/* #8 Transparency log (Rekor) */}
+          <TrustSignal {...resolveRekor(verifyResult.rekorVerified)} />
           {verifyResult.details.rekor?.logEntryUrl && (
             <div style={{ marginTop: '6px', fontSize: '12px' }}>
               <a

--- a/src/lib/evidence/trust-signal.test.ts
+++ b/src/lib/evidence/trust-signal.test.ts
@@ -53,6 +53,9 @@ import {
   CAPTURE_METHOD_LABELS,
   NOTEBOOK_PROVENANCE_VALUES,
   NOTEBOOK_PROVENANCE_SIGNALS,
+  NO_SIGNING_KEY_SIGNAL,
+  resolveKeyTrust,
+  resolveCaptureMethodLabel,
   type TrustSignalDescriptor,
 } from './trust-signal.ts';
 
@@ -233,4 +236,38 @@ test('captureMethod labels are informational (no tier) and cover the known metho
   for (const method of ['chat-flow-stream', 'claude-code-jsonl-readback', 'claude-code-self-report'] as const) {
     assert.ok(CAPTURE_METHOD_LABELS[method].length > 0, `captureMethod label "${method}"`);
   }
+});
+
+// --- #111 consumer resolvers (verify-panel re-skin) ----------------------
+
+test('resolveKeyTrust: unsigned (null/undefined) reads calm Normal; statuses pass through', () => {
+  // keyTrust:null is the unsigned package — expected, never a failure (the #111
+  // calm baseline). It must resolve to the calm NO_SIGNING_KEY_SIGNAL, not a
+  // hand-rolled tier in the component.
+  assert.equal(resolveKeyTrust(null), NO_SIGNING_KEY_SIGNAL);
+  assert.equal(resolveKeyTrust(undefined), NO_SIGNING_KEY_SIGNAL);
+  assert.equal(NO_SIGNING_KEY_SIGNAL.tier, 'normal');
+  // A real status passes straight through to its KEY_TRUST_SIGNALS descriptor.
+  assert.equal(resolveKeyTrust({ status: 'legacy_embedded' }), KEY_TRUST_SIGNALS.legacy_embedded);
+  assert.equal(resolveKeyTrust({ status: 'active' }), KEY_TRUST_SIGNALS.active);
+  assert.equal(resolveKeyTrust({ status: 'revoked' }).tier, 'alarm');
+});
+
+test('resolveCaptureMethodLabel: known methods, datHere ADR-0004 special case, omit-on-absent', () => {
+  // Known methods resolve to the canonical CAPTURE_METHOD_LABELS reading.
+  assert.equal(resolveCaptureMethodLabel('chat-flow-stream'), CAPTURE_METHOD_LABELS['chat-flow-stream']);
+  assert.equal(
+    resolveCaptureMethodLabel('claude-code-jsonl-readback'),
+    CAPTURE_METHOD_LABELS['claude-code-jsonl-readback'],
+  );
+  // Absent / pre-ADR-0003 → null so the consumer omits the line (calm legacy view).
+  assert.equal(resolveCaptureMethodLabel(null), null);
+  assert.equal(resolveCaptureMethodLabel(undefined), null);
+  assert.equal(resolveCaptureMethodLabel(''), null);
+  // datHere special case (ADR-0004) preserved: a non-null legacy annotation,
+  // distinct from a real capture method (must NOT regress to a plain reading).
+  const datHere = resolveCaptureMethodLabel('datHere');
+  assert.ok(datHere && /ADR-0004/.test(datHere), 'datHere preserves the ADR-0004 annotation');
+  // An unrecognized value omits rather than echoing a raw code.
+  assert.equal(resolveCaptureMethodLabel('something-else'), null);
 });

--- a/src/lib/evidence/trust-signal.ts
+++ b/src/lib/evidence/trust-signal.ts
@@ -251,12 +251,17 @@ export const KEY_TRUST_SIGNALS: Record<KeyTrustStatus, TrustSignalDescriptor> = 
     label: 'Trust registry could not be reached',
     detail: 'The trust registry could not be loaded, so the key status was not checked.',
   },
-  // Load-bearing: every pre-trust-registry package. Must read calm.
+  // Load-bearing: any package signed with an embedded key that carries no
+  // registry kid — genuinely-old packages AND recent ones signed before kid
+  // storage. Must read calm. Speaks ONLY to key trust (P7): the signature
+  // itself is check #2 and is never asserted here (older copy claimed "its
+  // signature verified against its embedded key", which contradicted a #2
+  // failure on any no-kid package whose signature did not verify).
   legacy_embedded: {
     tier: 'normal',
-    label: 'Signed before the trust registry existed',
+    label: 'Signed with an embedded key (not in the trust registry)',
     detail:
-      'This package predates the trust registry; its signature verified against its embedded key, but the registry cannot vouch for it.',
+      'The signature uses an embedded public key that is not listed in our published trust registry, so the registry cannot vouch for it.',
   },
 };
 

--- a/src/lib/evidence/trust-signal.ts
+++ b/src/lib/evidence/trust-signal.ts
@@ -260,6 +260,28 @@ export const KEY_TRUST_SIGNALS: Record<KeyTrustStatus, TrustSignalDescriptor> = 
   },
 };
 
+/**
+ * Calm reading for a package with NO signing key at all. The verify route emits
+ * `keyTrust: null` only for an unsigned package (it co-occurs with
+ * `signatureValid: null`), so "no key to check" is an expected, Normal state —
+ * never a failure. Defined here, not hand-rolled in the component, so the tier
+ * decision keeps a single source of truth.
+ */
+export const NO_SIGNING_KEY_SIGNAL: TrustSignalDescriptor = {
+  tier: 'normal',
+  label: 'No signing key',
+  detail:
+    'This package carries no signing key, so there is nothing to check against the trust registry.',
+};
+
+/** Resolve the trust-registry verdict, folding the unsigned (`null`) case into
+ *  the calm `NO_SIGNING_KEY_SIGNAL` so consumers never branch on a missing key. */
+export function resolveKeyTrust(
+  keyTrust: { status: KeyTrustStatus } | null | undefined,
+): TrustSignalDescriptor {
+  return keyTrust ? KEY_TRUST_SIGNALS[keyTrust.status] : NO_SIGNING_KEY_SIGNAL;
+}
+
 // --- #7 Timestamp validity (hasTimestamp: boolean) -----------------------
 
 export const TIMESTAMP_SIGNALS: Record<BiStateKey, TrustSignalDescriptor> = {
@@ -466,6 +488,27 @@ export const CAPTURE_METHOD_LABELS: Record<CaptureMethod, string> = {
   'claude-code-self-report':
     'Summarized by the AI from its own session memory (deprecated capture method).',
 };
+
+/**
+ * Resolve the plain-language capture-method reading rendered as a neutral label
+ * beside the signature verdict (#111). Returns `null` when there is nothing to
+ * show — a pre-ADR-0003 package with no captureMethod, or an unrecognized value
+ * — so the consumer simply omits the line (no noise on legacy packages).
+ *
+ * `datHere` is a preserved special case (ADR-0004): the 2026-05-19 reframe moved
+ * datHere out of captureMethod into a separate contentProfile column, but legacy
+ * pre-reframe records may still carry it here. It is surfaced as a legacy value
+ * with an ADR-0004 annotation, never treated as a real capture method.
+ */
+export function resolveCaptureMethodLabel(method: string | null | undefined): string | null {
+  if (!method) return null;
+  const known = (CAPTURE_METHOD_LABELS as Record<string, string | undefined>)[method];
+  if (known) return known;
+  if (method === 'datHere') {
+    return 'Recorded with a legacy datHere capture method (pre-ADR-0004 reframe); the content profile now carries this distinction.';
+  }
+  return null;
+}
 
 // --- #12 type resolution -------------------------------------------------
 

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict';
 import crypto from 'crypto';
 import canonicalize from 'canonicalize';
 import {
+  verifySignature,
   verifyKeyTrust,
   loadTrustRegistry,
   clearTrustRegistryCache,
@@ -36,6 +37,7 @@ import {
   ATTESTATION_REINSTATES,
 } from './attestation.ts';
 import type { BlobRef } from './blob-ref.ts';
+import { ed25519, ed25519ph } from '@noble/curves/ed25519.js';
 
 const KID = 'platform:evidence-2026-04';
 const NEW_KID = 'platform:evidence-2027-04';
@@ -287,6 +289,41 @@ test('legacyEmbeddedKeyTrust: pre-registry signatures get a neutral verdict', ()
   assert.equal(result.status, 'legacy_embedded');
   assert.equal(result.verified, false);
   assert.equal(result.kid, undefined);
+});
+
+// --- Signature algorithm dispatch (the Ed25519 -> Ed25519ph migration fix) ---
+//
+// Pre-switch legacy packages (e.g. the withdrawn da9246 package surfaced in the
+// #111 calm-baseline review) carry PLAIN Ed25519 signatures labeled
+// `algorithm: 'Ed25519'`. verifySignature must verify each signature under the
+// scheme it was actually created with: checking a valid plain-Ed25519 signature
+// with Ed25519ph is the false negative that made a genuinely-valid legacy
+// package show a red "signature does not verify". Dispatching on the stored
+// label fixes it without weakening anything — a forgery still fails under both.
+test('verifySignature: dispatches on the algorithm label (Ed25519 vs Ed25519ph)', () => {
+  const hash = 'da9246cd974b0fafb1d16190e80903727133d67127febab8c16ec28a67fcaf7f';
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  const pubB64 = publicKey.export({ format: 'der', type: 'spki' }).toString('base64');
+  const jwk = privateKey.export({ format: 'jwk' });
+  const rawPriv = Uint8Array.from(Buffer.from(jwk.d as string, 'base64url'));
+  const msg = Buffer.from(hash, 'utf-8');
+
+  // Plain Ed25519 (the legacy scheme): verifies ONLY when labeled 'Ed25519'.
+  const plainSig = Buffer.from(ed25519.sign(msg, rawPriv)).toString('base64');
+  assert.equal(verifySignature(hash, plainSig, pubB64, 'Ed25519'), true);
+  // The bug being fixed: the same valid signature, checked with the ph default.
+  assert.equal(verifySignature(hash, plainSig, pubB64), false);
+
+  // Ed25519ph (the modern scheme): verifies under the explicit label AND the
+  // no-label default (Ed25519ph), so modern packages are unaffected.
+  const phSig = Buffer.from(ed25519ph.sign(msg, rawPriv)).toString('base64');
+  assert.equal(verifySignature(hash, phSig, pubB64, 'Ed25519ph'), true);
+  assert.equal(verifySignature(hash, phSig, pubB64), true);
+
+  // Cross-scheme never passes regardless of label — the label only selects the
+  // verifier; the signature math must still hold.
+  assert.equal(verifySignature(hash, phSig, pubB64, 'Ed25519'), false);
+  assert.equal(verifySignature(hash, plainSig, pubB64, 'Ed25519ph'), false);
 });
 
 test('Compromise scenario: revoked key + replacement active key', () => {

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -610,7 +610,7 @@ export const KEY_TRUST_STATUSES = [
   'revoked',               // revoked key — package is never trusted
   'unknown_key',           // (kid, publicKey) pair not found in registry
   'registry_unavailable',  // registry could not be loaded
-  'legacy_embedded',       // signature predates the trust registry (no kid stored)
+  'legacy_embedded',       // signed with an embedded key, no registry kid stored
 ] as const;
 export type KeyTrustStatus = (typeof KEY_TRUST_STATUSES)[number];
 

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { ed25519ph } from '@noble/curves/ed25519.js';
+import { ed25519, ed25519ph } from '@noble/curves/ed25519.js';
 import { rekorHashForPackage, type SignerIdentity } from './signing.ts';
 import { captureVocabForProfile, resolveProfileType } from './profiles.ts';
 import type { CaptureMethod } from './packager.ts';
@@ -51,23 +51,35 @@ function extractRawPublicKey(publicKeyB64Der: string): Uint8Array {
 }
 
 /**
- * Verify an Ed25519ph signature against the package hash.
+ * Verify an evidence signature against the package hash.
  *
- * The signed message is the UTF-8 bytes of the package hex hash — the
- * same convention used by `signPackage` in `signing.ts`. Ed25519ph
- * prehashes the message with SHA-512 before the Ed25519 verify, which
- * matches the format Rekor uses to validate the same signature.
+ * The signed message is the UTF-8 bytes of the package hex hash — the same
+ * convention used by `signPackage` in `signing.ts`. The signature is verified
+ * under the algorithm it was actually created with (`algorithm`):
+ *   - `Ed25519ph` — the current scheme (SHA-512 prehash, matching what Rekor
+ *     validates). Used for every modern package; the default when no label is
+ *     given.
+ *   - `Ed25519`  — plain Ed25519, used by pre-switch legacy packages whose
+ *     stored signature is labeled `'Ed25519'` (these carry no kid and predate
+ *     the Ed25519→Ed25519ph migration).
+ *
+ * Dispatching on the stored label fixes a false negative where a valid
+ * plain-Ed25519 signature was checked with Ed25519ph and read as invalid. It
+ * does not weaken verification: the label only selects the verifier, the
+ * signature math must still hold, so a forgery fails under both.
  */
 export function verifySignature(
   packageHash: string,
   signatureB64: string,
   publicKeyB64: string,
+  algorithm?: string,
 ): boolean {
   try {
     const pubBytes = extractRawPublicKey(publicKeyB64);
     const sigBytes = Uint8Array.from(Buffer.from(signatureB64, 'base64'));
     const messageBytes = Uint8Array.from(Buffer.from(packageHash, 'utf-8'));
-    return ed25519ph.verify(sigBytes, messageBytes, pubBytes);
+    const verifier = algorithm === 'Ed25519' ? ed25519 : ed25519ph;
+    return verifier.verify(sigBytes, messageBytes, pubBytes);
   } catch (err) {
     console.error('[verify] Signature verification error:', err);
     return false;


### PR DESCRIPTION
## #111 — Verify panel: calm baseline + captureMethod adjacency (Wave 1)

**Do NOT merge — planning chat reviews first** (as with #110). Unlike #110, this renders **live** on civicaitools.org.

Closes #111 · Milestone: Evidence trust UX · Depends on #110 (merged, `783ee0f`).

First live consumer of the #110 trust-signal vocabulary: re-skins the existing verify panel onto `<TrustSignal>` and establishes the rendering pattern #113/#114 extend.

### What changed

**1. Re-skinned the five checks onto `<TrustSignal>`** (`EvidenceActions.tsx`). Replaced the ad-hoc `VerifyCheck` (check/cross/dash) + `keyTrustCopy` / `keyTrustIconStatus` + the local `KeyTrust`/`KeyTrustStatus` redeclaration. Each verdict resolves through `trust-signal.ts`:

| Check | Resolver |
|---|---|
| #1 Envelope integrity | `resolveEnvelopeIntegrity(hashMatch)` |
| #2 Cryptographic signature | `resolveSignature(signatureValid)` |
| #5 Key trust | `resolveKeyTrust(keyTrust)` |
| #7 RFC 3161 timestamp | `resolveTimestamp(hasTimestamp)` |
| #8 Transparency (Rekor) | `resolveRekor(rekorVerified)` |

No hand-rolled tiers in the component — the label is the verdict one-liner, the muted detail expands it (P5). The Rekor log-entry link is preserved.

**2. Calm baseline (load-bearing).** Legacy statuses resolve to Verified/Normal, never failure: `legacy_embedded` → Normal, `hasTimestamp:false` → Normal, `rekorVerified:null` → Normal. The unsigned `keyTrust:null` case is folded into a new calm `NO_SIGNING_KEY_SIGNAL` (not hand-rolled — the tier lives in `trust-signal.ts`).

**3. captureMethod adjacency** ("signed ≠ verbatim", spec §9.2 #11). The label moved **out of** the page-level "Captured via" rows and **into** the panel, as a neutral muted caption directly beneath the signature verdict, via `CAPTURE_METHOD_LABELS`.
- Removed `captureMethodLabel()` and **all three** page-level "Captured via" rows: the datHere header row + **both** Verification-Status sections.
- The brief flagged the third site (~785) as possibly "env-metadata" to keep. On inspection it's the **datHere Verification-Status trust label**, byte-identical to the non-datHere one — not environment detail — so it's removed too, for symmetry (both layouts now get captureMethod in the panel; neither duplicates it on the page). There is no separate captureMethod env-metadata site.
- `datHere` ADR-0004 special case **preserved** in `resolveCaptureMethodLabel` (legacy pre-reframe annotation, never treated as a real capture method). `null` / unrecognized → caption omitted (no noise on legacy packages).

**4. Lifecycle in the panel? No** (the deferred decision). Lifecycle is a separate axis from cryptographic integrity (design-principles P7) and the detail-page withdrawal banner already gives it prominence. The panel stays cryptographic-integrity-only; the lifecycle tiers remain available in `trust-signal.ts` for a future withdrawal-banner re-skin.

### Supporting changes
- `trust-signal.ts`: added `resolveKeyTrust` (+ `NO_SIGNING_KEY_SIGNAL`) and `resolveCaptureMethodLabel`, following the existing `resolve*` pattern — with unit tests.
- `VerifyResult` widened to the verify route's full emitted shape (type-only upstream imports → no `node:crypto` in the client bundle) as a clean base for #113/#114. **#111 still renders only the five** — the new checks are typed, not surfaced.
- Removed the dead `verificationStatus` prop (unused; single call site; cleared a pre-existing lint warning).

### Out of scope (held)
New checks (#3/#4/#12/#14/#15, blobRefs) → #113/#114 · notebookProvenance → #113 · shared chat↔detail renderer → #115 · ProvenanceChain → #88+.

### Verification
- `npm test` — **262/262 pass** (Node 22), incl. the new resolver tests + the #110 synthetic-legacy all-calm test.
- `npx tsc --noEmit` — clean modulo the **2 known** pre-existing `expert-attestation.test.ts` errors (untouched).
- `npm run lint` — clean on changed files.
- **Visual (first live mount of `<TrustSignal>`):** rendered the real component + resolvers locally and screenshotted —
  - all four glyphs distinguishable by **shape** (check / circle / triangle / octagon) **and** color, each `aria-label`led;
  - modern signed package → all green + captureMethod caption ("Captured from the live chat…") beside the signature;
  - **legacy package → zero red/amber** (2 green + 3 calm Normal), captureMethod caption omitted.
  - _Note:_ this used a faithful local render of the component + resolvers (no DB / `op` needed). The full on-prod eyeball of a real evidence record through the verify route was not run (1Password not signed in to this shell); the route response shape is type-checked and the resolvers are unit-tested. Easy to do as a follow-up with `op run … npm run dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
