### PR TITLE
feat(evidence): #116 WS1 — public proof sidecar (commitment endpoint)

### DIFF
--- a/docs/api/evidence-commitment.md
+++ b/docs/api/evidence-commitment.md
@@ -1,0 +1,136 @@
+# Evidence commitment API (`GET /api/evidence/<hash|slug>/commitment`)
+
+The commitment endpoint is the **public proof sidecar** for a published evidence package. It returns the spec §9.2.1 *commitment view* — the package hash, the signature envelope, and the public-log proofs (RFC 3161 timestamp, Rekor entry + inclusion proof), plus the signed envelope claims and pointers to the package blob and the publisher's trust registry.
+
+It exists so a third party can resolve a package's proofs and **verify it independently** — client-side, against public infrastructure — rather than trusting a civicaitools.org-rendered verdict. The view is *self-describing*: it carries `packageUrl` (the canonical blob) and `trustRegistryUrl` (the publisher's key registry), so a single `hash → commitment` lookup bootstraps the entire verification.
+
+It is the read-only counterpart to the write path documented in [`evidence-publish.md`](./evidence-publish.md), and the WS1 deliverable of [civic-ai-tools-website#116](https://github.com/npstorey/civic-ai-tools-website/issues/116) (the standalone third-party verifier).
+
+**Status:** Evidence protocol version `0.1.0`. Fields are added backwards-compatibly; absent optional fields are omitted (never emitted as `null`).
+
+---
+
+## Request
+
+```
+GET /api/evidence/<identifier>/commitment
+```
+
+`<identifier>` is **auto-detected**:
+
+| Form | Match | Resolution |
+|------|-------|------------|
+| **Hash** | 64 lowercase/uppercase hex chars (`/^[0-9a-f]{64}$/i`) — the base-package hash | Looks up by `basePackageHash`. See *hash → row ambiguity* below. |
+| **Slug** | anything else | Looks up by the unique `slug`. Unambiguous. |
+
+- **No authentication.** The proofs are public, read-only, and credential-free.
+- **Method:** `GET` (and `OPTIONS` for CORS preflight). No request body.
+- **Caching:** `Cache-Control: public, max-age=60, s-maxage=60`. The proofs are immutable for a given hash, but lifecycle state (withdrawal/reinstatement) can change after publish, so the window is short.
+
+### CORS
+
+The endpoint is **CORS-open** (`Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: GET, OPTIONS`, `Access-Control-Allow-Headers: Content-Type`). The proofs are public and the verifier is forkable / anyone-can-run ([ADR-0013](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0013-verification-rendering-delegation.md) / open-questions Q47), so access is open rather than restricted to a single origin.
+
+The two other resources a cross-origin verifier must fetch are already CORS-open (verified 2026-06-04): the **Vercel Blob** package object (`access-control-allow-origin: *`) and the **trust registry** at both `/.well-known/typed-publisher.json` (canonical) and `/.well-known/evidence-public-keys.json` (legacy).
+
+---
+
+## Response (`200`)
+
+A JSON object — the commitment view. Always-present fields:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `evidenceProtocolVersion` | constant | `"0.1.0"`. |
+| `packageHash` | DB `basePackageHash` | Hex SHA-256 of the canonical envelope; the content node's nodeId. |
+| `packageUrl` | DB `basePackageStorageKey` | Public, content-addressable Vercel Blob URL (`…/evidence-packages/<hash>.json`). The verifier fetches this to recompute the hash and verify the signature. |
+| `captureMethod` | DB `captureMethod` | Signed capture-method label (ADR-0003), or `null`. Shown next to the signature: *signed ≠ verbatim ≠ correct*. |
+| `contentProfile` | DB `contentProfile` | `"datHere"` or `"default"` (absent column ⇒ `"default"`). |
+| `trustRegistryUrl` | constant | **Canonical** `/.well-known/typed-publisher.json` (ADR-0012). New clients SHOULD resolve keys from here. |
+| `trustRegistryUrlLegacy` | constant | Byte-identical legacy `/.well-known/evidence-public-keys.json`, emitted alongside for older clients. |
+| `subjectTitle` | DB `title` | Public title. |
+| `subjectSummary` | DB `summary` | Public, citation-ready summary. |
+
+Conditionally-present fields (omitted when absent):
+
+| Field | Source | Present when |
+|-------|--------|--------------|
+| `signature` | DB `basePackageSignature` (parsed) | `{ signature, publicKey, algorithm, kid }`. Carried **verbatim**. `algorithm` is load-bearing — an independent verify-core MUST dispatch `ed25519` vs `ed25519ph` on it. `kid` is the registry lookup handle; both `algorithm` and `kid` may be absent on packages signed via a pre-kid / plain-Ed25519 path. |
+| `rfc3161Timestamp` | DB | Base64 RFC 3161 timestamp token. |
+| `rekorEntryId` | DB | Sigstore Rekor transparency-log entry id. |
+| `rekorInclusionProof` | DB | JSON-stringified Merkle inclusion proof, stored at publish time. |
+| `producerProfile` | package blob | Envelope §8.1.1 producer-profile label. |
+| `type` | package blob | Two-family node type (`content/<noun>/v<N>`); absence ⇒ `content/analysis/v1`. |
+| `signer` | package blob | **Envelope §8.5 signer claim** `{ bindingTier, identifier, displayName, verifiedAt? }` — the subject of verify check #14. Distinct from `signerIdentity` below. |
+| `contentHash` | package blob | Multihash digest set (§8.2), e.g. `{ "sha256": "…" }`. |
+| `contentCanonicalization` | package blob | Canonicalization-rule URI (§8.2). |
+| `signerIdentity` | DB `users` | The publishing user's **public GitHub identity** `{ provider: "github", providerId, displayName, profileUrl }` — *informational*. `providerId` is the public GitHub user id, **not** an internal DB id. |
+| `lifecycle` | DB lifecycle columns | Present only when the package has lifecycle history (see below). |
+
+> **`signer` vs `signerIdentity`.** These are two different things and must not be conflated. `signer` is the *envelope-side* identity claim that the signature commits to — a verifier treats `signer.identifier` as the check-#14 subject. `signerIdentity` is the *publishing user's* public GitHub identity, surfaced for human context only. A verifier MUST NOT use the GitHub identity as the signature subject.
+
+> **Envelope fields and the blob.** `producerProfile` / `type` / `signer` / `contentHash` / `contentCanonicalization` come from the canonical package JSON, which the endpoint fetches best-effort. If the blob is briefly unreachable, these are omitted but the DB-sourced proofs (hash, signature, timestamp, Rekor) are still served — and a verifier re-derives the envelope fields from the package it fetches itself via `packageUrl`. Pre-v0.1 (legacy) packages simply don't carry them, and read calm rather than failed.
+
+### Lifecycle
+
+`lifecycle` is present only when the package has been withdrawn at some point:
+
+```jsonc
+{
+  "status": "withdrawn",          // "withdrawn" if currently withdrawn, else "active" (reinstated)
+  "withdrawnAt": "2026-06-02T12:00:00.000Z",
+  "withdrawnReason": "…",         // present if the publisher gave one
+  "reinstatedAt": "…",            // present if later reinstated
+  "reinstatedReason": "…"
+}
+```
+
+A never-withdrawn package omits `lifecycle` entirely. The state is derived from the evidence row's lifecycle columns, which the withdraw/reinstate routes dual-write alongside the signed `attestation/*` node — the same columns are already public via `/api/evidence/list` and the detail page. Independent verification of the *signed lifecycle attestation chain itself* (not just the state) is tracked under WS2 / [#119](https://github.com/npstorey/civic-ai-tools-website/issues/119).
+
+> **Withdrawn packages are served, not 404'd.** A withdrawn package's base signature still verifies — withdrawal is a separate, separately-signed action. Independent verification must work on it, so the endpoint returns the full commitment with the `lifecycle` state attached.
+
+---
+
+## Errors
+
+| Status | When |
+|--------|------|
+| `404 { "error": "Evidence not found" }` | No row matches the identifier, or the row is not public (`isPublic = false`). |
+| `404 { "error": "No published evidence package for this identifier" }` | The row exists but never completed publishing (no `basePackageHash`) — nothing to commit to. |
+
+All error responses also carry the CORS headers.
+
+---
+
+## Hash → row ambiguity
+
+Re-publishing the same package under a different title creates a **second `evidence_records` row with the same `basePackageHash`** (the immutable blob is identical, possibly with a separate signing run). Because the signature is over the hash, *any* matching row's proofs verify.
+
+- The **hash form** returns the **canonical (first / oldest-created)** matching row, ordered by `createdAt` ascending.
+- The **slug form** is unambiguous (the slug is unique).
+
+A verifier that needs a specific publication should use the slug form; for pure cryptographic verification of the bytes, any matching row is equivalent.
+
+---
+
+## What a verification result means
+
+The commitment view supplies the *inputs* to verification; the verdict is computed by the verifier (client-side). A successful verification asserts **integrity** (bytes unaltered since signing), **publisher identity** (the signature traces to a key the declared publisher lists as authorized), **timestamp** (an independent TSA recorded the signature), and **public record** (the signature is in the Rekor transparency log). It does **not** assert **correctness** — whether the analysis is right, unbiased, or complete. See `civic-ai-tools/docs/trust-and-evidence.md`.
+
+---
+
+## Example
+
+```bash
+# By hash (canonical match)
+curl https://civicaitools.org/api/evidence/ef1a431c16bf00262bb4e706b0870617fd44bd5d0d3828f9885bd6aefea9a1ba/commitment
+
+# By slug (unambiguous)
+curl https://civicaitools.org/api/evidence/noise-trends-in-nyc-last-tuesday-ef1a43/commitment
+```
+
+---
+
+## Change log
+
+- **2026-06-04** — Initial endpoint. Extracted and generalized `buildCommitmentView` from the notebook bundle route into `src/lib/evidence/commitment.ts`; added the public, CORS-open `GET /api/evidence/<hash|slug>/commitment`. WS1 of #116.

--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -163,6 +163,11 @@ authoritative for verification regardless of bundle availability.
 Sibling-YAML serialization (OES §9.2.3) for non-notebook outputs is not
 yet implemented.
 
+The same §9.2.1 commitment view (the enrichment #1 embedded above) is also
+served standalone, for **all** content profiles, as a public proof sidecar at
+`GET /api/evidence/<hash|slug>/commitment` — the entry point for independent,
+client-side verification. See [`evidence-commitment.md`](./evidence-commitment.md).
+
 ---
 
 ## Success response

--- a/src/app/api/evidence/[slug]/bundle/route.ts
+++ b/src/app/api/evidence/[slug]/bundle/route.ts
@@ -4,6 +4,10 @@ import { evidenceRecords, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
+import {
+  buildCommitmentView,
+  CANONICAL_TRUST_REGISTRY_URL,
+} from '@/lib/evidence/commitment';
 
 /**
  * GET /api/evidence/[slug]/bundle
@@ -31,76 +35,14 @@ import type { EvidencePackage } from '@/lib/evidence/packager';
 
 const NOTEBOOK_EXTENSION_KEY = 'org.civicaitools.notebook';
 const EVIDENCE_NAMESPACE_KEY = 'org.civicaitools.evidence';
-const TRUST_REGISTRY_URL =
-  'https://civicaitools.org/.well-known/evidence-public-keys.json';
 
 type EvidenceRecord = typeof evidenceRecords.$inferSelect;
 type UserRecord = typeof users.$inferSelect;
 
-/**
- * Build the OES §9.2.1 commitment view from the evidence record + creator.
- * Optional fields (RFC 3161 timestamp, Rekor entry/proof) are conditionally
- * spread so absent values don't appear as `null` in the serialized output.
- */
-function buildCommitmentView(
-  record: EvidenceRecord,
-  creator: UserRecord | null,
-  pkg: EvidencePackage,
-): Record<string, unknown> {
-  let signature: Record<string, unknown> | null = null;
-  if (record.basePackageSignature) {
-    try {
-      signature = JSON.parse(record.basePackageSignature);
-    } catch {
-      signature = null;
-    }
-  }
-
-  const signerIdentity = creator
-    ? {
-        provider: 'github',
-        providerId: creator.githubId,
-        displayName: creator.displayName,
-        profileUrl: creator.githubProfileUrl,
-      }
-    : null;
-
-  return {
-    evidenceProtocolVersion: '0.1.0',
-    packageHash: record.basePackageHash,
-    packageUrl: record.basePackageStorageKey,
-    captureMethod: record.captureMethod ?? null,
-    contentProfile: 'datHere',
-    // Envelope fields sourced from the signed package JSON (spec §8.1.1).
-    // Conditionally spread so packages predating these fields omit them
-    // rather than emitting nulls. `producerProfile` / `type` / `signer` are
-    // the PR1 taxonomy fields; `contentHash` / `contentCanonicalization` are
-    // the PR2 §8.2 canonicalization fields. All are covered by the package
-    // signature, so surfacing them in the commitment view lets a cross-host
-    // reader resolve the same envelope the signature commits to.
-    ...(pkg.producerProfile ? { producerProfile: pkg.producerProfile } : {}),
-    ...(pkg.type ? { type: pkg.type } : {}),
-    ...(pkg.signer ? { signer: pkg.signer } : {}),
-    ...(pkg.contentHash ? { contentHash: pkg.contentHash } : {}),
-    ...(pkg.contentCanonicalization
-      ? { contentCanonicalization: pkg.contentCanonicalization }
-      : {}),
-    ...(signature ? { signature } : {}),
-    ...(signerIdentity ? { signerIdentity } : {}),
-    ...(record.basePackageRfc3161Timestamp
-      ? { rfc3161Timestamp: record.basePackageRfc3161Timestamp }
-      : {}),
-    ...(record.basePackageRekorEntryId
-      ? { rekorEntryId: record.basePackageRekorEntryId }
-      : {}),
-    ...(record.basePackageRekorInclusionProof
-      ? { rekorInclusionProof: record.basePackageRekorInclusionProof }
-      : {}),
-    trustRegistryUrl: TRUST_REGISTRY_URL,
-    subjectTitle: record.title,
-    subjectSummary: record.summary,
-  };
-}
+// `buildCommitmentView` (the §9.2.1 proof sidecar) now lives in
+// `@/lib/evidence/commitment` so the public commitment endpoint and this
+// notebook-embedded bundle emit the same self-describing proof object
+// (civic-ai-tools-website#116 WS1).
 
 /**
  * Build a cell-0 markdown metadata table per OES §9.2.4 (SHOULD-level
@@ -122,7 +64,7 @@ function buildCellZero(
     : creator?.displayName ?? 'Unknown';
   const publishedDate = record.createdAt.toISOString().split('T')[0];
   const detailUrl = `https://civicaitools.org/evidence/${record.slug}`;
-  const trustHost = TRUST_REGISTRY_URL.replace('https://', '');
+  const trustHost = CANONICAL_TRUST_REGISTRY_URL.replace('https://', '');
 
   const captureMethodFriendly =
     record.captureMethod === 'chat-flow-stream'
@@ -143,7 +85,7 @@ function buildCellZero(
     `| **Captured via** | ${captureMethodFriendly} |`,
     '| **Content profile** | datHere (A-G envelope, reproducible notebook) |',
     `| **Published** | ${publishedDate} via [civicaitools.org](${detailUrl}) |`,
-    `| **Trust registry** | [${trustHost}](${TRUST_REGISTRY_URL}) |`,
+    `| **Trust registry** | [${trustHost}](${CANONICAL_TRUST_REGISTRY_URL}) |`,
     '',
     "*Re-execute the cells below to reproduce the analysis. The cryptographic envelope is in this notebook's root `metadata.org.civicaitools.evidence` namespace — that's what binds the signature to this content. This cell is a reader affordance only.*",
   ];

--- a/src/app/api/evidence/[slug]/commitment/route.ts
+++ b/src/app/api/evidence/[slug]/commitment/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { evidenceRecords, users } from '@/lib/db/schema';
+import { eq, asc } from 'drizzle-orm';
+import { getPackage } from '@/lib/storage';
+import type { EvidencePackage } from '@/lib/evidence/packager';
+import { buildCommitmentView } from '@/lib/evidence/commitment';
+
+/**
+ * GET /api/evidence/[hash|slug]/commitment
+ *
+ * Public, unauthenticated proof sidecar (spec §9.2.1) — the WS1 "unlock" of
+ * civic-ai-tools-website#116. Returns the §9.2.1 commitment view for a package
+ * so a third party can resolve its proofs and verify INDEPENDENTLY (client-side,
+ * against public infra) instead of trusting a civicaitools.org-rendered verdict.
+ * The view is self-describing (carries `packageUrl` + `trustRegistryUrl`), so a
+ * single `hash → commitment` lookup bootstraps the whole verification.
+ *
+ * The `[slug]` path segment accepts EITHER:
+ *   - a 64-hex base-package hash (`/api/evidence/<hash>/commitment`), or
+ *   - an evidence slug (`/api/evidence/<slug>/commitment`).
+ *
+ * Hash → row ambiguity: re-publishing the same package under a different title
+ * creates a second row with the same `basePackageHash` (identical immutable
+ * blob, possibly a separate signing run). Since the signature is over the hash,
+ * ANY matching row's proofs verify — the hash form returns the CANONICAL (first /
+ * oldest-created) matching row. The slug form is unambiguous (slug is unique).
+ *
+ * Withdrawn packages ARE served (not 404'd): a withdrawn package's base
+ * signature still verifies — withdrawal is a separate, separately-signed action.
+ * The view carries the lifecycle/withdrawal state alongside the proofs.
+ *
+ * CORS: open (`Access-Control-Allow-Origin: *`). The proofs are public,
+ * read-only, and credential-free, and the verifier is forkable / anyone-can-run
+ * (ADR-0013 / Q47) — so the endpoint is open, not restricted to typedstandards
+ * .org. The package blob (Vercel Blob) and the `/.well-known/*` trust registry
+ * the view points at are already CORS-open, so a cross-origin verifier can fetch
+ * all three.
+ *
+ * Pure DB read + JSON.parse for the proofs (signature, RFC 3161 token, Rekor
+ * entry + inclusion proof are all persisted on `evidence_records`); the canonical
+ * package blob is additionally fetched best-effort to surface the signed envelope
+ * fields (`signer`, `type`, `producerProfile`, `contentHash`,
+ * `contentCanonicalization`). No live Rekor / TSA call.
+ */
+
+// A base-package hash is the hex SHA-256 of the canonical envelope: 64 hex chars.
+const HASH_RE = /^[0-9a-f]{64}$/i;
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+function jsonResponse(
+  body: unknown,
+  status: number,
+  extraHeaders: Record<string, string> = {},
+): NextResponse {
+  return NextResponse.json(body as Record<string, unknown>, {
+    status,
+    headers: { ...CORS_HEADERS, ...extraHeaders },
+  });
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug: identifier } = await params;
+
+  // Resolve the row by hash (canonical/first match) or by slug (unambiguous).
+  const records = HASH_RE.test(identifier)
+    ? await db
+        .select()
+        .from(evidenceRecords)
+        .where(eq(evidenceRecords.basePackageHash, identifier))
+        .orderBy(asc(evidenceRecords.createdAt))
+        .limit(1)
+    : await db
+        .select()
+        .from(evidenceRecords)
+        .where(eq(evidenceRecords.slug, identifier))
+        .limit(1);
+
+  if (records.length === 0) {
+    return jsonResponse({ error: 'Evidence not found' }, 404);
+  }
+  const record = records[0];
+
+  // A row with no base-package hash never completed publishing — there are no
+  // proofs to commit to. Treat as not found (nothing to verify).
+  if (!record.basePackageHash) {
+    return jsonResponse(
+      { error: 'No published evidence package for this identifier' },
+      404,
+    );
+  }
+
+  // Non-public records are not exposed (mirrors the existing read-back; the
+  // public flag is independent of withdrawal — withdrawn-but-public is served).
+  if (!record.isPublic) {
+    return jsonResponse({ error: 'Evidence not found' }, 404);
+  }
+
+  const creators = await db
+    .select()
+    .from(users)
+    .where(eq(users.id, record.creatorId))
+    .limit(1);
+  const creator = creators[0] ?? null;
+
+  // Best-effort fetch of the canonical package blob for the signed envelope
+  // fields (signer/type/producerProfile/contentHash/contentCanonicalization).
+  // If the blob can't be fetched, the commitment still serves the DB-sourced
+  // proofs (hash, signature, timestamp, Rekor) and `packageUrl`; an independent
+  // verifier re-derives the envelope fields from the package it fetches itself.
+  let pkg: EvidencePackage | null = null;
+  if (record.basePackageStorageKey) {
+    try {
+      pkg = (await getPackage(record.basePackageStorageKey)) as
+        | EvidencePackage
+        | null;
+    } catch {
+      pkg = null;
+    }
+  }
+
+  const commitment = buildCommitmentView(record, creator, pkg);
+
+  // Short cache: the proofs are immutable for a given hash, but lifecycle state
+  // (withdrawal/reinstatement) can change after publish, so keep it brief.
+  return jsonResponse(commitment, 200, {
+    'Cache-Control': 'public, max-age=60, s-maxage=60',
+  });
+}

--- a/src/lib/evidence/commitment.test.ts
+++ b/src/lib/evidence/commitment.test.ts
@@ -1,0 +1,326 @@
+// Unit tests for the §9.2.1 proof-sidecar builder (commitment.ts), the WS1
+// core of civic-ai-tools-website#116. These prove the generalization beyond the
+// datHere-shaped inline original AND the security-audit invariants for the
+// net-new public exposure: only intended-public fields leave the server.
+//
+// Run with: npm test (Node 22+).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildCommitmentView,
+  buildCommitmentLifecycle,
+  CANONICAL_TRUST_REGISTRY_URL,
+  LEGACY_TRUST_REGISTRY_URL,
+} from './commitment.ts';
+import { evidenceRecords, users } from '../db/schema.ts';
+import type { EvidencePackage } from './packager.ts';
+
+type EvidenceRecord = typeof evidenceRecords.$inferSelect;
+type UserRecord = typeof users.$inferSelect;
+
+// Every key the sidecar is ALLOWED to emit. Anything outside this set is an
+// unintended leak. This is the load-bearing assertion of the security audit:
+// no email, no internal DB UUID (record.id / creatorId / users.id), no private
+// columns (promptText / systemPromptHash / withdrawalSignature / …).
+const ALLOWED_KEYS = new Set([
+  'evidenceProtocolVersion',
+  'packageHash',
+  'packageUrl',
+  'captureMethod',
+  'contentProfile',
+  'producerProfile',
+  'type',
+  'signer',
+  'contentHash',
+  'contentCanonicalization',
+  'signature',
+  'signerIdentity',
+  'rfc3161Timestamp',
+  'rekorEntryId',
+  'rekorInclusionProof',
+  'lifecycle',
+  'trustRegistryUrl',
+  'trustRegistryUrlLegacy',
+  'subjectTitle',
+  'subjectSummary',
+]);
+
+function makeRecord(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  const base: EvidenceRecord = {
+    id: '11111111-1111-1111-1111-111111111111',
+    slug: 'sample-analysis-abc123',
+    creatorId: '22222222-2222-2222-2222-222222222222',
+    title: 'Sample analysis',
+    summary: 'A short, citation-ready summary of the analysis.',
+    model: 'claude-opus-4-8',
+    promptHash: 'sha256:promptdigest',
+    promptVisibility: 'full_text',
+    promptText: 'SECRET prompt text that must never leak into the sidecar',
+    systemPromptHash: 'sha256:systemdigest',
+    mcpServer: 'https://socrata-mcp.civicaitools.org',
+    jurisdiction: 'NYC',
+    civicContext: 'civic context note',
+    basePackageHash:
+      'ef1a431c16bf00262bb4e706b0870617fd44bd5d0d3828f9885bd6aefea9a1ba',
+    basePackageStorageKey:
+      'https://store.public.blob.vercel-storage.com/evidence-packages/ef1a431c16bf00262bb4e706b0870617fd44bd5d0d3828f9885bd6aefea9a1ba.json',
+    basePackageSignature: JSON.stringify({
+      signature: 'BASE64SIG',
+      publicKey: 'BASE64PUBKEY',
+      algorithm: 'Ed25519ph',
+      kid: 'platform:evidence-2026-04',
+    }),
+    basePackageRfc3161Timestamp: 'BASE64TSTOKEN',
+    basePackageRekorEntryId: 'rekor-entry-123',
+    basePackageRekorInclusionProof: JSON.stringify({ logIndex: 42 }),
+    captureMethod: 'chat-flow-stream',
+    contentProfile: null,
+    verificationStatus: 'unverified',
+    consistencyClassification: null,
+    isPublic: true,
+    withdrawnAt: null,
+    withdrawnReason: null,
+    withdrawalSignature: 'SECRET withdrawal signature',
+    withdrawalTimestamp: null,
+    reinstatedAt: null,
+    reinstatedReason: null,
+    reinstatementSignature: null,
+    reinstatementTimestamp: null,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+  };
+  return { ...base, ...overrides };
+}
+
+function makeCreator(overrides: Partial<UserRecord> = {}): UserRecord {
+  return {
+    id: '22222222-2222-2222-2222-222222222222',
+    githubId: '583231', // public GitHub user id (token.sub), NOT the DB UUID
+    displayName: 'Octocat',
+    githubProfileUrl: 'https://github.com/octocat',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+// Only the envelope fields buildCommitmentView reads are exercised; cast keeps
+// the fixture small. (The full EvidencePackage shape is tested in packager.test.)
+function makePkg(overrides: Partial<EvidencePackage> = {}): EvidencePackage {
+  return {
+    producerProfile: 'analysis/socrata-civic/v1',
+    type: 'content/analysis/v1',
+    signer: {
+      bindingTier: 'platform',
+      identifier: 'platform:civic-ai-tools',
+      displayName: 'Civic AI Tools Platform',
+    },
+    contentCanonicalization: 'https://typedstandards.org/canonicalization/legacy-json/v1',
+    contentHash: { sha256: 'deadbeef' },
+    ...overrides,
+  } as unknown as EvidencePackage;
+}
+
+test('non-datHere package (contentProfile null) yields a coherent default sidecar', () => {
+  const view = buildCommitmentView(makeRecord(), makeCreator(), makePkg());
+
+  // The generalization: profile sourced from the row, not hardcoded 'datHere'.
+  assert.equal(view.contentProfile, 'default');
+  // Self-describing: carries the blob URL and BOTH registry paths.
+  assert.equal(
+    view.packageUrl,
+    'https://store.public.blob.vercel-storage.com/evidence-packages/ef1a431c16bf00262bb4e706b0870617fd44bd5d0d3828f9885bd6aefea9a1ba.json',
+  );
+  assert.equal(view.trustRegistryUrl, CANONICAL_TRUST_REGISTRY_URL);
+  assert.equal(view.trustRegistryUrlLegacy, LEGACY_TRUST_REGISTRY_URL);
+  assert.match(view.trustRegistryUrl as string, /typed-publisher\.json$/);
+  // Proofs present.
+  assert.equal(
+    view.packageHash,
+    'ef1a431c16bf00262bb4e706b0870617fd44bd5d0d3828f9885bd6aefea9a1ba',
+  );
+  assert.equal(view.rfc3161Timestamp, 'BASE64TSTOKEN');
+  assert.equal(view.rekorEntryId, 'rekor-entry-123');
+  assert.equal(view.evidenceProtocolVersion, '0.1.0');
+});
+
+test('datHere package surfaces contentProfile datHere', () => {
+  const view = buildCommitmentView(
+    makeRecord({ contentProfile: 'datHere' }),
+    makeCreator(),
+    makePkg(),
+  );
+  assert.equal(view.contentProfile, 'datHere');
+});
+
+test('signature is carried verbatim with algorithm + kid (load-bearing for verify-core dispatch)', () => {
+  const view = buildCommitmentView(makeRecord(), makeCreator(), makePkg());
+  const sig = view.signature as Record<string, unknown>;
+  assert.equal(sig.algorithm, 'Ed25519ph');
+  assert.equal(sig.kid, 'platform:evidence-2026-04');
+  assert.equal(sig.publicKey, 'BASE64PUBKEY');
+  assert.equal(sig.signature, 'BASE64SIG');
+});
+
+test('pre-kid / plain-Ed25519 signature is carried as-is (no kid)', () => {
+  const view = buildCommitmentView(
+    makeRecord({
+      basePackageSignature: JSON.stringify({
+        signature: 'SIG',
+        publicKey: 'PK',
+        algorithm: 'Ed25519',
+      }),
+    }),
+    makeCreator(),
+    makePkg(),
+  );
+  const sig = view.signature as Record<string, unknown>;
+  // Dispatch must select plain ed25519 for legacy packages (the #111 fix).
+  assert.equal(sig.algorithm, 'Ed25519');
+  assert.equal('kid' in sig, false);
+});
+
+test('malformed signature JSON degrades to no signature field, not a throw', () => {
+  const view = buildCommitmentView(
+    makeRecord({ basePackageSignature: '{not valid json' }),
+    makeCreator(),
+    makePkg(),
+  );
+  assert.equal('signature' in view, false);
+});
+
+test('signer (envelope §8.5 claim) and signerIdentity (public GitHub) are distinct fields', () => {
+  const view = buildCommitmentView(makeRecord(), makeCreator(), makePkg());
+
+  const signer = view.signer as Record<string, unknown>;
+  const signerIdentity = view.signerIdentity as Record<string, unknown>;
+
+  // Envelope signer — the check-#14 subject.
+  assert.equal(signer.identifier, 'platform:civic-ai-tools');
+  // Public GitHub identity — informational; providerId is the GitHub user id.
+  assert.equal(signerIdentity.provider, 'github');
+  assert.equal(signerIdentity.providerId, '583231');
+  assert.equal(signerIdentity.profileUrl, 'https://github.com/octocat');
+  // They must not be conflated.
+  assert.notEqual(signer.identifier, signerIdentity.providerId);
+});
+
+test('null pkg: envelope fields omitted, proofs + packageUrl still served', () => {
+  const view = buildCommitmentView(makeRecord(), makeCreator(), null);
+
+  assert.equal('producerProfile' in view, false);
+  assert.equal('type' in view, false);
+  assert.equal('signer' in view, false);
+  assert.equal('contentHash' in view, false);
+  assert.equal('contentCanonicalization' in view, false);
+  // Core proofs survive a missing blob.
+  assert.equal(
+    view.packageHash,
+    'ef1a431c16bf00262bb4e706b0870617fd44bd5d0d3828f9885bd6aefea9a1ba',
+  );
+  assert.ok(view.signature);
+  assert.equal(view.rekorEntryId, 'rekor-entry-123');
+  assert.ok(view.packageUrl);
+});
+
+test('no creator: signerIdentity omitted, no throw', () => {
+  const view = buildCommitmentView(makeRecord(), null, makePkg());
+  assert.equal('signerIdentity' in view, false);
+});
+
+test('lifecycle: active package omits the lifecycle field entirely', () => {
+  const view = buildCommitmentView(makeRecord(), makeCreator(), makePkg());
+  assert.equal('lifecycle' in view, false);
+});
+
+test('lifecycle: currently-withdrawn package is served with withdrawn state', () => {
+  const view = buildCommitmentView(
+    makeRecord({
+      withdrawnAt: new Date('2026-06-02T12:00:00.000Z'),
+      withdrawnReason: 'Superseded by a corrected analysis',
+    }),
+    makeCreator(),
+    makePkg(),
+  );
+  const lc = view.lifecycle as Record<string, unknown>;
+  assert.equal(lc.status, 'withdrawn');
+  assert.equal(lc.withdrawnAt, '2026-06-02T12:00:00.000Z');
+  assert.equal(lc.withdrawnReason, 'Superseded by a corrected analysis');
+  // The package's proofs are STILL present (withdrawal is a separate action).
+  assert.ok(view.signature);
+  assert.ok(view.packageHash);
+});
+
+test('lifecycle: reinstated package reads active but carries history', () => {
+  const view = buildCommitmentView(
+    makeRecord({
+      withdrawnAt: new Date('2026-06-02T12:00:00.000Z'),
+      withdrawnReason: 'mistake',
+      reinstatedAt: new Date('2026-06-03T09:00:00.000Z'),
+      reinstatedReason: 'resolved',
+    }),
+    makeCreator(),
+    makePkg(),
+  );
+  const lc = view.lifecycle as Record<string, unknown>;
+  assert.equal(lc.status, 'active');
+  assert.equal(lc.withdrawnAt, '2026-06-02T12:00:00.000Z');
+  assert.equal(lc.reinstatedAt, '2026-06-03T09:00:00.000Z');
+  assert.equal(lc.reinstatedReason, 'resolved');
+});
+
+test('buildCommitmentLifecycle returns null when never withdrawn', () => {
+  assert.equal(
+    buildCommitmentLifecycle({
+      withdrawnAt: null,
+      withdrawnReason: null,
+      reinstatedAt: null,
+      reinstatedReason: null,
+    }),
+    null,
+  );
+});
+
+test('SECURITY: only intended-public keys are emitted (no PII / internal IDs / private columns)', () => {
+  // Exercise the widest field set: withdrawn + full pkg + creator.
+  const view = buildCommitmentView(
+    makeRecord({
+      withdrawnAt: new Date('2026-06-02T12:00:00.000Z'),
+      withdrawnReason: 'reason',
+    }),
+    makeCreator(),
+    makePkg(),
+  );
+
+  for (const key of Object.keys(view)) {
+    assert.ok(
+      ALLOWED_KEYS.has(key),
+      `unexpected key leaked into commitment view: ${key}`,
+    );
+  }
+
+  // Spot-check the specific sensitive values are absent anywhere in the JSON.
+  const serialized = JSON.stringify(view);
+  assert.equal(
+    serialized.includes('SECRET prompt text'),
+    false,
+    'prompt text leaked',
+  );
+  assert.equal(
+    serialized.includes('SECRET withdrawal signature'),
+    false,
+    'withdrawal signature leaked',
+  );
+  // Internal DB UUIDs (record.id / creatorId / users.id) must never appear.
+  assert.equal(
+    serialized.includes('11111111-1111-1111-1111-111111111111'),
+    false,
+    'record UUID leaked',
+  );
+  assert.equal(
+    serialized.includes('22222222-2222-2222-2222-222222222222'),
+    false,
+    'creator UUID leaked',
+  );
+});

--- a/src/lib/evidence/commitment.ts
+++ b/src/lib/evidence/commitment.ts
@@ -1,0 +1,196 @@
+import { evidenceRecords, users } from '../db/schema.ts';
+import type { EvidencePackage } from './packager.ts';
+
+/**
+ * Proof sidecar ("commitment view") builder — spec §9.2.1.
+ *
+ * Extracted from `src/app/api/evidence/[slug]/bundle/route.ts` (WS1 of
+ * civic-ai-tools-website#116) so the same self-describing proof object is
+ * produced by two surfaces:
+ *
+ *   1. the notebook-embedded bundle (`/api/evidence/[slug]/bundle`), where it
+ *      lives under the notebook root's `org.civicaitools.evidence` namespace;
+ *   2. the public, hash-addressable commitment endpoint
+ *      (`/api/evidence/[hash|slug]/commitment`), which returns it directly so a
+ *      third party can resolve a package's proofs and verify INDEPENDENTLY
+ *      (client-side, against public infra) rather than trusting a
+ *      civicaitools.org-rendered verdict.
+ *
+ * The view is self-describing: it carries `packageUrl` (the canonical blob) and
+ * `trustRegistryUrl` (the publisher's key registry), so a `hash → commitment`
+ * lookup bootstraps the entire §9.2 verification without any further knowledge
+ * of civicaitools.org's internals.
+ *
+ * Every field here is intended-public (see the security audit in the WS1 PR and
+ * `docs/api/evidence-commitment.md`): package hash, blob URL, the signature
+ * envelope (signature/publicKey/algorithm/kid — all public; no private key
+ * material), the public-log proofs (RFC 3161 token, Rekor entry + inclusion
+ * proof), the signed envelope claims (signer/type/producerProfile/contentHash),
+ * the creator's PUBLIC GitHub identity, and the public title/summary. It emits
+ * NO email, NO internal DB UUIDs, and NO private columns (prompt text, etc.).
+ */
+
+type EvidenceRecord = typeof evidenceRecords.$inferSelect;
+type UserRecord = typeof users.$inferSelect;
+
+/**
+ * Canonical trust-registry path (spec §8.3.3, ADR-0012 §3). New external
+ * clients SHOULD resolve the publisher's keys from this path. Served
+ * byte-identical to the legacy path below (parallel-serve).
+ */
+export const CANONICAL_TRUST_REGISTRY_URL =
+  'https://civicaitools.org/.well-known/typed-publisher.json';
+
+/**
+ * Legacy trust-registry path (pre-ADR-0012). Served indefinitely, byte-identical
+ * to the canonical path; emitted alongside the canonical URL so existing clients
+ * that only know the legacy path keep resolving.
+ */
+export const LEGACY_TRUST_REGISTRY_URL =
+  'https://civicaitools.org/.well-known/evidence-public-keys.json';
+
+/**
+ * Current lifecycle state of the content node, surfaced alongside the proofs so
+ * an independent verifier can render "this package was withdrawn" without a
+ * separate lookup. A withdrawn package's base signature still verifies
+ * (withdrawal is a separate, separately-signed action) — the proofs are served
+ * regardless; this is informational state.
+ *
+ * Derived directly from the evidence row's legacy lifecycle columns, which the
+ * withdraw / reinstate routes dual-write alongside the signed `attestation/*`
+ * node — so these columns track the signed lifecycle and don't go stale. The
+ * same columns are already public via `/api/evidence/list` (withdrawnAt /
+ * reinstatedAt) and the detail page (+ reasons). Independent verification of the
+ * signed lifecycle attestation chain itself is WS2 / civic-ai-tools-website#119.
+ */
+export interface CommitmentLifecycle {
+  status: 'active' | 'withdrawn';
+  withdrawnAt?: string;
+  withdrawnReason?: string;
+  reinstatedAt?: string;
+  reinstatedReason?: string;
+}
+
+/**
+ * Build the §9.2.1 lifecycle summary from a record's legacy columns, or null
+ * when the package has no lifecycle history (never withdrawn) — in which case
+ * the commitment view omits the `lifecycle` field entirely.
+ *
+ * "Currently withdrawn" mirrors the `/api/evidence/list` predicate exactly:
+ * withdrawn iff `withdrawnAt` is set and `reinstatedAt` is not. A reinstated
+ * package reads `active` but carries its withdrawal/reinstatement history.
+ */
+export function buildCommitmentLifecycle(
+  record: Pick<
+    EvidenceRecord,
+    'withdrawnAt' | 'withdrawnReason' | 'reinstatedAt' | 'reinstatedReason'
+  >,
+): CommitmentLifecycle | null {
+  if (!record.withdrawnAt) return null;
+
+  const status: CommitmentLifecycle['status'] = record.reinstatedAt
+    ? 'active'
+    : 'withdrawn';
+
+  return {
+    status,
+    withdrawnAt: record.withdrawnAt.toISOString(),
+    ...(record.withdrawnReason ? { withdrawnReason: record.withdrawnReason } : {}),
+    ...(record.reinstatedAt ? { reinstatedAt: record.reinstatedAt.toISOString() } : {}),
+    ...(record.reinstatedReason
+      ? { reinstatedReason: record.reinstatedReason }
+      : {}),
+  };
+}
+
+/**
+ * Build the spec §9.2.1 commitment view from the evidence record + creator + the
+ * signed package JSON. Optional fields (envelope taxonomy, canonicalization,
+ * RFC 3161 timestamp, Rekor entry/proof, lifecycle) are conditionally spread so
+ * absent values don't appear as `null` in the serialized output.
+ *
+ * `pkg` is the canonical package JSON fetched from the blob. It carries the
+ * signed envelope fields (`producerProfile`, `type`, `signer`, `contentHash`,
+ * `contentCanonicalization`) that aren't on the DB row. It is nullable: the
+ * commitment endpoint degrades gracefully if the blob can't be fetched —
+ * envelope fields are omitted, but the DB-sourced proofs (hash, signature,
+ * timestamp, Rekor) are still served, and a verifier re-derives the envelope
+ * fields from the package it fetches itself via `packageUrl`.
+ */
+export function buildCommitmentView(
+  record: EvidenceRecord,
+  creator: UserRecord | null,
+  pkg: EvidencePackage | null,
+): Record<string, unknown> {
+  let signature: Record<string, unknown> | null = null;
+  if (record.basePackageSignature) {
+    try {
+      // The parsed object is `{signature, publicKey, algorithm, kid}`. It is
+      // carried VERBATIM: `algorithm` is load-bearing — an independent
+      // verify-core MUST dispatch ed25519 vs ed25519ph on it (the #111 fix),
+      // and `kid` is the trust-registry lookup handle. Both may be absent on
+      // packages signed via a pre-kid / plain-Ed25519 path; carried as-is.
+      signature = JSON.parse(record.basePackageSignature);
+    } catch {
+      signature = null;
+    }
+  }
+
+  // The creator's PUBLIC GitHub identity (informational). `providerId` is the
+  // GitHub user id (`token.sub` from the OAuth profile), NOT the internal DB
+  // UUID. Distinct from the envelope-side `pkg.signer` claim (§8.5), which is
+  // the subject of verify check #14; a verifier must treat `pkg.signer.
+  // identifier` as the check-#14 subject, not this GitHub identity.
+  const signerIdentity = creator
+    ? {
+        provider: 'github',
+        providerId: creator.githubId,
+        displayName: creator.displayName,
+        profileUrl: creator.githubProfileUrl,
+      }
+    : null;
+
+  const lifecycle = buildCommitmentLifecycle(record);
+
+  return {
+    evidenceProtocolVersion: '0.1.0',
+    packageHash: record.basePackageHash,
+    packageUrl: record.basePackageStorageKey,
+    captureMethod: record.captureMethod ?? null,
+    // Generalized for all packages (WS1): sourced from the row, not hardcoded
+    // 'datHere'. Absent column ⇒ 'default' (legacy / default content shape).
+    contentProfile: record.contentProfile ?? 'default',
+    // Envelope fields sourced from the signed package JSON (spec §8.1.1).
+    // Conditionally spread so packages predating these fields (or a missing
+    // blob) omit them rather than emitting nulls. `producerProfile` / `type` /
+    // `signer` are the PR1 taxonomy fields; `contentHash` /
+    // `contentCanonicalization` are the PR2 §8.2 canonicalization fields. All
+    // are covered by the package signature, so surfacing them lets a cross-host
+    // reader resolve the same envelope the signature commits to.
+    ...(pkg?.producerProfile ? { producerProfile: pkg.producerProfile } : {}),
+    ...(pkg?.type ? { type: pkg.type } : {}),
+    ...(pkg?.signer ? { signer: pkg.signer } : {}),
+    ...(pkg?.contentHash ? { contentHash: pkg.contentHash } : {}),
+    ...(pkg?.contentCanonicalization
+      ? { contentCanonicalization: pkg.contentCanonicalization }
+      : {}),
+    ...(signature ? { signature } : {}),
+    ...(signerIdentity ? { signerIdentity } : {}),
+    ...(record.basePackageRfc3161Timestamp
+      ? { rfc3161Timestamp: record.basePackageRfc3161Timestamp }
+      : {}),
+    ...(record.basePackageRekorEntryId
+      ? { rekorEntryId: record.basePackageRekorEntryId }
+      : {}),
+    ...(record.basePackageRekorInclusionProof
+      ? { rekorInclusionProof: record.basePackageRekorInclusionProof }
+      : {}),
+    ...(lifecycle ? { lifecycle } : {}),
+    // Canonical path (ADR-0012); new clients SHOULD use this. `…Legacy` is the
+    // byte-identical pre-ADR-0012 path, emitted alongside for older clients.
+    trustRegistryUrl: CANONICAL_TRUST_REGISTRY_URL,
+    trustRegistryUrlLegacy: LEGACY_TRUST_REGISTRY_URL,
+    subjectTitle: record.title,
+    subjectSummary: record.summary,
+  };
+}


### PR DESCRIPTION
## #116 WS1 — Public proof sidecar (the "unlock")

> **Do not merge — planning review first.** This is the WS1 critical-path deliverable of #116; the verifier (WS2/WS3) builds on it.

Today the only verify path is server-side and slug-coupled (`/api/evidence/[slug]/verify` returns *verdicts*), so consuming it means trusting civicaitools.org's verification. This PR exposes the **proofs themselves** at a public, hash-addressable URL so anyone can verify independently, client-side, against public infrastructure.

### What changed

1. **Extracted** `buildCommitmentView` from `src/app/api/evidence/[slug]/bundle/route.ts` into `src/lib/evidence/commitment.ts` (behavior-preserving), so the notebook bundle and the new endpoint emit the same §9.2.1 self-describing proof object.
2. **Generalized** it for all packages (it was `datHere`-shaped):
   - `contentProfile` sourced from the row (`record.contentProfile ?? 'default'`), not hardcoded `'datHere'`.
   - `trustRegistryUrl` → **canonical** `/.well-known/typed-publisher.json` (ADR-0012); legacy `/.well-known/evidence-public-keys.json` emitted alongside as `trustRegistryUrlLegacy`.
   - Signature carried **verbatim** so `algorithm` (load-bearing — an independent verify-core must dispatch `ed25519` vs `ed25519ph` on it, the #111 fix / carry-forward note) and `kid` survive. Both are nullable for pre-kid / plain-Ed25519 packages — carried as-is.
   - Lifecycle/withdrawal state surfaced; `pkg` made nullable so a missing blob degrades gracefully (proofs still served).
3. **New endpoint** `GET /api/evidence/<hash|slug>/commitment` — public, unauthenticated, CORS-open. Hash form (64-hex) returns the **canonical/first match** for the hash; slug form is unambiguous. `OPTIONS` preflight handled.
4. Endpoint contract in [`docs/api/evidence-commitment.md`](./docs/api/evidence-commitment.md) (+ a cross-link from `evidence-publish.md`).

### Planning-decision implementations

- **CORS open** (`Access-Control-Allow-Origin: *`): proofs are public, read-only, credential-free, and the verifier is forkable / anyone-can-run (ADR-0013 / Q47). Verified the **Vercel Blob** and **both `/.well-known/*` registry paths** are already CORS-open (live, 2026-06-04) — no change needed there.
- **Withdrawn packages are served, not 404'd**: a withdrawn package's base signature still verifies (withdrawal is a separate, separately-signed action). The `lifecycle` state is attached alongside the proofs.
- **Hash → row ambiguity**: re-publishing under a new title creates a second row with the same `basePackageHash`; any matching row's proofs verify (signature is over the hash). The hash form returns the canonical (oldest-created) match; the slug form is unambiguous. Documented.

### Security audit (net-new public exposure)

The public read-back exposes only `basePackageHash` today; the sidecar newly exposes the signature envelope, RFC 3161 / Rekor proofs, blob URL, signer claims, and the publisher's GitHub identity. Audited every emitted field:

- Only intended-public data leaves the server. **No email** (the `users` table has none), **no internal DB UUIDs** (`record.id` / `creatorId` / `users.id` are never emitted), **no private columns** (prompt text, withdrawal signatures, etc.).
- `signerIdentity.providerId` is the **public GitHub user id** (`token.sub`), not an internal id — confirmed against the auth callback. Kept distinct from and not conflated with the envelope-side `pkg.signer` §8.5 claim (the verify check-#14 subject).
- The no-leak invariant is asserted in `commitment.test.ts` (emitted keys must be a subset of an explicit allowlist; sensitive sentinel values must be absent from the serialized output).

### Verification

- **Unit tests** (`commitment.test.ts`, 13 cases): non-datHere `default` sidecar, datHere, `algorithm`+`kid` carried, pre-kid plain-Ed25519 carried as-is, malformed-signature degradation, `signer`≠`signerIdentity`, null-pkg degradation, lifecycle (active/withdrawn/reinstated), and the security no-leak invariant.
- **Real-bytes check**: ran the extracted module against actual production package blobs — a legacy non-datHere chat-flow package (envelope fields correctly omitted, `contentProfile: "default"`) and a v0.1 datHere package (`producerProfile`/`type`/`signer`/`contentHash` flow through). Both emit only allowed keys.
- **Gates**: `npm test` 276/276 green (Node 22); `tsc --noEmit` clean modulo the 2 pre-existing `expert-attestation.test.ts` errors; `eslint` clean on all changed/new files (repo-wide lint count unchanged from base — the 5 pre-existing errors are in untouched files).

### Note on bundle output

The bundle route's *code* is now a thin import (behavior-preserving extraction). Its *embedded* commitment view changes only in the deliberate generalization ways: `trustRegistryUrl` legacy→canonical (+ the new legacy field) and `lifecycle` added when a datHere package is withdrawn. Both registry paths serve byte-identical content, so verification is unaffected.

### Not run

The full **live HTTP integration smoke test** (DB → endpoint over HTTP) wasn't run because it needs an interactive `op signin` for `DATABASE_URL`. The creds-free real-bytes check above exercises the substantive DB-row → blob → sidecar logic; happy to run the live endpoint check once signed in.

### Out of scope (WS2 / WS3 / #119)

Portable browser-safe verify-core, the typedstandards.org site, the embeddable verify badge, offline-crypto hardening, and signed-lifecycle independent verification.

Closes nothing — WS1 of #116.
