### PR TITLE
feat(evidence): carry the Rekor entry body for offline inclusion (#119 P1/D2)

### DIFF
--- a/drizzle/0011_aberrant_squadron_sinister.sql
+++ b/drizzle/0011_aberrant_squadron_sinister.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "evidence_records" ADD COLUMN "base_package_rekor_entry_body" text;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,783 @@
+{
+  "id": "205ccf69-e877-45e8-8d11-a9189387474f",
+  "prevId": "04e879b3-a049-442b-ae7e-5cfa88fea501",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_nodes": {
+      "name": "attestation_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rfc3161_timestamp": {
+          "name": "rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_entry_id": {
+          "name": "rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_inclusion_proof": {
+          "name": "rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer": {
+          "name": "signer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_nodes_creator_id_users_id_fk": {
+          "name": "attestation_nodes_creator_id_users_id_fk",
+          "tableFrom": "attestation_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_packages": {
+      "name": "attestation_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evidence_record_id": {
+          "name": "evidence_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attestation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_hash": {
+          "name": "package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references_base_hash": {
+          "name": "references_base_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_packages_evidence_record_id_evidence_records_id_fk": {
+          "name": "attestation_packages_evidence_record_id_evidence_records_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "evidence_records",
+          "columnsFrom": [
+            "evidence_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attestation_packages_creator_id_users_id_fk": {
+          "name": "attestation_packages_creator_id_users_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_approved_user_id_users_id_fk": {
+          "name": "device_codes_approved_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_records": {
+      "name": "evidence_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_visibility": {
+          "name": "prompt_visibility",
+          "type": "prompt_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_text'"
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_server": {
+          "name": "mcp_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civic_context": {
+          "name": "civic_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_hash": {
+          "name": "base_package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_storage_key": {
+          "name": "base_package_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_signature": {
+          "name": "base_package_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rfc3161_timestamp": {
+          "name": "base_package_rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_id": {
+          "name": "base_package_rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_inclusion_proof": {
+          "name": "base_package_rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_body": {
+          "name": "base_package_rekor_entry_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_method": {
+          "name": "capture_method",
+          "type": "capture_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_profile": {
+          "name": "content_profile",
+          "type": "content_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "consistency_classification": {
+          "name": "consistency_classification",
+          "type": "consistency_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_reason": {
+          "name": "withdrawn_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_signature": {
+          "name": "withdrawal_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_timestamp": {
+          "name": "withdrawal_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_reason": {
+          "name": "reinstated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_signature": {
+          "name": "reinstatement_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_timestamp": {
+          "name": "reinstatement_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evidence_records_creator_id_users_id_fk": {
+          "name": "evidence_records_creator_id_users_id_fk",
+          "tableFrom": "evidence_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evidence_records_slug_unique": {
+          "name": "evidence_records_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attestation_type": {
+      "name": "attestation_type",
+      "schema": "public",
+      "values": [
+        "consistency",
+        "evaluation",
+        "re_evaluation",
+        "correction",
+        "expert_attestation"
+      ]
+    },
+    "public.capture_method": {
+      "name": "capture_method",
+      "schema": "public",
+      "values": [
+        "chat-flow-stream",
+        "claude-code-jsonl-readback",
+        "claude-code-self-report",
+        "datHere"
+      ]
+    },
+    "public.consistency_classification": {
+      "name": "consistency_classification",
+      "schema": "public",
+      "values": [
+        "highly_reproducible",
+        "moderately_stable",
+        "inconsistent"
+      ]
+    },
+    "public.content_profile": {
+      "name": "content_profile",
+      "schema": "public",
+      "values": [
+        "default",
+        "datHere"
+      ]
+    },
+    "public.prompt_visibility": {
+      "name": "prompt_visibility",
+      "schema": "public",
+      "values": [
+        "full_text",
+        "hash_only"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "consistency_tested",
+        "evaluated",
+        "fully_attested"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1780066435792,
       "tag": "0010_add_attestation_nodes",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1780779327133,
+      "tag": "0011_aberrant_squadron_sinister",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -277,6 +277,7 @@ export async function POST(request: NextRequest) {
       basePackageRfc3161Timestamp: rfc3161Token,
       basePackageRekorEntryId: rekorResult?.entryId || null,
       basePackageRekorInclusionProof: rekorResult?.inclusionProof || null,
+      basePackageRekorEntryBody: rekorResult?.entryBody || null,
       captureMethod: body.captureMethod,
       contentProfile: body.contentProfile ?? null,
     });

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -119,6 +119,11 @@ export const evidenceRecords = pgTable('evidence_records', {
   basePackageRfc3161Timestamp: text('base_package_rfc3161_timestamp'),
   basePackageRekorEntryId: text('base_package_rekor_entry_id'),
   basePackageRekorInclusionProof: text('base_package_rekor_inclusion_proof'),
+  // The Rekor entry's canonical leaf bytes (its base64 `body`), captured at publish
+  // so an independent verifier can recompute the RFC 6962 leaf and verify Merkle
+  // inclusion OFFLINE — no re-fetch from Rekor, no civicaitools.org dependency
+  // (civic-ai-tools-website#119 P1 / D2). Carried in the commitment as `rekorEntryBody`.
+  basePackageRekorEntryBody: text('base_package_rekor_entry_body'),
   captureMethod: captureMethodEnum('capture_method'),
   contentProfile: contentProfileEnum('content_profile'),
   verificationStatus: verificationStatusEnum('verification_status')

--- a/src/lib/evidence/commitment.test.ts
+++ b/src/lib/evidence/commitment.test.ts
@@ -40,6 +40,7 @@ const ALLOWED_KEYS = new Set([
   'rfc3161Timestamp',
   'rekorEntryId',
   'rekorInclusionProof',
+  'rekorEntryBody',
   'lifecycle',
   'trustRegistryUrl',
   'trustRegistryUrlLegacy',
@@ -75,6 +76,7 @@ function makeRecord(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
     basePackageRfc3161Timestamp: 'BASE64TSTOKEN',
     basePackageRekorEntryId: 'rekor-entry-123',
     basePackageRekorInclusionProof: JSON.stringify({ logIndex: 42 }),
+    basePackageRekorEntryBody: 'eyJhcGlWZXJzaW9uIjoiMC4wLjEifQ==',
     captureMethod: 'chat-flow-stream',
     contentProfile: null,
     verificationStatus: 'unverified',
@@ -142,7 +144,18 @@ test('non-datHere package (contentProfile null) yields a coherent default sideca
   );
   assert.equal(view.rfc3161Timestamp, 'BASE64TSTOKEN');
   assert.equal(view.rekorEntryId, 'rekor-entry-123');
+  // The Rekor entry body is carried so inclusion can be verified offline (#119 P1).
+  assert.equal(view.rekorEntryBody, 'eyJhcGlWZXJzaW9uIjoiMC4wLjEifQ==');
   assert.equal(view.evidenceProtocolVersion, '0.1.0');
+});
+
+test('rekorEntryBody is omitted (not null) when the column is empty', () => {
+  const view = buildCommitmentView(
+    makeRecord({ basePackageRekorEntryBody: null }),
+    makeCreator(),
+    makePkg(),
+  );
+  assert.equal('rekorEntryBody' in view, false);
 });
 
 test('datHere package surfaces contentProfile datHere', () => {

--- a/src/lib/evidence/commitment.ts
+++ b/src/lib/evidence/commitment.ts
@@ -25,7 +25,8 @@ import type { EvidencePackage } from './packager.ts';
  * `docs/api/evidence-commitment.md`): package hash, blob URL, the signature
  * envelope (signature/publicKey/algorithm/kid — all public; no private key
  * material), the public-log proofs (RFC 3161 token, Rekor entry + inclusion
- * proof), the signed envelope claims (signer/type/producerProfile/contentHash),
+ * proof + the entry's public canonical body), the signed envelope claims
+ * (signer/type/producerProfile/contentHash),
  * the creator's PUBLIC GitHub identity, and the public title/summary. It emits
  * NO email, NO internal DB UUIDs, and NO private columns (prompt text, etc.).
  */
@@ -184,6 +185,12 @@ export function buildCommitmentView(
       : {}),
     ...(record.basePackageRekorInclusionProof
       ? { rekorInclusionProof: record.basePackageRekorInclusionProof }
+      : {}),
+    // The Rekor entry's canonical leaf bytes (base64), carried so a verifier can
+    // recompute the RFC 6962 leaf and verify Merkle inclusion OFFLINE against the
+    // carried proof + checkpoint — no re-fetch (#119 P1 / D2). Public log data.
+    ...(record.basePackageRekorEntryBody
+      ? { rekorEntryBody: record.basePackageRekorEntryBody }
       : {}),
     ...(lifecycle ? { lifecycle } : {}),
     // Canonical path (ADR-0012); new clients SHOULD use this. `…Legacy` is the

--- a/src/lib/evidence/signing.ts
+++ b/src/lib/evidence/signing.ts
@@ -84,6 +84,9 @@ interface RekorResult {
   entryId: string;
   logIndex: number;
   inclusionProof: string; // JSON stringified
+  /** The entry's canonical leaf bytes (base64 `body`) — captured so a verifier can
+   *  recompute the RFC 6962 leaf and verify Merkle inclusion OFFLINE (#119 / D2). */
+  entryBody: string | null;
 }
 
 /**
@@ -247,7 +250,7 @@ export async function publishToRekor(
     }
 
     const result = await response.json();
-    // Response is { [entryId]: { logIndex, ... } }
+    // Response is { [entryId]: { body, logIndex, verification: { inclusionProof }, ... } }
     const entryId = Object.keys(result)[0];
     const entry = result[entryId];
 
@@ -255,6 +258,8 @@ export async function publishToRekor(
       entryId,
       logIndex: entry.logIndex,
       inclusionProof: JSON.stringify(entry.verification?.inclusionProof || {}),
+      // The base64 `body` Rekor canonicalized and logged — the RFC 6962 leaf input.
+      entryBody: typeof entry.body === 'string' ? entry.body : null,
     };
   } catch (err) {
     console.warn('[signing] Rekor publish failed:', err instanceof Error ? err.message : err);


### PR DESCRIPTION
**P1 carrier (produce side) for the offline-verification hardening** ([typedstandards#6](https://github.com/npstorey/typedstandards/pull/6) landed the verify-core math; decisions D1–D4 on civic-ai-tools-website#119).

## Why
The commitment/bundle already carry `rekorEntryId` + `rekorInclusionProof`, but **not the entry's canonical leaf bytes**. Without them, an independent verifier can't recompute the RFC 6962 leaf and must re-fetch from Rekor — defeating offline. This captures the entry `body` at publish and carries it as `rekorEntryBody`, closing the last gap for **zero-dependency offline check #8** (consumed by `@typedstandards/verify-core@0.2.0`'s `verifyRekorInclusion`).

## Changes (produce side only — no verify-core dep)
- **schema**: nullable `base_package_rekor_entry_body` column + drizzle `0011` (additive; safe to apply).
- **signing**: `publishToRekor` captures `entry.body` (the base64 Rekor canonicalized + logged — the leaf input).
- **route**: store it with the other Rekor proof columns.
- **commitment**: carry `rekorEntryBody` (omitted, not null, when absent). Public transparency-log data — no private material; the leak-allowlist test is updated and the no-leak assertions still pass.

## Tests
commitment + signing green; full suite **285/285**. No new `tsc`/eslint errors (the repo's pre-existing ones are untouched).

## Sequencing (what's gated, and on what)
1. **This PR** (produce) — mergeable now; new publishes start carrying `rekorEntryBody`.
2. **verify-core 0.2.0 publish** — `npm publish` (needs your npm auth; not available in the agent env).
3. **Consume + dep bump** (follow-up PR) — server verify route passes the carried `rekorInclusionProof` + `rekorEntryBody` into `verifyEvidence`; bump `@typedstandards/verify-core` to `^0.2.0`.
4. **Backfill** existing prod rows (255b8e etc.) — one-time, self-validating (re-fetch each entry, confirm the body folds to the stored proof before writing), then re-confirm the 255b8e baseline. Prod migration — yours to run.

## Deploy note
Migration `0011` adds a **nullable** column (non-breaking); apply it via the repo's migration process before the consume PR + backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
