### PR TITLE
feat(verify): server route verifies Rekor inclusion from carried proof (#119 P1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@typedstandards/verify-core": "^0.1.0",
+        "@typedstandards/verify-core": "^0.2.0",
         "@vercel/blob": "^2.3.3",
         "@vercel/kv": "^3.0.0",
         "@vercel/sandbox": "^1.10.2",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@typedstandards/verify-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.1.0.tgz",
-      "integrity": "sha512-oK6wLVSlGdQQ2/Sc6tz/C8yl0bI7lKN7NM5uG4RhS4ikXl89FpMZEy4+dCiHYTLVzA76qyQZlLRpEi6Tcn+YGg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.2.0.tgz",
+      "integrity": "sha512-aCYn+IGxlGbXwjZcoYxAS+aRq+18CV45toFd623CE/9BJLnrZUkxOaa8+OOPzW3OeDIaxO6Rya4GM69f6VhZWg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@typedstandards/verify-core": "^0.1.0",
+    "@typedstandards/verify-core": "^0.2.0",
     "@vercel/blob": "^2.3.3",
     "@vercel/kv": "^3.0.0",
     "@vercel/sandbox": "^1.10.2",

--- a/scripts/backfill-rekor-entry-body.ts
+++ b/scripts/backfill-rekor-entry-body.ts
@@ -1,0 +1,175 @@
+/**
+ * One-time backfill (civic-ai-tools-website#119 P1 / D2): populate
+ * `base_package_rekor_entry_body` for evidence rows published before the column
+ * existed, so their Rekor inclusion proof can be verified OFFLINE (no re-fetch).
+ *
+ * SELF-VALIDATING — a row is only written if the re-fetched entry body actually
+ * folds to a verified inclusion proof:
+ *   - If the row already stores a REAL proof (audit path + checkpoint), the fetched
+ *     body MUST fold to THAT stored proof before we trust/write it. This is the
+ *     guard: we never store a body that doesn't match what we already committed to.
+ *   - If the row stored an empty `{}` proof (early `publishToRekor` wrote
+ *     `… || {}`), there's nothing to fold against, so we validate the body against
+ *     the entry's FRESH proof from Rekor and refresh both columns together.
+ * A row whose body fails to fold is SKIPPED and reported — never written.
+ *
+ * Idempotent: rows that already have a body which still folds are left untouched.
+ *
+ * DRY RUN by default (writes nothing, reports the plan). Pass `--apply` to write.
+ * Migration 0011 (the nullable column) must already be applied.
+ *
+ *   Dry run:  op run --env-file=.env.local -- npx tsx scripts/backfill-rekor-entry-body.ts
+ *   Apply:    op run --env-file=.env.local -- npx tsx scripts/backfill-rekor-entry-body.ts --apply
+ */
+
+import { eq, isNotNull } from 'drizzle-orm';
+import { db } from '../src/lib/db';
+import { evidenceRecords } from '../src/lib/db/schema';
+import {
+  verifyRekorInclusion,
+  type RekorInclusionProof,
+  type RekorInclusionResult,
+} from '@typedstandards/verify-core';
+
+const APPLY = process.argv.includes('--apply');
+
+interface RekorEntry {
+  body?: string;
+  verification?: { inclusionProof?: RekorInclusionProof };
+}
+
+/** A proof is usable only if it carries an audit path + a signed checkpoint. */
+function isRealProof(proof: unknown): proof is RekorInclusionProof {
+  return (
+    !!proof &&
+    typeof proof === 'object' &&
+    Array.isArray((proof as RekorInclusionProof).hashes) &&
+    typeof (proof as RekorInclusionProof).checkpoint === 'string'
+  );
+}
+
+function parseStoredProof(raw: string | null): RekorInclusionProof | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isRealProof(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchRekorEntry(entryId: string): Promise<RekorEntry | null> {
+  const res = await fetch(`https://rekor.sigstore.dev/api/v1/log/entries/${entryId}`, {
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) return null;
+  const json = (await res.json()) as Record<string, RekorEntry>;
+  return json[entryId] ?? Object.values(json)[0] ?? null;
+}
+
+type Outcome =
+  | { kind: 'skip-has-body' }
+  | { kind: 'skip-no-entry' }
+  | { kind: 'skip-no-body' }
+  | { kind: 'skip-no-proof' }
+  | { kind: 'skip-fold-failed'; result: RekorInclusionResult }
+  | { kind: 'write-body' }
+  | { kind: 'write-body-and-refresh-proof' };
+
+async function planRow(row: {
+  id: string;
+  slug: string;
+  basePackageRekorEntryId: string | null;
+  basePackageRekorEntryBody: string | null;
+  basePackageRekorInclusionProof: string | null;
+}): Promise<{ outcome: Outcome; body?: string; proofJson?: string }> {
+  const entryId = row.basePackageRekorEntryId;
+  if (!entryId) return { outcome: { kind: 'skip-no-proof' } };
+
+  const entry = await fetchRekorEntry(entryId);
+  if (!entry) return { outcome: { kind: 'skip-no-entry' } };
+  if (typeof entry.body !== 'string') return { outcome: { kind: 'skip-no-body' } };
+
+  const storedProof = parseStoredProof(row.basePackageRekorInclusionProof);
+  const freshProof = isRealProof(entry.verification?.inclusionProof)
+    ? entry.verification!.inclusionProof!
+    : null;
+
+  // Idempotent: a row that already has a body which still folds is left as-is.
+  if (row.basePackageRekorEntryBody && storedProof) {
+    const check = verifyRekorInclusion(row.basePackageRekorEntryBody, storedProof);
+    if (check.inclusionVerified) return { outcome: { kind: 'skip-has-body' } };
+  }
+
+  if (storedProof) {
+    // Validate the fetched body against the ALREADY-STORED proof before writing.
+    const result = verifyRekorInclusion(entry.body, storedProof);
+    if (!result.inclusionVerified) return { outcome: { kind: 'skip-fold-failed', result } };
+    return { outcome: { kind: 'write-body' }, body: entry.body };
+  }
+
+  // Empty/missing stored proof: validate the body against the fresh proof and
+  // refresh both columns together.
+  if (!freshProof) return { outcome: { kind: 'skip-no-proof' } };
+  const result = verifyRekorInclusion(entry.body, freshProof);
+  if (!result.inclusionVerified) return { outcome: { kind: 'skip-fold-failed', result } };
+  return {
+    outcome: { kind: 'write-body-and-refresh-proof' },
+    body: entry.body,
+    proofJson: JSON.stringify(freshProof),
+  };
+}
+
+async function main(): Promise<void> {
+  const rows = await db
+    .select({
+      id: evidenceRecords.id,
+      slug: evidenceRecords.slug,
+      basePackageRekorEntryId: evidenceRecords.basePackageRekorEntryId,
+      basePackageRekorEntryBody: evidenceRecords.basePackageRekorEntryBody,
+      basePackageRekorInclusionProof: evidenceRecords.basePackageRekorInclusionProof,
+    })
+    .from(evidenceRecords)
+    .where(isNotNull(evidenceRecords.basePackageRekorEntryId));
+
+  console.log(`[backfill] ${rows.length} rows with a Rekor entry id. ${APPLY ? 'APPLY' : 'DRY RUN'}.`);
+  const tally: Record<string, number> = {};
+  let written = 0;
+
+  for (const row of rows) {
+    const { outcome, body, proofJson } = await planRow(row);
+    tally[outcome.kind] = (tally[outcome.kind] ?? 0) + 1;
+
+    if (outcome.kind === 'skip-fold-failed') {
+      console.warn(`[backfill] FOLD FAILED ${row.slug} (${row.basePackageRekorEntryId}) — ${outcome.result.reason}; NOT writing.`);
+      continue;
+    }
+    if ((outcome.kind === 'write-body' || outcome.kind === 'write-body-and-refresh-proof') && body) {
+      console.log(`[backfill] ${APPLY ? 'WRITE' : 'would write'} ${outcome.kind} → ${row.slug}`);
+      if (APPLY) {
+        await db
+          .update(evidenceRecords)
+          .set(
+            outcome.kind === 'write-body-and-refresh-proof' && proofJson
+              ? { basePackageRekorEntryBody: body, basePackageRekorInclusionProof: proofJson }
+              : { basePackageRekorEntryBody: body },
+          )
+          .where(eq(evidenceRecords.id, row.id));
+        written += 1;
+      }
+    }
+  }
+
+  console.log('[backfill] summary:', tally);
+  console.log(`[backfill] ${APPLY ? `wrote ${written} rows` : 'dry run — nothing written'}.`);
+  if (tally['skip-fold-failed']) {
+    console.warn(`[backfill] ${tally['skip-fold-failed']} row(s) failed to fold — investigate before trusting those entries.`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('[backfill] fatal:', err);
+    process.exit(1);
+  });

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -14,6 +14,7 @@ import { getPackage } from '@/lib/storage';
 import {
   verifyEvidence,
   type VerifySignatureEnvelope,
+  type RekorInclusionProof,
 } from '@/lib/evidence/verify-core';
 import { loadTrustRegistry } from '@/lib/evidence/verify';
 import { resolveLifecycle } from '@/lib/evidence/lifecycle';
@@ -56,6 +57,23 @@ export async function GET(
     }
   }
 
+  // Parse the persisted Rekor inclusion proof. Only a REAL proof (carrying the
+  // audit path + signed checkpoint) is usable for cryptographic Merkle inclusion
+  // (#119 P1); the empty `{}` placeholder some early rows stored is treated as
+  // absent (those rows are healed by the backfill). With the carried entry body
+  // (#119 P1/D2), inclusion verifies OFFLINE — no re-fetch from Rekor.
+  let rekorInclusionProof: RekorInclusionProof | null = null;
+  if (record.basePackageRekorInclusionProof) {
+    try {
+      const parsed = JSON.parse(record.basePackageRekorInclusionProof);
+      if (parsed && Array.isArray(parsed.hashes) && typeof parsed.checkpoint === 'string') {
+        rekorInclusionProof = parsed as RekorInclusionProof;
+      }
+    } catch {
+      // malformed proof column ⇒ leave null (inclusion simply not verified here)
+    }
+  }
+
   // Load the trust registry once (cached; falls back to the build-time embedded
   // copy) and resolve lifecycle at the server's chain depth.
   const [registry, lifecycleResolution] = await Promise.all([
@@ -74,6 +92,8 @@ export async function GET(
       signatureMalformed,
       rfc3161Timestamp: record.basePackageRfc3161Timestamp,
       rekorEntryId: record.basePackageRekorEntryId,
+      rekorInclusionProof,
+      rekorEntryBody: record.basePackageRekorEntryBody,
       legacyExternalHash: record.basePackageHash ?? undefined,
     },
     { registry, fetch: globalThis.fetch, lifecycleResolution },
@@ -83,6 +103,10 @@ export async function GET(
     hashMatch: result.hashMatch,
     signatureValid: result.signatureValid,
     rekorVerified: result.rekorVerified,
+    // Cryptographic Merkle-inclusion verdict (#119 P1), additive to the hash-parity
+    // `rekorVerified`. Null when no usable proof was carried (e.g. da9246 has no
+    // Rekor). Data only — the #8 UI/depth-label rendering is unchanged (that is P4).
+    rekorInclusion: result.rekorInclusion,
     hasTimestamp: result.hasTimestamp,
     keyTrust: result.keyTrust,
     blobRefsVerified: result.blobRefsVerified,


### PR DESCRIPTION
**P1 consume (server side)** — pairs with typedstandards#8 (browser verify-flow). Follows the carrier-produce #126 (merged) and verify-core **0.2.0** (published).

## What
The server verify route now threads the carried Rekor inclusion proof + entry body into `verifyEvidence`, so §9.2 **check #8 deepens from hash-PARITY to cryptographic Merkle inclusion** against the pinned log key — verified **offline** from the carried body (no re-fetch).

- Parse `base_package_rekor_inclusion_proof`; only a real proof (audit path + signed checkpoint) is used. Empty `{}` early rows → treated as absent (healed by the backfill).
- Pass `rekorInclusionProof` + `rekorEntryBody` to `verifyEvidence`; bump `@typedstandards/verify-core` → `^0.2.0`.
- Surface `result.rekorInclusion` as a **new, additive** response field.

## Guardrails
- **Additive only** — existing response fields (`rekorVerified` hash-parity, etc.) unchanged; **#8 UI/depth labels NOT touched** (surfacing is P4). Data threading only.
- tsc/lint/build green (pre-existing repo errors only); full suite **285/285**.
- **Prod parity intended to deepen**: after deploy, 255b8e's `/verify` gains a `rekorInclusion` verdict; da9246 (no Rekor) stays null. Re-baseline — not a regression.

## After merge
Run the self-validating **backfill** (migration 0011 already applied) to heal existing rows' entry body + empty `{}` proofs, then re-confirm 255b8e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)