### PR TITLE
feat(verify): surface the RFC 3161 TSA verdict from the server route (#119 P2a)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@typedstandards/verify-core": "^0.2.0",
+        "@typedstandards/verify-core": "^0.3.1",
         "@vercel/blob": "^2.3.3",
         "@vercel/kv": "^3.0.0",
         "@vercel/sandbox": "^1.10.2",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@typedstandards/verify-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.2.0.tgz",
-      "integrity": "sha512-aCYn+IGxlGbXwjZcoYxAS+aRq+18CV45toFd623CE/9BJLnrZUkxOaa8+OOPzW3OeDIaxO6Rya4GM69f6VhZWg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.3.1.tgz",
+      "integrity": "sha512-t+Vvc8K8Zakoqepb5R4QYl8H5SYQR7eqXOIy9hWWLyD5tZOV0gZAOolxabJRIIo7OTQkABhc+tqafUCD/QGaDQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@typedstandards/verify-core": "^0.2.0",
+    "@typedstandards/verify-core": "^0.3.1",
     "@vercel/blob": "^2.3.3",
     "@vercel/kv": "^3.0.0",
     "@vercel/sandbox": "^1.10.2",

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -108,6 +108,11 @@ export async function GET(
     // Rekor). Data only — the #8 UI/depth-label rendering is unchanged (that is P4).
     rekorInclusion: result.rekorInclusion,
     hasTimestamp: result.hasTimestamp,
+    // Cryptographic RFC 3161 TSA verdict (#119 P2a), additive to the presence-only
+    // `hasTimestamp`. verifyEvidence runs it from the already-passed token (offline,
+    // ECDSA-P384 vs the pinned FreeTSA anchor). Data only — the #7 UI/depth labels
+    // are unchanged (surfacing is P4).
+    rfc3161: result.rfc3161,
     keyTrust: result.keyTrust,
     blobRefsVerified: result.blobRefsVerified,
     blobRefs: result.blobRefs,


### PR DESCRIPTION
**P2a propagation (server side)** — pairs with typedstandards#11. Follows the lowS fix (verify-core **0.3.1**, published).

## What
Bump `@typedstandards/verify-core` → `^0.3.1` and surface `result.rfc3161` as a new **additive** response field. The route already passes the token into `verifyEvidence`, so the cryptographic #7 verdict (ECDSA-P384 vs the pinned FreeTSA anchor, **offline**) now flows out alongside the unchanged presence-only `hasTimestamp`.

## Guardrails
- **Additive only** — `rfc3161` is new; `hasTimestamp` and all existing fields unchanged; **#7 UI/depth labels NOT touched** (surfacing is P4).
- tsc/lint/build green (pre-existing repo errors only); full suite **285/285**.

## Pre-validated against prod (0.3.1, before deploy)
- **255b8e** → `rfc3161.verified:true` (sig/imprint/contentBound/withinValidity all true, tsa freetsa.org) + `rekorInclusion{incl,ckpt}:true`.
- **da9246** → `rfc3161.verified:true` (the **high-S** token that exposed the lowS bug now verifies) + no Rekor.

## After merge
Re-baseline both on prod `/verify` (the lowS fix is the whole point of this round). If either shows `rfc3161` ≠ `verified:true`, stop and flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)