### PR TITLE
chore: bump verify-core to ^0.4.0 — surface RFC 3161 chain verdict (#119 P2b)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@typedstandards/verify-core": "^0.3.1",
+        "@typedstandards/verify-core": "^0.4.0",
         "@vercel/blob": "^2.3.3",
         "@vercel/kv": "^3.0.0",
         "@vercel/sandbox": "^1.10.2",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@typedstandards/verify-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.3.1.tgz",
-      "integrity": "sha512-t+Vvc8K8Zakoqepb5R4QYl8H5SYQR7eqXOIy9hWWLyD5tZOV0gZAOolxabJRIIo7OTQkABhc+tqafUCD/QGaDQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.4.0.tgz",
+      "integrity": "sha512-XTAk1imZ4ArTGEI39R5Efl6TRSDOD/qnLhF+h7/QM7kFc2PxcHrvJ0X3LZ4PVX4jljv21nQk12uasmlva26aBQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@typedstandards/verify-core": "^0.3.1",
+    "@typedstandards/verify-core": "^0.4.0",
     "@vercel/blob": "^2.3.3",
     "@vercel/kv": "^3.0.0",
     "@vercel/sandbox": "^1.10.2",


### PR DESCRIPTION
**P2b propagation (server side)** — pairs with typedstandards#13. verify-core **0.4.0** published.

## What
Dep bump only — the verify route already surfaces the whole `result.rfc3161`, so the new **additive** fields appear automatically: **`chainVerified`** (the signing cert chains to the pinned FreeTSA RSA-4096 root) + **`ekuTimestamping`**. `verifyEvidence` now performs full RFC 3161 #7 (token → TSTInfo → CMS sig → cert chain → pinned root).

## Re-baseline (pre-validated vs prod 0.4.0)
- **255b8e** → `verified:true` + **`chainVerified:true`** + **`ekuTimestamping:true`**, tsa freetsa.org.
- **da9246** → same (the high-S token; chain to the pinned root).
Existing fields (verified/imprintMatches/contentBound/withinValidity/signatureValid/genTime/tsa) stable; **#7 UI/depth labels unchanged** (surfacing is P4).

tsc/lint/build green (pre-existing repo errors only); **285/285**.

After merge: confirm both on prod `/verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)