### PR TITLE
feat(evidence): carry the signed lifecycle attestation chain (#119 P3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@typedstandards/verify-core": "^0.4.0",
+        "@typedstandards/verify-core": "^0.5.0",
         "@vercel/blob": "^2.3.3",
         "@vercel/kv": "^3.0.0",
         "@vercel/sandbox": "^1.10.2",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@typedstandards/verify-core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.4.0.tgz",
-      "integrity": "sha512-XTAk1imZ4ArTGEI39R5Efl6TRSDOD/qnLhF+h7/QM7kFc2PxcHrvJ0X3LZ4PVX4jljv21nQk12uasmlva26aBQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.5.0.tgz",
+      "integrity": "sha512-cMUCQQ9tfrEaaPIvBcEuDxVarENunc8vf7Ugr3Zu3O3HCXYc5f6mKrwE28fEpxL1dJ1lyakp4mE+it6KlBhtHg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@typedstandards/verify-core": "^0.4.0",
+    "@typedstandards/verify-core": "^0.5.0",
     "@vercel/blob": "^2.3.3",
     "@vercel/kv": "^3.0.0",
     "@vercel/sandbox": "^1.10.2",

--- a/src/app/api/evidence/[slug]/bundle/route.ts
+++ b/src/app/api/evidence/[slug]/bundle/route.ts
@@ -4,6 +4,7 @@ import { evidenceRecords, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
+import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
 import {
   buildCommitmentView,
   CANONICAL_TRUST_REGISTRY_URL,
@@ -167,9 +168,13 @@ export async function GET(
   // Deep-clone so we don't mutate the cached package
   const notebook = JSON.parse(JSON.stringify(notebookRaw)) as Record<string, unknown>;
 
-  // Inject commitment view at notebook root metadata (OES §9.2.2)
+  // Inject commitment view at notebook root metadata (OES §9.2.2), carrying the
+  // signed lifecycle attestation chain (#119 P3) for offline #10 resolution.
+  const lifecycleAttestations = record.basePackageHash
+    ? await loadCarriedLifecycleAttestations(record.basePackageHash)
+    : [];
   const metadata = (notebook.metadata as Record<string, unknown>) ?? {};
-  metadata[EVIDENCE_NAMESPACE_KEY] = buildCommitmentView(record, creator, pkg);
+  metadata[EVIDENCE_NAMESPACE_KEY] = buildCommitmentView(record, creator, pkg, lifecycleAttestations);
   notebook.metadata = metadata;
 
   // Prepend cell-0 reader-affordance table (OES §9.2.4)

--- a/src/app/api/evidence/[slug]/commitment/route.ts
+++ b/src/app/api/evidence/[slug]/commitment/route.ts
@@ -5,6 +5,7 @@ import { eq, asc } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
 import { buildCommitmentView } from '@/lib/evidence/commitment';
+import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
 
 /**
  * GET /api/evidence/[hash|slug]/commitment
@@ -131,7 +132,13 @@ export async function GET(
     }
   }
 
-  const commitment = buildCommitmentView(record, creator, pkg);
+  // Carry the signed lifecycle attestation chain (#119 P3) so an independent
+  // verifier resolves #10 offline. Empty for packages with no signed chain.
+  const lifecycleAttestations = record.basePackageHash
+    ? await loadCarriedLifecycleAttestations(record.basePackageHash)
+    : [];
+
+  const commitment = buildCommitmentView(record, creator, pkg, lifecycleAttestations);
 
   // Short cache: the proofs are immutable for a given hash, but lifecycle state
   // (withdrawal/reinstatement) can change after publish, so keep it brief.

--- a/src/lib/evidence/commitment.test.ts
+++ b/src/lib/evidence/commitment.test.ts
@@ -42,6 +42,7 @@ const ALLOWED_KEYS = new Set([
   'rekorInclusionProof',
   'rekorEntryBody',
   'lifecycle',
+  'lifecycleAttestations',
   'trustRegistryUrl',
   'trustRegistryUrlLegacy',
   'subjectTitle',
@@ -156,6 +157,23 @@ test('rekorEntryBody is omitted (not null) when the column is empty', () => {
     makePkg(),
   );
   assert.equal('rekorEntryBody' in view, false);
+});
+
+test('carries lifecycleAttestations when present, omits when empty (#119 P3)', () => {
+  const att = [
+    {
+      node: { type: 'attestation/withdraws/v1', targetNodeId: 'abc' },
+      nodeId: 'deadbeef',
+      signature: { signature: 'SIG', publicKey: 'PUB', algorithm: 'Ed25519ph' },
+      hasTimestamp: false,
+      hasRekor: false,
+    },
+  ];
+  const withChain = buildCommitmentView(makeRecord(), makeCreator(), makePkg(), att);
+  assert.deepEqual(withChain.lifecycleAttestations, att);
+  // No signed chain ⇒ the key is omitted (verifier falls back to STATE).
+  const noChain = buildCommitmentView(makeRecord(), makeCreator(), makePkg(), []);
+  assert.equal('lifecycleAttestations' in noChain, false);
 });
 
 test('datHere package surfaces contentProfile datHere', () => {

--- a/src/lib/evidence/commitment.ts
+++ b/src/lib/evidence/commitment.ts
@@ -1,5 +1,6 @@
 import { evidenceRecords, users } from '../db/schema.ts';
 import type { EvidencePackage } from './packager.ts';
+import type { CarriedLifecycleAttestation } from './lifecycle.ts';
 
 /**
  * Proof sidecar ("commitment view") builder — spec §9.2.1.
@@ -25,7 +26,8 @@ import type { EvidencePackage } from './packager.ts';
  * `docs/api/evidence-commitment.md`): package hash, blob URL, the signature
  * envelope (signature/publicKey/algorithm/kid — all public; no private key
  * material), the public-log proofs (RFC 3161 token, Rekor entry + inclusion
- * proof + the entry's public canonical body), the signed envelope claims
+ * proof + the entry's public canonical body), the signed lifecycle attestation
+ * chain (public signed envelopes + signatures), the signed envelope claims
  * (signer/type/producerProfile/contentHash),
  * the creator's PUBLIC GitHub identity, and the public title/summary. It emits
  * NO email, NO internal DB UUIDs, and NO private columns (prompt text, etc.).
@@ -122,6 +124,11 @@ export function buildCommitmentView(
   record: EvidenceRecord,
   creator: UserRecord | null,
   pkg: EvidencePackage | null,
+  /** Signed lifecycle attestation envelopes (from `loadCarriedLifecycleAttestations`),
+   *  carried so an independent verifier resolves #10 OFFLINE via verify-core's
+   *  `verifyLifecycleChain` — no reference-impl dependency (#119 P3). Omitted when the
+   *  package has no signed lifecycle chain (it then stays at STATE / legacy columns). */
+  lifecycleAttestations?: CarriedLifecycleAttestation[],
 ): Record<string, unknown> {
   let signature: Record<string, unknown> | null = null;
   if (record.basePackageSignature) {
@@ -193,6 +200,10 @@ export function buildCommitmentView(
       ? { rekorEntryBody: record.basePackageRekorEntryBody }
       : {}),
     ...(lifecycle ? { lifecycle } : {}),
+    // The signed lifecycle attestation chain (#119 P3), carried so an independent
+    // verifier resolves #10 offline. Omitted when there is no signed chain — the
+    // verifier then resolves lifecycle at STATE depth from `lifecycle` above.
+    ...(lifecycleAttestations?.length ? { lifecycleAttestations } : {}),
     // Canonical path (ADR-0012); new clients SHOULD use this. `…Legacy` is the
     // byte-identical pre-ADR-0012 path, emitted alongside for older clients.
     trustRegistryUrl: CANONICAL_TRUST_REGISTRY_URL,

--- a/src/lib/evidence/lifecycle.ts
+++ b/src/lib/evidence/lifecycle.ts
@@ -156,3 +156,63 @@ async function buildAttestationView(
 function pickString(v: unknown): string | undefined {
   return typeof v === 'string' ? v : undefined;
 }
+
+/** A signed lifecycle attestation carried in the commitment/bundle so an independent
+ *  verifier resolves #10 OFFLINE — verify-core's `verifyLifecycleChain` shape
+ *  (civic-ai-tools-website#119 P3). All public: the signed node envelope + its public
+ *  signature (no private key, no internal DB ids). */
+export interface CarriedLifecycleAttestation {
+  node: Record<string, unknown>;
+  nodeId: string;
+  signature: { signature?: string; publicKey?: string; algorithm?: string } | null;
+  hasTimestamp: boolean;
+  hasRekor: boolean;
+}
+
+/**
+ * Load the signed lifecycle attestation envelopes targeting a content node, for
+ * CARRYING (not resolving) in the commitment/bundle. Each is the signed node JSON
+ * (from blob) + its stored nodeId + signature, so an offline verifier can recompute
+ * the envelope hash, check the signature, and resolve the chain itself — no
+ * reference-implementation dependency. A node whose blob can't be fetched is skipped
+ * (it can't be carried as a self-contained envelope). Returns [] on any query error
+ * (same degrade-not-down posture as `resolveLifecycle`).
+ */
+export async function loadCarriedLifecycleAttestations(
+  targetNodeId: string,
+): Promise<CarriedLifecycleAttestation[]> {
+  let rows: AttestationRow[] = [];
+  try {
+    rows = await db
+      .select()
+      .from(attestationNodes)
+      .where(eq(attestationNodes.targetNodeId, targetNodeId));
+  } catch {
+    return [];
+  }
+
+  const carried: CarriedLifecycleAttestation[] = [];
+  for (const row of rows) {
+    const node = (await getPackage(row.storageKey).catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    if (!node) continue;
+    let signature: CarriedLifecycleAttestation['signature'] = null;
+    if (row.signature) {
+      try {
+        signature = JSON.parse(row.signature);
+      } catch {
+        signature = null;
+      }
+    }
+    carried.push({
+      node,
+      nodeId: row.nodeId,
+      signature,
+      hasTimestamp: !!row.rfc3161Timestamp,
+      hasRekor: !!row.rekorEntryId,
+    });
+  }
+  return carried;
+}


### PR DESCRIPTION
**P3 carrier (produce side)** — pairs with typedstandards#15. verify-core **0.5.0** (verifyLifecycleChain) published.

## What
Expose the signed lifecycle attestation-node envelopes in the commitment/bundle so an independent verifier resolves **#10 offline** via verify-core's `verifyLifecycleChain` — no reference-impl dependency. **No migration** — `attestation_nodes` are already stored; this *exposes* them.

- `loadCarriedLifecycleAttestations(targetNodeId)` — fetches each signed node envelope (blob) + its stored `nodeId` + public signature; degrade-not-down on query error (same posture as `resolveLifecycle`). All public (signed envelopes + signatures; **no private key, no internal DB ids**).
- `buildCommitmentView` carries `lifecycleAttestations` when present, **omitted** when there's no signed chain (verifier then resolves at STATE depth). Leak-allowlist test updated; carry test added.
- commitment + bundle routes load + pass them. Bump verify-core `^0.5.0`.

## Guardrails
- **Additive** — packages with no signed chain (legacy / da9246) carry nothing and stay at STATE/legacy-columns. The **server route's own lifecycle** (its `resolveLifecycle` injection) is **unchanged → byte-identical** output. #10 UI/depth labels untouched (P4).
- tsc/lint/build green (pre-existing repo errors only); **286/286**.

## After merge (the demo)
da9246/255b8e predate the dual-write (da9246 attestations are empty), so to demonstrate `source:'attestation-chain'`: **withdraw a fresh test package** (the withdraw route dual-writes the signed node), then verify it — the browser resolves the chain independently. A reinstate exercises withdrawn→reinstated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)