### PR TITLE
chore: verify-core ^0.6.0 + share parseInclusionProof guard (#119 P4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@typedstandards/verify-core": "^0.5.0",
+        "@typedstandards/verify-core": "^0.6.0",
         "@vercel/blob": "^2.3.3",
         "@vercel/kv": "^3.0.0",
         "@vercel/sandbox": "^1.10.2",
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/@typedstandards/verify-core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.5.0.tgz",
-      "integrity": "sha512-cMUCQQ9tfrEaaPIvBcEuDxVarENunc8vf7Ugr3Zu3O3HCXYc5f6mKrwE28fEpxL1dJ1lyakp4mE+it6KlBhtHg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.6.0.tgz",
+      "integrity": "sha512-0u/AlCGtgDTFVpqgIg0yJMb1vB+brdFhbuXYS2AEeo4/XQYZAIBdz32MH0j0INOZ5MZ0t94rM14BmrC8iwvysw==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@typedstandards/verify-core": "^0.5.0",
+    "@typedstandards/verify-core": "^0.6.0",
     "@vercel/blob": "^2.3.3",
     "@vercel/kv": "^3.0.0",
     "@vercel/sandbox": "^1.10.2",

--- a/scripts/backfill-rekor-entry-body.ts
+++ b/scripts/backfill-rekor-entry-body.ts
@@ -27,6 +27,7 @@ import { db } from '../src/lib/db';
 import { evidenceRecords } from '../src/lib/db/schema';
 import {
   verifyRekorInclusion,
+  parseInclusionProof,
   type RekorInclusionProof,
   type RekorInclusionResult,
 } from '@typedstandards/verify-core';
@@ -38,7 +39,11 @@ interface RekorEntry {
   verification?: { inclusionProof?: RekorInclusionProof };
 }
 
-/** A proof is usable only if it carries an audit path + a signed checkpoint. */
+// A proof is usable only if it carries an audit path + a signed checkpoint. The
+// STORED column (a JSON string) is parsed with verify-core's shared
+// `parseInclusionProof` (#119 P4) — the same guard the verify route and browser
+// verify-flow use. `isRealProof` is its object-level twin, for validating the FRESH
+// proof object pulled from a re-fetched Rekor entry (already parsed, not a string).
 function isRealProof(proof: unknown): proof is RekorInclusionProof {
   return (
     !!proof &&
@@ -46,16 +51,6 @@ function isRealProof(proof: unknown): proof is RekorInclusionProof {
     Array.isArray((proof as RekorInclusionProof).hashes) &&
     typeof (proof as RekorInclusionProof).checkpoint === 'string'
   );
-}
-
-function parseStoredProof(raw: string | null): RekorInclusionProof | null {
-  if (!raw) return null;
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return isRealProof(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
 }
 
 async function fetchRekorEntry(entryId: string): Promise<RekorEntry | null> {
@@ -90,7 +85,7 @@ async function planRow(row: {
   if (!entry) return { outcome: { kind: 'skip-no-entry' } };
   if (typeof entry.body !== 'string') return { outcome: { kind: 'skip-no-body' } };
 
-  const storedProof = parseStoredProof(row.basePackageRekorInclusionProof);
+  const storedProof = parseInclusionProof(row.basePackageRekorInclusionProof);
   const freshProof = isRealProof(entry.verification?.inclusionProof)
     ? entry.verification!.inclusionProof!
     : null;

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -13,8 +13,8 @@ import { getPackage } from '@/lib/storage';
 // state depth).
 import {
   verifyEvidence,
+  parseInclusionProof,
   type VerifySignatureEnvelope,
-  type RekorInclusionProof,
 } from '@/lib/evidence/verify-core';
 import { loadTrustRegistry } from '@/lib/evidence/verify';
 import { resolveLifecycle } from '@/lib/evidence/lifecycle';
@@ -57,22 +57,14 @@ export async function GET(
     }
   }
 
-  // Parse the persisted Rekor inclusion proof. Only a REAL proof (carrying the
-  // audit path + signed checkpoint) is usable for cryptographic Merkle inclusion
-  // (#119 P1); the empty `{}` placeholder some early rows stored is treated as
-  // absent (those rows are healed by the backfill). With the carried entry body
-  // (#119 P1/D2), inclusion verifies OFFLINE — no re-fetch from Rekor.
-  let rekorInclusionProof: RekorInclusionProof | null = null;
-  if (record.basePackageRekorInclusionProof) {
-    try {
-      const parsed = JSON.parse(record.basePackageRekorInclusionProof);
-      if (parsed && Array.isArray(parsed.hashes) && typeof parsed.checkpoint === 'string') {
-        rekorInclusionProof = parsed as RekorInclusionProof;
-      }
-    } catch {
-      // malformed proof column ⇒ leave null (inclusion simply not verified here)
-    }
-  }
+  // Parse the persisted Rekor inclusion proof with verify-core's shared
+  // `parseInclusionProof` (#119 P4) — the one guard this route, the browser
+  // verify-flow, and the backfill share. Only a REAL proof (audit path + signed
+  // checkpoint) is usable for cryptographic Merkle inclusion (#119 P1); the empty
+  // `{}` placeholder some early rows stored is treated as absent (those rows are
+  // healed by the backfill). With the carried entry body (#119 P1/D2), inclusion
+  // verifies OFFLINE — no re-fetch from Rekor.
+  const rekorInclusionProof = parseInclusionProof(record.basePackageRekorInclusionProof);
 
   // Load the trust registry once (cached; falls back to the build-time embedded
   // copy) and resolve lifecycle at the server's chain depth.


### PR DESCRIPTION
**#119 P4 propagation — server (PR-B/B).** Additive, behaviour byte-identical, no migration.

- Dep `@typedstandards/verify-core` `^0.5.0 → ^0.6.0` — the server `/verify` route inherits PR-A's strict RFC 5280 X.509 hardening for the RFC 3161 cert chain (non-exploitable under the pinned FreeTSA root; the real chain still verifies).
- **Shared `parseInclusionProof`** replaces both remaining hand-rolled copies:
  - `src/app/api/evidence/[slug]/verify/route.ts` — the inline `JSON.parse` + `Array.isArray(hashes) && typeof checkpoint==='string'` guard.
  - `scripts/backfill-rekor-entry-body.ts` — `parseStoredProof` (the stored JSON-string path). The object-level `isRealProof` is **kept** — it validates the FRESH proof object from a re-fetched Rekor entry (already parsed, not a string), which the string guard doesn't cover.
- No new column → no migration. The guard swap is behaviour-identical to the removed copies.

**Gates (independently re-run):** `npm test` **286/286** (the real CI gate) · `parseInclusionProof` resolves at runtime from the published 0.6.0 via the `export *` shim.

Pre-existing red (NOT this PR): `tsc --noEmit` (2 errors) + `lint` (5) live in `expert-attestation.test.ts` and other untouched files — confirmed isolated; `next build` excludes test files and skips eslint. Candidate for a separate dev-tooling cleanup (à la #125).

No UI change — verification rendering delegates to typedstandards.org/verify (ADR-0013 / Q46), so this is guard+bump only.

Part of #119 P4.