### PR TITLE
feat(evidence): stamp registry generatedAt (as-of date) (#119 P4 PR-C)

### DIFF
--- a/docs/key-rotation.md
+++ b/docs/key-rotation.md
@@ -79,6 +79,12 @@ verifiable after the rotation.
      timestamp.
    - Flip the previous key's `status` to `deprecated`, set `deprecatedAt`
      to the same ISO timestamp, and leave `revokedAt` as `null`.
+   - **Bump the document-level `generatedAt`** to the current ISO timestamp.
+     This is the registry's "thisUpdate" (CRL precedent): it declares when
+     this version of the list was issued, so offline verifiers can state the
+     as-of date of the snapshot they checked against (#119 P4). Bump it on
+     **every** registry edit, not only rotations — a verifier that only has a
+     stale snapshot cannot see a revocation made after this date.
 
 4. **Merge and deploy the registry** before rotating env vars. Verifiers
    must be able to see the new key before they see any package signed by

--- a/public/.well-known/evidence-public-keys.json
+++ b/public/.well-known/evidence-public-keys.json
@@ -1,5 +1,6 @@
 {
   "$comment": "Platform trust registry for civicaitools.org evidence packages. Verifiers fetch this file, match the (kid, publicKey) pair embedded in a package's signature, and apply the status semantics below. See docs/key-rotation.md for the rotation runbook.",
+  "generatedAt": "2026-06-07T00:00:00.000Z",
   "statusSemantics": {
     "active": "Valid for signing new packages and for verification.",
     "deprecated": "Cannot sign new packages. Signatures are valid for verification only when the package's Rekor integratedTime precedes deprecatedAt.",


### PR DESCRIPTION
**#119 P4 PR-C — registry producer half.** Additive; no verify-core bump (key-trust evaluation is untouched).

- Stamps `"generatedAt": "2026-06-07T00:00:00.000Z"` on `public/.well-known/evidence-public-keys.json` — the CRL `thisUpdate` precedent: the registry declares its own as-of date. One file covers all three consumers: the canonical `/.well-known/typed-publisher.json` route serves it verbatim, the legacy path serves it, and `verify.ts` imports it at build time as the embedded fallback. `validateRegistry` passes the field through (it only structurally checks `keys`).
- `docs/key-rotation.md`: bump `generatedAt` on every registry edit (thisUpdate semantics).
- The bundle carries the registry **URL**, not an inline snapshot, so no carrier code is needed; any future inline-snapshot embed inherits the field for free.

This is the data half the verifier's staleness note (npstorey/typedstandards apps/web PR-C) reads to render *"verified against the registry as of `<date>`"*.

**Gates:** JSON valid · `npm test` 286/286. No migration. Part of #119 P4.