### PR TITLE
feat(evidence): self-contained commitment bundle (?inline=1) (#119 Q15a)

### DIFF
--- a/docs/api/evidence-commitment.md
+++ b/docs/api/evidence-commitment.md
@@ -33,6 +33,21 @@ The endpoint is **CORS-open** (`Access-Control-Allow-Origin: *`, `Access-Control
 
 The two other resources a cross-origin verifier must fetch are already CORS-open (verified 2026-06-04): the **Vercel Blob** package object (`access-control-allow-origin: *`) and the **trust registry** at both `/.well-known/typed-publisher.json` (canonical) and `/.well-known/evidence-public-keys.json` (legacy).
 
+### Self-contained bundle (`?inline=1`)
+
+By default the commitment is a lightweight **pointer**: it carries `packageUrl` and `trustRegistryUrl`, and a verifier fetches those two resources to complete verification.
+
+Pass **`?inline=1`** (also `?inline` / `?inline=true`; `?inline=0` / `?inline=false` are off) to get a **self-contained bundle** — the same commitment view, plus:
+
+| Field | Inlined value |
+|-------|---------------|
+| `package` | the full canonical package JSON (otherwise fetched from `packageUrl`) |
+| `trustRegistry` | the publisher's trust registry document, with its `generatedAt` as-of date (otherwise fetched from `trustRegistryUrl`) |
+
+The RFC 3161 timestamp, the Rekor entry body + inclusion proof, and the signed lifecycle attestation chain are **already inline** in the default view, so an `?inline=1` response needs **zero network** to verify: the client-side verifier recomputes the hash, signature, content fingerprint, key trust (against the inlined registry — surfaced with the snapshot's as-of date and an online-recheck affordance), the RFC 3161 chain, the Rekor Merkle inclusion, and the lifecycle chain, all offline (`#119` Q15). Save the response to a file and verify it anywhere, later, with no connectivity.
+
+Trade-off: the inline form is larger (it embeds the whole package), so the default stays the lightweight pointer. Both forms cache separately (the cache key includes the query string).
+
 ---
 
 ## Response (`200`)
@@ -134,3 +149,4 @@ curl https://civicaitools.org/api/evidence/noise-trends-in-nyc-last-tuesday-ef1a
 ## Change log
 
 - **2026-06-04** — Initial endpoint. Extracted and generalized `buildCommitmentView` from the notebook bundle route into `src/lib/evidence/commitment.ts`; added the public, CORS-open `GET /api/evidence/<hash|slug>/commitment`. WS1 of #116.
+- **2026-06-08** — Added the opt-in `?inline=1` self-contained bundle (inlines `package` + the stamped `trustRegistry`) so the commitment verifies with zero network — the verifier reaches `fullyOffline`. Default form unchanged. #119 Q15a.

--- a/src/app/api/evidence/[slug]/commitment/route.ts
+++ b/src/app/api/evidence/[slug]/commitment/route.ts
@@ -5,6 +5,7 @@ import { eq, asc } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
 import { buildCommitmentView } from '@/lib/evidence/commitment';
+import { loadTrustRegistry } from '@/lib/evidence/verify';
 import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
 
 /**
@@ -43,6 +44,15 @@ import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
  * package blob is additionally fetched best-effort to surface the signed envelope
  * fields (`signer`, `type`, `producerProfile`, `contentHash`,
  * `contentCanonicalization`). No live Rekor / TSA call.
+ *
+ * Self-contained bundle (`?inline=1`): opt-in, the response additionally INLINES the
+ * full package JSON (`package`) and the stamped trust registry (`trustRegistry`) so
+ * the commitment verifies with ZERO network — the client-side verifier reaches
+ * `fullyOffline` (package inline + registry inline; the RFC 3161 token, Rekor entry
+ * body + inclusion proof, and lifecycle chain are already inline). The DEFAULT (no
+ * flag) is unchanged — the lightweight URL sidecar — so the online verify path is not
+ * bloated. Pass `?inline` / `?inline=1` / `?inline=true`; `?inline=0` / `=false` are
+ * off. (#119 Q15a)
  */
 
 // A base-package hash is the hex SHA-256 of the canonical envelope: 64 hex chars.
@@ -70,7 +80,7 @@ export async function OPTIONS() {
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ) {
   const { slug: identifier } = await params;
@@ -140,9 +150,28 @@ export async function GET(
 
   const commitment = buildCommitmentView(record, creator, pkg, lifecycleAttestations);
 
+  // `?inline=1` → self-contained bundle (#119 Q15a): inline the package + the stamped
+  // trust registry so the commitment needs zero network to verify. The package is the
+  // one `buildCommitmentView` already received; the registry is exactly what the verify
+  // route trusts (the build-time-bundled, generatedAt-stamped `/.well-known` file). When
+  // the blob couldn't be fetched (`pkg === null`), `package` is simply omitted — the
+  // bundle then falls back to `packageUrl` rather than serving a hollow inline field.
+  const inlineParam = request.nextUrl.searchParams.get('inline');
+  const inline = inlineParam !== null && inlineParam !== '0' && inlineParam !== 'false';
+  let body: Record<string, unknown> = commitment;
+  if (inline) {
+    const registry = await loadTrustRegistry();
+    body = {
+      ...commitment,
+      ...(pkg ? { package: pkg } : {}),
+      ...(registry ? { trustRegistry: registry } : {}),
+    };
+  }
+
   // Short cache: the proofs are immutable for a given hash, but lifecycle state
-  // (withdrawal/reinstatement) can change after publish, so keep it brief.
-  return jsonResponse(commitment, 200, {
+  // (withdrawal/reinstatement) can change after publish, so keep it brief. The inline
+  // and default forms cache separately (the cache key includes the query string).
+  return jsonResponse(body, 200, {
     'Cache-Control': 'public, max-age=60, s-maxage=60',
   });
 }


### PR DESCRIPTION
**#119 Q15a — self-contained, zero-network commitment.** Carrier-only, additive, no migration, no verify-core bump.

`GET /api/evidence/<hash|slug>/commitment?inline=1` returns the usual commitment view **plus**:
- `package` — the full canonical package JSON (the exact `pkg` object `buildCommitmentView` already fetched best-effort) → the client verifier takes `pkgSource='inline'`. Hash recompute is identical to the fetched path. `pkg===null` (blob unavailable) → `package` omitted, falls back to `packageUrl` (no hollow field).
- `trustRegistry` — `loadTrustRegistry()`, i.e. the exact `generatedAt`-stamped `/.well-known` registry the verify route trusts → `registrySource='inline'`.

The RFC 3161 token, Rekor entry body + inclusion proof, and signed lifecycle chain are **already** inline, so an `?inline=1` response verifies at full depth with **zero network** → the verifier reaches `fullyOffline`. This also un-dormants PR-C: an inline bundle's #5 row shows the *"snapshot, as of `<date>`"* note + offers the live recheck.

**Conservative by default:** plain `/commitment` is byte-unchanged (the lightweight URL sidecar — online verify path not bloated). Flag: `?inline`/`=1`/`=true` on; `=0`/`=false` off. Inline + default forms cache separately (query string is part of the cache key).

**Gates (independently re-run):** `npm test` 286/286 · tsc adds 0 errors (the 2 in `expert-attestation.test.ts` are pre-existing/unrelated, see #132). Docs: `evidence-commitment.md` gains a *"Self-contained bundle (?inline=1)"* section + changelog.

Acceptance (a real 255b8e `?inline=1` → `fullyOffline===true`, full depth) is demonstrated in **Q15b** against a fixture captured after this deploys — the merge/deploy gate. Part of #119 Q15.