### PR TITLE
chore: declare MIT license field in package.json (civic-ai-tools#75)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "civic-ai-tools-website",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
One-line companion to the cross-repo license audit (civic-ai-tools#75): the repo has carried an MIT LICENSE file all along, but `package.json` never declared it. The audit's full record lands as `LICENSING.md` in the hub repo (npstorey/civic-ai-tools PR for #75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
