### PR TITLE
feat(evidence): in-page integrity glance summary (#113)

### DIFF
--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -1,13 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import TrustSignal from './TrustSignal';
 import {
-  resolveEnvelopeIntegrity,
-  resolveSignature,
-  resolveTimestamp,
-  resolveRekor,
-  resolveKeyTrust,
+  summarizeIntegrity,
   resolveCaptureMethodLabel,
 } from '@/lib/evidence/trust-signal';
 import type {
@@ -103,12 +99,13 @@ function CitePopover({ title, creatorName, createdAt, slug, onClose }: {
 }
 
 /**
- * The verify-route response shape. #111 renders only the five legacy checks
- * (hashMatch, signatureValid, keyTrust, hasTimestamp, rekorVerified), but the
- * type is aligned to the route's full emitted shape (spec §9.2 checks #3-#15 +
- * lifecycle) as a clean base for the #113/#114 panel waves — those fields are
- * typed here but intentionally NOT surfaced yet. The upstream interfaces are
- * type-only imports, so this client component pulls in no node:crypto runtime.
+ * The verify-route response shape. The #113 in-page glance rolls these checks
+ * into ONE worst-tier-wins summary (`summarizeIntegrity`); the full per-check
+ * "show the math" is delegated to the neutral verifier at typedstandards.org
+ * /verify (ADR-0013 / Q46), reached via the verify badge (#114). The structural
+ * superset of `IntegrityGlanceInput`, so the fetched result passes straight in.
+ * The upstream interfaces are type-only imports, so this client component pulls
+ * in no node:crypto runtime.
  */
 interface VerifyResult {
   hashMatch: boolean;
@@ -140,7 +137,7 @@ export default function EvidenceActions({
 }: EvidenceActionsProps) {
   const [linkCopied, setLinkCopied] = useState(false);
   const [showCite, setShowCite] = useState(false);
-  const [verifyState, setVerifyState] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [verifyState, setVerifyState] = useState<'loading' | 'done' | 'error'>('loading');
   const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
 
   // captureMethod LABEL (#11, "signed != verbatim"): a neutral, signature-covered
@@ -162,7 +159,12 @@ export default function EvidenceActions({
     a.click();
   };
 
-  const handleVerify = async () => {
+  // The integrity glance auto-loads so it is a true glance (always present,
+  // P5's glance layer), not gated behind a click. A failure to LOAD the check
+  // is rendered calm (a muted "couldn't load" + Retry), never as an integrity
+  // failure — our endpoint being unreachable says nothing about the package
+  // (P1 disclosure ≠ validation, P3 no false precision).
+  const runVerify = async () => {
     setVerifyState('loading');
     try {
       const res = await fetch(`/api/evidence/${slug}/verify`);
@@ -174,6 +176,11 @@ export default function EvidenceActions({
       setVerifyState('error');
     }
   };
+
+  useEffect(() => {
+    runVerify();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug]);
 
   const btnStyle: React.CSSProperties = {
     background: 'none',
@@ -191,6 +198,71 @@ export default function EvidenceActions({
 
   return (
     <>
+      {/* Integrity glance (#113) — a single calm, worst-tier-wins overall
+          verdict, auto-loaded so it is always present (P5's glance layer), not
+          gated behind a click. The full per-check "show the math" is delegated
+          to the neutral verifier at typedstandards.org/verify (ADR-0013 / Q46),
+          reached via the verify badge (#114), and is not rendered here. */}
+      <div style={{ marginBottom: '16px' }}>
+        {verifyState === 'loading' && (
+          <div style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
+            Checking integrity…
+          </div>
+        )}
+
+        {verifyState === 'done' && verifyResult && (
+          <>
+            {/* Worst-tier-wins summary. Legacy / back-compat checks
+                (legacy_relabeled, legacy_embedded, no timestamp, …) roll up into
+                the calm "Integrity verified" — never amber/red (the load-bearing
+                calm requirement). Amber/red appear only on a genuine
+                unconfirmed/failed check. */}
+            <TrustSignal {...summarizeIntegrity(verifyResult)} />
+
+            {/* captureMethod label adjacent to the glance — "signed ≠ verbatim"
+                (spec §9.2 #11): the summary's signature check proves the bytes
+                are unchanged since signing, not that they are a verbatim
+                capture; this caption says how the signed bytes were obtained.
+                Omitted for pre-ADR-0003 packages (null), keeping legacy calm. */}
+            {captureMethodCaption && (
+              <div
+                style={{
+                  marginLeft: '24px',
+                  fontSize: '12px',
+                  lineHeight: 1.45,
+                  color: 'var(--text-muted)',
+                }}
+              >
+                {captureMethodCaption}
+              </div>
+            )}
+          </>
+        )}
+
+        {/* A failure to LOAD the check is calm, not an alarm — our endpoint
+            being unreachable says nothing about the package (P1 / P3). */}
+        {verifyState === 'error' && (
+          <div style={{ fontSize: '13px', color: 'var(--text-muted)' }}>
+            Integrity check couldn’t be loaded.{' '}
+            <button
+              onClick={runVerify}
+              style={{
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                fontSize: '13px',
+                color: 'var(--nyc-blue)',
+                textDecoration: 'underline',
+                cursor: 'pointer',
+              }}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
         <button onClick={handleDownload} style={btnStyle}>
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
@@ -199,13 +271,6 @@ export default function EvidenceActions({
           </svg>
           Download Package
         </button>
-        <button
-          onClick={handleVerify}
-          disabled={verifyState === 'loading'}
-          style={{ ...btnStyle, color: verifyState === 'loading' ? 'var(--text-muted)' : btnStyle.color }}
-        >
-          {verifyState === 'loading' ? 'Verifying...' : 'Verify Integrity'}
-        </button>
         <button onClick={handleCopyLink} style={{ ...btnStyle, color: linkCopied ? 'var(--nyc-success)' : btnStyle.color }}>
           {linkCopied ? 'Copied' : 'Copy Link'}
         </button>
@@ -213,74 +278,6 @@ export default function EvidenceActions({
           Cite
         </button>
       </div>
-
-      {/* Verification results */}
-      {verifyState === 'done' && verifyResult && (
-        <div style={{
-          marginTop: '12px', padding: '14px 16px',
-          border: '1px solid var(--border-color)', borderRadius: '6px',
-          backgroundColor: 'white',
-        }}>
-          <div style={{ fontSize: '14px', fontWeight: 600, marginBottom: '10px' }}>Verification Results</div>
-          {/* The five integrity checks, re-skinned onto <TrustSignal> and driven
-              entirely by the trust-signal vocabulary (#110). Legacy / back-compat
-              statuses resolve to Verified or Normal — never amber or red — so a
-              pre-v0.1 package reads calm (the #111 calm baseline). The label is
-              the verdict one-liner; the muted detail expands it (P5). */}
-
-          {/* #1 Envelope integrity */}
-          <TrustSignal {...resolveEnvelopeIntegrity(verifyResult.hashMatch)} />
-
-          {/* #2 Cryptographic signature, with the captureMethod label directly
-              beneath it — "signed ≠ verbatim" (spec §9.2 #11). A valid signature
-              proves the bytes are unchanged since signing, not that they are a
-              verbatim capture; the caption says how the signed bytes were obtained. */}
-          <TrustSignal {...resolveSignature(verifyResult.signatureValid)} />
-          {captureMethodCaption && (
-            <div
-              style={{
-                marginLeft: '24px',
-                marginBottom: '8px',
-                fontSize: '12px',
-                lineHeight: 1.45,
-                color: 'var(--text-muted)',
-              }}
-            >
-              {captureMethodCaption}
-            </div>
-          )}
-
-          {/* #5 Key trust (keyTrust:null = unsigned → calm Normal) */}
-          <TrustSignal {...resolveKeyTrust(verifyResult.keyTrust)} />
-
-          {/* #7 RFC 3161 timestamp */}
-          <TrustSignal {...resolveTimestamp(verifyResult.hasTimestamp)} />
-
-          {/* #8 Transparency log (Rekor) */}
-          <TrustSignal {...resolveRekor(verifyResult.rekorVerified)} />
-          {verifyResult.details.rekor?.logEntryUrl && (
-            <div style={{ marginTop: '6px', fontSize: '12px' }}>
-              <a
-                href={verifyResult.details.rekor.logEntryUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: 'var(--nyc-blue)', textDecoration: 'underline' }}
-              >
-                View Rekor log entry (index {verifyResult.details.rekor.logIndex})
-              </a>
-            </div>
-          )}
-        </div>
-      )}
-      {verifyState === 'error' && (
-        <div style={{
-          marginTop: '12px', padding: '10px 14px', fontSize: '13px',
-          color: 'var(--nyc-error)', backgroundColor: 'rgba(236, 19, 30, 0.06)',
-          borderRadius: '4px',
-        }}>
-          Verification request failed. Try again.
-        </div>
-      )}
 
       {showCite && (
         <CitePopover

--- a/src/lib/evidence/trust-signal.test.ts
+++ b/src/lib/evidence/trust-signal.test.ts
@@ -54,9 +54,13 @@ import {
   NOTEBOOK_PROVENANCE_VALUES,
   NOTEBOOK_PROVENANCE_SIGNALS,
   NO_SIGNING_KEY_SIGNAL,
+  OVERALL_INTEGRITY_SIGNALS,
+  collectIntegrityDescriptors,
+  summarizeIntegrity,
   resolveKeyTrust,
   resolveCaptureMethodLabel,
   type TrustSignalDescriptor,
+  type IntegrityGlanceInput,
 } from './trust-signal.ts';
 
 // The valid tiers, derived from the source so the test cannot drift from it.
@@ -270,4 +274,84 @@ test('resolveCaptureMethodLabel: known methods, datHere ADR-0004 special case, o
   assert.ok(datHere && /ADR-0004/.test(datHere), 'datHere preserves the ADR-0004 annotation');
   // An unrecognized value omits rather than echoing a raw code.
   assert.equal(resolveCaptureMethodLabel('something-else'), null);
+});
+
+// --- #113 overall-integrity glance (worst-tier-wins summary) -------------
+
+// A fully-affirmative current-format result: every emitted check is Verified.
+const CLEAN_RESULT: IntegrityGlanceInput = {
+  hashMatch: true,
+  signatureValid: true,
+  keyTrust: { status: 'active' },
+  hasTimestamp: true,
+  rekorVerified: true,
+  blobRefsVerified: null,
+  contentCanonicalization: { status: 'ok' },
+  contentHash: { status: 'ok' },
+  typeResolution: { status: 'ok' },
+  signerIdentity: { status: 'ok' },
+  captureMethodVocab: { status: 'ok' },
+};
+
+// A synthetic pre-v0.1 legacy result: a fistful of "not ok but expected"
+// statuses, all Verified or Normal — the load-bearing calm case.
+const LEGACY_RESULT: IntegrityGlanceInput = {
+  hashMatch: true,
+  signatureValid: true,
+  keyTrust: { status: 'legacy_embedded' },
+  hasTimestamp: false,
+  rekorVerified: null,
+  blobRefsVerified: null,
+  contentCanonicalization: { status: 'implicit' },
+  contentHash: { status: 'legacy_relabeled' },
+  typeResolution: { status: 'implicit' },
+  signerIdentity: { status: 'no_signer' },
+  captureMethodVocab: { status: 'no_capture_method' },
+};
+
+test('summarizeIntegrity: a clean current-format package reads Verified', () => {
+  assert.equal(summarizeIntegrity(CLEAN_RESULT), OVERALL_INTEGRITY_SIGNALS.verified);
+});
+
+test('summarizeIntegrity: a legacy package reads calm Verified (the load-bearing case)', () => {
+  // The whole point of #113's roll-up: Normal-tier back-compat checks collapse
+  // into the calm "Integrity verified" — zero amber/red on a legacy package.
+  const summary = summarizeIntegrity(LEGACY_RESULT);
+  assert.equal(summary, OVERALL_INTEGRITY_SIGNALS.verified);
+  assert.notEqual(summary.tier, 'attention');
+  assert.notEqual(summary.tier, 'alarm');
+  // And every per-check descriptor that fed it is itself calm (verified/normal).
+  for (const d of collectIntegrityDescriptors(LEGACY_RESULT)) {
+    assert.ok(d.tier === 'verified' || d.tier === 'normal', `legacy check tier ${d.tier}`);
+  }
+});
+
+test('summarizeIntegrity: a content-hash mismatch escalates to Alarm', () => {
+  // Same check as legacy_relabeled, opposite tier — off-log content altered.
+  const summary = summarizeIntegrity({ ...LEGACY_RESULT, contentHash: { status: 'content_hash_mismatch' } });
+  assert.equal(summary, OVERALL_INTEGRITY_SIGNALS.alarm);
+});
+
+test('summarizeIntegrity: an invalid signature escalates to Alarm', () => {
+  assert.equal(
+    summarizeIntegrity({ ...CLEAN_RESULT, signatureValid: false }).tier,
+    'alarm',
+  );
+});
+
+test('summarizeIntegrity: an unconfirmed check (no alarm) reads Attention', () => {
+  // unknown_key is absence-of-trust (Attention), not positive distrust (Alarm).
+  assert.equal(
+    summarizeIntegrity({ ...CLEAN_RESULT, keyTrust: { status: 'unknown_key' } }),
+    OVERALL_INTEGRITY_SIGNALS.attention,
+  );
+  // Alarm out-ranks Attention when both are present (worst-tier-wins).
+  assert.equal(
+    summarizeIntegrity({
+      ...CLEAN_RESULT,
+      keyTrust: { status: 'unknown_key' },
+      hashMatch: false,
+    }).tier,
+    'alarm',
+  );
 });

--- a/src/lib/evidence/trust-signal.ts
+++ b/src/lib/evidence/trust-signal.ts
@@ -589,6 +589,114 @@ export const CAPTURE_METHOD_VOCAB_SIGNALS: Record<
   },
 };
 
+// --- Overall integrity glance (worst-tier-wins) — #113 -------------------
+//
+// ADR-0013 / Q46 splits verification rendering by disclosure depth: the
+// publishing host renders only a calm GLANCE (this summary); the full §9.2
+// per-check "show the math" is delegated to the neutral verifier at
+// typedstandards.org/verify. This rolls the per-check tiers into ONE of the
+// three summary states the issue names — Verified / Attention / Alarm — by
+// worst-tier-wins, with Normal collapsing into the calm Verified summary.
+//
+// Why Normal → Verified (not its own glance state): a pre-v0.1 legacy package
+// produces only Verified + Normal checks (legacy_relabeled, legacy_embedded,
+// no timestamp, …). The load-bearing calm requirement (§3 of the design note)
+// is that such a package reads calm and affirmative, never amber/red — so with
+// no Attention and no Alarm present, the glance is "Integrity verified". The
+// Normal-tier back-compat nuance lives in the delegated per-check verifier, not
+// in the one-line in-page glance (P5: glance here, detail there).
+
+const TIER_RANK: Record<TrustTier, number> = {
+  verified: 0,
+  normal: 1,
+  attention: 2,
+  alarm: 3,
+};
+
+/** The three overall-integrity summary states (#113). Disclosure, never
+ *  validation (P1): "Integrity verified" speaks to the cryptographic/structural
+ *  checks, never to whether the analysis is correct. */
+export const OVERALL_INTEGRITY_SIGNALS: Record<
+  'verified' | 'attention' | 'alarm',
+  TrustSignalDescriptor
+> = {
+  verified: {
+    tier: 'verified',
+    label: 'Integrity verified',
+    detail: 'The integrity checks ran cleanly. You can re-run them yourself in the independent verifier.',
+  },
+  attention: {
+    tier: 'attention',
+    label: 'Some checks need a closer look',
+    detail: 'One or more checks could not be confirmed. See the full breakdown in the independent verifier.',
+  },
+  alarm: {
+    tier: 'alarm',
+    label: 'Integrity problem detected',
+    detail: 'One or more checks did not pass. See the full breakdown in the independent verifier.',
+  },
+};
+
+/** The verify-result fields the integrity glance rolls up. Structurally a
+ *  subset of the verify route's response (and the component's `VerifyResult`),
+ *  so the resolved object passes straight in. Status-bearing checks are
+ *  optional (absent → skipped) to stay tolerant of partial / legacy results. */
+export interface IntegrityGlanceInput {
+  hashMatch: boolean;
+  signatureValid: boolean | null;
+  keyTrust: { status: KeyTrustStatus } | null;
+  hasTimestamp: boolean;
+  rekorVerified: boolean | null;
+  blobRefsVerified: boolean | null;
+  contentCanonicalization: { status: ContentCanonicalizationStatus } | null;
+  contentHash: { status: ContentHashStatus } | null;
+  typeResolution: { status: TypeResolutionStatus } | null;
+  signerIdentity: { status: SignerIdentityCheckStatus } | null;
+  captureMethodVocab: { status: CaptureMethodVocabStatus } | null;
+}
+
+/**
+ * Collect the per-check descriptors the integrity glance rolls up. Each is
+ * resolved through the SAME source-of-truth maps the (delegated) per-check
+ * verifier uses, so the in-page glance and the full breakdown can never assign a
+ * status a different tier. Lifecycle (#10) is deliberately excluded — it is a
+ * separate axis from cryptographic integrity (P7) and has its own page surface
+ * (the withdrawal banner + Status History).
+ */
+export function collectIntegrityDescriptors(r: IntegrityGlanceInput): TrustSignalDescriptor[] {
+  const d: TrustSignalDescriptor[] = [
+    resolveEnvelopeIntegrity(r.hashMatch),
+    resolveSignature(r.signatureValid),
+    resolveKeyTrust(r.keyTrust),
+    resolveTimestamp(r.hasTimestamp),
+    resolveRekor(r.rekorVerified),
+    resolveBlobRefs(r.blobRefsVerified),
+  ];
+  if (r.contentCanonicalization)
+    d.push(CONTENT_CANONICALIZATION_SIGNALS[r.contentCanonicalization.status]);
+  if (r.contentHash) d.push(CONTENT_HASH_SIGNALS[r.contentHash.status]);
+  if (r.typeResolution) d.push(TYPE_RESOLUTION_SIGNALS[r.typeResolution.status]);
+  if (r.signerIdentity) d.push(SIGNER_IDENTITY_SIGNALS[r.signerIdentity.status]);
+  if (r.captureMethodVocab) d.push(CAPTURE_METHOD_VOCAB_SIGNALS[r.captureMethodVocab.status]);
+  return d;
+}
+
+/**
+ * Roll the integrity checks into ONE calm overall glance (#113), worst-tier-wins.
+ * Alarm if any check alarms; else Attention if any needs a closer look; else the
+ * calm "Integrity verified" (Verified + Normal back-compat checks both land
+ * here, so legacy packages read calm — never amber/red).
+ */
+export function summarizeIntegrity(r: IntegrityGlanceInput): TrustSignalDescriptor {
+  let worst = 0;
+  for (const d of collectIntegrityDescriptors(r)) {
+    worst = Math.max(worst, TIER_RANK[d.tier]);
+  }
+  if (worst >= TIER_RANK.alarm) return OVERALL_INTEGRITY_SIGNALS.alarm;
+  if (worst >= TIER_RANK.attention) return OVERALL_INTEGRITY_SIGNALS.attention;
+  return OVERALL_INTEGRITY_SIGNALS.verified;
+}
+
 // --- notebookProvenance (honest execution label) -------------------------
 //
 // Not a verify-library status: `metadata.extensions["org.civicaitools.notebook"]


### PR DESCRIPTION
## #113 — in-page integrity glance summary

Closes #113. Implements ADR-0013 / Q46's split-by-disclosure-depth: the publishing host shows a calm **glance**; the full §9.2 per-check "show the math" is delegated to the neutral verifier at typedstandards.org/verify (the badge that links there is #114, stacked on this branch).

### What changed
- **`src/lib/evidence/trust-signal.ts`** — `summarizeIntegrity()` rolls the per-check tiers into ONE worst-tier-wins summary, returning one of the three states the issue names: **Verified / Attention / Alarm**. Normal-tier back-compat checks (`legacy_relabeled`, `legacy_embedded`, absent timestamp, …) collapse into the calm **"Integrity verified"**, so a pre-v0.1 package reads calm — never amber/red (the load-bearing calm requirement). Each per-check tier is resolved through the **same source-of-truth maps** the delegated per-check verifier uses, so the in-page glance and the full breakdown can't drift. Lifecycle (#10) is excluded — separate axis (P7), with its own page surface (withdrawal banner + Status History).
- **`src/components/evidence/EvidenceActions.tsx`** — the glance **auto-loads** on mount (a true glance, P5 — not behind a click), replacing the click-triggered 5-check panel. The `captureMethod` label stays adjacent to the glance ("signed ≠ verbatim", §9.2 #11). A failure to *load* the check reads calm with a **Retry**, never as an integrity failure (P1/P3). `Download` / `Copy Link` / `Cite` preserved; the old **"Verify Integrity"** button and the per-check "Verification Results" panel are removed.
- **`src/lib/evidence/trust-signal.test.ts`** — 5 new tests: clean → Verified; legacy synthetic → calm Verified (load-bearing); `content_hash_mismatch` / invalid signature → Alarm; `unknown_key` → Attention; worst-tier-wins ordering.

### Scope guardrails honored
- Published path only. No committed-glance label designed (vocabulary frozen).
- No new status words — only `docs/trust-signal-vocabulary.md` tiers.
- Legacy `ProvenanceChain` untouched (that's #135).

### Verified in the running app (`npm run dev`, real DB)
- `/evidence/<published-slug>` renders 200; SSR shows the calm `Checking integrity…` loading line; `Download Package` / `Copy Link` / `Cite` present; **`Verify Integrity` button and the old per-check panel gone**.
- `/api/evidence/<slug>/verify` → 200; running `summarizeIntegrity()` against the **real** result yields **"Integrity verified"** (per-check tiers all verified except one calm `normal` for `blobRefsVerified: null`).
- `npx tsc --noEmit` clean · `eslint` clean · 19 trust-signal tests pass.
