### PR TITLE
feat(evidence): embeddable verify badge → delegated verifier (#114)

### DIFF
--- a/src/app/evidence/[slug]/page.tsx
+++ b/src/app/evidence/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation';
+import { headers } from 'next/headers';
 import type { Metadata } from 'next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -212,6 +213,14 @@ export default async function EvidencePage({ params }: PageProps) {
   // modulo the shallow clone.
   const renderPkg = resolution?.pkg ?? pkg;
   const dateStr = record.createdAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  // Absolute, publicly-fetchable commitment endpoint for the verify badge
+  // (#114), resolved from the request host so the deep-link is correct on
+  // production AND preview deploys (the verifier fetches it cross-origin).
+  const hdrs = await headers();
+  const host = hdrs.get('x-forwarded-host') ?? hdrs.get('host') ?? 'civicaitools.org';
+  const proto = hdrs.get('x-forwarded-proto') ?? 'https';
+  const commitmentUrl = `${proto}://${host}/api/evidence/${slug}/commitment`;
 
   // ADR-0004: detail-page layout branches on contentProfile. When the value
   // is 'datHere', the page renders the A-G envelope as its primary structure
@@ -834,6 +843,8 @@ export default async function EvidencePage({ params }: PageProps) {
             createdAt={record.createdAt.toISOString()}
             packageUrl={record.basePackageStorageKey || ''}
             captureMethod={record.captureMethod}
+            visibility={record.visibility}
+            commitmentUrl={commitmentUrl}
           />
         </Section>
 

--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import TrustSignal from './TrustSignal';
+import VerifyBadge from './VerifyBadge';
 import {
   summarizeIntegrity,
   resolveCaptureMethodLabel,
@@ -27,6 +28,15 @@ interface EvidenceActionsProps {
    *  neutral informational label beside the signature verdict (#11,
    *  "signed ≠ verbatim"). */
   captureMethod: string | null;
+  /** Record visibility (`published` | `committed`). Gates the verify badge
+   *  (#114): the delegated verifier resolves a package via its commitment
+   *  sidecar, which is redacted for committed records, so the badge is
+   *  published-only. */
+  visibility: string;
+  /** Absolute, publicly-fetchable commitment endpoint for this package
+   *  (resolved server-side from the request host). The verify badge (#114)
+   *  deep-links the neutral verifier to it. */
+  commitmentUrl: string;
 }
 
 function CitePopover({ title, creatorName, createdAt, slug, onClose }: {
@@ -133,7 +143,7 @@ interface VerifyResult {
 }
 
 export default function EvidenceActions({
-  slug, title, creatorName, createdAt, packageUrl, captureMethod,
+  slug, title, creatorName, createdAt, packageUrl, captureMethod, visibility, commitmentUrl,
 }: EvidenceActionsProps) {
   const [linkCopied, setLinkCopied] = useState(false);
   const [showCite, setShowCite] = useState(false);
@@ -260,6 +270,15 @@ export default function EvidenceActions({
             </button>
           </div>
         )}
+
+        {/* Verify-independently badge (#114) — the host-side entry point to the
+            neutral verifier (ADR-0013 / Q46). Published-only: the verifier
+            resolves a package through its commitment sidecar, which is redacted
+            for committed records (content private), so /verify would show a
+            missing-content alarm. Rendered independent of the glance's load
+            state — when our own check can't load, "verify it yourself" matters
+            most. */}
+        {visibility === 'published' && <VerifyBadge commitmentUrl={commitmentUrl} />}
       </div>
 
       {/* Actions */}

--- a/src/components/evidence/VerifyBadge.tsx
+++ b/src/components/evidence/VerifyBadge.tsx
@@ -1,0 +1,74 @@
+/**
+ * The embeddable "verify independently" badge (civic-ai-tools-website#114).
+ *
+ * Per ADR-0013 / Q46, the full §9.2 per-check verification is delegated to the
+ * neutral client-side verifier at typedstandards.org/verify — "don't trust the
+ * publisher, verify independently" is far stronger when the verifier is not
+ * hosted by the publisher. This is civicaitools.org's host-side rendering of the
+ * cross-host badge specced in #116: a plain `<a><img>` (no third-party JS on the
+ * page) that deep-links to the verifier with this package's commitment URL.
+ *
+ * THE LOAD-BEARING HONESTY CONSTRAINT (regression-locked in #116 Phase E): the
+ * badge is a CALL TO ACTION, never a verdict. It carries no "verified" / green
+ * check — a static claim the badge can't back and anyone could forge. The real
+ * §9.2 verdict is computed in the reader's own browser on the neutral domain and
+ * shown ONLY there. The badge SVG (served by typedstandards.org) enforces this;
+ * this component only points at it.
+ *
+ * CALLER GATE: render this ONLY for `visibility === 'published'` records. The
+ * verifier resolves a package through its `/commitment` sidecar, and a committed
+ * record's commitment is redacted of the package location (content is private),
+ * so /verify would surface a missing-content alarm. Committed support is tracked
+ * separately (arch-gated); until then the badge is published-only.
+ *
+ * `commitmentUrl` is the absolute, publicly-fetchable commitment endpoint for
+ * this package, resolved server-side from the request host so it is correct on
+ * production AND preview deploys (and so there is no client-side window read /
+ * hydration mismatch).
+ */
+
+const TYPEDSTANDARDS_VERIFY_BASE = 'https://typedstandards.org/verify';
+const TYPEDSTANDARDS_BADGE_SVG = 'https://typedstandards.org/badge/typed-standards-verify.svg';
+const BADGE_ALT = 'Verify this evidence with Typed Standards';
+const BADGE_WIDTH = 248;
+const BADGE_HEIGHT = 30;
+
+export default function VerifyBadge({ commitmentUrl }: { commitmentUrl: string }) {
+  const verifyHref = `${TYPEDSTANDARDS_VERIFY_BASE}?url=${encodeURIComponent(commitmentUrl)}`;
+
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <a
+        href={verifyHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ display: 'inline-block', lineHeight: 0 }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element -- cross-origin,
+            CORS-served, fixed-size badge asset from typedstandards.org; the
+            Next image optimizer must not proxy/rewrite it. */}
+        <img
+          src={TYPEDSTANDARDS_BADGE_SVG}
+          alt={BADGE_ALT}
+          width={BADGE_WIDTH}
+          height={BADGE_HEIGHT}
+        />
+      </a>
+      {/* Plainly states what verification asserts — and what it does not (P1
+          disclosure ≠ validation; trust-and-evidence.md; civic-ai-tools#63). */}
+      <div
+        style={{
+          marginTop: '6px',
+          fontSize: '12px',
+          lineHeight: 1.45,
+          color: 'var(--text-muted)',
+          maxWidth: '440px',
+        }}
+      >
+        Re-runs the integrity, signature, timestamp, and transparency-log checks
+        in your own browser on a neutral site. It confirms how this analysis was
+        recorded and that it has not changed — not that the analysis is correct.
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## #114 — embeddable verify badge → delegated verifier

Closes #114. Implements ADR-0013 / Q46's delegated-verifier entry point: civicaitools.org renders a calm glance (#113) plus this **"verify independently" badge** linking to the neutral client-side verifier at `typedstandards.org/verify`. The full §9.2 per-check "show the math" runs in the reader's own browser on a surface the publisher does not control.

> **Stacked on #113** (PR #144) — base is `feat/integrity-glance-113`, so this diff shows only the badge changes. GitHub will retarget to `main` when #113 merges.

### What changed
- **`src/components/evidence/VerifyBadge.tsx`** (new) — a plain `<a><img>` (no third-party JS on the page, forgery-proof) deep-linking to `typedstandards.org/verify?url=<commitment-url>`. The badge SVG is the typedstandards.org CTA asset — a magnifier + "Verify with Typed Standards", deliberately **no checkmark / "verified" / green tier**: it is a **call to action, never a verdict** (regression-locked discipline from #116 Phase E). A short caption states what verification asserts (integrity / signature / timestamp / transparency-log) and what it does **not** (that the analysis is correct — P1).
- **`src/components/evidence/EvidenceActions.tsx`** — renders the badge beneath the integrity glance, **gated on `visibility === 'published'`**. Committed records do **not** render it (their commitment sidecar is redacted of the package location, so `/verify` would show a missing-content alarm — arch-gated, tracked separately). Rendered independent of the glance's load state.
- **`src/app/evidence/[slug]/page.tsx`** — resolves the absolute commitment URL server-side from the request host (`x-forwarded-host`/`host`), so the deep-link is correct on production **and** preview deploys, with no client `window` read / hydration mismatch.

### Scope guardrails honored
- **Published-only** — the critical gate. The badge never renders for committed records.
- Badge is a CTA, never a verdict (the SVG enforces it; this PR only points at it).
- Published path only; no committed vocabulary touched.

### Verified in the running app (`npm run dev`, real DB)
- A published record renders the badge: `img` src = `typedstandards.org/badge/typed-standards-verify.svg`; deep-link = `https://typedstandards.org/verify?url=<commitment-url>`; alt = "Verify this evidence with Typed Standards" (CTA, no verdict word); honesty caption present.
- The deep-linked `/api/evidence/<slug>/commitment` returns 200 with `packageUrl` + `trustRegistryUrl` + `subjectTitle` (published = not redacted), so the verifier can resolve the package and run the checks end-to-end. A committed commitment is redacted of those fields — which is exactly why the badge is published-only.
- `npx tsc --noEmit` clean · `eslint` clean.
