### PR TITLE
Add demo-day env-var preflight script

### DIFF
--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Demo-day environment preflight.
+ *
+ * Checks the PRESENCE (never the value) of the environment variables the
+ * civic-ai-tools-website needs in production, and prints a grouped pass/fail
+ * table. Built for the demo dry-run: several of these vars fail silently or
+ * with a generic error when absent (DATABASE_URL, BLOB_READ_WRITE_TOKEN,
+ * EVIDENCE_SIGNING_KEY, EVIDENCE_KEY_ID, the MCP endpoints, the model key),
+ * so a one-shot "is everything wired?" check removes that failure mode.
+ *
+ * SECRET HYGIENE (absolute): this script only reads whether
+ * `process.env[NAME]` is a non-empty string. It never prints, logs, hashes,
+ * stores, or transmits any value — not even its length. The output is a
+ * present/absent table keyed by variable NAME only.
+ *
+ * Run it through 1Password so the op:// references in .env.local resolve into
+ * this process's environment:
+ *
+ *   op run --env-file=.env.local -- node scripts/preflight-env.mjs
+ *
+ * Exit code is 0 when every REQUIRED variable is present and 1 otherwise, so
+ * the script can gate a deploy check or a CI step. Missing RECOMMENDED or
+ * OPTIONAL variables are reported but never fail the run.
+ *
+ * The pure check logic (`evaluateEnv`, `ENV_SPEC`) is exported and covered by
+ * scripts/preflight-env.test.mjs (run: `node --test scripts/preflight-env.test.mjs`).
+ */
+
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The variables the app actually reads (grepped from `process.env.*` across
+ * src/). Tiers:
+ *   - required:    the demo's load-bearing path fails without it.
+ *   - recommended: a feature degrades or a fallback kicks in; not fatal.
+ *   - optional:    nice-to-have / non-demo / analytics / dev-only.
+ * `hasFallback: true` means the code substitutes a hardcoded default when the
+ * var is absent, so its absence is a soft note rather than a hard miss.
+ */
+export const ENV_SPEC = [
+  // --- Core query path (every demo query depends on these) ---
+  { name: 'OPENROUTER_API_KEY', tier: 'required', purpose: 'LLM access — every query (no fallback)' },
+  { name: 'SOCRATA_MCP_URL', tier: 'required', purpose: 'Socrata MCP endpoint (the demo data source)', hasFallback: true },
+
+  // --- Evidence publish + verify (the demo centerpiece: publish → badge) ---
+  { name: 'DATABASE_URL', tier: 'required', purpose: 'Evidence DB — publish + dashboard + detail page' },
+  { name: 'BLOB_READ_WRITE_TOKEN', tier: 'required', purpose: 'Evidence package storage (Vercel Blob)' },
+  { name: 'EVIDENCE_SIGNING_KEY', tier: 'required', purpose: 'Ed25519 private key — signs evidence packages' },
+  { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry' },
+
+  // --- Sign-in path (the rate-limit headroom option; OAuth) ---
+  { name: 'NEXTAUTH_SECRET', tier: 'required', purpose: 'NextAuth session encryption' },
+  { name: 'NEXTAUTH_URL', tier: 'required', purpose: 'OAuth callback base URL (must match the deploy origin)' },
+  { name: 'GITHUB_CLIENT_ID', tier: 'required', purpose: 'GitHub sign-in (raises the per-user rate limit)' },
+  { name: 'GITHUB_CLIENT_SECRET', tier: 'required', purpose: 'GitHub sign-in (raises the per-user rate limit)' },
+
+  // --- Rate limiting (durable counter; without it, falls back to per-instance memory) ---
+  { name: 'KV_REST_API_URL', tier: 'required', purpose: 'Durable rate-limit counter (Upstash/Vercel KV)' },
+  { name: 'KV_REST_API_TOKEN', tier: 'required', purpose: 'Durable rate-limit counter (Upstash/Vercel KV)' },
+
+  // --- Secondary MCP sources (not on the storyboard-3 critical path) ---
+  { name: 'DATA_COMMONS_MCP_URL', tier: 'recommended', purpose: 'Data Commons MCP endpoint', hasFallback: true },
+  { name: 'DATA_COMMONS_API_KEY', tier: 'recommended', purpose: 'Data Commons auth — DC tool calls fail without it' },
+  { name: 'BOSTON_OPENCONTEXT_MCP_URL', tier: 'recommended', purpose: 'Boston OpenContext MCP endpoint', hasFallback: true },
+
+  // --- Optional / feature / ops ---
+  { name: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },
+  { name: 'CIVICAITOOLS_SESSION_TOKEN', tier: 'optional', purpose: 'publish-evidence skill (Claude Code) auth' },
+  { name: 'CRON_SECRET', tier: 'optional', purpose: 'Cron endpoint auth (blob-gc, portal refresh)' },
+  { name: 'NEXT_PUBLIC_GA_MEASUREMENT_ID', tier: 'optional', purpose: 'Google Analytics 4' },
+];
+
+const TIER_ORDER = ['required', 'recommended', 'optional'];
+
+/**
+ * Pure presence evaluation. Reads only whether each value is a non-empty
+ * string; returns no values. `ok` is true iff every required var is present.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @param {typeof ENV_SPEC} [spec]
+ */
+export function evaluateEnv(env, spec = ENV_SPEC) {
+  const rows = spec.map((s) => {
+    const raw = env[s.name];
+    const present = typeof raw === 'string' && raw.trim().length > 0;
+    return {
+      name: s.name,
+      tier: s.tier,
+      purpose: s.purpose,
+      hasFallback: Boolean(s.hasFallback),
+      present,
+    };
+  });
+
+  const missingRequired = rows.filter((r) => r.tier === 'required' && !r.present);
+  const missingRecommended = rows.filter((r) => r.tier === 'recommended' && !r.present);
+
+  return { rows, missingRequired, missingRecommended, ok: missingRequired.length === 0 };
+}
+
+/** Status token for a row. Pure; no values involved. */
+function statusToken(row) {
+  if (row.present) return 'PASS   ';
+  if (row.tier === 'required') return 'MISSING';
+  if (row.hasFallback) return 'fallbk ';
+  return 'absent ';
+}
+
+/** Render the table as a string (so it is testable / not coupled to stdout). */
+export function renderReport(result) {
+  const lines = [];
+  lines.push('');
+  lines.push('  civic-ai-tools-website — environment preflight');
+  lines.push('  (presence only; no values are read or shown)');
+  lines.push('');
+
+  const nameWidth = Math.max(...result.rows.map((r) => r.name.length));
+
+  for (const tier of TIER_ORDER) {
+    const tierRows = result.rows.filter((r) => r.tier === tier);
+    if (tierRows.length === 0) continue;
+    lines.push(`  ${tier.toUpperCase()}`);
+    for (const r of tierRows) {
+      lines.push(`    [${statusToken(r)}] ${r.name.padEnd(nameWidth)}  ${r.purpose}`);
+    }
+    lines.push('');
+  }
+
+  if (result.ok) {
+    lines.push('  RESULT: PASS — all required variables present.');
+  } else {
+    lines.push(`  RESULT: FAIL — ${result.missingRequired.length} required variable(s) missing:`);
+    for (const r of result.missingRequired) lines.push(`            - ${r.name}`);
+  }
+  if (result.missingRecommended.length > 0) {
+    lines.push(`  NOTE: ${result.missingRecommended.length} recommended variable(s) absent (feature(s) will degrade):`);
+    for (const r of result.missingRecommended) lines.push(`            - ${r.name}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Entry point when run directly (not when imported by the test). */
+function main() {
+  const result = evaluateEnv(process.env);
+  process.stdout.write(renderReport(result));
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+// Run main() only when invoked as a script, not when imported.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -1,0 +1,68 @@
+// Unit tests for the demo-day env preflight.
+//
+// Run with:  node --test scripts/preflight-env.test.mjs
+//
+// (The repo's `npm test` globs src/**/*.test.ts; this scripts/ test is run
+// explicitly — and would be wired into the cross-repo CI bundle, brief #5.)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateEnv, renderReport, ENV_SPEC } from './preflight-env.mjs';
+
+const REQUIRED = ENV_SPEC.filter((s) => s.tier === 'required').map((s) => s.name);
+const RECOMMENDED = ENV_SPEC.filter((s) => s.tier === 'recommended').map((s) => s.name);
+
+/** Build an env object with every required var present (non-empty). */
+function envWithAllRequired() {
+  const env = {};
+  for (const name of REQUIRED) env[name] = 'present';
+  return env;
+}
+
+test('ok=true when every required variable is present', () => {
+  const result = evaluateEnv(envWithAllRequired());
+  assert.equal(result.ok, true);
+  assert.equal(result.missingRequired.length, 0);
+});
+
+test('ok=false and the missing required var is reported when one is absent', () => {
+  const env = envWithAllRequired();
+  delete env.DATABASE_URL;
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missingRequired.map((r) => r.name), ['DATABASE_URL']);
+});
+
+test('empty string and whitespace-only count as absent (not present)', () => {
+  const env = envWithAllRequired();
+  env.EVIDENCE_SIGNING_KEY = '';
+  env.EVIDENCE_KEY_ID = '   ';
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false);
+  const names = result.missingRequired.map((r) => r.name).sort();
+  assert.deepEqual(names, ['EVIDENCE_KEY_ID', 'EVIDENCE_SIGNING_KEY']);
+});
+
+test('missing recommended variables do not fail the run', () => {
+  const env = envWithAllRequired(); // recommended vars all absent
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, true);
+  assert.equal(result.missingRecommended.length, RECOMMENDED.length);
+});
+
+test('renderReport never emits a variable value — only names and statuses', () => {
+  const env = envWithAllRequired();
+  // Use a recognizable sentinel value; it must never appear in the report.
+  env.OPENROUTER_API_KEY = 'sk-or-SECRET-SENTINEL-DO-NOT-LEAK';
+  const report = renderReport(evaluateEnv(env));
+  assert.ok(!report.includes('SECRET-SENTINEL'), 'report must not contain any env value');
+  assert.ok(report.includes('OPENROUTER_API_KEY'), 'report should list the variable name');
+  assert.ok(report.includes('PASS'), 'report should show an overall PASS');
+});
+
+test('every spec entry has a known tier and a purpose', () => {
+  for (const s of ENV_SPEC) {
+    assert.ok(['required', 'recommended', 'optional'].includes(s.tier), `${s.name} has a valid tier`);
+    assert.ok(typeof s.purpose === 'string' && s.purpose.length > 0, `${s.name} has a purpose`);
+  }
+});


### PR DESCRIPTION
## Demo dry-run hardening — Pass 1, item 1 of 4

A committed env-var **preflight** for the demo dry-run. Several infrastructure variables fail silently or with a generic error when absent, so a one-shot "is everything wired?" check removes that failure mode.

### What it does
`scripts/preflight-env.mjs` checks the **presence** (never the value) of the variables the app reads, grouped by tier, and prints a pass/fail table. Exit code is `0` when every **required** var is present and `1` otherwise (so it can gate a CI/deploy step). Missing recommended/optional vars are reported but never fail the run.

Run it through 1Password so the `op://` references in `.env.local` resolve:

```
op run --env-file=.env.local -- node scripts/preflight-env.mjs
```

### Secret hygiene (absolute)
The script reads only whether `process.env[NAME]` is a non-empty string. It never prints, logs, hashes, stores, or transmits any value — not even its length. Output is keyed by variable **name** only. A unit-test regression asserts that no env value ever appears in the rendered report.

### Tiers (grepped from `process.env.*` across `src/`)
- **required** — the demo's load-bearing path fails without it (model key, Socrata MCP, evidence DB/blob/signing key/kid, NextAuth + GitHub OAuth, Vercel KV).
- **recommended** — a feature degrades or a hardcoded fallback kicks in (Data Commons, Boston OpenContext).
- **optional** — non-demo / analytics / ops.

### Verification done
- `node --test scripts/preflight-env.test.mjs` — 6/6 pass (presence detection, empty/whitespace = absent, required-vs-recommended exit semantics, the no-value-leak regression, spec integrity).
- Synthetic runs demonstrate **FAIL → exit 1** (required missing) and **PASS → exit 0** (all required present); the rendered table shows no values.

### One step left for the maintainer
The against-prod `op run` confirmation needs an interactive 1Password Touch ID / desktop approval that this automation session can't satisfy (`authorization timeout`). Please run the one-liner above once to confirm the prod set resolves clean — the script logic itself is proven by the tests + synthetic runs.

### Scope / guardrails
- New files only (`scripts/`), no app code touched.
- Branch + PR; not merging — maintainer merges.
