### PR TITLE
Render friendly copy for MCP-down / timeout / stream errors

### DIFF
--- a/src/hooks/useLiveTrace.ts
+++ b/src/hooks/useLiveTrace.ts
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { connectSSE, SSEError } from '@/lib/sse-client';
+import { connectSSE } from '@/lib/sse-client';
 import { createTraceCapture } from '@/lib/bpmn/capture-trace';
 import { mapEventToNodes } from '@/lib/bpmn/node-mapping';
 import type { TraceEvent, PreRecordedTrace } from '@/lib/bpmn/traces';
-import type { ProgressPhase } from '@/lib/streaming';
+import { friendlyStreamError, type ProgressPhase } from '@/lib/streaming';
 import type { ProgressLogEntry, ProgressGroup, ToolCall } from '@/hooks/useStreamingComparison';
 import { generateGroupLabel } from '@/hooks/useStreamingComparison';
 import {
@@ -402,7 +402,7 @@ export function useLiveTrace(): UseLiveTraceReturn {
         }
 
         if (type === 'error') {
-          setError(eventData.message as string);
+          setError(friendlyStreamError(eventData.message));
           setStatus('error');
           clearTimers();
         }
@@ -440,11 +440,9 @@ export function useLiveTrace(): UseLiveTraceReturn {
     }).catch((err) => {
       if (err instanceof Error && err.name === 'AbortError') return;
       clearTimers();
-      if (err instanceof SSEError && err.status === 429) {
-        setError('Rate limit exceeded. Please try again tomorrow or sign in for more requests.');
-      } else {
-        setError(err instanceof Error ? err.message : 'Failed to connect to the server. Please try again.');
-      }
+      // friendlyStreamError covers SSEError 429, MCP timeout/down, and connection
+      // drops with calm copy — never the raw error message.
+      setError(friendlyStreamError(err));
       setStatus('error');
     });
   }, [clearTimers, handleProgressEvent, finalizeProgress]);

--- a/src/hooks/useNotebookStream.ts
+++ b/src/hooks/useNotebookStream.ts
@@ -14,7 +14,8 @@
  * arrives, so the rest of the UI does not re-render every second.
  */
 import { useCallback, useRef, useState } from 'react';
-import { connectSSE, SSEError } from '@/lib/sse-client';
+import { connectSSE } from '@/lib/sse-client';
+import { friendlyStreamError } from '@/lib/streaming';
 import type { Notebook } from '@/lib/notebook-author';
 import type { NotebookPhase } from '@/components/notebook/NotebookProgress';
 
@@ -217,7 +218,7 @@ export function useNotebookStream() {
           break;
         }
         case 'error': {
-          const message = (raw.message as string | undefined) || 'Notebook generation failed';
+          const message = friendlyStreamError((raw.message as string | undefined) || 'Notebook generation failed');
           setState((prev) => ({
             ...prev,
             error: message,
@@ -247,13 +248,9 @@ export function useNotebookStream() {
       });
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') return;
-      const message =
-        err instanceof SSEError && err.status === 429
-          ? 'Rate limit exceeded. Try again tomorrow or sign in for more requests.'
-          : err instanceof Error
-            ? err.message
-            : 'Failed to connect to /api/query-notebook';
-      setState((prev) => ({ ...prev, error: message, isLoading: false, completedAt: Date.now() }));
+      // friendlyStreamError maps SSEError 429, MCP timeout/down, and connection
+      // drops to calm copy — the raw error/server text never reaches the UI.
+      setState((prev) => ({ ...prev, error: friendlyStreamError(err), isLoading: false, completedAt: Date.now() }));
     }
   }, []);
 

--- a/src/hooks/useStreamingComparison.ts
+++ b/src/hooks/useStreamingComparison.ts
@@ -2,8 +2,8 @@
 
 import { useState, useCallback, useRef } from 'react';
 import { createTraceCapture } from '@/lib/bpmn/capture-trace';
-import { connectSSE, SSEError } from '@/lib/sse-client';
-import type { ProgressPhase } from '@/lib/streaming';
+import { connectSSE } from '@/lib/sse-client';
+import { friendlyStreamError, type ProgressPhase } from '@/lib/streaming';
 
 export interface ToolCall {
   name: string;
@@ -147,26 +147,12 @@ export function useStreamingComparison() {
       if (error instanceof Error && error.name === 'AbortError') {
         return;
       }
-      if (error instanceof SSEError) {
-        if (error.status === 429) {
-          setState(prev => ({
-            ...prev,
-            isLoading: false,
-            error: 'Rate limit exceeded. Please try again tomorrow or sign in for more requests.',
-          }));
-        } else {
-          setState(prev => ({
-            ...prev,
-            isLoading: false,
-            error: error.message || 'An error occurred',
-          }));
-        }
-        return;
-      }
+      // friendlyStreamError maps every shape (SSEError 429, MCP timeout/down,
+      // connection drop, generic) to calm copy — no raw error text reaches the UI.
       setState(prev => ({
         ...prev,
         isLoading: false,
-        error: 'Failed to connect to the server. Please try again.',
+        error: friendlyStreamError(error),
       }));
     }
   }, []);
@@ -492,7 +478,7 @@ function handleEvent(
         ...prev,
         [panel]: {
           ...prev[panel],
-          error: event.message as string,
+          error: friendlyStreamError(event.message),
           isComplete: true,
           progress: null,
         },

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
-import { formatToolProgress, formatToolResult, generateToolReason, type PanelType, type ProgressPhase } from './streaming';
+import { formatToolProgress, formatToolResult, generateToolReason, describeToolFailureForLlm, type PanelType, type ProgressPhase } from './streaming';
 import type { TraceBuilder } from './evidence/trace';
 import { hash as traceHash } from './evidence/trace';
 import { deriveOperationType } from './mcp/operation-types';
@@ -271,10 +271,13 @@ export async function queryWithMcpStreaming(
                 'error.message': error instanceof Error ? error.message : 'Unknown error',
               });
             }
+            // Feed the model neutral guidance instead of the raw error string:
+            // keep it honest (no invented data) without letting raw infra text
+            // (timeouts, status codes, server names) reach the final answer.
             messages.push({
               role: 'tool',
               tool_call_id: toolCall.id,
-              content: `Error executing tool: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              content: describeToolFailureForLlm(toolCall.function.name, error),
             });
           }
         }

--- a/src/lib/streaming.test.ts
+++ b/src/lib/streaming.test.ts
@@ -1,0 +1,91 @@
+// Tests for the friendly error-copy helpers added for demo dry-run hardening.
+//
+// These guard the load-bearing property: no raw error string, status code, or
+// server name ever reaches the reader, while the model still gets honest
+// (anti-hallucination) guidance when a data source fails.
+//
+// Run with: npm test   (or: node --test --experimental-strip-types src/lib/streaming.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyStreamError, friendlyStreamError, describeToolFailureForLlm } from './streaming.ts';
+
+// The actual raw strings produced across the streaming/error path, paired with
+// the kind each should classify to. Sources: mcp/client.ts, compare-stream
+// route Promise.race, sse-client.ts.
+const RAW_CASES: { raw: unknown; kind: ReturnType<typeof classifyStreamError> }[] = [
+  { raw: 'MCP server "socrata" did not respond within 45s — the upstream server may be starting up or unresponsive. Please try again.', kind: 'mcp_timeout' },
+  { raw: 'MCP tool call "get_data" timed out after 45s — the data source may be slow or unresponsive. Try a simpler query.', kind: 'mcp_timeout' },
+  { raw: 'MCP tool "get_data" timed out after 45s', kind: 'mcp_timeout' },
+  { raw: 'MCP initialization failed for "socrata": 502', kind: 'mcp_unavailable' },
+  { raw: 'MCP server "socrata" error: 503 Service Unavailable', kind: 'mcp_unavailable' },
+  { raw: 'No MCP server registered for tool "get_data"', kind: 'mcp_unavailable' },
+  { raw: 'No response body', kind: 'connection' },
+  { raw: 'Failed to connect to the server. Please try again.', kind: 'connection' },
+  { raw: 'Connection lost before the query finished. Partial results may be shown.', kind: 'connection' },
+  { raw: 'Rate limit exceeded', kind: 'rate_limit' },
+  { raw: { status: 429, message: 'Rate limit exceeded' }, kind: 'rate_limit' }, // SSEError-like
+  { raw: new Error('TypeError: something obscure'), kind: 'generic' },
+  { raw: '', kind: 'generic' },
+  { raw: null, kind: 'generic' },
+  { raw: undefined, kind: 'generic' },
+];
+
+test('classifyStreamError maps each real raw string to the right kind', () => {
+  for (const { raw, kind } of RAW_CASES) {
+    assert.equal(classifyStreamError(raw), kind, `classify: ${JSON.stringify(raw)}`);
+  }
+});
+
+test('an SSEError-like object with status 429 is rate_limit even with an unrelated message', () => {
+  assert.equal(classifyStreamError({ status: 429, message: 'whatever' }), 'rate_limit');
+});
+
+// Fragments that must never appear in any reader-facing copy.
+const FORBIDDEN_FRAGMENTS = ['45s', 'socrata', 'mcp', 'tool', '502', '503', '429', 'upstream', 'jsonrpc', 'fetch failed', 'econnrefused'];
+
+test('friendlyStreamError never leaks raw fragments and returns non-empty calm copy', () => {
+  for (const { raw } of RAW_CASES) {
+    const copy = friendlyStreamError(raw);
+    assert.ok(copy.length > 0, 'copy is non-empty');
+    const lower = copy.toLowerCase();
+    for (const frag of FORBIDDEN_FRAGMENTS) {
+      assert.ok(!lower.includes(frag), `copy for ${JSON.stringify(raw)} leaks "${frag}": ${copy}`);
+    }
+  }
+});
+
+test('friendlyStreamError gives distinct copy for timeout vs unavailable vs rate limit', () => {
+  const timeout = friendlyStreamError('MCP tool "get_data" timed out after 45s');
+  const unavailable = friendlyStreamError('MCP server "socrata" error: 503 Service Unavailable');
+  const rate = friendlyStreamError({ status: 429 });
+  assert.match(timeout, /too long to respond/i);
+  assert.match(unavailable, /temporarily unavailable/i);
+  assert.match(rate, /request limit/i);
+  // "data source" is user language (design-principles P9), not "MCP server".
+  assert.match(timeout, /data source/i);
+  assert.match(unavailable, /data source/i);
+});
+
+test('describeToolFailureForLlm keeps the anti-hallucination guard and bans raw leakage', () => {
+  const rawTimeout = 'MCP tool call "get_data" timed out after 45s';
+  const guidance = describeToolFailureForLlm('get_data', rawTimeout);
+  // Anti-hallucination: the model must not invent values.
+  assert.match(guidance, /do not estimate|fabricate|do not.*guess/i);
+  // Must instruct the model not to echo raw infra detail into the answer.
+  assert.match(guidance, /do not include any raw error text/i);
+  // Timeout-specific guidance present.
+  assert.match(guidance, /did not respond in time|timed out/i);
+  // The guidance text itself must not contain the raw error string fragments.
+  const lower = guidance.toLowerCase();
+  for (const frag of ['45s', 'socrata', '502', '503']) {
+    assert.ok(!lower.includes(frag), `LLM guidance leaks "${frag}"`);
+  }
+});
+
+test('describeToolFailureForLlm distinguishes unavailable from generic', () => {
+  const unavailable = describeToolFailureForLlm('get_data', 'MCP initialization failed for "socrata": 503');
+  const generic = describeToolFailureForLlm('get_data', new Error('obscure non-mcp failure'));
+  assert.match(unavailable, /temporarily unavailable/i);
+  assert.match(generic, /could not be completed/i);
+});

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -42,6 +42,113 @@ export interface ErrorEvent extends StreamEvent {
   message: string;
 }
 
+// --- Friendly error copy -----------------------------------------------------
+//
+// Streaming failures (an unavailable or slow MCP data source, a dropped
+// connection, a rate-limit response) must never surface raw error strings,
+// status codes, or server names to the reader. These helpers classify any
+// error shape into a small set of kinds and map each kind to calm, plain
+// user-language copy (design-principles.md P9: "data source", "AI"; no
+// implementation jargon; no new trust/status vocabulary). They are the single
+// place error-to-copy mapping lives, consumed by every SSE-consuming hook.
+
+export type StreamErrorKind = 'rate_limit' | 'mcp_timeout' | 'mcp_unavailable' | 'connection' | 'generic';
+
+/** Pull a lowercased message string out of any error-ish input. */
+function errorMessageOf(input: unknown): string {
+  if (input instanceof Error) return input.message;
+  if (typeof input === 'string') return input;
+  if (input !== null && typeof input === 'object' && 'message' in input) {
+    const m = (input as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return '';
+}
+
+/**
+ * Classify an error (an `Error`, an SSEError-like object with `status`, a raw
+ * message string, or an SSE `error`-event message) into a `StreamErrorKind`.
+ * Order matters: rate-limit first (status or text), then the more specific MCP
+ * timeout before the broader MCP-unavailable, then generic connection.
+ */
+export function classifyStreamError(input: unknown): StreamErrorKind {
+  const status =
+    input !== null && typeof input === 'object' && 'status' in input
+      ? (input as { status?: unknown }).status
+      : undefined;
+  if (status === 429) return 'rate_limit';
+
+  const m = errorMessageOf(input).toLowerCase();
+  if (!m) return 'generic';
+
+  if (m.includes('rate limit') || m.includes('429')) return 'rate_limit';
+  if (m.includes('timed out') || m.includes('timeout') || m.includes('did not respond within')) return 'mcp_timeout';
+  if (
+    m.includes('unavailable') ||
+    m.includes('initialization failed') ||
+    m.includes('mcp server') ||
+    m.includes('mcp tool') ||
+    m.includes('econnrefused') ||
+    m.includes('enotfound') ||
+    m.includes('fetch failed') ||
+    m.includes('502') ||
+    m.includes('503') ||
+    m.includes('504')
+  ) {
+    return 'mcp_unavailable';
+  }
+  if (
+    m.includes('failed to connect') ||
+    m.includes('no response body') ||
+    m.includes('network') ||
+    m.includes('connection')
+  ) {
+    return 'connection';
+  }
+  return 'generic';
+}
+
+const FRIENDLY_STREAM_COPY: Record<StreamErrorKind, string> = {
+  rate_limit: 'You’ve reached today’s request limit. Sign in for more requests, or try again tomorrow.',
+  mcp_timeout:
+    'The live data source took too long to respond, so this query couldn’t finish. Try again in a moment, or narrow the question (for example, add a date range).',
+  mcp_unavailable:
+    'The live data source is temporarily unavailable, so this query couldn’t be completed. Please try again shortly.',
+  connection: 'The connection was interrupted before the response finished. Please try again.',
+  generic: 'Something went wrong while running this query. Please try again in a moment.',
+};
+
+/** Map any streaming error into calm, reader-facing copy. Never leaks raw text. */
+export function friendlyStreamError(input: unknown): string {
+  return FRIENDLY_STREAM_COPY[classifyStreamError(input)];
+}
+
+/**
+ * Server-side: the neutral text fed back to the model when an MCP tool call
+ * fails, in place of the raw `Error executing tool: <message>` string. It (1)
+ * preserves the anti-hallucination guard (the model must not invent values to
+ * fill the gap), and (2) instructs the model to tell the user plainly that the
+ * live data couldn't be retrieved, without echoing raw error text, status
+ * codes, or server names into the answer.
+ */
+export function describeToolFailureForLlm(_toolName: string, input: unknown): string {
+  const preamble =
+    'This data request returned no data. Do not estimate, guess, or fabricate any values to fill the gap.';
+  const tellUser = (detail: string) =>
+    `${preamble} ${detail} In your answer, briefly tell the user in plain language that the live data could not be retrieved, and do not include any raw error text, status codes, server names, or system details.`;
+
+  switch (classifyStreamError(input)) {
+    case 'mcp_timeout':
+      return tellUser(
+        'The live data source did not respond in time and the request timed out. Suggest trying again or narrowing the query (for example, adding a date range).',
+      );
+    case 'mcp_unavailable':
+      return tellUser('The live data source is temporarily unavailable. Suggest trying again shortly.');
+    default:
+      return tellUser('The request could not be completed. Suggest trying again.');
+  }
+}
+
 // Format tool call arguments into human-readable progress messages
 export function formatToolProgress(
   name: string,


### PR DESCRIPTION
## Demo dry-run hardening — Pass 1, item 3 of 4

Makes **MCP-unavailable** and **MCP-timeout** (and other streaming failures) render **calm, plain-language copy** instead of raw error strings.

### The two leak channels (traced)
1. **SSE error event / connection rejection.** When a query throws (e.g. the ~45s MCP timeout, or `openrouter` errors), the server sends `error.message` over SSE, and three hooks (`useStreamingComparison`, `useLiveTrace`, `useNotebookStream`) rendered that raw string directly (`MCP server "socrata" did not respond within 45s …`, status codes, server names).
2. **The model echoing the tool-error.** A failed tool call fed `Error executing tool: <raw message>` back into the model's context, so the synthesized answer could parrot raw infra text.

### The fix — one mapping, applied at every reader-facing site
New helpers in `src/lib/streaming.ts` (the shared utility hub):
- `classifyStreamError` + `friendlyStreamError` — map every error shape (SSEError 429, MCP timeout, MCP unavailable, connection drop, generic) to calm copy. User language per design-principles **P9** ("the live data source", not "MCP server"); **no new trust/status vocabulary**.
- `describeToolFailureForLlm` — the neutral text now fed to the model in place of the raw tool error. Preserves the **anti-hallucination guard** (the model must not invent values to fill the gap) while instructing it not to echo raw error text / status codes / server names.

Applied at: the SSE `error`-event handlers and the rejection/`catch` handlers in all three hooks, and the tool-failure path in `openrouter-streaming.ts`. This also **DRYs up** the 429 copy that was duplicated across the three hooks.

### Demo-load-bearing
Render cold starts make the 45s MCP timeout a realistic demo-day event. Previously a slow/cold data source showed raw timeout text to the room; now it shows: *"The live data source took too long to respond, so this query couldn't finish. Try again in a moment, or narrow the question."*

### Verification
- `npm test` — **314/314 pass**, incl. new `src/lib/streaming.test.ts` (classification of the real raw strings; a no-leak regression asserting no `45s`/`socrata`/`mcp`/status-code fragment ever appears in reader-facing copy; LLM-guidance anti-hallucination + no-leak).
- `npx tsc --noEmit` clean; `eslint` on all changed files clean.

### Acceptance criteria met
- MCP-down / MCP-timeout / stream-error paths show friendly copy, not raw error text ✓
- Trust-signal/vocabulary discipline respected (no new status words; user language) ✓
- Tests for each changed path ✓

### Relationship to item 4 (separate PR)
Item 4 removes the dead `SSEClientOptions.onError`. After this PR, error→copy mapping lives at the rejection-handling sites via `friendlyStreamError` — confirming `onError` was never the channel. The two PRs touch disjoint files.

Branch + PR; not merging — maintainer merges.
