### PR TITLE
Remove dead SSE onError callback; document the rejection contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,7 +383,7 @@ CSS keyframes (`blink`, `spin`, `pulse`) and component-specific styles use style
 3. **`useLiveTrace` responsibility accumulation** — Manages SSE connection, diagram animation, progress logs, tool tracking, trace capture, slow timers, elapsed time, and abort control. Works but is a code smell.
 4. **bpmn-js type gaps** — 4 `@typescript-eslint/no-explicit-any` suppressions for untyped bpmn-js APIs.
 5. **BPMN XML hand-authored** — Should be round-tripped through bpmn.io visual modeler for maintainability.
-6. **Pre-existing lint warnings** — TraceControls setState-in-effect, unused `mapEventToNodes` in animation.ts, unused `onError` in sse-client.ts.
+6. **Pre-existing lint warnings** — TraceControls setState-in-effect, unused `mapEventToNodes` in animation.ts. (The unused `onError` in sse-client.ts was removed — see its error-contract JSDoc; errors flow through promise rejection only.)
 
 ## Retrospectives
 

--- a/src/lib/sse-client.test.ts
+++ b/src/lib/sse-client.test.ts
@@ -1,0 +1,102 @@
+// Tests for connectSSE's error contract.
+//
+// The `onError?` option was removed (it was destructured but never invoked,
+// and no caller passed it). These tests pin the REAL error channel that all
+// callers rely on: connectSSE rejects on failure, with the HTTP status
+// preserved on an SSEError. If a future change tried to swallow errors instead
+// of rejecting, these fail.
+//
+// Run with: npm test   (or: node --test --experimental-strip-types src/lib/sse-client.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { connectSSE, SSEError } from './sse-client.ts';
+
+/** Swap global.fetch for the duration of `fn`, restoring it afterward. */
+async function withFetch(impl: typeof fetch, fn: () => Promise<void>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+test('rejects with SSEError (status + parsed message preserved) on a non-ok response', async () => {
+  const impl = (async () =>
+    new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
+      status: 429,
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof fetch;
+
+  await withFetch(impl, async () => {
+    await assert.rejects(
+      connectSSE({ url: '/x', body: {}, onEvent: () => {} }),
+      (err: unknown) => {
+        assert.ok(err instanceof SSEError, 'rejects with SSEError');
+        assert.equal((err as SSEError).status, 429, 'status is preserved');
+        assert.equal((err as SSEError).message, 'Rate limit exceeded', 'parsed error message is preserved');
+        return true;
+      },
+    );
+  });
+});
+
+test('rejects when the response has no body', async () => {
+  const impl = (async () => ({ ok: true, body: null }) as unknown as Response) as typeof fetch;
+  await withFetch(impl, async () => {
+    await assert.rejects(connectSSE({ url: '/x', body: {}, onEvent: () => {} }), /No response body/);
+  });
+});
+
+test('dispatches each event and calls onComplete on a normal stream', async () => {
+  const body = new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      controller.enqueue(enc.encode('data: {"type":"progress","message":"hi"}\n\n'));
+      controller.enqueue(enc.encode('data: {"type":"complete"}\n\n'));
+      controller.close();
+    },
+  });
+  const impl = (async () => new Response(body, { status: 200 })) as typeof fetch;
+
+  const events: Record<string, unknown>[] = [];
+  let completed = false;
+  await withFetch(impl, async () => {
+    await connectSSE({
+      url: '/x',
+      body: {},
+      onEvent: (e) => events.push(e),
+      onComplete: () => {
+        completed = true;
+      },
+    });
+  });
+
+  assert.equal(events.length, 2);
+  assert.equal(events[0].type, 'progress');
+  assert.equal(events[1].type, 'complete');
+  assert.equal(completed, true, 'onComplete fires when the stream ends');
+});
+
+test('a malformed event line is swallowed, not thrown — the stream still completes', async () => {
+  const body = new ReadableStream({
+    start(controller) {
+      const enc = new TextEncoder();
+      controller.enqueue(enc.encode('data: {not valid json}\n\n'));
+      controller.enqueue(enc.encode('data: {"type":"complete"}\n\n'));
+      controller.close();
+    },
+  });
+  const impl = (async () => new Response(body, { status: 200 })) as typeof fetch;
+
+  const events: Record<string, unknown>[] = [];
+  await withFetch(impl, async () => {
+    // Must not reject on the unparseable first event.
+    await connectSSE({ url: '/x', body: {}, onEvent: (e) => events.push(e) });
+  });
+  // Only the valid event is dispatched; the malformed one is skipped.
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'complete');
+});

--- a/src/lib/sse-client.ts
+++ b/src/lib/sse-client.ts
@@ -19,17 +19,35 @@ export interface SSEClientOptions {
   url: string;
   body: Record<string, unknown>;
   onEvent: (event: Record<string, unknown>) => void;
-  onError?: (error: Error) => void;
   onComplete?: () => void;
   signal?: AbortSignal;
 }
 
 /**
  * Opens an SSE connection via POST, parses events, and dispatches them.
- * Resolves when the stream ends; rejects on HTTP error or network failure.
+ *
+ * Error contract: this function communicates ALL fatal failures by REJECTING
+ * the returned promise — an `SSEError` (carrying the HTTP status) on a non-ok
+ * response, or the underlying error on a missing body / mid-stream network
+ * drop. Promise rejection is the single error channel; every caller handles it
+ * with try/catch or `.catch()` and maps it to user copy via
+ * `friendlyStreamError` (see lib/streaming.ts). There is deliberately no
+ * `onError` callback — see the removal rationale below.
+ *
+ * Per-event JSON parse errors are intentionally swallowed (logged, not thrown):
+ * one malformed event must not tear down an otherwise-healthy stream.
+ *
+ * `onComplete` runs in a `finally` when the read loop exits, on both the
+ * success path and a mid-stream drop (in the latter case the promise also
+ * rejects afterward; callers' rejection handler is authoritative).
+ *
+ * Removed: a previously-declared `onError?` option that was destructured but
+ * never invoked, and which no caller ever passed. It was a dead second error
+ * channel — keeping it invited a future caller to wire it up and silently get
+ * no callbacks. Errors flow through promise rejection only.
  */
 export async function connectSSE(options: SSEClientOptions): Promise<void> {
-  const { url, body, onEvent, onError, onComplete, signal } = options;
+  const { url, body, onEvent, onComplete, signal } = options;
 
   const response = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
## Demo dry-run hardening — Pass 1, item 4 of 4

Dispositions the `src/lib/sse-client.ts:32` finding: `onError?` was declared and destructured in `connectSSE` but **never invoked**. This was flagged as the highest-signal item ("investigate whether SSE errors silently vanish") — so it's traced, not lint-swept.

### Investigation
- `SSEClientOptions.onError` is destructured in `connectSSE` but **never called** anywhere in the function.
- **No caller passes it.** All three consumers — `useStreamingComparison`, `useLiveTrace`, `useNotebookStream` — handle failures via the returned promise's **rejection** (try/catch or `.catch()`).
- So fatal SSE errors do **not** silently vanish: `connectSSE`'s documented contract is to reject (`SSEError` with HTTP status on a non-ok response; the underlying error on a missing body / mid-stream drop), and every caller handles that rejection. With item 3 merged, each renders calm copy from it.
- The **only** swallowed errors are per-event JSON parse failures, logged-not-thrown on purpose so one malformed event can't tear down a healthy stream. That's correct, and not a candidate for `onError`.

### Disposition: remove (with rationale), not wire
A second, never-fired error channel is a footgun — a future caller could pass `onError` expecting it to fire and silently get nothing. Wiring it would create two channels for one failure, inviting double-handling. So:
- Removed `onError` from `SSEClientOptions` and the destructure.
- Documented the **single error channel** (promise rejection) in `connectSSE`'s JSDoc, including the deliberate per-event swallow and the `onComplete`-then-reject ordering on a mid-stream drop.

### Tests (`src/lib/sse-client.test.ts`)
- rejects with `SSEError` (status + parsed message preserved) on a non-ok response;
- rejects on a missing body;
- dispatches each event and fires `onComplete` on a normal stream;
- swallows a malformed event without rejecting (the stream still completes).

`npx tsc --noEmit` passing confirms **no call site relied on the removed option**. Eslint clean. Also clears the stale "unused `onError`" entry in CLAUDE.md Known Tech Debt #6.

### Relationship to item 3 (separate PR #150)
Disjoint files (item 4 = `sse-client.ts`; item 3 = hooks + `streaming.ts` + `openrouter-streaming.ts`). Item 3 routes rejection-handler errors through `friendlyStreamError` — which is exactly the channel this disposition confirms is the real one.

Branch + PR; not merging — maintainer merges.
