### PR TITLE
chore(preflight): honor coded fallbacks so a fallback-backed required var isn't a false FAIL

### DIFF
--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -47,7 +47,7 @@ export const ENV_SPEC = [
   { name: 'DATABASE_URL', tier: 'required', purpose: 'Evidence DB — publish + dashboard + detail page' },
   { name: 'BLOB_READ_WRITE_TOKEN', tier: 'required', purpose: 'Evidence package storage (Vercel Blob)' },
   { name: 'EVIDENCE_SIGNING_KEY', tier: 'required', purpose: 'Ed25519 private key — signs evidence packages' },
-  { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry' },
+  { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry', hasFallback: true }, // signing.ts: `EVIDENCE_KEY_ID || DEFAULT_KEY_ID`; the default mirrors the registry's active kid
 
   // --- Sign-in path (the rate-limit headroom option; OAuth) ---
   { name: 'NEXTAUTH_SECRET', tier: 'required', purpose: 'NextAuth session encryption' },
@@ -93,17 +93,25 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
     };
   });
 
-  const missingRequired = rows.filter((r) => r.tier === 'required' && !r.present);
+  // A required var with a coded fallback (`hasFallback`) is NOT a hard miss when
+  // absent — the app substitutes a built-in default (e.g. signing.ts uses
+  // DEFAULT_KEY_ID for EVIDENCE_KEY_ID). It is surfaced separately so the
+  // default's continued correctness (e.g. the kid still matching the trust
+  // registry across a key rotation) can be confirmed, without failing the run.
+  const missingRequired = rows.filter((r) => r.tier === 'required' && !r.present && !r.hasFallback);
+  const requiredOnFallback = rows.filter((r) => r.tier === 'required' && !r.present && r.hasFallback);
   const missingRecommended = rows.filter((r) => r.tier === 'recommended' && !r.present);
 
-  return { rows, missingRequired, missingRecommended, ok: missingRequired.length === 0 };
+  return { rows, missingRequired, requiredOnFallback, missingRecommended, ok: missingRequired.length === 0 };
 }
 
 /** Status token for a row. Pure; no values involved. */
 function statusToken(row) {
   if (row.present) return 'PASS   ';
-  if (row.tier === 'required') return 'MISSING';
+  // A coded fallback applies whether the var is required or optional: an absent
+  // var with a hardcoded default is running on that default, not missing.
   if (row.hasFallback) return 'fallbk ';
+  if (row.tier === 'required') return 'MISSING';
   return 'absent ';
 }
 
@@ -132,6 +140,10 @@ export function renderReport(result) {
   } else {
     lines.push(`  RESULT: FAIL — ${result.missingRequired.length} required variable(s) missing:`);
     for (const r of result.missingRequired) lines.push(`            - ${r.name}`);
+  }
+  if (result.requiredOnFallback && result.requiredOnFallback.length > 0) {
+    lines.push(`  NOTE: ${result.requiredOnFallback.length} required variable(s) absent but running on a built-in fallback (confirm the default is still correct):`);
+    for (const r of result.requiredOnFallback) lines.push(`            - ${r.name}`);
   }
   if (result.missingRecommended.length > 0) {
     lines.push(`  NOTE: ${result.missingRecommended.length} recommended variable(s) absent (feature(s) will degrade):`);

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -35,12 +35,25 @@ test('ok=false and the missing required var is reported when one is absent', () 
 
 test('empty string and whitespace-only count as absent (not present)', () => {
   const env = envWithAllRequired();
+  // Two required vars with NO coded fallback, so they count as hard misses.
   env.EVIDENCE_SIGNING_KEY = '';
-  env.EVIDENCE_KEY_ID = '   ';
+  env.NEXTAUTH_SECRET = '   ';
   const result = evaluateEnv(env);
   assert.equal(result.ok, false);
   const names = result.missingRequired.map((r) => r.name).sort();
-  assert.deepEqual(names, ['EVIDENCE_KEY_ID', 'EVIDENCE_SIGNING_KEY']);
+  assert.deepEqual(names, ['EVIDENCE_SIGNING_KEY', 'NEXTAUTH_SECRET']);
+});
+
+test('a required var with a coded fallback is soft when absent (fallbk, run still passes)', () => {
+  const env = envWithAllRequired();
+  delete env.EVIDENCE_KEY_ID; // required, but hasFallback (signing.ts → DEFAULT_KEY_ID)
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, true, 'a fallback-backed required var does not fail the run');
+  assert.equal(result.missingRequired.length, 0);
+  assert.deepEqual(result.requiredOnFallback.map((r) => r.name), ['EVIDENCE_KEY_ID']);
+  const report = renderReport(result);
+  assert.match(report, /fallbk/);
+  assert.match(report, /built-in fallback/);
 });
 
 test('missing recommended variables do not fail the run', () => {


### PR DESCRIPTION
## What

The demo-day preflight (`scripts/preflight-env.mjs`, #148) flagged `EVIDENCE_KEY_ID` as a hard **FAIL** when absent from `.env.local`. That's a false alarm: `signing.ts` reads `EVIDENCE_KEY_ID || DEFAULT_KEY_ID`, and `DEFAULT_KEY_ID = 'platform:evidence-2026-04'` — which is the **active kid in the live trust registry** (verified at `civicaitools.org/.well-known/evidence-public-keys.json`). So an absent `EVIDENCE_KEY_ID` signs with exactly the right kid; publishing + verification work.

Root cause was in the preflight itself: `hasFallback` was **ignored for `required` vars**. `statusToken` returned `MISSING` before it ever checked `hasFallback`, and `evaluateEnv` counted any absent required var as a hard miss. (This latent gap also silently affected `SOCRATA_MCP_URL`, already `required + hasFallback`.)

## Change

- `EVIDENCE_KEY_ID` marked `hasFallback: true` (matching the `signing.ts` reality).
- `statusToken` now checks `hasFallback` **before** the required→`MISSING` branch, so a fallback-backed absent var reports `fallbk`.
- `evaluateEnv` excludes fallback-backed vars from `missingRequired` (so the run no longer hard-fails on them) and surfaces them in a new `requiredOnFallback` group.
- `renderReport` prints a NOTE for those: *"absent but running on a built-in fallback (confirm the default is still correct)"* — preserving the one real caveat: if the platform key rotates and `DEFAULT_KEY_ID` isn't updated (and `EVIDENCE_KEY_ID` isn't set), signing would drift from the registry.
- Regression test added; existing whitespace test re-pointed to two genuinely no-fallback required vars.

## Result

`EVIDENCE_KEY_ID` absent → `[fallbk]` + `RESULT: PASS` + the confirm-the-default NOTE, instead of a red FAIL. 7/7 preflight tests pass.

Not in scope (blocked by the repo's secret-read guard on `.env*`): adding `EVIDENCE_KEY_ID` to `.env.example`. The kid is public (not a secret); it's being added to Vercel prod + `.env.local` by hand as separate hygiene.
