### PR TITLE
roadmap: reflect resolved evidence-system fork in /roadmap page metadata

### DIFF
--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -6,7 +6,7 @@ import RoadmapBody from '@/components/roadmap/RoadmapBody';
 export const metadata: Metadata = {
   title: 'Roadmap - Civic AI Tools',
   description:
-    'The civic-ai-tools public roadmap — vision pillars, trust commitments, near-term plans, and the evidence-system fork. Mirrored from the hub repo.',
+    'The civic-ai-tools public roadmap — vision pillars, trust commitments, near-term plans, and how the evidence-system fork resolved (toward a domain-neutral, spec-first protocol). Mirrored from the hub repo.',
 };
 
 export default async function RoadmapPage() {


### PR DESCRIPTION
## What

Updates the one hardcoded reference on the `/roadmap` page that still framed the **evidence-system fork as open**.

The `/roadmap` body mirrors `civic-ai-tools/ROADMAP.md` dynamically (`getRoadmapMarkdown()` → GitHub raw, 1-hour ISR), so the resolved §6 content flows through automatically once the hub-repo PR merges. The page's `metadata.description` string is the only place the fork status is hardcoded in this repo.

## Change

- `src/app/roadmap/page.tsx` — metadata description: "…and the evidence-system fork" → "…and how the evidence-system fork resolved (toward a domain-neutral, spec-first protocol)."

Mirrors **ADR-0014** (Path B, domain-neutral, realized spec-first). Pairs with **npstorey/civic-ai-tools#86**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
