### PR TITLE
fix(evidence): resolve commitment hash case-insensitively + index base_package_hash

### DIFF
--- a/drizzle/0013_add_base_package_hash_index.sql
+++ b/drizzle/0013_add_base_package_hash_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "evidence_records_base_package_hash_idx" ON "evidence_records" USING btree ("base_package_hash");

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,815 @@
+{
+  "id": "bc495c2f-64d6-4403-a87f-039f8ff66d64",
+  "prevId": "54b5dcfb-34b2-418c-9719-3bd243d2eda4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_nodes": {
+      "name": "attestation_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rfc3161_timestamp": {
+          "name": "rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_entry_id": {
+          "name": "rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_inclusion_proof": {
+          "name": "rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer": {
+          "name": "signer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_nodes_creator_id_users_id_fk": {
+          "name": "attestation_nodes_creator_id_users_id_fk",
+          "tableFrom": "attestation_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_packages": {
+      "name": "attestation_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evidence_record_id": {
+          "name": "evidence_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attestation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_hash": {
+          "name": "package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references_base_hash": {
+          "name": "references_base_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_packages_evidence_record_id_evidence_records_id_fk": {
+          "name": "attestation_packages_evidence_record_id_evidence_records_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "evidence_records",
+          "columnsFrom": [
+            "evidence_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attestation_packages_creator_id_users_id_fk": {
+          "name": "attestation_packages_creator_id_users_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_approved_user_id_users_id_fk": {
+          "name": "device_codes_approved_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_records": {
+      "name": "evidence_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_visibility": {
+          "name": "prompt_visibility",
+          "type": "prompt_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_text'"
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_server": {
+          "name": "mcp_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civic_context": {
+          "name": "civic_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_hash": {
+          "name": "base_package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_storage_key": {
+          "name": "base_package_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_signature": {
+          "name": "base_package_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rfc3161_timestamp": {
+          "name": "base_package_rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_id": {
+          "name": "base_package_rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_inclusion_proof": {
+          "name": "base_package_rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_body": {
+          "name": "base_package_rekor_entry_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_method": {
+          "name": "capture_method",
+          "type": "capture_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_profile": {
+          "name": "content_profile",
+          "type": "content_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "consistency_classification": {
+          "name": "consistency_classification",
+          "type": "consistency_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_reason": {
+          "name": "withdrawn_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_signature": {
+          "name": "withdrawal_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_timestamp": {
+          "name": "withdrawal_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_reason": {
+          "name": "reinstated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_signature": {
+          "name": "reinstatement_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_timestamp": {
+          "name": "reinstatement_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidence_records_base_package_hash_idx": {
+          "name": "evidence_records_base_package_hash_idx",
+          "columns": [
+            {
+              "expression": "base_package_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidence_records_creator_id_users_id_fk": {
+          "name": "evidence_records_creator_id_users_id_fk",
+          "tableFrom": "evidence_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evidence_records_slug_unique": {
+          "name": "evidence_records_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attestation_type": {
+      "name": "attestation_type",
+      "schema": "public",
+      "values": [
+        "consistency",
+        "evaluation",
+        "re_evaluation",
+        "correction",
+        "expert_attestation"
+      ]
+    },
+    "public.capture_method": {
+      "name": "capture_method",
+      "schema": "public",
+      "values": [
+        "chat-flow-stream",
+        "claude-code-jsonl-readback",
+        "claude-code-self-report",
+        "datHere"
+      ]
+    },
+    "public.consistency_classification": {
+      "name": "consistency_classification",
+      "schema": "public",
+      "values": [
+        "highly_reproducible",
+        "moderately_stable",
+        "inconsistent"
+      ]
+    },
+    "public.content_profile": {
+      "name": "content_profile",
+      "schema": "public",
+      "values": [
+        "default",
+        "datHere"
+      ]
+    },
+    "public.prompt_visibility": {
+      "name": "prompt_visibility",
+      "schema": "public",
+      "values": [
+        "full_text",
+        "hash_only"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "consistency_tested",
+        "evaluated",
+        "fully_attested"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "published",
+        "committed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1781231818401,
       "tag": "0012_add_visibility",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1782929788389,
+      "tag": "0013_add_base_package_hash_index",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/evidence/[slug]/commitment/route.ts
+++ b/src/app/api/evidence/[slug]/commitment/route.ts
@@ -7,6 +7,7 @@ import type { EvidencePackage } from '@/lib/evidence/packager';
 import { buildCommitmentView } from '@/lib/evidence/commitment';
 import { loadTrustRegistry } from '@/lib/evidence/verify';
 import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
+import { classifyIdentifier, commitmentAccessError } from '@/lib/evidence/identifier';
 
 /**
  * GET /api/evidence/[hash|slug]/commitment
@@ -21,6 +22,11 @@ import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
  * The `[slug]` path segment accepts EITHER:
  *   - a 64-hex base-package hash (`/api/evidence/<hash>/commitment`), or
  *   - an evidence slug (`/api/evidence/<slug>/commitment`).
+ * The two forms are interchangeable and resolve to the SAME commitment. Hash
+ * matching is case-INSENSITIVE (an upper- or mixed-case hash pasted by a user,
+ * or embedded in an older link/badge, still resolves). Classification and the
+ * public-visibility gate live in `@/lib/evidence/identifier` so the hash and
+ * slug paths share one authorization surface (civic-ai-tools-website#116).
  *
  * Hash → row ambiguity: re-publishing the same package under a different title
  * creates a second row with the same `basePackageHash` (identical immutable
@@ -55,9 +61,6 @@ import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
  * off. (#119 Q15a)
  */
 
-// A base-package hash is the hex SHA-256 of the canonical envelope: 64 hex chars.
-const HASH_RE = /^[0-9a-f]{64}$/i;
-
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -85,18 +88,23 @@ export async function GET(
 ) {
   const { slug: identifier } = await params;
 
-  // Resolve the row by hash (canonical/first match) or by slug (unambiguous).
-  const records = HASH_RE.test(identifier)
+  // Resolve the row by base-package hash or by slug — the two forms are
+  // interchangeable (see `classifyIdentifier`). Hash matching is
+  // case-insensitive and hits the `base_package_hash` index; a re-published
+  // package can share a hash across rows, so the hash form takes the canonical
+  // (first-created) row. The slug is unique — at most one row.
+  const q = classifyIdentifier(identifier);
+  const records = q.isHash
     ? await db
         .select()
         .from(evidenceRecords)
-        .where(eq(evidenceRecords.basePackageHash, identifier))
+        .where(eq(evidenceRecords.basePackageHash, q.value))
         .orderBy(asc(evidenceRecords.createdAt))
         .limit(1)
     : await db
         .select()
         .from(evidenceRecords)
-        .where(eq(evidenceRecords.slug, identifier))
+        .where(eq(evidenceRecords.slug, q.value))
         .limit(1);
 
   if (records.length === 0) {
@@ -104,19 +112,13 @@ export async function GET(
   }
   const record = records[0];
 
-  // A row with no base-package hash never completed publishing — there are no
-  // proofs to commit to. Treat as not found (nothing to verify).
-  if (!record.basePackageHash) {
-    return jsonResponse(
-      { error: 'No published evidence package for this identifier' },
-      404,
-    );
-  }
-
-  // Non-public records are not exposed (mirrors the existing read-back; the
-  // public flag is independent of withdrawal — withdrawn-but-public is served).
-  if (!record.isPublic) {
-    return jsonResponse({ error: 'Evidence not found' }, 404);
+  // Public-visibility gate — applied to the RESOLVED record, so it is identical
+  // whether the record was addressed by hash or by slug: addressing by hash
+  // grants no more access than addressing by slug (a record with no published
+  // base package, or one that is not public, is unreachable by either form).
+  const accessError = commitmentAccessError(record);
+  if (accessError) {
+    return jsonResponse({ error: accessError }, 404);
   }
 
   const creators = await db

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -6,6 +6,7 @@ import {
   boolean,
   pgEnum,
   jsonb,
+  index,
 } from 'drizzle-orm/pg-core';
 
 // --- Enums ---
@@ -163,7 +164,15 @@ export const evidenceRecords = pgTable('evidence_records', {
   updatedAt: timestamp('updated_at', { withTimezone: true })
     .defaultNow()
     .notNull(),
-});
+}, (table) => ({
+  // Hash-addressable commitment lookup (`GET /api/evidence/<hash>/commitment`)
+  // matches on `base_package_hash`; index it so the lookup is not a table scan.
+  // Non-unique on purpose: a re-published package can share a base_package_hash
+  // across rows (identical immutable blob, a separate signing run).
+  basePackageHashIdx: index('evidence_records_base_package_hash_idx').on(
+    table.basePackageHash,
+  ),
+}));
 
 export const attestationPackages = pgTable('attestation_packages', {
   id: uuid('id').defaultRandom().primaryKey(),

--- a/src/lib/evidence/identifier.test.ts
+++ b/src/lib/evidence/identifier.test.ts
@@ -1,0 +1,251 @@
+// Tests for identifier resolution on the public commitment endpoint
+// (civic-ai-tools-website#116 durable backend half): a bare base-package hash
+// and a slug MUST resolve to the same §9.2.1 commitment, hash matching MUST be
+// case-insensitive, slug resolution MUST be unchanged, and a non-public package
+// MUST stay unreachable by hash.
+//
+// The commitment route imports `@/lib/db` (a live Neon client) so it can't run
+// under the `node --test` harness. These tests instead drive the SAME pure
+// functions the route uses — `classifyIdentifier`, `commitmentAccessError`,
+// `buildCommitmentView` — through a tiny in-memory store that mirrors the route's
+// DB resolution (equality match + canonical-row ordering). The live deployed
+// behavior (uppercase hash 404 before this fix, 200 after) was additionally
+// confirmed by curl against civicaitools.org.
+//
+// Run with: npm test (Node 22+).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyIdentifier,
+  commitmentAccessError,
+  IDENTIFIER_HASH_RE,
+} from './identifier.ts';
+import { buildCommitmentView } from './commitment.ts';
+import { evidenceRecords, users } from '../db/schema.ts';
+
+type EvidenceRecord = typeof evidenceRecords.$inferSelect;
+type UserRecord = typeof users.$inferSelect;
+
+const HASH = 'e84455d16b154641c264480fad9423bf9a33328e97c3915d6eba76ac26e85b16';
+
+function makeRecord(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  const base: EvidenceRecord = {
+    id: '11111111-1111-1111-1111-111111111111',
+    slug: 'noise-trends-in-nyc-last-week-e84455',
+    creatorId: '22222222-2222-2222-2222-222222222222',
+    title: 'Noise trends in NYC last week',
+    summary: 'A short, citation-ready summary of the analysis.',
+    model: 'openai/gpt-4o',
+    promptHash: 'sha256:promptdigest',
+    promptVisibility: 'full_text',
+    promptText: 'SECRET prompt text that must never leak into the sidecar',
+    systemPromptHash: 'sha256:systemdigest',
+    mcpServer: 'https://socrata-mcp.civicaitools.org',
+    jurisdiction: 'NYC',
+    civicContext: 'civic context note',
+    basePackageHash: HASH,
+    basePackageStorageKey:
+      'https://store.public.blob.vercel-storage.com/evidence-packages/' +
+      HASH +
+      '.json',
+    basePackageSignature: JSON.stringify({
+      signature: 'BASE64SIG',
+      publicKey: 'BASE64PUBKEY',
+      algorithm: 'Ed25519ph',
+      kid: 'platform:evidence-2026-04',
+    }),
+    basePackageRfc3161Timestamp: 'BASE64TSTOKEN',
+    basePackageRekorEntryId: 'rekor-entry-123',
+    basePackageRekorInclusionProof: JSON.stringify({ logIndex: 42 }),
+    basePackageRekorEntryBody: 'eyJhcGlWZXJzaW9uIjoiMC4wLjEifQ==',
+    captureMethod: 'chat-flow-stream',
+    contentProfile: null,
+    verificationStatus: 'unverified',
+    consistencyClassification: null,
+    isPublic: true,
+    visibility: 'published',
+    withdrawnAt: null,
+    withdrawnReason: null,
+    withdrawalSignature: null,
+    withdrawalTimestamp: null,
+    reinstatedAt: null,
+    reinstatedReason: null,
+    reinstatementSignature: null,
+    reinstatementTimestamp: null,
+    createdAt: new Date('2026-06-16T00:31:59.875Z'),
+    updatedAt: new Date('2026-06-16T00:31:59.875Z'),
+  };
+  return { ...base, ...overrides };
+}
+
+function makeCreator(overrides: Partial<UserRecord> = {}): UserRecord {
+  return {
+    id: '22222222-2222-2222-2222-222222222222',
+    githubId: '583231',
+    displayName: 'Nathan Storey',
+    githubProfileUrl: 'https://github.com/npstorey',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+/**
+ * Mirror of the commitment route's DB resolution using the REAL classifier:
+ * equality match on the classified column, and — for the hash form — the
+ * canonical (oldest-created) row when several share a base_package_hash.
+ * Returns the matched row or null.
+ */
+function resolveFromStore(
+  store: EvidenceRecord[],
+  identifier: string,
+): EvidenceRecord | null {
+  const q = classifyIdentifier(identifier);
+  const matched = store.filter((r) =>
+    q.by === 'basePackageHash' ? r.basePackageHash === q.value : r.slug === q.value,
+  );
+  if (matched.length === 0) return null;
+  if (q.isHash) {
+    matched.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+  return matched[0];
+}
+
+/**
+ * Mirror of the commitment route's full pipeline: resolve → public-visibility
+ * gate → build the §9.2.1 view. `pkg` is passed null (the route degrades to
+ * DB-sourced proofs when the blob can't be fetched), which is enough to compare
+ * commitment identity across address forms.
+ */
+function serveCommitment(
+  store: EvidenceRecord[],
+  creator: UserRecord | null,
+  identifier: string,
+): { status: number; error?: string; body?: Record<string, unknown> } {
+  const record = resolveFromStore(store, identifier);
+  if (!record) return { status: 404, error: 'Evidence not found' };
+  const accessError = commitmentAccessError(record);
+  if (accessError) return { status: 404, error: accessError };
+  return { status: 200, body: buildCommitmentView(record, creator, null) };
+}
+
+// --- classifyIdentifier ---
+
+test('classifyIdentifier: lowercase 64-hex is a hash, matched verbatim', () => {
+  const q = classifyIdentifier(HASH);
+  assert.deepEqual(q, { by: 'basePackageHash', value: HASH, isHash: true });
+});
+
+test('classifyIdentifier: UPPERCASE/mixed-case hash lowercases for the lookup (the fix)', () => {
+  const upper = classifyIdentifier(HASH.toUpperCase());
+  assert.deepEqual(upper, { by: 'basePackageHash', value: HASH, isHash: true });
+
+  const mixed =
+    HASH.slice(0, 32).toUpperCase() + HASH.slice(32); // half upper, half lower
+  const q = classifyIdentifier(mixed);
+  assert.equal(q.by, 'basePackageHash');
+  assert.equal(q.isHash, true);
+  assert.equal(q.value, HASH); // normalized to the lowercase stored digest
+});
+
+test('classifyIdentifier: a real slug is a slug, passed through verbatim', () => {
+  const slug = 'noise-trends-in-nyc-last-week-e84455';
+  assert.deepEqual(classifyIdentifier(slug), {
+    by: 'slug',
+    value: slug,
+    isHash: false,
+  });
+});
+
+test('classifyIdentifier: near-hash strings are NOT hashes (63/65 chars, non-hex)', () => {
+  assert.equal(classifyIdentifier(HASH.slice(0, 63)).isHash, false); // 63 chars
+  assert.equal(classifyIdentifier(HASH + 'a').isHash, false); // 65 chars
+  assert.equal(classifyIdentifier('g'.repeat(64)).isHash, false); // non-hex
+  assert.equal(IDENTIFIER_HASH_RE.test(HASH.toUpperCase()), true); // case-insensitive re
+});
+
+// --- commitmentAccessError (the "no more access by hash than by slug" gate) ---
+
+test('commitmentAccessError: public, published record is served', () => {
+  assert.equal(commitmentAccessError(makeRecord()), null);
+});
+
+test('commitmentAccessError: unpublished (no base hash) and non-public are 404', () => {
+  assert.equal(
+    commitmentAccessError(makeRecord({ basePackageHash: null })),
+    'No published evidence package for this identifier',
+  );
+  assert.equal(
+    commitmentAccessError(makeRecord({ isPublic: false })),
+    'Evidence not found',
+  );
+});
+
+// --- end-to-end: hash and slug are interchangeable ---
+
+test('GET-by-hash and GET-by-slug return the SAME commitment', () => {
+  const store = [makeRecord()];
+  const creator = makeCreator();
+
+  const byHash = serveCommitment(store, creator, HASH);
+  const bySlug = serveCommitment(store, creator, store[0].slug);
+
+  assert.equal(byHash.status, 200);
+  assert.equal(bySlug.status, 200);
+  assert.deepEqual(byHash.body, bySlug.body);
+  assert.equal(byHash.body?.packageHash, HASH);
+});
+
+test('GET-by-UPPERCASE-hash returns the same commitment (regression: no 404 by case)', () => {
+  const store = [makeRecord()];
+  const creator = makeCreator();
+
+  const byUpper = serveCommitment(store, creator, HASH.toUpperCase());
+  const bySlug = serveCommitment(store, creator, store[0].slug);
+
+  assert.equal(byUpper.status, 200);
+  assert.deepEqual(byUpper.body, bySlug.body);
+});
+
+test('slug resolution is unchanged (regression)', () => {
+  const store = [makeRecord()];
+  const res = serveCommitment(store, makeCreator(), store[0].slug);
+  assert.equal(res.status, 200);
+  assert.equal(res.body?.packageHash, HASH);
+  assert.equal(res.body?.subjectTitle, 'Noise trends in NYC last week');
+});
+
+test('a non-public package stays unreachable by hash AND by slug (identical authz)', () => {
+  const store = [makeRecord({ isPublic: false })];
+  const creator = makeCreator();
+
+  const byHash = serveCommitment(store, creator, HASH);
+  const bySlug = serveCommitment(store, creator, store[0].slug);
+
+  assert.equal(byHash.status, 404);
+  assert.equal(bySlug.status, 404);
+  assert.equal(byHash.error, 'Evidence not found');
+  // Addressing by hash reveals no more than addressing by slug: same status,
+  // same body, no proof fields leaked.
+  assert.deepEqual(byHash, bySlug);
+});
+
+test('hash form returns the canonical (oldest-created) row when a hash is shared', () => {
+  const older = makeRecord({
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    slug: 'noise-trends-original-e84455',
+    title: 'Original title',
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+  });
+  const newer = makeRecord({
+    id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    slug: 'noise-trends-republished-e84455',
+    title: 'Republished title',
+    createdAt: new Date('2026-06-20T00:00:00.000Z'),
+  });
+  // Store in newest-first order to prove ordering, not insertion order, decides.
+  const res = serveCommitment([newer, older], makeCreator(), HASH);
+  assert.equal(res.status, 200);
+  assert.equal(res.body?.subjectTitle, 'Original title');
+});

--- a/src/lib/evidence/identifier.ts
+++ b/src/lib/evidence/identifier.ts
@@ -1,0 +1,80 @@
+import { evidenceRecords } from '../db/schema.ts';
+
+type EvidenceRecord = typeof evidenceRecords.$inferSelect;
+
+/**
+ * A base-package hash is the hex SHA-256 of the canonical envelope: exactly 64
+ * hex chars. Case-INSENSITIVE (`/i`): stored digests are lowercase hex, but a
+ * bare hash pasted by a user — or embedded in an older link/badge — may arrive
+ * upper- or mixed-case, and it must still resolve (civic-ai-tools-website#116
+ * durable backend half).
+ */
+export const IDENTIFIER_HASH_RE = /^[0-9a-f]{64}$/i;
+
+export interface ResolvedIdentifier {
+  /** Which `evidence_records` column the identifier matches. */
+  by: 'basePackageHash' | 'slug';
+  /**
+   * The normalized match value. The hash form is lowercased so the match is
+   * case-insensitive yet stays sargable against a plain btree index (stored
+   * digests are already lowercase hex, so lowercasing the INPUT — rather than
+   * `lower(column)` — keeps the index usable). The slug form passes through
+   * verbatim (slugs are case-sensitive and unique).
+   */
+  value: string;
+  /**
+   * True when the identifier is a base-package hash. A re-published package can
+   * produce multiple rows sharing one `basePackageHash` (identical immutable
+   * blob, a separate signing run), so hash callers order by `createdAt asc` and
+   * take the first (canonical) row. Slugs are unique — at most one row.
+   */
+  isHash: boolean;
+}
+
+/**
+ * Classify a `[slug]`-segment identifier as a base-package hash or an evidence
+ * slug, and return the normalized DB lookup for it. This is the single seam that
+ * makes the two identifier forms interchangeable for a public read.
+ *
+ * Precedence — hash SHAPE wins: a 64-hex string is matched as a hash, anything
+ * else as a slug. This is unambiguous in this data model because every slug
+ * carries a human title portion plus a `-<6hex>` suffix
+ * (e.g. `noise-trends-in-nyc-last-week-e84455`), so a real slug always contains
+ * a hyphen and non-hex title characters and is never a bare 64-hex string —
+ * it cannot collide with the hash form.
+ */
+export function classifyIdentifier(identifier: string): ResolvedIdentifier {
+  if (IDENTIFIER_HASH_RE.test(identifier)) {
+    return { by: 'basePackageHash', value: identifier.toLowerCase(), isHash: true };
+  }
+  return { by: 'slug', value: identifier, isHash: false };
+}
+
+/**
+ * The commitment endpoint's public-visibility gate, factored out so it is applied
+ * IDENTICALLY however the record was addressed (by hash or by slug). Returns the
+ * 404 error message when the record must not be served publicly, or `null` when
+ * it may be.
+ *
+ * This is the load-bearing authorization invariant of the hash-lookup fix:
+ * addressing a record by hash grants NO more access than addressing it by slug.
+ * A record with no published base package, or one that is not public (private /
+ * unlisted), is unreachable by EITHER form. Committed-visibility redaction is
+ * handled separately by the route (the commitment is public by design — the hash
+ * is already on the transparency log — but content and location are redacted).
+ */
+export function commitmentAccessError(
+  record: Pick<EvidenceRecord, 'basePackageHash' | 'isPublic'>,
+): string | null {
+  // A row with no base-package hash never completed publishing — there are no
+  // proofs to commit to. (A bare-hash lookup could never have matched it either.)
+  if (!record.basePackageHash) {
+    return 'No published evidence package for this identifier';
+  }
+  // Non-public records are not exposed — mirrors the slug read-back. The public
+  // flag is independent of withdrawal (withdrawn-but-public is still served).
+  if (!record.isPublic) {
+    return 'Evidence not found';
+  }
+  return null;
+}


### PR DESCRIPTION
## Root cause

`GET /api/evidence/<id>/commitment` accepts either a 64-hex base-package hash or a slug. Live behavior before this change:

| Form | Result |
|------|--------|
| slug | 200 |
| **lowercase** hash | 200 |
| **UPPERCASE / mixed-case** hash | **404** |

`HASH_RE = /^[0-9a-f]{64}$/i` matches case-insensitively, so an uppercase hash passes the shape check and takes the hash branch — but the lookup `eq(evidenceRecords.basePackageHash, identifier)` is a **case-sensitive** Postgres text match against a **lowercase-stored** digest, so no row matched → 404. This violated the contract that hex hash matching be case-insensitive. A bare hash pasted by a user, or embedded in an older link/badge, must resolve the same commitment as the slug (durable backend half of #116; the frontend share-link half shipped in typedstandards#25).

Secondary: `base_package_hash` had no index (only `slug` is indexed via `.unique()`), so the hash lookup was a table scan.

## The fix

- **`src/lib/evidence/identifier.ts`** (new) — one shared resolution seam:
  - `classifyIdentifier()` lowercases the hash for the lookup, so matching is case-insensitive **and** stays sargable against a plain btree index (stored digests are already lowercase — no `lower(column)` needed). Slugs pass through verbatim.
  - `commitmentAccessError()` factors out the public-visibility gate so it is applied to the **resolved** record identically for both address forms — addressing by hash grants no more access than by slug (a private/unpublished package stays unreachable by either).
- **`commitment/route.ts`** — wired to the shared seam. **Direct resolution, not redirect:** a hash→slug redirect would leak a private/committed record's canonical slug; direct resolution 404s via the identical gate without disclosing anything.
- **`schema.ts` + `drizzle/0013_add_base_package_hash_index.sql`** — btree index on `base_package_hash`.

**Precedence:** hash-shape wins — a 64-hex string is a hash, anything else a slug. Unambiguous because every slug is `<title>-<6hex>` (contains a hyphen + non-hex title chars) and is never a bare 64-hex string.

## Test coverage

`src/lib/evidence/identifier.test.ts` (11 tests, driving the real `classifyIdentifier` + `commitmentAccessError` + `buildCommitmentView` through an in-memory store that mirrors the route's DB resolution):

- GET-by-hash and GET-by-slug return the **same** commitment.
- GET-by-**uppercase**-hash returns the same commitment (the regression).
- Slug resolution unchanged.
- A non-public package 404s **identically** by hash and by slug (no proof fields leaked).
- Hash form returns the canonical (oldest-created) row when a hash is shared across re-published rows.
- Classifier edge cases: 63/65-char and non-hex strings are slugs, not hashes.

Full suite: 335/335 pass. Lint: 0 errors. Build: compiles + typechecks clean.

## Notes for the reviewer

- **Migration 0013 is not yet applied** — will be run against Neon separately (`op run --env-file=.env.local -- npx drizzle-kit migrate`, then verify with `\d evidence_records`). It's additive (a `CREATE INDEX` on a tiny table) and safe to apply before merge.
- **Parity** for the remaining slug-only read endpoints (`[slug]` base record, `package`, `bundle`, `verify`, `attestations`) is tracked in #156. Mutation endpoints stay intentionally slug-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
