### PR TITLE
feat(home): Typed Standards positioning band below the demo hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ KV_REST_API_TOKEN=
 
 - [`POST /api/evidence`](docs/api/evidence-publish.md) — publish an evidence package (request/response schema, auth pattern, worked curl example for external clients)
 
+## Contact / express-interest links
+
+All "get in touch" links on the site (home positioning band, `/about`) read from
+`EXPRESS_INTEREST_URL` in [`src/lib/site-config.ts`](src/lib/site-config.ts).
+Re-pointing them to a different destination is a one-line change to that constant.
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { prose, sectionHeading, sectionSpacing } from '@/styles/page-styles';
+import { EXPRESS_INTEREST_URL } from '@/lib/site-config';
 
 export const metadata = {
   title: 'About - Civic AI Tools',
@@ -73,7 +74,7 @@ export default function AboutPage() {
             Publishing Office, and France&apos;s data.gouv.fr. The starter repo pre-configures the
             best ones for immediate use. Know of a civic data MCP server that should be in the
             directory?{' '}
-            <a href="https://nathanstorey.com/contact/" target="_blank" rel="noopener noreferrer">
+            <a href={EXPRESS_INTEREST_URL} target="_blank" rel="noopener noreferrer">
               Get in touch
             </a>.
           </li>
@@ -99,7 +100,7 @@ export default function AboutPage() {
             &mdash; an entry point for exploring what AI-assisted data analysis looks like, and a
             resource for building open data literacy and AI literacy. If you&apos;re interested in
             using Civic AI Tools in an educational, open data literacy, or AI literacy context,{' '}
-            <a href="https://nathanstorey.com/contact/" target="_blank" rel="noopener noreferrer">
+            <a href={EXPRESS_INTEREST_URL} target="_blank" rel="noopener noreferrer">
               get in touch
             </a>.
           </li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import QueryForm, { type QueryMode } from '@/components/QueryForm';
 import ComparisonDisplay from '@/components/ComparisonDisplay';
 import NotebookOutput from '@/components/notebook/NotebookOutput';
+import PositioningBand from '@/components/home/PositioningBand';
 import { useStreamingComparison } from '@/hooks/useStreamingComparison';
 import { useNotebookStream } from '@/hooks/useNotebookStream';
 
@@ -221,6 +222,9 @@ export default function Home() {
           </div>
         </div>
       </div>
+
+      {/* Positioning band: the demo above is the hero; this zooms out */}
+      <PositioningBand />
     </>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { signIn, signOut, useSession } from 'next-auth/react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { TYPED_STANDARDS_URL } from '@/lib/site-config';
 
 const NAV_LINK_STYLE: React.CSSProperties = {
   color: 'var(--text-secondary)',
@@ -218,6 +219,16 @@ export default function Header() {
                 </div>
               )}
             </div>
+            <a
+              href={TYPED_STANDARDS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="no-link-style"
+              style={NAV_LINK_STYLE}
+            >
+              Typed Standards
+              <span aria-hidden="true" style={{ fontSize: '11px', marginLeft: '4px', color: 'var(--text-muted)' }}>&#8599;</span>
+            </a>
           </nav>
         </div>
 
@@ -451,6 +462,23 @@ export default function Header() {
           >
             Roadmap
           </Link>
+          {/* Divider */}
+          <div style={{ borderTop: '1px solid var(--border-color)', margin: '4px 0' }} />
+          <a
+            href={TYPED_STANDARDS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setMobileMenuOpen(false)}
+            style={{
+              color: 'var(--text-secondary)',
+              fontWeight: 500,
+              fontSize: '16px',
+              textDecoration: 'none',
+            }}
+          >
+            Typed Standards
+            <span aria-hidden="true" style={{ fontSize: '11px', marginLeft: '4px', color: 'var(--text-muted)' }}>&#8599;</span>
+          </a>
           {/* Account section (logged in only) */}
           {session && (
             <>

--- a/src/components/home/PositioningBand.tsx
+++ b/src/components/home/PositioningBand.tsx
@@ -199,7 +199,8 @@ export default function PositioningBand() {
               </strong>{' '}
               This site is a working prototype <LegendLabel status="built" />
               {' '}&mdash; real data, real signatures, demo-scale limits. A
-              production city deployment is a different bar{' '}
+              production deployment customized to one city&apos;s portals,
+              policies, and scale is the next step{' '}
               <LegendLabel status="upcoming" />.
             </li>
             <li style={bodyText}>

--- a/src/components/home/PositioningBand.tsx
+++ b/src/components/home/PositioningBand.tsx
@@ -1,0 +1,314 @@
+import { EXPRESS_INTEREST_URL, TYPED_STANDARDS_URL } from '@/lib/site-config';
+
+// Legend statuses shared with the Typed Standards architecture docs
+// (end-state-vision.md) and typedstandards.org: exactly these three labels.
+type LegendStatus = 'built' | 'designed' | 'upcoming';
+
+const LEGEND_META: Record<LegendStatus, { label: string; color: string }> = {
+  built: { label: 'Built', color: 'var(--nyc-success)' },
+  designed: { label: 'Designed', color: 'var(--nyc-caution)' },
+  upcoming: { label: 'Upcoming', color: 'var(--text-muted)' },
+};
+
+function LegendLabel({ status }: { status: LegendStatus }) {
+  const { label, color } = LEGEND_META[status];
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '5px',
+        fontSize: '13px',
+        fontWeight: 600,
+        color: 'var(--text-secondary)',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: '8px',
+          height: '8px',
+          borderRadius: '50%',
+          backgroundColor: color,
+          display: 'inline-block',
+        }}
+      />
+      {label}
+    </span>
+  );
+}
+
+const eyebrow: React.CSSProperties = {
+  fontSize: '13px',
+  fontWeight: 600,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: 'var(--text-muted)',
+  marginBottom: '12px',
+};
+
+const subHeading: React.CSSProperties = {
+  fontSize: '20px',
+  fontWeight: 600,
+  marginBottom: '16px',
+  marginTop: 0,
+};
+
+const bodyText: React.CSSProperties = {
+  fontSize: '15px',
+  lineHeight: '170%',
+  color: 'var(--text-secondary)',
+  margin: 0,
+};
+
+const cardLabel: React.CSSProperties = {
+  fontSize: '14px',
+  fontWeight: 600,
+  color: 'var(--text-primary)',
+  marginBottom: '8px',
+};
+
+export default function PositioningBand() {
+  return (
+    <section
+      id="positioning"
+      aria-labelledby="positioning-heading"
+      style={{
+        borderTop: '1px solid var(--border-color)',
+        backgroundColor: 'var(--card-background)',
+        marginTop: '48px',
+      }}
+    >
+      <div className="max-w-6xl mx-auto px-6" style={{ padding: '56px 24px' }}>
+        {/* Headline */}
+        <p style={eyebrow}>Beyond the demo</p>
+        <h2
+          id="positioning-heading"
+          style={{
+            fontSize: '26px',
+            lineHeight: '140%',
+            maxWidth: '820px',
+            marginTop: 0,
+            marginBottom: '40px',
+            fontWeight: 600,
+          }}
+        >
+          Civic AI Tools is the civic reference implementation of{' '}
+          <a href={TYPED_STANDARDS_URL} target="_blank" rel="noopener noreferrer">
+            Typed Standards
+          </a>{' '}
+          &mdash; an open protocol for independent verification of AI-generated
+          answers.
+        </h2>
+
+        {/* Layered stack: protocol → software → city implementations */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6" style={{ marginBottom: '48px' }}>
+          <div>
+            <p style={cardLabel}>1. Protocol</p>
+            <p style={bodyText}>
+              <a href={TYPED_STANDARDS_URL} target="_blank" rel="noopener noreferrer">
+                Typed Standards
+              </a>{' '}
+              defines how an AI-generated answer is published as a signed
+              record &mdash; so anyone can check what data was used, how, and by
+              which model, without trusting the site that published it.
+            </p>
+          </div>
+          <div>
+            <p style={cardLabel}>2. Open-source software</p>
+            <p style={bodyText}>
+              The working parts: this website, the data connectors through
+              which AI mediates open-data portals for people, and the shared
+              verification library used by both this site and the independent
+              verifier. All open source.
+            </p>
+          </div>
+          <div>
+            <p style={cardLabel}>3. City implementations</p>
+            <p style={bodyText}>
+              This site is the first: a reference implementation running
+              against public data portals for New York, Chicago, and San
+              Francisco. The same stack is what another city would pick up and
+              run against its own portals.
+            </p>
+          </div>
+        </div>
+
+        {/* Three readers */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6" style={{ marginBottom: '48px' }}>
+          <div>
+            <p style={cardLabel}>If you set policy</p>
+            <p style={bodyText}>
+              AI-assisted answers about public data should come with receipts.
+              Every analysis published here permanently records which datasets
+              were used, what was asked of them, and which model did the work
+              &mdash; and the record is signed, so a third party can confirm it
+              hasn&apos;t been altered. The record shows how an answer was
+              produced; it does not claim the answer is correct.
+            </p>
+          </div>
+          <div>
+            <p style={cardLabel}>If you own a data function</p>
+            <p style={bodyText}>
+              This is a working example of putting AI in front of your data on
+              your terms: AI mediates public data for residents and staff, with
+              citations, provenance capture, logging, and sign-in &mdash; while
+              your analysts stay in the loop. Every piece is open source and
+              portable to your portals.
+            </p>
+          </div>
+          <div>
+            <p style={cardLabel}>If you analyze data</p>
+            <p style={bodyText}>
+              Ask a real question against live portal data and watch the work:
+              every query the AI issues is visible as actual SoQL, exportable
+              as a Jupyter notebook you can re-run yourself, and publishable as
+              a signed evidence record others can verify without taking your
+              word for it.
+            </p>
+          </div>
+        </div>
+
+        {/* Boundaries: where the line is today */}
+        <div style={{ marginBottom: '48px' }}>
+          <h3 style={subHeading}>Where the line is today</h3>
+          <p style={{ ...bodyText, marginBottom: '16px' }}>
+            <LegendLabel status="built" />{' '}
+            <span style={{ fontSize: '14px' }}>&mdash; running on this site today</span>
+            <span style={{ margin: '0 10px', color: 'var(--text-muted)' }}>&middot;</span>
+            <LegendLabel status="designed" />{' '}
+            <span style={{ fontSize: '14px' }}>&mdash; specified, not yet running</span>
+            <span style={{ margin: '0 10px', color: 'var(--text-muted)' }}>&middot;</span>
+            <LegendLabel status="upcoming" />{' '}
+            <span style={{ fontSize: '14px' }}>&mdash; planned direction</span>
+          </p>
+          <ul
+            style={{
+              listStyle: 'none',
+              padding: 0,
+              margin: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '14px',
+            }}
+          >
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>
+                Prototype vs. production.
+              </strong>{' '}
+              This site is a working prototype <LegendLabel status="built" />
+              {' '}&mdash; real data, real signatures, demo-scale limits. A
+              production city deployment is a different bar{' '}
+              <LegendLabel status="upcoming" />.
+            </li>
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>
+                Open data vs. restricted data.
+              </strong>{' '}
+              Everything here runs against open, public data portals{' '}
+              <LegendLabel status="built" />. Extending the same verification pattern to
+              access-controlled internal data is a planned direction{' '}
+              <LegendLabel status="upcoming" />.
+            </li>
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>
+                Retrieval vs. analysis.
+              </strong>{' '}
+              The AI here both retrieves records with citations and runs
+              multi-step analysis, published as signed evidence records{' '}
+              <LegendLabel status="built" />. Extracting typed, machine-checkable claims
+              from an analysis is specified but not yet running{' '}
+              <LegendLabel status="designed" />.
+            </li>
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>
+                AI-generated vs. human-validated.
+              </strong>{' '}
+              Everything the AI produces is permanently labeled AI-generated,
+              and human review attaches as its own signed attestation{' '}
+              <LegendLabel status="built" />. AI-generated work is never silently promoted
+              to human-validated.
+            </li>
+          </ul>
+        </div>
+
+        {/* Trust & transferability */}
+        <div style={{ marginBottom: '40px' }}>
+          <h3 style={subHeading}>What another city could reuse</h3>
+          <ul
+            style={{
+              listStyle: 'none',
+              padding: 0,
+              margin: '0 0 16px 0',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '10px',
+            }}
+          >
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>Citations</strong>{' '}
+              &mdash; answers name the datasets they draw on, linked back to
+              the source portal.
+            </li>
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>Provenance</strong>{' '}
+              &mdash; the full trail (model, data sources, every query,
+              timestamps) travels with each published analysis.
+            </li>
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>Access controls</strong>{' '}
+              &mdash; sign-in and per-user limits, so usage is accountable.
+            </li>
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>Logging</strong>{' '}
+              &mdash; every tool call is captured as a replayable trace &mdash;
+              see the <a href="/explore">Explore page</a>.
+            </li>
+            <li style={bodyText}>
+              <strong style={{ color: 'var(--text-primary)' }}>Human-in-the-loop</strong>{' '}
+              &mdash; publishing is a deliberate human action, and human review
+              is recorded as its own signed attestation.
+            </li>
+          </ul>
+          <p style={bodyText}>
+            All of it is open source: the protocol, the software, and the
+            safeguards are built to be run by another city against its own data
+            portals.
+          </p>
+        </div>
+
+        {/* Express interest */}
+        <div
+          style={{
+            borderTop: '1px solid var(--border-color)',
+            paddingTop: '24px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '16px',
+            flexWrap: 'wrap',
+          }}
+        >
+          <p style={{ ...bodyText, flex: '1 1 320px' }}>
+            Interested in running this against your city&apos;s data, or in the
+            verification standard behind it?
+          </p>
+          <a
+            href={EXPRESS_INTEREST_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nyc-button nyc-button-primary"
+            style={{
+              textDecoration: 'none',
+              fontSize: '14px',
+              padding: '10px 24px',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Get in touch
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,0 +1,14 @@
+// Site-wide external URLs. Import from here rather than hard-coding hrefs so
+// each destination can be changed in one place.
+
+/** The Typed Standards protocol site — spec home and neutral verifier. */
+export const TYPED_STANDARDS_URL = 'https://typedstandards.org';
+
+/**
+ * Where "express interest" / contact links point.
+ *
+ * WS3 swap point: when a dedicated express-interest destination exists,
+ * changing this one line re-points every contact entry on the site
+ * (home positioning band + /about). Links out only — no embedded form.
+ */
+export const EXPRESS_INTEREST_URL = 'https://nathanstorey.com/contact/';


### PR DESCRIPTION
## What this does

Repositions the front door **additively**: the live demo remains the hero, and a new full-width positioning band renders below it (above the footer).

### Positioning band (`src/components/home/PositioningBand.tsx`)
- Headline (verbatim): *"Civic AI Tools is the civic reference implementation of Typed Standards — an open protocol for independent verification of AI-generated answers."* — with an inline link to typedstandards.org
- The layered stack: **protocol → open-source software → city implementations**
- Written for three readers: a policy maker ("if you set policy"), a data/analytics function owner ("if you own a data function"), and an analyst ("if you analyze data")
- Explicit boundaries on four axes — prototype vs. production, open vs. restricted data, retrieval vs. analysis, AI-generated vs. human-validated — using the shared **built / designed / upcoming** legend
- Trust and transferability signals: citations, provenance, access controls, logging, human-in-the-loop — and a plain statement of what another city could reuse

### Navigation
- External "Typed Standards" link in the header nav (desktop + mobile)

### Contact / express-interest plumbing
- New `src/lib/site-config.ts` with `TYPED_STANDARDS_URL` and `EXPRESS_INTEREST_URL`
- The two existing `/about` contact links now read from `EXPRESS_INTEREST_URL` (hrefs only — no copy changes on `/about`)
- The band surfaces the same entry point ("Get in touch"), linking out
- The one-line swap point is documented in a code comment and a README note

### Untouched (deliberately)
- The demo hero and query flow
- The footer's short affiliation line (verified it still renders with the new section)
- All `/about` copy, including the full affiliation paragraph

## Relationship to #61

Part of #61. This ships the home-page slice of that re-scoped positioning pass: the front door now tells the verifiable-analysis story and points to typedstandards.org. It does **not** close #61 — the About/Learn/post-response copy, Evidence index framing, and nav treatment of Evidence remain; a comment on the issue enumerates what's left.

## Verification

- `npm run lint` — no errors (only pre-existing warnings)
- `npm run build` — passes
- Rendered pages checked locally (headless browser): band layout, nav link, legend rendering, footer affiliation, `/about` links resolve to the same destination as before

Merge is go-live (auto-deploy) — please review the Vercel preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)