### PR TITLE
docs: CONTRIBUTING — DCO sign-off + IPR pointer (ADR-0017 follow-up)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,12 @@ Thank you for your interest in contributing! This is the demo website for the ci
 
 ## This is a multi-repo project
 
-This website is one part of a larger project. If you're unsure where to contribute, see the [civic-ai-tools CONTRIBUTING guide](https://github.com/npstorey/civic-ai-tools/blob/main/CONTRIBUTING.md) for an overview of all three repos.
+This website is one part of a larger project. If you're unsure where to contribute, see the [civic-ai-tools CONTRIBUTING guide](https://github.com/npstorey/civic-ai-tools/blob/main/CONTRIBUTING.md) for an overview of all four repos.
+
+## Legal: sign-off and IPR
+
+- Every contribution requires a Developer Certificate of Origin sign-off: commit with `git commit -s`, which adds a `Signed-off-by: Your Name <email>` line. What that certifies, and the project-wide policy: [IPR.md](https://github.com/npstorey/civic-ai-tools/blob/main/IPR.md) (hub repo; adopted per [ADR-0017](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0017-ipr-posture-dco-rf-statement.md)).
+- The project's patent posture is the royalty-free statement at [PATENTS.md](https://github.com/npstorey/civic-ai-tools/blob/main/PATENTS.md).
 
 ## Questions?
 


### PR DESCRIPTION
Mechanical follow-up to civic-ai-tools#103 (merged): adds the Legal section pointing at the hub IPR.md / PATENTS.md, and fixes the stale three-repo count. Pre-announced in ADR-0017 §5 / civic-ai-tools#99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)