### PR TITLE
fix(site): point contact links at civicaitools@metagov.org

### DIFF
--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -11,7 +11,7 @@ export const TYPED_STANDARDS_URL = 'https://typedstandards.org';
  * changing this one line re-points every contact entry on the site
  * (home positioning band + /about + /project). Links out only — no embedded form.
  */
-export const EXPRESS_INTEREST_URL = 'https://nathanstorey.com/contact/';
+export const EXPRESS_INTEREST_URL = 'mailto:civicaitools@metagov.org';
 
 /**
  * Optional sponsor acknowledgment, rendered in the global footer and the


### PR DESCRIPTION
Re-routes every contact entry on civicaitools.org (home positioning band, /about ×2, /project) from the old personal contact URL to `mailto:civicaitools@metagov.org`, matching typedstandards.org.

One-line swap of the single-source `EXPRESS_INTEREST_URL` in `src/lib/site-config.ts`. The existing `target="_blank" rel="noopener"` on the links is harmless on a `mailto:` — no call-site edits. Ships as the coordinated `v0.12.1` (re-syncs with typedstandards v0.12.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)