### PR TITLE
S3a P3: unsigned-tier gate-off (ADR-0020 B/C) + instance-identity config rehearsal

### DIFF
--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -16,7 +16,7 @@ This contract spans three repositories. If you're integrating, here's how they r
 
 Every ADR, `§`-reference, issue, and Q-number below is hyperlinked to its source — follow the link rather than guessing which repo it's in.
 
-_Last updated: 2026-06-13 — see the [change log](#change-log) for dated changes._
+_Last updated: 2026-08-02 — see the [change log](#change-log) for dated changes._
 
 **Status:** Schema version `0.1.0`. Fields may be added in a backwards-compatible way; breaking changes will bump the `schemaVersion` inside the package and be noted in the change log at the bottom of this document. The 2026-05-19 amendment introduces the `contentProfile` field per [ADR-0004](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0004-dathere-captureMethod-variant.md) and reverts the brief 2026-05-18 `datHere` captureMethod variant; both changes are additive — pre-ADR-0004 packages hash byte-identical with the new code.
 
@@ -524,10 +524,12 @@ Hosts express the eval requirement in their self-attestation — a `content/host
 |--------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | `401`  | `{ "error": "Authentication required" }`                          | Missing, invalid, expired, or revoked bearer token; or missing/invalid NextAuth session cookie. |
 | `403`  | `{ "error": "Token missing required scope: evidence:publish" }`   | Bearer token is valid but does not hold the `evidence:publish` scope.                           |
+| `403`  | `{ "error": "This instance is running unsigned …", "code": "unsigned_tier" }` | The instance holds no signing key (the ADR-0020 unsigned dev tier). Both request-level visibilities are refused: an unsigned package can reach neither the sealed nor the public state (Decision C), so nothing is persisted. Also returned by `POST /api/evidence/:slug/publish` on an unsigned instance. Configure signing per [docs/instance-setup.md](../instance-setup.md). |
 | `404`  | `{ "error": "User not found in database" }`                       | Session is valid but the user record has not been provisioned (can occur if `DATABASE_URL` was unset when the user first signed in — a re-sign-in fixes it). |
+| `409`  | `{ "error": "This record was persisted without a signature …", "code": "unsigned_package" }` | `POST /api/evidence/:slug/publish` only: the committed record predates the unsigned-tier gate and has no base-package signature — it cannot be promoted to `published` even on a signed instance (ADR-0020 Decision C is a property of the package). |
 | `500`  | `{ "error": "<message>" }` with `<message>` from the thrown error | Database, blob storage, or evidence-package-building failure.                                    |
 
-Signing, RFC 3161 timestamp, and Rekor submission are non-blocking. Failures for any of these are logged server-side but still return `200` — the resulting record will simply have `null` values for the corresponding database columns.
+RFC 3161 timestamp and Rekor submission are non-blocking. Failures for either are logged server-side but still return `200` — the resulting record will simply have `null` values for the corresponding database columns. Signing itself is **not** optional as of S3a P3: a missing key is refused up front with the `unsigned_tier` `403` above (previously the record persisted with a `null` signature), while a signing *failure* with a configured key still surfaces as `500`.
 
 ---
 
@@ -680,6 +682,8 @@ These are implementation details that may surprise an external client. None of t
 ---
 
 ## Change log
+
+- **2026-08-02** — **Unsigned-tier gate-off** (S3a P3, [#166](https://github.com/npstorey/civic-ai-tools-website/issues/166); [ADR-0020](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0020-instance-key-custody.md) Decisions B/C, G0-3): on an instance with no `EVIDENCE_SIGNING_KEY`, `POST /api/evidence` (both request-level visibilities) and `POST /api/evidence/:slug/publish` are refused with `403 { code: "unsigned_tier" }` — an unsigned package can reach neither the sealed nor the public state, so nothing is persisted (previously the record persisted with a `null` signature and a `committed`/`published` visibility). The publish route additionally refuses a historical committed record that carries no base-package signature with `409 { code: "unsigned_package" }` (existing rows are not migrated or relabeled). New presence-only endpoint `GET /api/evidence/signing-status` returns `{ "signingConfigured": boolean }` for client affordances. Unsigned packages now render prominently (Attention-tier "Unsigned package — no cryptographic commitment" glance + detail-page banner), and a running-unsigned site banner shows outside dev environments.
 
 - **2026-06-13** — Added a "Repositories & layers" orientation section at the top of the doc plus a last-updated stamp, and hyperlinked the previously-bare `§8.10` / `§8.12` spec references in the integration-contract section to the specification source in `civic-ai-tools`. Docs-only; no API or schema change.
 

--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -6,12 +6,16 @@ unsigned dev tier). Follow it once at go-to-production time; afterwards, key
 changes follow the rotation runbook in
 [`docs/key-rotation.md`](key-rotation.md).
 
-An instance works unsigned out of the box — packages are produced and can be
-inspected, and verification calmly reports that no signing key is configured.
-Signing is the **go-to-production** step: keygen → registry → environment.
-Nothing unsigned can reach the `sealed` or `public` states, so an instance
-that skips this guide has opted out of the evidence layer, never silently
-mislabeled its output.
+An instance works unsigned out of the box — analyses run and packages can be
+produced and inspected. Signing is the **go-to-production** step: keygen →
+registry → environment. Nothing unsigned can reach the `sealed` or `public`
+states, and the application enforces this (ADR-0020 Decisions B/C): with no
+signing key configured, the evidence **commit and publish actions are gated
+off** server-side and in the UI, verification labels unsigned output
+prominently ("Unsigned package — no cryptographic commitment"), and a
+**running-unsigned banner** shows site-wide outside a dev environment
+(`next dev` stays calm). An instance that skips this guide has opted out of
+the evidence layer — a legitimate choice, never a silent one.
 
 ## 1. Generate a keypair
 

--- a/docs/trust-signal-vocabulary.md
+++ b/docs/trust-signal-vocabulary.md
@@ -44,10 +44,10 @@ A pre-v0.1 (legacy) package must show **zero red and zero amber** on the default
 | Check | Legacy status | Tier |
 |---|---|---|
 | #1 envelope integrity | `hashMatch: true` | Verified |
-| #2 signature | `signatureValid: true` (embedded key) or `null` (unsigned) | Verified / Normal |
+| #2 signature | `signatureValid: true` (embedded key) | Verified |
 | #3 canonicalization | `implicit` | Normal |
 | #4 content hash | `legacy_relabeled` | **Normal** |
-| #5 key trust | `legacy_embedded` (or `null`) | **Normal** |
+| #5 key trust | `legacy_embedded` | **Normal** |
 | #7 timestamp | `hasTimestamp: false` | Normal |
 | #8 Rekor | `rekorVerified: null` | Normal |
 | #9 BlobRefs | `blobRefsVerified: null` | Normal |
@@ -58,6 +58,8 @@ A pre-v0.1 (legacy) package must show **zero red and zero amber** on the default
 | notebookProvenance | `skeleton` | Normal |
 
 The hardest split is **content-hash (#4)**: `legacy_relabeled` (every pre-v0.1 package) is **Normal**, while `content_hash_mismatch` (off-log content altered after signing) is **Alarm** — the same check, opposite tiers. The coverage test (`trust-signal.test.ts`) asserts both this split and that the full synthetic-legacy status set above tiers all-calm.
+
+**The calm requirement applies to SIGNED legacy packages only.** A fully **unsigned** package (no signature envelope at all — `signatureValid: null` co-occurring with `keyTrust: null`) is a different case, deliberately elevated in S3a P3 per ADR-0020 §Consequences guard 2 ("mandatory labeling"): `NO_SIGNING_KEY_SIGNAL` is tiered **Attention**, and the #113 overall glance renders a dedicated `UNSIGNED_PACKAGE_SIGNAL` ("Unsigned package — no cryptographic commitment", Attention) instead of the calm all-clear. Attention, never Alarm — the unsigned dev tier is a legitimate producer state (ADR-0020 §B), but it must be surfaced prominently wherever the package appears, never silently.
 
 ---
 
@@ -104,6 +106,7 @@ Ordered by spec §9.2 check number. "Copy" is the glanceable one-liner; the libr
 | `unknown_key` | Attention | Signing key not in the trust registry |
 | `registry_unavailable` | Attention | Trust registry could not be reached |
 | `legacy_embedded` | Normal | Signed with an embedded key (not in the trust registry) |
+| `null` (unsigned package) | **Attention** | No signing key *(`NO_SIGNING_KEY_SIGNAL`; elevated from Normal in S3a P3 per ADR-0020 guard 2 — see the note in §3)* |
 
 ### #7 Timestamp — `hasTimestamp: boolean`
 | Status | Tier | Copy |

--- a/scripts/rehearse-instance-identity.ts
+++ b/scripts/rehearse-instance-identity.ts
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+/**
+ * ADR-0020 config rehearsal — the "instance identity is config, not code"
+ * built bar (S3a P3, #166; S3a acceptance §3).
+ *
+ * With ZERO code edits, configuration only, this script:
+ *
+ *   1. generates an EPHEMERAL Ed25519 keypair in-process (never the real
+ *      `EVIDENCE_SIGNING_KEY`; nothing is read from or written to any
+ *      secret store — the keypair lives and dies with this run);
+ *   2. builds a local trust-registry JSON from the docs/instance-setup.md §3
+ *      template, carrying the ephemeral PUBLIC key under a rehearsal kid;
+ *   3. runs the app's produce path under a fully alternate identity
+ *      (`EVIDENCE_SITE_ORIGIN` / `EVIDENCE_PUBLICATION_HOST` /
+ *      `EVIDENCE_SIGNER_*` / registry URLs pointed at the local registry);
+ *   4. verifies the emitted package OFFLINE (verify-core §9.2 checks) against
+ *      that local registry, resolved from the sidecar's own
+ *      `trustRegistryUrl` — the same bootstrap a third-party verifier uses.
+ *
+ * PASS means: the emitted package carries the alternate identity throughout
+ * (envelope signer, sidecar registry URLs, environment-extension host, PROV
+ * platform agent, notebook attribution) and verifies cleanly against a
+ * registry that contains only the ephemeral key — i.e. an instance needs no
+ * code edits to become its own publisher.
+ *
+ * Run (an operator can run this as-is; it touches no network and no DB):
+ *
+ *   node --experimental-strip-types scripts/rehearse-instance-identity.ts
+ *
+ * Exit code 0 on PASS, 1 on any failed step. Also exercised by `npm test`
+ * via src/lib/evidence/instance-rehearsal.test.ts, which spawns exactly the
+ * command above.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+// --- The alternate identity (pure config; every value is synthetic) --------
+
+const REHEARSAL_ORIGIN = 'https://rehearsal.example.org';
+const REHEARSAL_HOST = 'rehearsal.example.org';
+const REHEARSAL_KID = 'platform:evidence-rehearsal';
+const REHEARSAL_SIGNER = {
+  bindingTier: 'platform',
+  identifier: 'platform:rehearsal-instance',
+  displayName: 'Rehearsal Instance',
+} as const;
+const REHEARSAL_AGENT_ID = 'rehearsal-instance';
+
+/** Fixed ISO instants for fixture fields (guard-safe: no epoch-milliseconds). */
+const FIXED_ISO = '2026-08-01T00:00:00.000Z';
+
+function log(line: string) {
+  process.stdout.write(`${line}\n`);
+}
+
+async function main(): Promise<void> {
+  // --- 1. Ephemeral keypair (in-process; never persisted, never real) -----
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+  const privB64 = privateKey.export({ format: 'der', type: 'pkcs8' }).toString('base64');
+  const pubB64 = publicKey.export({ format: 'der', type: 'spki' }).toString('base64');
+  log('[1/6] ephemeral Ed25519 keypair generated (in-process only)');
+
+  // --- 2. Local trust registry from the instance-setup.md §3 template -----
+  const registry = {
+    $comment:
+      `Trust registry for ${REHEARSAL_HOST} evidence packages (ADR-0020 config ` +
+      'rehearsal; ephemeral key, local file, discarded after the run). ' +
+      'Verifiers fetch this file, match the (kid, publicKey) pair embedded in ' +
+      "a package's signature, and apply the status semantics below.",
+    generatedAt: FIXED_ISO,
+    statusSemantics: {
+      active: 'Valid for signing new packages and for verification.',
+      deprecated:
+        "Cannot sign new packages. Signatures are valid for verification only when the package's Rekor integratedTime precedes deprecatedAt.",
+      revoked:
+        'Never valid — any signature is treated as suspect regardless of when the package was integrated.',
+    },
+    keys: [
+      {
+        kid: REHEARSAL_KID,
+        publicKey: pubB64,
+        signerIdentity: { ...REHEARSAL_SIGNER },
+        status: 'active',
+        activatedAt: FIXED_ISO,
+        deprecatedAt: null,
+        revokedAt: null,
+      },
+    ],
+  };
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oes-rehearsal-'));
+  const registryPath = path.join(tmpDir, 'typed-publisher.json');
+  fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+  const registryUrl = pathToFileURL(registryPath).href;
+  log(`[2/6] local trust registry written from the instance-setup template`);
+
+  // --- 3. Alternate identity via CONFIG ONLY (the ADR-0020 claim) ---------
+  process.env.EVIDENCE_SIGNING_KEY = privB64;
+  process.env.EVIDENCE_KEY_ID = REHEARSAL_KID;
+  process.env.EVIDENCE_SITE_ORIGIN = REHEARSAL_ORIGIN;
+  process.env.EVIDENCE_PUBLICATION_HOST = REHEARSAL_HOST;
+  process.env.EVIDENCE_SIGNER_BINDING_TIER = REHEARSAL_SIGNER.bindingTier;
+  process.env.EVIDENCE_SIGNER_IDENTIFIER = REHEARSAL_SIGNER.identifier;
+  process.env.EVIDENCE_SIGNER_DISPLAY_NAME = REHEARSAL_SIGNER.displayName;
+  process.env.EVIDENCE_TRUST_REGISTRY_CANONICAL_URL = registryUrl;
+  process.env.EVIDENCE_TRUST_REGISTRY_LEGACY_URL = ''; // omit — no legacy client base
+  process.env.EVIDENCE_PLATFORM_AGENT_ID = REHEARSAL_AGENT_ID;
+  process.env.EVIDENCE_PLATFORM_AGENT_TITLE = REHEARSAL_SIGNER.displayName;
+
+  // App modules are imported AFTER the environment is set (config getters
+  // read at call time; the late import simply removes any load-order doubt).
+  const { buildEvidencePackage, DEFAULT_CONTENT_TYPE } = await import(
+    '../src/lib/evidence/packager.ts'
+  );
+  const { signPackage, getActiveSigner, getActiveKeyId } = await import(
+    '../src/lib/evidence/signing.ts'
+  );
+  const { buildCommitmentView } = await import('../src/lib/evidence/commitment.ts');
+  const { generateNotebook } = await import('../src/lib/notebook.ts');
+
+  // --- 4. Produce: build + sign a package under the alternate identity ----
+  const notebook = generateNotebook(
+    'How many permits were filed last year?',
+    'data.example.gov',
+    [
+      {
+        name: 'get_data',
+        args: { type: 'query', portal: 'data.example.gov', dataset_id: 'abcd-efab' },
+        operationType: 'query',
+      },
+    ],
+    'About 1,200 permits were filed.',
+  );
+
+  const { pkg, hash: packageHash } = buildEvidencePackage({
+    trace: { resourceSpans: [] },
+    prompt: 'How many permits were filed last year?',
+    output: 'About 1,200 permits were filed.',
+    toolCalls: [
+      {
+        name: 'get_data',
+        args: { type: 'query', portal: 'data.example.gov', dataset_id: 'abcd-efab' },
+        resultSummary: { rows: 1, columns: 1 },
+        operationType: 'query',
+      },
+    ],
+    model: 'test/model',
+    portal: 'data.example.gov',
+    tokenUsage: { promptTokens: 10, completionTokens: 5 },
+    promptVisibility: 'full_text',
+    title: 'Rehearsal analysis',
+    summary: 'A rehearsal package emitted under an alternate instance identity.',
+    captureMethod: 'chat-flow-stream',
+    contentProfile: 'datHere',
+    type: DEFAULT_CONTENT_TYPE,
+    signer: getActiveSigner(),
+    extensions: { 'org.civicaitools.notebook': notebook },
+  });
+
+  const signResult = signPackage(packageHash);
+  assert.ok(signResult, 'signPackage must sign under the ephemeral key');
+  assert.equal(signResult.kid, REHEARSAL_KID, 'signature kid must be the rehearsal kid');
+  assert.equal(getActiveKeyId(), REHEARSAL_KID);
+  log('[3/6] produce path ran under alternate identity config (package built + signed)');
+
+  // --- 5. Sidecar: the proof object a third party bootstraps from ---------
+  // Synthetic row/creator fixtures (guard-safe: hex-letter ids, ISO dates).
+  const record = {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    slug: 'rehearsal-analysis-abcdef',
+    creatorId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    title: 'Rehearsal analysis',
+    summary: 'A rehearsal package emitted under an alternate instance identity.',
+    model: 'test/model',
+    promptHash: 'sha256:promptdigest',
+    promptVisibility: 'full_text',
+    promptText: 'How many permits were filed last year?',
+    systemPromptHash: null,
+    mcpServer: null,
+    jurisdiction: null,
+    civicContext: null,
+    basePackageHash: packageHash,
+    basePackageStorageKey: `${REHEARSAL_ORIGIN}/evidence-packages/feedface.json`,
+    basePackageSignature: JSON.stringify({
+      signature: signResult.signature,
+      publicKey: signResult.publicKey,
+      algorithm: signResult.algorithm,
+      kid: signResult.kid,
+    }),
+    basePackageRfc3161Timestamp: null,
+    basePackageRekorEntryId: null,
+    basePackageRekorInclusionProof: null,
+    basePackageRekorEntryBody: null,
+    captureMethod: 'chat-flow-stream',
+    contentProfile: 'datHere',
+    verificationStatus: 'unverified',
+    consistencyClassification: null,
+    isPublic: true,
+    visibility: 'published',
+    withdrawnAt: null,
+    withdrawnReason: null,
+    withdrawalSignature: null,
+    withdrawalTimestamp: null,
+    reinstatedAt: null,
+    reinstatedReason: null,
+    reinstatementSignature: null,
+    reinstatementTimestamp: null,
+    createdAt: new Date(FIXED_ISO),
+    updatedAt: new Date(FIXED_ISO),
+  } as unknown as Parameters<typeof buildCommitmentView>[0];
+
+  const creator = {
+    id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    githubId: 'abcdef',
+    displayName: 'Rehearsal Operator',
+    githubProfileUrl: 'https://github.com/octocat',
+    createdAt: new Date(FIXED_ISO),
+  } as unknown as Parameters<typeof buildCommitmentView>[1];
+
+  const sidecar = buildCommitmentView(record, creator, pkg) as Record<string, unknown>;
+
+  assert.equal(
+    sidecar.trustRegistryUrl,
+    registryUrl,
+    'sidecar trustRegistryUrl must point at the LOCAL registry',
+  );
+  assert.equal(
+    'trustRegistryUrlLegacy' in sidecar,
+    false,
+    'legacy registry URL must be omitted (empty-string config)',
+  );
+  log('[4/6] sidecar carries the local registry URL (legacy path omitted)');
+
+  // --- 6. Verify OFFLINE against the local registry (§9.2) ----------------
+  // The registry is resolved from the SIDECAR's own trustRegistryUrl — the
+  // same bootstrap a third-party verifier performs — then passed to
+  // verify-core as data. No network anywhere in this run.
+  const {
+    recomputePackageHash,
+    verifySignature,
+    resolveContentCanonicalization,
+    verifyContentHash,
+    resolvePackageType,
+    checkSignerIdentity,
+    checkCaptureMethodVocab,
+    validateRegistry,
+    verifyKeyTrust,
+  } = await import('@typedstandards/verify-core');
+
+  const pkgJson = pkg as unknown as Record<string, unknown>;
+  const sidecarSig = sidecar.signature as {
+    signature: string;
+    publicKey: string;
+    algorithm?: string;
+    kid?: string;
+  };
+
+  // #1/#13 envelope integrity: the bytes hash to the signed nodeId.
+  assert.equal(recomputePackageHash(pkgJson), packageHash, '#1 envelope hash must match');
+  // #2 signature mathematics, from the sidecar's carried envelope.
+  assert.equal(
+    verifySignature(packageHash, sidecarSig.signature, sidecarSig.publicKey, sidecarSig.algorithm),
+    true,
+    '#2 signature must verify',
+  );
+  // #3/#4 content canonicalization + content hash.
+  const canon = resolveContentCanonicalization(pkgJson);
+  assert.equal(canon.status, 'ok', '#3 canonicalization rule must resolve');
+  assert.equal(verifyContentHash(pkgJson, canon).status, 'ok', '#4 content hash must verify');
+  // #5 key trust — against the LOCAL registry, resolved via the sidecar URL.
+  const loadedRegistry = validateRegistry(
+    JSON.parse(fs.readFileSync(fileURLToPath(sidecar.trustRegistryUrl as string), 'utf-8')),
+  );
+  assert.ok(loadedRegistry, 'local registry must validate structurally');
+  const keyTrust = verifyKeyTrust(sidecarSig.publicKey, sidecarSig.kid!, undefined, loadedRegistry);
+  assert.equal(keyTrust.status, 'active', '#5 ephemeral key must be active in the local registry');
+  // #12 type resolution.
+  assert.equal(resolvePackageType(pkgJson).status, 'ok', '#12 type must resolve');
+  // #14 signer identity ↔ registry cross-check — THE identity check: the
+  // envelope's alternate signer claim must match what the local registry
+  // binds to the rehearsal kid.
+  assert.equal(
+    checkSignerIdentity(pkgJson, sidecarSig.kid, loadedRegistry).status,
+    'ok',
+    '#14 signer identity must match the local registry entry',
+  );
+  // #15 captureMethod vocabulary conformance.
+  assert.equal(checkCaptureMethodVocab(pkgJson).status, 'ok', '#15 captureMethod must conform');
+  log('[5/6] verify-core §9.2 offline checks PASS against the local registry (#1 #2 #3 #4 #5 #12 #14 #15)');
+
+  // --- Alternate identity throughout the emitted output -------------------
+  assert.deepEqual(pkg.signer, { ...REHEARSAL_SIGNER }, 'envelope signer must be the alternate identity');
+
+  const env = pkg.extensions?.['org.civicaitools.environment'] as Record<string, unknown>;
+  assert.ok(env, 'environment extension must be present (datHere)');
+  assert.equal(env.host, REHEARSAL_HOST, 'environment host must be the alternate host');
+
+  const agent = pkg.provenance!['@graph'].find(
+    (n) => n['@id'] === `urn:civic-evidence:platform:${REHEARSAL_AGENT_ID}`,
+  );
+  assert.ok(agent, 'PROV platform agent must carry the alternate id');
+  assert.equal(agent!['dcterms:title'], REHEARSAL_SIGNER.displayName);
+  assert.equal(agent!['civic:url'], REHEARSAL_ORIGIN);
+
+  const notebookJson = JSON.stringify(pkg.extensions?.['org.civicaitools.notebook']);
+  assert.ok(
+    notebookJson.includes(`via [${REHEARSAL_HOST}](${REHEARSAL_ORIGIN})`),
+    'notebook attribution must carry the alternate host',
+  );
+  assert.ok(
+    notebookJson.includes(`Generated by [${REHEARSAL_SIGNER.displayName}](${REHEARSAL_ORIGIN})`),
+    'notebook attribution must carry the alternate instance name',
+  );
+
+  // Tier-2 guard (docs/instance-setup.md "Do not parameterize"): vocabulary
+  // identifiers are NOT instance identity — the civic: namespace must still
+  // point at the shared vocabulary URL even under a fully alternate identity.
+  assert.ok(
+    JSON.stringify(pkg.provenance!['@context']).includes('https://civicaitools.org/ns/evidence/'),
+    'civic: vocabulary namespace must remain unparameterized (Tier-2 guard)',
+  );
+  log('[6/6] alternate identity present throughout: signer, sidecar registry URLs, environment host, PROV agent, notebook attribution; vocabulary identifiers unchanged');
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+
+  log('');
+  log('REHEARSAL PASS — alternate instance identity emitted and verified against the local registry with zero code edits (ADR-0020 "built" bar).');
+}
+
+main().catch((err) => {
+  console.error('REHEARSAL FAIL:', err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/src/app/api/evidence/[slug]/publish/route.ts
+++ b/src/app/api/evidence/[slug]/publish/route.ts
@@ -11,6 +11,10 @@ import {
   runAdversarialEval,
   emitEvaluationAttestation,
 } from '@/lib/evidence/adversarial-eval';
+import {
+  evaluateSealCommitGate,
+  evaluateUnsignedRecordPublishGate,
+} from '@/lib/evidence/unsigned-tier';
 
 /**
  * POST /api/evidence/[slug]/publish
@@ -71,6 +75,15 @@ export async function POST(
     );
   }
 
+  // Unsigned-tier gate-off (S3a P3, #166; ADR-0020 Decisions B/C, G0-3): the
+  // committed→published promotion emits SIGNED publication attestations — an
+  // instance with no signing key cannot back them, and an unsigned package
+  // may reach neither sealed nor public. Refused before any lookup.
+  const gate = evaluateSealCommitGate();
+  if (gate) {
+    return NextResponse.json(gate.body, { status: gate.status });
+  }
+
   const records = await db
     .select()
     .from(evidenceRecords)
@@ -89,6 +102,17 @@ export async function POST(
 
   if (record.visibility !== 'committed') {
     return NextResponse.json({ error: 'Evidence is already published' }, { status: 400 });
+  }
+
+  // Per-record form of the same gate: a historical row persisted WITHOUT a
+  // signature (pre-gate unsigned-committed) cannot be promoted to public even
+  // on a signed instance — the base package has no signature to back a public
+  // state (ADR-0020 Decision C is a property of the package). The row itself
+  // is not migrated or relabeled; it stays committed and renders with the
+  // prominent unsigned labeling.
+  const recordGate = evaluateUnsignedRecordPublishGate(record.basePackageSignature);
+  if (recordGate) {
+    return NextResponse.json(recordGate.body, { status: recordGate.status });
   }
 
   // A withdrawn committed claim must be reinstated before it can publish —

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -10,6 +10,7 @@ import { captureVocabForProfile } from '@/lib/evidence/profiles';
 import { type BlobRef } from '@/lib/evidence/blob-ref';
 import { resolveRequestUser, hasScope } from '@/lib/api-auth';
 import { emitPublicationPair } from '@/lib/evidence/publication';
+import { evaluateSealCommitGate } from '@/lib/evidence/unsigned-tier';
 
 function slugify(text: string): string {
   return text
@@ -128,6 +129,17 @@ export async function POST(request: NextRequest) {
       );
     }
     const userId = auth.userId;
+
+    // Unsigned-tier gate-off (S3a P3, #166; ADR-0020 Decisions B/C, G0-3).
+    // Both request-level visibilities are persist actions this route signs:
+    // "committed" registers a commitment (sealed-family) and "published" is
+    // the public state — an unsigned package may reach NEITHER, so with no
+    // signing key configured the whole persist path is refused up front
+    // rather than storing a record with a null signature.
+    const gate = evaluateSealCommitGate();
+    if (gate) {
+      return NextResponse.json(gate.body, { status: gate.status });
+    }
 
     const body: PublishRequest = await request.json();
 

--- a/src/app/api/evidence/signing-status/route.ts
+++ b/src/app/api/evidence/signing-status/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { isSigningConfigured } from '@/lib/evidence/unsigned-tier';
+
+/**
+ * GET /api/evidence/signing-status
+ *
+ * Producer-tier disclosure for client surfaces (S3a P3, #166; ADR-0020):
+ * whether this instance holds a signing key — i.e. whether the seal/commit
+ * actions are reachable. Client components (the publish dialog) cannot read
+ * server env, so they ask here and render the gate-off affordance (disabled
+ * action + explanation) instead of a dead button that errors.
+ *
+ * SECRET HYGIENE: presence-only. This endpoint never reads the key's value
+ * beyond non-emptiness and returns a single boolean. The tier is not a
+ * secret — the same fact is disclosed by the running-unsigned banner and by
+ * every gate refusal.
+ */
+export async function GET() {
+  return NextResponse.json({ signingConfigured: isSigningConfigured() });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { db } from '@/lib/db';
 import { apiTokens, evidenceRecords, attestationPackages, users } from '@/lib/db/schema';
 import { eq, desc, and, ne, isNull, sql } from 'drizzle-orm';
 import DashboardTabs from '@/components/dashboard/DashboardTabs';
+import { isSigningConfigured } from '@/lib/evidence/unsigned-tier';
 
 export const dynamic = 'force-dynamic';
 
@@ -161,6 +162,7 @@ export default async function DashboardPage() {
         myEvaluations={myEvaluationsData}
         activity={activityData}
         tokens={tokenData}
+        signingConfigured={isSigningConfigured()}
       />
     </div>
   );

--- a/src/app/evidence/[slug]/page.tsx
+++ b/src/app/evidence/[slug]/page.tsx
@@ -210,6 +210,9 @@ export default async function EvidencePage({ params }: PageProps) {
   }
 
   const { record, creator, pkg, resolution } = data;
+  // Unsigned-package discriminator (ADR-0020 guard 2): a record persisted
+  // with no signature envelope. Drives the prominent unsigned banner below.
+  const isUnsignedRecord = !record.basePackageSignature;
   // Use the resolved package everywhere we render package content — it has
   // BlobRef outputs eagerly pulled into strings so child components can stay
   // ignorant of the reference layer. When the package isn't a BlobRef user
@@ -264,9 +267,39 @@ export default async function EvidencePage({ params }: PageProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '40px 24px 64px' }}>
+        {/* Unsigned-package banner (S3a P3, #166; ADR-0020 §Consequences
+            guard 2 — mandatory labeling wherever an unsigned package appears).
+            A record persisted without a signature carries no cryptographic
+            commitment: no signature, no registered key, and — Rekor logging
+            being signature-gated — no transparency-log entry. Going forward
+            the seal/commit gate prevents such rows from being created; a
+            historical row is not migrated or relabeled, it renders with this
+            prominent label (and cannot be published — the per-record gate). */}
+        {isUnsignedRecord && (
+          <div style={{
+            padding: '16px 20px', marginBottom: '24px',
+            backgroundColor: 'rgba(255, 179, 32, 0.12)',
+            border: '1px solid var(--nyc-caution, #FFB320)',
+            borderRadius: '6px',
+          }}>
+            <div style={{ fontSize: '15px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '6px' }}>
+              Unsigned package — no cryptographic commitment
+            </div>
+            <div style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
+              This record was produced without a signing key (the unsigned dev
+              tier). It carries no signature, no registered key, and no
+              transparency-log entry, so its origin cannot be cryptographically
+              confirmed. An unsigned package can reach neither the sealed nor
+              the public state.
+            </div>
+          </div>
+        )}
+
         {/* Committed banner (civic-ai-tools#71) — creator-only view of a
             committed-not-published record. The commitment (hash + signature +
-            timestamp + Rekor) is publicly registered; the content is not. */}
+            timestamp + Rekor) is publicly registered; the content is not.
+            The proof sentence is signature-conditional: a historical unsigned
+            row registered no commitment, and the banner must not claim one. */}
         {isCommitted && (
           <div style={{
             padding: '16px 20px', marginBottom: '24px',
@@ -278,11 +311,23 @@ export default async function EvidencePage({ params }: PageProps) {
               Committed — not published
             </div>
             <div style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
-              This record is signed, timestamped, and registered on the public
-              transparency log, but its content is not publicly accessible and
-              it does not appear in the public registry. Only you can see this
-              page. Publishing is a separate, irreversible step that makes the
-              content public and emits signed publication attestations.
+              {isUnsignedRecord ? (
+                <>
+                  This record is unlisted: its content is not publicly
+                  accessible and it does not appear in the public registry.
+                  Only you can see this page. It was persisted without a
+                  signature, so no public commitment backs it and it cannot be
+                  published.
+                </>
+              ) : (
+                <>
+                  This record is signed, timestamped, and registered on the public
+                  transparency log, but its content is not publicly accessible and
+                  it does not appear in the public registry. Only you can see this
+                  page. Publishing is a separate, irreversible step that makes the
+                  content public and emits signed publication attestations.
+                </>
+              )}
             </div>
           </div>
         )}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import Link from 'next/link';
 import Providers from '@/components/Providers';
 import Header from '@/components/Header';
+import RunningUnsignedBanner from '@/components/RunningUnsignedBanner';
 import SponsorLine from '@/components/SponsorLine';
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
@@ -70,6 +71,9 @@ export default function RootLayout({
         <Providers>
           <div className="flex flex-col">
             <Header />
+            {/* ADR-0020: running-unsigned indicator — renders only when this
+                instance has no signing key AND is outside a dev environment. */}
+            <RunningUnsignedBanner />
             <main>{children}</main>
             <footer className="border-t py-8 text-center" style={{ borderColor: 'var(--border-color)' }}>
               <div style={{ maxWidth: '600px', margin: '0 auto' }}>

--- a/src/components/PublishEvidenceDialog.tsx
+++ b/src/components/PublishEvidenceDialog.tsx
@@ -71,11 +71,37 @@ export default function PublishEvidenceDialog({
   const [resultUrl, setResultUrl] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [urlCopied, setUrlCopied] = useState(false);
+  // Unsigned-tier gate-off (ADR-0020, S3a P3): whether this instance holds a
+  // signing key, fetched presence-only from /api/evidence/signing-status.
+  // null = not yet known (treated as available; the SERVER gate is the
+  // enforcement — this state only drives the explanatory affordance).
+  const [signingConfigured, setSigningConfigured] = useState<boolean | null>(null);
 
   const router = useRouter();
 
   // Track whether we've already kicked off summary generation for this session
   const summaryRequested = useRef(false);
+  // Track whether we've asked for the signing tier for this open.
+  const signingStatusRequested = useRef(false);
+
+  // Ask the producer tier once per dialog session. When the instance runs
+  // unsigned, the seal/commit server gate refuses every persist — render a
+  // disabled action with an explanation instead of a dead button that errors.
+  useEffect(() => {
+    if (!isOpen || signingStatusRequested.current) return;
+    signingStatusRequested.current = true;
+    fetch('/api/evidence/signing-status')
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        const data = await res.json();
+        setSigningConfigured(data.signingConfigured !== false);
+      })
+      .catch(() => {
+        // Unknown tier → leave the action enabled; the server gate still
+        // enforces and its refusal message renders in the error state.
+        setSigningConfigured(null);
+      });
+  }, [isOpen]);
 
   // Auto-generate summary when dialog opens — only once per open. Skipped
   // when a structured summary was provided (#112: the executed notebook's
@@ -417,9 +443,34 @@ export default function PublishEvidenceDialog({
                 </div>
               </div>
 
+              {/* Unsigned-tier gate-off (ADR-0020, S3a P3): with no signing
+                  key, neither Commit (sealed) nor Publish (public) is
+                  reachable — the action renders disabled with an explanation,
+                  mirroring the server-side gate. */}
+              {signingConfigured === false && (
+                <div style={{
+                  padding: '12px',
+                  marginBottom: '12px',
+                  borderRadius: '4px',
+                  backgroundColor: 'rgba(255, 179, 32, 0.12)',
+                  border: '1px solid var(--nyc-caution, #FFB320)',
+                  fontSize: '13px',
+                  lineHeight: 1.5,
+                  color: 'var(--text-secondary)',
+                }}>
+                  <strong style={{ color: 'var(--text-primary)' }}>
+                    This instance is running unsigned.
+                  </strong>{' '}
+                  No signing key is configured, so evidence cannot be committed
+                  or published — an unsigned package can reach neither the
+                  sealed nor the public state. The analysis itself still works;
+                  an operator enables signing via the instance setup guide.
+                </div>
+              )}
+
               <button
                 onClick={handlePublish}
-                disabled={!title.trim() || !summary.trim()}
+                disabled={!title.trim() || !summary.trim() || signingConfigured === false}
                 style={{
                   width: '100%',
                   padding: '10px 20px',
@@ -429,11 +480,13 @@ export default function PublishEvidenceDialog({
                   borderRadius: '4px',
                   fontSize: '14px',
                   fontWeight: 600,
-                  cursor: title.trim() && summary.trim() ? 'pointer' : 'not-allowed',
-                  opacity: title.trim() && summary.trim() ? 1 : 0.5,
+                  cursor: title.trim() && summary.trim() && signingConfigured !== false ? 'pointer' : 'not-allowed',
+                  opacity: title.trim() && summary.trim() && signingConfigured !== false ? 1 : 0.5,
                 }}
               >
-                {visibility === 'committed' ? 'Commit' : 'Publish'}
+                {signingConfigured === false
+                  ? 'Unavailable (running unsigned)'
+                  : visibility === 'committed' ? 'Commit' : 'Publish'}
               </button>
             </>
           )}

--- a/src/components/RunningUnsignedBanner.tsx
+++ b/src/components/RunningUnsignedBanner.tsx
@@ -1,0 +1,48 @@
+import { shouldShowRunningUnsignedIndicator } from '@/lib/evidence/unsigned-tier';
+
+/**
+ * Running-unsigned indicator (S3a P3, #166; ADR-0020 §Consequences: "a
+ * running-unsigned indicator/banner shows outside a dev environment").
+ *
+ * Server component: renders a site-wide amber strip under the header when
+ * this instance has no signing key configured AND is not running in a dev
+ * environment. Dev stays calm — the unsigned tier is the intended first-run
+ * state there. The banner is what keeps "stayed unsigned" a legitimate but
+ * never SILENT choice (guard against silent opt-out).
+ *
+ * Note: on statically prerendered pages the condition is evaluated with the
+ * build-time environment; on dynamic routes, at request time. Both reflect
+ * the deploy's configuration.
+ */
+export default function RunningUnsignedBanner() {
+  if (!shouldShowRunningUnsignedIndicator()) return null;
+
+  return (
+    <div
+      role="status"
+      style={{
+        backgroundColor: 'rgba(255, 179, 32, 0.15)',
+        borderBottom: '1px solid var(--nyc-caution, #FFB320)',
+        padding: '8px 24px',
+        fontSize: '13px',
+        lineHeight: 1.5,
+        color: 'var(--text-primary)',
+        textAlign: 'center',
+      }}
+    >
+      <strong>Running unsigned</strong> — no signing key is configured, so
+      evidence commit and publish are disabled and any output produced here
+      carries no cryptographic commitment. Signing is the go-to-production
+      step; see the{' '}
+      <a
+        href="https://github.com/npstorey/civic-ai-tools-website/blob/main/docs/instance-setup.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ textDecoration: 'underline' }}
+      >
+        instance setup guide
+      </a>
+      .
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardTabs.tsx
+++ b/src/components/dashboard/DashboardTabs.tsx
@@ -57,6 +57,11 @@ interface DashboardTabsProps {
   myEvaluations: EvaluationRow[];
   activity: ActivityRow[];
   tokens: TokenRow[];
+  /** Whether this instance holds a signing key (ADR-0020, S3a P3): with no
+   *  key the committed→published promotion is gated off server-side, so the
+   *  Publish affordance renders disabled-with-explanation instead of a dead
+   *  button that errors. */
+  signingConfigured?: boolean;
 }
 
 // --- Shared styles ---
@@ -132,7 +137,7 @@ function EmptyState({ message, cta }: { message: string; cta?: { text: string; h
 
 // --- Main component ---
 
-export default function DashboardTabs({ myEvidence, myEvaluations, activity, tokens }: DashboardTabsProps) {
+export default function DashboardTabs({ myEvidence, myEvaluations, activity, tokens, signingConfigured = true }: DashboardTabsProps) {
   const [activeTab, setActiveTab] = useState<'evidence' | 'evaluations' | 'activity' | 'tokens'>('evidence');
 
   return (
@@ -152,7 +157,7 @@ export default function DashboardTabs({ myEvidence, myEvaluations, activity, tok
         </button>
       </div>
 
-      {activeTab === 'evidence' && <MyEvidenceTab rows={myEvidence} />}
+      {activeTab === 'evidence' && <MyEvidenceTab rows={myEvidence} signingConfigured={signingConfigured} />}
       {activeTab === 'evaluations' && <MyEvaluationsTab rows={myEvaluations} />}
       {activeTab === 'activity' && <ActivityTab rows={activity} />}
       {activeTab === 'tokens' && <TokensTab rows={tokens} />}
@@ -162,7 +167,7 @@ export default function DashboardTabs({ myEvidence, myEvaluations, activity, tok
 
 // --- Tab panels ---
 
-function MyEvidenceTab({ rows }: { rows: EvidenceRow[] }) {
+function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signingConfigured: boolean }) {
   const router = useRouter();
   const [withdrawTarget, setWithdrawTarget] = useState<EvidenceRow | null>(null);
   const [withdrawReason, setWithdrawReason] = useState('');
@@ -334,16 +339,34 @@ function MyEvidenceTab({ rows }: { rows: EvidenceRow[] }) {
                 {r.visibility === 'committed' && !isCurrentlyWithdrawn && (
                   <>
                     <span>{'\u00b7'}</span>
-                    <button
-                      onClick={() => { setPublishTarget(r); setPublishRunEval(true); setPublishError(''); }}
-                      style={{
-                        background: 'none', border: 'none', padding: 0,
-                        fontSize: '12px', color: 'var(--nyc-blue)', cursor: 'pointer',
-                        textDecoration: 'underline', fontWeight: 600,
-                      }}
-                    >
-                      Publish
-                    </button>
+                    {signingConfigured ? (
+                      <button
+                        onClick={() => { setPublishTarget(r); setPublishRunEval(true); setPublishError(''); }}
+                        style={{
+                          background: 'none', border: 'none', padding: 0,
+                          fontSize: '12px', color: 'var(--nyc-blue)', cursor: 'pointer',
+                          textDecoration: 'underline', fontWeight: 600,
+                        }}
+                      >
+                        Publish
+                      </button>
+                    ) : (
+                      /* Unsigned-tier gate-off (ADR-0020, S3a P3): publishing
+                         emits signed attestations this instance cannot back,
+                         so the action is disabled with an explanation rather
+                         than left as a dead button that errors. */
+                      <button
+                        disabled
+                        title="Publishing is unavailable \u2014 this instance is running unsigned (no signing key is configured). Signing is the go-to-production step; see docs/instance-setup.md."
+                        style={{
+                          background: 'none', border: 'none', padding: 0,
+                          fontSize: '12px', color: 'var(--text-muted)',
+                          cursor: 'not-allowed', fontWeight: 600,
+                        }}
+                      >
+                        Publish unavailable (unsigned)
+                      </button>
+                    )}
                   </>
                 )}
                 {!isCurrentlyWithdrawn && !isReinstated && (

--- a/src/lib/evidence/instance-rehearsal.test.ts
+++ b/src/lib/evidence/instance-rehearsal.test.ts
@@ -1,0 +1,51 @@
+// ADR-0020 config-rehearsal harness test (S3a P3, #166; S3a acceptance §3).
+//
+// Spawns scripts/rehearse-instance-identity.ts as a CHILD PROCESS — exactly
+// the command an operator runs — so the rehearsal proves itself repeatable
+// under `npm test` while its environment mutations (ephemeral signing key,
+// alternate identity vars) stay confined to the child. The child:
+//
+//   - generates an ephemeral Ed25519 keypair (never the real key),
+//   - builds a local trust registry from the docs/instance-setup.md template,
+//   - runs the produce path under fully alternate identity config,
+//   - verifies the emitted package offline (§9.2) against that registry,
+//   - asserts the alternate identity appears throughout the emitted output.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../scripts/rehearse-instance-identity.ts',
+);
+
+test('config rehearsal: alternate identity + local registry, zero code edits (child process)', () => {
+  // Strip every EVIDENCE_* variable from the inherited environment so the
+  // rehearsal's config is exactly what the script sets — the run must not
+  // borrow identity (or, worse, a key) from the invoking shell.
+  const env: Record<string, string> = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (value !== undefined && !name.startsWith('EVIDENCE_')) env[name] = value;
+  }
+
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', SCRIPT],
+    { env, encoding: 'utf-8', timeout: 120_000 },
+  );
+
+  assert.equal(
+    result.status,
+    0,
+    `rehearsal exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  // The §9.2 offline pass against the local registry, and the closing verdict.
+  assert.match(result.stdout, /§9\.2 offline checks PASS against the local registry/);
+  assert.match(result.stdout, /alternate identity present throughout/);
+  assert.match(result.stdout, /REHEARSAL PASS/);
+});

--- a/src/lib/evidence/trust-signal.test.ts
+++ b/src/lib/evidence/trust-signal.test.ts
@@ -54,6 +54,8 @@ import {
   NOTEBOOK_PROVENANCE_VALUES,
   NOTEBOOK_PROVENANCE_SIGNALS,
   NO_SIGNING_KEY_SIGNAL,
+  UNSIGNED_PACKAGE_SIGNAL,
+  isUnsignedGlance,
   OVERALL_INTEGRITY_SIGNALS,
   collectIntegrityDescriptors,
   summarizeIntegrity,
@@ -244,13 +246,17 @@ test('captureMethod labels are informational (no tier) and cover the known metho
 
 // --- #111 consumer resolvers (verify-panel re-skin) ----------------------
 
-test('resolveKeyTrust: unsigned (null/undefined) reads calm Normal; statuses pass through', () => {
-  // keyTrust:null is the unsigned package — expected, never a failure (the #111
-  // calm baseline). It must resolve to the calm NO_SIGNING_KEY_SIGNAL, not a
-  // hand-rolled tier in the component.
+test('resolveKeyTrust: unsigned (null/undefined) is prominently labeled; statuses pass through', () => {
+  // DELIBERATE UPDATE (S3a P3, #166 — ADR-0020 §Consequences guard 2): this
+  // test previously pinned NO_SIGNING_KEY_SIGNAL at calm Normal. G0-3 chose
+  // gate-off for the unsigned tier, and ADR-0020 requires the unsigned
+  // rendering to be surfaced PROMINENTLY wherever an unsigned package
+  // appears — so the signal is elevated to Attention (unconfirmed, not
+  // proven-bad; never Alarm). It still resolves through the single
+  // NO_SIGNING_KEY_SIGNAL source of truth, not a hand-rolled component tier.
   assert.equal(resolveKeyTrust(null), NO_SIGNING_KEY_SIGNAL);
   assert.equal(resolveKeyTrust(undefined), NO_SIGNING_KEY_SIGNAL);
-  assert.equal(NO_SIGNING_KEY_SIGNAL.tier, 'normal');
+  assert.equal(NO_SIGNING_KEY_SIGNAL.tier, 'attention');
   // A real status passes straight through to its KEY_TRUST_SIGNALS descriptor.
   assert.equal(resolveKeyTrust({ status: 'legacy_embedded' }), KEY_TRUST_SIGNALS.legacy_embedded);
   assert.equal(resolveKeyTrust({ status: 'active' }), KEY_TRUST_SIGNALS.active);
@@ -354,4 +360,70 @@ test('summarizeIntegrity: an unconfirmed check (no alarm) reads Attention', () =
     }).tier,
     'alarm',
   );
+});
+
+// --- S3a P3 (#166): unsigned-package prominence (ADR-0020 guard 2) --------
+//
+// NEW behavior: an unsigned package (no signature envelope at all — the
+// verify path emits signatureValid:null AND keyTrust:null together) must be
+// labeled prominently wherever it appears, never fold into the calm
+// "Integrity verified" glance. Signed packages — including legacy
+// embedded-key ones — are untouched (the LEGACY_RESULT test above still pins
+// the calm requirement, unmodified).
+
+// The verify-result shape an unsigned package produces (mirrors the verify
+// route: no signature → #2 null, #5 null, no timestamp, no Rekor).
+const UNSIGNED_RESULT: IntegrityGlanceInput = {
+  hashMatch: true,
+  signatureValid: null,
+  keyTrust: null,
+  hasTimestamp: false,
+  rekorVerified: null,
+  blobRefsVerified: null,
+  contentCanonicalization: { status: 'ok' },
+  contentHash: { status: 'ok' },
+  typeResolution: { status: 'ok' },
+  signerIdentity: { status: 'no_signer' },
+  captureMethodVocab: { status: 'ok' },
+};
+
+test('isUnsignedGlance: discriminates the no-signature co-occurrence only', () => {
+  assert.equal(isUnsignedGlance(UNSIGNED_RESULT), true);
+  // A signed package (even one whose key trust is merely legacy) is NOT unsigned.
+  assert.equal(isUnsignedGlance(LEGACY_RESULT), false);
+  assert.equal(isUnsignedGlance(CLEAN_RESULT), false);
+  // signatureValid:null with a NON-null keyTrust is not the unsigned shape.
+  assert.equal(
+    isUnsignedGlance({ signatureValid: null, keyTrust: { status: 'legacy_embedded' } }),
+    false,
+  );
+});
+
+test('summarizeIntegrity: an unsigned package reads the dedicated prominent unsigned glance', () => {
+  const summary = summarizeIntegrity(UNSIGNED_RESULT);
+  assert.equal(summary, UNSIGNED_PACKAGE_SIGNAL);
+  assert.equal(summary.tier, 'attention');
+  // The label names the condition — not the generic "closer look" copy.
+  assert.match(summary.label, /Unsigned/);
+});
+
+test('summarizeIntegrity: Alarm still out-ranks the unsigned glance (worst-tier-wins)', () => {
+  // Unsigned AND altered content → the genuine integrity failure wins.
+  assert.equal(
+    summarizeIntegrity({ ...UNSIGNED_RESULT, hashMatch: false }),
+    OVERALL_INTEGRITY_SIGNALS.alarm,
+  );
+  assert.equal(
+    summarizeIntegrity({ ...UNSIGNED_RESULT, contentHash: { status: 'content_hash_mismatch' } }),
+    OVERALL_INTEGRITY_SIGNALS.alarm,
+  );
+});
+
+test('unsigned prominence never regresses to Alarm, and signed packages never see it', () => {
+  // The unsigned dev tier is legitimate (ADR-0020 §B): prominent, not "broken".
+  assert.equal(UNSIGNED_PACKAGE_SIGNAL.tier, 'attention');
+  assert.equal(NO_SIGNING_KEY_SIGNAL.tier, 'attention');
+  // A signed legacy package still rolls up calm — the load-bearing requirement
+  // (also pinned, unmodified, by the LEGACY_RESULT test above).
+  assert.equal(summarizeIntegrity(LEGACY_RESULT), OVERALL_INTEGRITY_SIGNALS.verified);
 });

--- a/src/lib/evidence/trust-signal.ts
+++ b/src/lib/evidence/trust-signal.ts
@@ -266,17 +266,22 @@ export const KEY_TRUST_SIGNALS: Record<KeyTrustStatus, TrustSignalDescriptor> = 
 };
 
 /**
- * Calm reading for a package with NO signing key at all. The verify route emits
- * `keyTrust: null` only for an unsigned package (it co-occurs with
- * `signatureValid: null`), so "no key to check" is an expected, Normal state —
- * never a failure. Defined here, not hand-rolled in the component, so the tier
- * decision keeps a single source of truth.
+ * Prominent reading for a package with NO signing key at all. The verify route
+ * emits `keyTrust: null` only for an unsigned package (it co-occurs with
+ * `signatureValid: null`). Deliberately elevated from calm Normal to Attention
+ * in S3a P3 (ADR-0020 §Consequences guard 2, "mandatory labeling"): an
+ * unsigned package is the intentional dev tier — legitimate, not proven-bad —
+ * but its rendering must be surfaced prominently wherever the package
+ * appears, never fold into a calm all-clear. Attention is the honest tier:
+ * "unconfirmed, look closer", not Alarm's "provably wrong". Defined here, not
+ * hand-rolled in the component, so the tier decision keeps a single source of
+ * truth.
  */
 export const NO_SIGNING_KEY_SIGNAL: TrustSignalDescriptor = {
-  tier: 'normal',
+  tier: 'attention',
   label: 'No signing key',
   detail:
-    'This package carries no signing key, so there is nothing to check against the trust registry.',
+    'This package carries no signing key — it was produced by an instance running in the unsigned dev tier, so its origin is not cryptographically attributable and there is nothing to check against the trust registry.',
 };
 
 /** Resolve the trust-registry verdict, folding the unsigned (`null`) case into
@@ -613,6 +618,36 @@ const TIER_RANK: Record<TrustTier, number> = {
   alarm: 3,
 };
 
+/**
+ * Dedicated overall glance for an UNSIGNED package (S3a P3; ADR-0020 guard 2
+ * "mandatory labeling"). An unsigned package has no signature, no registered
+ * key, and — because Rekor logging is signature-gated — no transparency-log
+ * entry: there is no cryptographic commitment for the glance to speak to, so
+ * the generic "some checks need a closer look" would under-describe the
+ * condition. Attention tier (unconfirmed, not proven-bad — the unsigned dev
+ * tier is a legitimate producer state per ADR-0020 §B); named explicitly so
+ * the label travels with every surface that renders the glance.
+ */
+export const UNSIGNED_PACKAGE_SIGNAL: TrustSignalDescriptor = {
+  tier: 'attention',
+  label: 'Unsigned package — no cryptographic commitment',
+  detail:
+    'This package was produced without a signing key (the unsigned dev tier). It carries no signature, no registered key, and no transparency-log entry, so its origin cannot be cryptographically confirmed.',
+};
+
+/**
+ * The unsigned-package discriminator: the verify path emits `signatureValid:
+ * null` AND `keyTrust: null` together only when the package carries no
+ * signature envelope at all. Every signed package — including legacy
+ * embedded-key packages — has a non-null keyTrust, so the legacy calm
+ * requirement is untouched by this branch.
+ */
+export function isUnsignedGlance(
+  r: Pick<IntegrityGlanceInput, 'signatureValid' | 'keyTrust'>,
+): boolean {
+  return r.signatureValid === null && r.keyTrust === null;
+}
+
 /** The three overall-integrity summary states (#113). Disclosure, never
  *  validation (P1): "Integrity verified" speaks to the cryptographic/structural
  *  checks, never to whether the analysis is correct. */
@@ -683,9 +718,12 @@ export function collectIntegrityDescriptors(r: IntegrityGlanceInput): TrustSigna
 
 /**
  * Roll the integrity checks into ONE calm overall glance (#113), worst-tier-wins.
- * Alarm if any check alarms; else Attention if any needs a closer look; else the
- * calm "Integrity verified" (Verified + Normal back-compat checks both land
- * here, so legacy packages read calm — never amber/red).
+ * Alarm if any check alarms; else — for an unsigned package — the dedicated
+ * prominent unsigned label (S3a P3, ADR-0020 guard 2: mandatory labeling
+ * wherever an unsigned package appears; Attention tier, so it outranks
+ * nothing genuinely broken); else Attention if any check needs a closer look;
+ * else the calm "Integrity verified" (Verified + Normal back-compat checks
+ * both land here, so SIGNED legacy packages read calm — never amber/red).
  */
 export function summarizeIntegrity(r: IntegrityGlanceInput): TrustSignalDescriptor {
   let worst = 0;
@@ -693,6 +731,7 @@ export function summarizeIntegrity(r: IntegrityGlanceInput): TrustSignalDescript
     worst = Math.max(worst, TIER_RANK[d.tier]);
   }
   if (worst >= TIER_RANK.alarm) return OVERALL_INTEGRITY_SIGNALS.alarm;
+  if (isUnsignedGlance(r)) return UNSIGNED_PACKAGE_SIGNAL;
   if (worst >= TIER_RANK.attention) return OVERALL_INTEGRITY_SIGNALS.attention;
   return OVERALL_INTEGRITY_SIGNALS.verified;
 }

--- a/src/lib/evidence/unsigned-tier.test.ts
+++ b/src/lib/evidence/unsigned-tier.test.ts
@@ -1,0 +1,85 @@
+// Unsigned-tier gate + indicator tests (S3a P3, #166; ADR-0020 Decisions B/C).
+//
+// NEW file covering NEW behavior: the G0-3 gate-off. The server-side seal/
+// commit enforcement is decided by these pure functions; the publish/commit
+// routes wire them in front of every persist path (POST /api/evidence and
+// POST /api/evidence/[slug]/publish), so "the gate refuses" here IS the
+// server-side refusal an unsigned run receives.
+//
+// All functions take an env-shaped record — no process.env mutation.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isSigningConfigured,
+  evaluateSealCommitGate,
+  evaluateUnsignedRecordPublishGate,
+  shouldShowRunningUnsignedIndicator,
+} from './unsigned-tier.ts';
+
+// Deliberately inert stand-in — presence is all the tier logic reads, so the
+// fixture never needs to look like key material.
+const KEY_PRESENT = 'presence-only-stand-in';
+
+test('isSigningConfigured: presence-only — set means signed tier, unset/empty means unsigned', () => {
+  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: KEY_PRESENT }), true);
+  assert.equal(isSigningConfigured({}), false);
+  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: undefined }), false);
+  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: '' }), false);
+  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: '   ' }), false);
+});
+
+test('gate-off (ADR-0020 C): an unsigned run cannot reach seal/commit — the gate refuses server-side', () => {
+  const refusal = evaluateSealCommitGate({});
+  assert.ok(refusal, 'unsigned tier must be refused');
+  assert.equal(refusal!.status, 403);
+  assert.equal(refusal!.body.code, 'unsigned_tier');
+  // The refusal explains the tier and the rule (neither sealed nor public),
+  // and points at the setup path — an explanatory refusal, not a bare error.
+  assert.match(refusal!.body.error, /running unsigned/);
+  assert.match(refusal!.body.error, /neither the sealed nor the public state/);
+  assert.match(refusal!.body.error, /instance-setup/);
+});
+
+test('gate-off: a signed instance passes the gate (the action proceeds)', () => {
+  assert.equal(evaluateSealCommitGate({ EVIDENCE_SIGNING_KEY: KEY_PRESENT }), null);
+});
+
+test('per-record gate: a historical unsigned-persisted record cannot be promoted to published', () => {
+  // Even on a signed instance: the BASE PACKAGE has no signature to back a
+  // public state (Decision C is a property of the package, not the runtime).
+  const refusal = evaluateUnsignedRecordPublishGate(null);
+  assert.ok(refusal);
+  assert.equal(refusal!.status, 409);
+  assert.equal(refusal!.body.code, 'unsigned_package');
+  assert.match(refusal!.body.error, /neither the sealed nor the public/);
+});
+
+test('per-record gate: a signed record passes', () => {
+  const sigJson = JSON.stringify({ signature: 'QQ==', publicKey: 'QQ==', algorithm: 'Ed25519ph' });
+  assert.equal(evaluateUnsignedRecordPublishGate(sigJson), null);
+});
+
+test('running-unsigned indicator: shows outside dev, calm in dev/test (ADR-0020 §Consequences)', () => {
+  // Unsigned + production → indicator shows.
+  assert.equal(shouldShowRunningUnsignedIndicator({ NODE_ENV: 'production' }), true);
+  // Unknown environment is NOT a dev environment — never silently unsigned.
+  assert.equal(shouldShowRunningUnsignedIndicator({}), true);
+  // Dev and test stay calm — the unsigned tier is the intended first-run state.
+  assert.equal(shouldShowRunningUnsignedIndicator({ NODE_ENV: 'development' }), false);
+  assert.equal(shouldShowRunningUnsignedIndicator({ NODE_ENV: 'test' }), false);
+});
+
+test('running-unsigned indicator: never shows when signing is configured', () => {
+  assert.equal(
+    shouldShowRunningUnsignedIndicator({ EVIDENCE_SIGNING_KEY: KEY_PRESENT, NODE_ENV: 'production' }),
+    false,
+  );
+  assert.equal(
+    shouldShowRunningUnsignedIndicator({ EVIDENCE_SIGNING_KEY: KEY_PRESENT, NODE_ENV: 'development' }),
+    false,
+  );
+});

--- a/src/lib/evidence/unsigned-tier.ts
+++ b/src/lib/evidence/unsigned-tier.ts
@@ -1,0 +1,111 @@
+// Unsigned-tier gate + indicator logic (S3a P3, #166; ADR-0020 Decisions B/C).
+//
+// ADR-0020 models "unsigned" as a SIGNING STATUS orthogonal to visibility:
+// an unsigned package carries no signature, and because Rekor logging is
+// signature-gated it has no transparency-log entry and no attributable
+// commitment. It is therefore not `sealed` (ADR-0016 §A: sealed = signed +
+// RFC-3161-timestamped + Rekor-logged) and may reach NEITHER `sealed` NOR
+// `public` (Decision C) — the unsigned dev tier is confined to local
+// produce-and-inspect. Three guards bound the tier (ADR-0020 §Consequences):
+//
+//   1. the seal/commit action is unreachable unsigned  → `evaluateSealCommitGate`
+//      (server-side, wired into POST /api/evidence and POST
+//      /api/evidence/[slug]/publish) + `evaluateUnsignedRecordPublishGate`
+//      (the per-record form: a historical row persisted without a signature
+//      cannot be promoted to public even on a signed instance);
+//   2. mandatory labeling                              → trust-signal.ts
+//      (`NO_SIGNING_KEY_SIGNAL` / `UNSIGNED_PACKAGE_SIGNAL`);
+//   3. the verifier won't bless it                     → structural (an
+//      unsigned artifact cannot produce "commitment verified").
+//
+// Plus: a running-unsigned indicator shows outside a dev environment
+// (`shouldShowRunningUnsignedIndicator`, rendered by
+// components/RunningUnsignedBanner.tsx). Dev stays calm.
+//
+// Everything here is PURE over an env-shaped record (default `process.env`,
+// read at call time) so the decisions are unit-testable without touching the
+// process environment. No values are ever read beyond presence.
+
+type EnvLike = Record<string, string | undefined>;
+
+/**
+ * Whether this instance holds a signing key — the producer-tier discriminator
+ * (ADR-0020 §B: unsigned dev → per-instance signed). Presence-only; the value
+ * is never inspected beyond non-emptiness.
+ */
+export function isSigningConfigured(env: EnvLike = process.env): boolean {
+  const key = env.EVIDENCE_SIGNING_KEY;
+  return typeof key === 'string' && key.trim().length > 0;
+}
+
+/** The refusal a seal/commit attempt receives in the unsigned tier. */
+export interface SealCommitGateRefusal {
+  status: number;
+  body: { error: string; code: string };
+}
+
+/**
+ * Guard 1 (instance form): the seal/commit action is unreachable in the
+ * unsigned tier. Returns `null` when signing is configured (the action may
+ * proceed) and a refusal otherwise. Wired server-side into the publish/commit
+ * routes so an unsigned run cannot persist a `committed`- or
+ * `published`-labeled record — per Decision C an unsigned package may reach
+ * neither state, so the whole persist action is gated, not just one
+ * visibility value.
+ */
+export function evaluateSealCommitGate(
+  env: EnvLike = process.env,
+): SealCommitGateRefusal | null {
+  if (isSigningConfigured(env)) return null;
+  return {
+    status: 403,
+    body: {
+      error:
+        'This instance is running unsigned — no signing key is configured. ' +
+        'Committing or publishing evidence requires a signature: an unsigned ' +
+        'package can reach neither the sealed nor the public state (ADR-0020). ' +
+        'Analyses still run and can be inspected locally; an operator enables ' +
+        'signing via docs/instance-setup.md.',
+      code: 'unsigned_tier',
+    },
+  };
+}
+
+/**
+ * Guard 1 (per-record form): a record persisted WITHOUT a signature (a
+ * historical unsigned-committed row, predating this gate) cannot be promoted
+ * to `published` — even on an instance that has since configured signing. The
+ * base package has no signature to back a public state; per Decision C it can
+ * reach neither `sealed` nor `public`. The row itself is NOT migrated or
+ * relabeled — the gate is on the action going forward, and the record keeps
+ * rendering (with prominent unsigned labeling per guard 2).
+ */
+export function evaluateUnsignedRecordPublishGate(
+  basePackageSignature: string | null,
+): SealCommitGateRefusal | null {
+  if (basePackageSignature) return null;
+  return {
+    status: 409,
+    body: {
+      error:
+        'This record was persisted without a signature; an unsigned package ' +
+        'cannot be published — it can reach neither the sealed nor the public ' +
+        'state (ADR-0020).',
+      code: 'unsigned_package',
+    },
+  };
+}
+
+/**
+ * Whether the running-unsigned indicator/banner should render (ADR-0020
+ * §Consequences: "a running-unsigned indicator/banner shows outside a dev
+ * environment"). Dev (and test) stay calm — the unsigned tier is the intended
+ * first-run state there; anywhere else, running unsigned must never be
+ * silent, so an unknown NODE_ENV shows the indicator too.
+ */
+export function shouldShowRunningUnsignedIndicator(
+  env: EnvLike = process.env,
+): boolean {
+  if (isSigningConfigured(env)) return false;
+  return env.NODE_ENV !== 'development' && env.NODE_ENV !== 'test';
+}


### PR DESCRIPTION
S3a **P3** (final phase) per the sprint contract on #166: the G0-3 **gate-off** — ADR-0020 Decisions B/C made real (an unsigned instance cannot reach seal/commit; prominent unsigned labeling; running-unsigned indicator outside dev) — plus the **ADR-0020 config rehearsal** proving an instance needs zero code edits for identity. **No DB migration; no visibility-enum changes; zero emission modules touched** (`packager`/`signing`/`commitment`/`publication`/`attestation`/`provenance` all untouched — signed-path byte-parity holds by construction). **Owner merges after preview review (G0-4) — merge auto-deploys to production.**

## The as-built path this closes

Before this PR, `POST /api/evidence` persisted rows with the requested visibility even when `signPackage()` returned null (no `EVIDENCE_SIGNING_KEY`) — an unsigned run could persist both `committed` and `published` rows, and `resolveKeyTrust(null)` rolled up to a calm green **"Integrity verified"** glance. Per ADR-0020 Decision C (unsigned may reach *neither* `sealed` nor `public`), the gate now sits server-side in both persist routes, and the unsigned state is prominently labeled everywhere it renders.

## What this PR does

**Gate-off (guard 1 — server-side enforcement):**
- New `src/lib/evidence/unsigned-tier.ts` (pure tier logic): `evaluateSealCommitGate` wired as the first act after auth in `POST /api/evidence` (403 `unsigned_tier`, nothing persisted — both visibilities) and in `POST /api/evidence/[slug]/publish`; plus `evaluateUnsignedRecordPublishGate` (409 `unsigned_package`) blocking promotion of any historical unsigned row even on a signed instance.
- UI affordances reflect it rather than dead-ending: `PublishEvidenceDialog` and the dashboard Publish action render disabled-with-explanation when unsigned (via a presence-only `signing-status` endpoint; dialog fails open by design — the server gate is the enforcement).

**Prominent labeling (guard 2):** `NO_SIGNING_KEY_SIGNAL` Normal → **Attention**; new `UNSIGNED_PACKAGE_SIGNAL` + unsigned glance ("Unsigned package — no cryptographic commitment"); server-rendered unsigned banner on the evidence detail page; the committed-banner proof sentence is now signature-conditional (no more "signed, timestamped, registered" over a null signature). Signed rendering unchanged — the legacy-calm test passes unmodified.

**Running-unsigned indicator (guard 3):** site-wide `RunningUnsignedBanner` under the header outside dev/test environments.

**Historical rows:** not migrated, not relabeled (gate is on the action going forward); if any unsigned-committed rows exist they render with the prominent labeling and cannot be promoted.

**Config rehearsal (the ADR-0020 "built" bar):** `scripts/rehearse-instance-identity.ts` (+ an `npm test` harness that strips inherited `EVIDENCE_*` from the child env): generates an **ephemeral in-process Ed25519 keypair** (the real signing key is never read), builds a local trust registry from the `docs/instance-setup.md` template, runs the produce path under alternate identity config, resolves the registry for verification **from the sidecar's own `trustRegistryUrl`** (the third-party bootstrap), and passes verify-core §9.2 offline checks (#1–#5, #12, #14, #15) — with the alternate identity present throughout (signer, sidecar registry URLs, environment host, PROV agent, notebook attribution) and the `civic:` vocabulary unparameterized under a full identity swap (the Tier-2 guard).

## Evidence (IMPL runs, independently re-verified by ORCH)

- **`npm test`: 361/361** — 348 existing kept green **unmodified** (every signed-path emission suite byte-unmodified), **1 existing deliberately updated** (disclosed: the calm-Normal pin on `NO_SIGNING_KEY_SIGNAL` was the old unsigned-committed presentation; flipped to Attention per ADR-0020 guard 2 — Attention, never Alarm, the tier is legitimate), **12 new** (gate refusal/pass, per-record gate, indicator dev/prod, unsigned-prominence, rehearsal harness).
- **ORCH direct rehearsal run: REHEARSAL PASS** (own invocation of the script, not just the test harness).
- **Lint:** 0 errors (same 4 pre-existing warnings, untouched files). **Build:** clean, 27/27 pages (one pre-existing Turbopack NFT warning, verified present on unmodified main).
- **Blast zone:** 18 files — routes, tier logic, trust-signal vocabulary, four UI surfaces, rehearsal, three docs; per-file justification in the phase report; emission modules untouched (mechanically verified).

## Flagged, not fixed (follow-ups, none blocking)

1. **Withdraw/reinstate/evaluate/attestation routes** remain null-tolerant on `signPackage` — a signed→unsigned config regression on an instance with existing records could persist unsigned lifecycle/eval attestations (their RFC-3161 legs also aren't signature-gated). Outside P3's seal/commit scope; candidate for the post-sprint cleanup track.
2. **Static-page banner timing:** statically prerendered pages evaluate the indicator with build-time env (documented in the component; not the Vercel setup).
3. **Index/list rows carry no unsigned chip** — labeling lives on detail page + glance; cheap follow-up if wanted.
4. **`preflight-env.mjs` still tiers `EVIDENCE_SIGNING_KEY` as required** — right for this deployment; a deliberately-unsigned instance sees a preflight FAIL; tier-aware preflight is future work.
5. Gate-off proof is unit-level on the pure gate (route modules can't load under `node --test`); the 3-line wiring per route is in the diff, and the natural live check is a 403 on an unsigned deployment.

**Sprint:** S3a P3 · branch `s3a/p3-unsigned-gate-rehearsal` off `rollback/pre-s3a-p3` (220fb1c) · 2 commits · **Model: Fable 5** (IMPL + ORCH verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
