### PR TITLE
chore: mirror the instance-identity env contract into .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 # OpenRouter
-OPENROUTER_API_KEY=sk-or-...
+OPENROUTER_API_KEY=
 
 # socrata-mcp-server
 SOCRATA_MCP_URL=https://socrata-mcp.civicaitools.org
+# Client-side mirror for notebook output links (defaults to SOCRATA_MCP_URL)
+# NEXT_PUBLIC_SOCRATA_MCP_URL=
 
 # Data Commons MCP (Google-hosted; US demographic + federal statistical data)
 # The hosted endpoint requires an X-API-Key header. Free key from
@@ -26,12 +28,34 @@ BLOB_READ_WRITE_TOKEN=     # From Vercel Blob store settings
 
 # Evidence package signing (generate with: npx tsx scripts/generate-signing-key.ts)
 EVIDENCE_SIGNING_KEY=      # Base64-encoded Ed25519 private key (PKCS8 DER)
-EVIDENCE_PUBLIC_KEY=       # Base64-encoded Ed25519 public key (SPKI DER) — for reference only
+EVIDENCE_KEY_ID=           # kid of the active signing key — must match the trust registry (unset = demo kid)
+EVIDENCE_PUBLIC_KEY=       # Public half (SPKI DER). NOT read by the app — operator reference for trust-registry updates
+
+# Instance identity (ADR-0020) — all optional; unset, the app runs as the demo
+# instance (civicaitools.org). A self-hosted instance sets EVIDENCE_SITE_ORIGIN
+# plus the signer set, and every derived surface follows. Full walkthrough:
+# docs/instance-setup.md. Keep unused lines commented rather than empty — for
+# EVIDENCE_TRUST_REGISTRY_LEGACY_URL an explicit empty string is meaningful
+# (it omits the legacy field from sidecars).
+# EVIDENCE_SITE_ORIGIN=https://your-instance.example.org
+# EVIDENCE_SIGNER_BINDING_TIER=platform
+# EVIDENCE_SIGNER_IDENTIFIER=        # must match the trust-registry entry
+# EVIDENCE_SIGNER_DISPLAY_NAME=      # must match the trust-registry entry
+# EVIDENCE_PUBLICATION_HOST=         # host label on publishes-attestations + notebook "Generated via" lines
+# EVIDENCE_TRUST_REGISTRY_CANONICAL_URL=   # only if the registry is hosted off-origin
+# EVIDENCE_TRUST_REGISTRY_LEGACY_URL=      # empty string omits the sidecar legacy field
+# EVIDENCE_PLATFORM_AGENT_ID=
+# EVIDENCE_PLATFORM_AGENT_TITLE=
+# EVIDENCE_PLATFORM_AGENT_URL=       # defaults to EVIDENCE_SITE_ORIGIN when set
+# EVIDENCE_TRUST_REGISTRY_URL=       # verify-side external trust-registry override
+
+# Cron endpoint auth (blob-gc, portal refresh)
+# CRON_SECRET=
 
 # Google Analytics (set in production only — omit locally)
 # NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 
-# Vercel KV (auto-populated if using Vercel KV)
+# Vercel KV (auto-populated if using Vercel KV; the REST URL/token pair powers the durable rate-limit counter)
 KV_URL=
 KV_REST_API_URL=
 KV_REST_API_TOKEN=


### PR DESCRIPTION
S3a follow-up (post-sprint queue item 1 on #166): mirror the instance-identity env contract into the template so a deployer sees the full set without opening the docs.

## What changed

- **Added the ten ADR-0020 instance-identity vars** as a commented block (`EVIDENCE_SITE_ORIGIN` … `EVIDENCE_PLATFORM_AGENT_URL`), pointing at `docs/instance-setup.md`. Commented rather than `VAR=` on purpose: for `EVIDENCE_TRUST_REGISTRY_LEGACY_URL` an explicit empty string is meaningful (omits the sidecar legacy field), so the template must not ship empty assignments for this block.
- **Added `EVIDENCE_KEY_ID`** (required-with-fallback; was missing entirely).
- **Annotated `EVIDENCE_PUBLIC_KEY`** instead of dropping it: nothing in `src/` reads it, but `scripts/generate-signing-key.ts` prints it and the key-rotation runbook uses it for trust-registry updates — so it stays as an operator-reference line marked "NOT read by the app".
- **Completed the optional tail against `scripts/preflight-env.mjs`** (the authoritative inventory): commented `NEXT_PUBLIC_SOCRATA_MCP_URL`, `EVIDENCE_TRUST_REGISTRY_URL`, `CRON_SECRET`.
- Emptied the OpenRouter placeholder value and noted the KV REST pair's rate-limit role.

## Verification

- Var set cross-checked against `scripts/preflight-env.mjs` and the table in `docs/instance-setup.md` (10 identity vars, lines 113–122).
- Placeholders only — no literal values anywhere in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
