### PR TITLE
S3b P2: cheap seams — model-client factory, DB dual-driver, generic OIDC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # OpenRouter
 OPENROUTER_API_KEY=
+# Chat-completions endpoint override — any OpenAI-compatible endpoint
+# (unset = OpenRouter: https://openrouter.ai/api/v1)
+# MODEL_API_BASE_URL=
 
 # socrata-mcp-server
 SOCRATA_MCP_URL=https://socrata-mcp.civicaitools.org
@@ -20,8 +23,18 @@ GITHUB_CLIENT_SECRET=
 NEXTAUTH_SECRET=       # Generate with: openssl rand -base64 32
 NEXTAUTH_URL=http://localhost:3000   # Update for production
 
+# Generic OIDC sign-in (optional) — any OIDC provider with standard discovery
+# (/.well-known/openid-configuration). Active only when ISSUER + CLIENT_ID +
+# CLIENT_SECRET are all set; unset, sign-in is GitHub only.
+# OIDC_ISSUER=https://your-idp.example.org
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_PROVIDER_NAME=      # sign-in button label (default "SSO")
+
 # Neon PostgreSQL (evidence system)
 DATABASE_URL=              # postgres://user:pass@host/dbname?sslmode=require
+# DB driver: neon-http (default) or node-postgres (any Postgres over TCP)
+# DB_DRIVER=
 
 # Vercel Blob (evidence package storage)
 BLOB_READ_WRITE_TOKEN=     # From Vercel Blob store settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "next": "16.2.7",
         "next-auth": "^4.24.13",
         "openai": "^6.16.0",
+        "pg": "^8.22.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -32,6 +33,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/pg": "^8.20.3",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "drizzle-kit": "^0.31.10",
@@ -2618,9 +2620,9 @@
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "version": "8.20.3",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.3.tgz",
+      "integrity": "sha512-4Tvg+HO6+oQaAkpT8GTYoSExzpGGZz532GXgbbCElWJQeQdMozBWxEKNBhJJpHFjWXsMxqPbyypvj/89FWNoSQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -8182,6 +8184,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -8191,10 +8233,19 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -8211,6 +8262,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -8975,6 +9035,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next": "16.2.7",
     "next-auth": "^4.24.13",
     "openai": "^6.16.0",
+    "pg": "^8.22.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pg": "^8.20.3",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "drizzle-kit": "^0.31.10",

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -41,10 +41,12 @@ import { fileURLToPath } from 'node:url';
 export const ENV_SPEC = [
   // --- Core query path (every demo query depends on these) ---
   { name: 'OPENROUTER_API_KEY', tier: 'required', purpose: 'LLM access — every query (no fallback)' },
+  { name: 'MODEL_API_BASE_URL', tier: 'optional', purpose: 'Chat-completions endpoint override — any OpenAI-compatible endpoint (default: OpenRouter)', hasFallback: true },
   { name: 'SOCRATA_MCP_URL', tier: 'required', purpose: 'Socrata MCP endpoint (the demo data source)', hasFallback: true },
 
   // --- Evidence publish + verify (the demo centerpiece: publish → badge) ---
   { name: 'DATABASE_URL', tier: 'required', purpose: 'Evidence DB — publish + dashboard + detail page' },
+  { name: 'DB_DRIVER', tier: 'optional', purpose: "DB driver — 'neon-http' (default) or 'node-postgres' (any Postgres over TCP)", hasFallback: true },
   { name: 'BLOB_READ_WRITE_TOKEN', tier: 'required', purpose: 'Evidence package storage (Vercel Blob)' },
   { name: 'EVIDENCE_SIGNING_KEY', tier: 'required', purpose: 'Ed25519 private key — signs evidence packages' },
   { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry', hasFallback: true }, // signing.ts: `EVIDENCE_KEY_ID || DEFAULT_KEY_ID`; the default mirrors the registry's active kid
@@ -54,6 +56,12 @@ export const ENV_SPEC = [
   { name: 'NEXTAUTH_URL', tier: 'required', purpose: 'OAuth callback base URL (must match the deploy origin)' },
   { name: 'GITHUB_CLIENT_ID', tier: 'required', purpose: 'GitHub sign-in (raises the per-user rate limit)' },
   { name: 'GITHUB_CLIENT_SECRET', tier: 'required', purpose: 'GitHub sign-in (raises the per-user rate limit)' },
+  // Generic OIDC sign-in (optional — active only when ISSUER + CLIENT_ID +
+  // CLIENT_SECRET are all present; unset, sign-in is GitHub only).
+  { name: 'OIDC_ISSUER', tier: 'optional', purpose: 'Generic OIDC sign-in — issuer URL (discovery-based)' },
+  { name: 'OIDC_CLIENT_ID', tier: 'optional', purpose: 'Generic OIDC sign-in — client id' },
+  { name: 'OIDC_CLIENT_SECRET', tier: 'optional', purpose: 'Generic OIDC sign-in — client secret' },
+  { name: 'OIDC_PROVIDER_NAME', tier: 'optional', purpose: 'OIDC sign-in button label (default "SSO")', hasFallback: true },
 
   // --- Rate limiting (durable counter; without it, falls back to per-instance memory) ---
   { name: 'KV_REST_API_URL', tier: 'required', purpose: 'Durable rate-limit counter (Upstash/Vercel KV)' },

--- a/src/app/api/evidence/[slug]/evaluate/route.ts
+++ b/src/app/api/evidence/[slug]/evaluate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
+import { createModelClient } from '@/lib/model-client';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
@@ -78,10 +78,7 @@ export async function POST(
     );
   }
 
-  const openrouter = new OpenAI({
-    baseURL: 'https://openrouter.ai/api/v1',
-    apiKey: openRouterApiKey,
-  });
+  const openrouter = createModelClient({ apiKey: openRouterApiKey });
 
   try {
     const evaluationContent = buildEvaluationPrompt(pkg);

--- a/src/app/api/evidence/[slug]/replay/route.ts
+++ b/src/app/api/evidence/[slug]/replay/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
+import { createModelClient } from '@/lib/model-client';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
@@ -101,11 +101,8 @@ export async function POST(
   // Build system prompt (regenerated fresh — may differ slightly if guidance updated)
   const systemPrompt = await buildSystemPrompt(portal);
 
-  // Create OpenRouter client with user's API key
-  const openrouter = new OpenAI({
-    baseURL: 'https://openrouter.ai/api/v1',
-    apiKey: openRouterApiKey,
-  });
+  // Create a model client with the user's API key
+  const openrouter = createModelClient({ apiKey: openRouterApiKey });
 
   const startTime = Date.now();
   const toolsCalled: { name: string; args: Record<string, unknown> }[] = [];

--- a/src/app/api/evidence/generate-summary/route.ts
+++ b/src/app/api/evidence/generate-summary/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
+import { createModelClient } from '@/lib/model-client';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 
@@ -65,10 +65,7 @@ Analysis output:
 ${output.slice(0, 4000)}`;
 
   try {
-    const openrouter = new OpenAI({
-      baseURL: 'https://openrouter.ai/api/v1',
-      apiKey: process.env.OPENROUTER_API_KEY,
-    });
+    const openrouter = createModelClient();
 
     const response = await openrouter.chat.completions.create({
       model: SUMMARY_MODEL,

--- a/src/lib/auth-providers.test.ts
+++ b/src/lib/auth-providers.test.ts
@@ -1,0 +1,113 @@
+// Provider-list tests (S3b P2 seam 3: generic-OIDC auth provider).
+//
+// buildProviders(env) is a pure function of the env it is handed, so these
+// tests pass explicit env objects — no process.env mutation needed.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildProviders,
+  normalizeIssuer,
+  oidcAccountKey,
+  OIDC_PROVIDER_ID,
+} from './auth-providers.ts';
+
+const OIDC_ENV = {
+  OIDC_ISSUER: 'https://issuer.example.org',
+  OIDC_CLIENT_ID: 'example-client-id',
+  OIDC_CLIENT_SECRET: 'example-client-secret',
+};
+
+test('provider list without OIDC env is GitHub only (demo default)', () => {
+  const providers = buildProviders({});
+  assert.equal(providers.length, 1);
+  assert.equal(providers[0].id, 'github');
+});
+
+test('GitHub env alone does not add the OIDC provider', () => {
+  const providers = buildProviders({
+    GITHUB_CLIENT_ID: 'example-github-id',
+    GITHUB_CLIENT_SECRET: 'example-github-secret',
+  });
+  assert.equal(providers.length, 1);
+  assert.equal(providers[0].id, 'github');
+});
+
+test('partial OIDC env (any of the three missing) stays GitHub only', () => {
+  const partials = [
+    { OIDC_ISSUER: OIDC_ENV.OIDC_ISSUER },
+    { OIDC_ISSUER: OIDC_ENV.OIDC_ISSUER, OIDC_CLIENT_ID: OIDC_ENV.OIDC_CLIENT_ID },
+    { OIDC_CLIENT_ID: OIDC_ENV.OIDC_CLIENT_ID, OIDC_CLIENT_SECRET: OIDC_ENV.OIDC_CLIENT_SECRET },
+  ];
+  for (const env of partials) {
+    const providers = buildProviders(env);
+    assert.equal(providers.length, 1, `expected GitHub only for ${JSON.stringify(Object.keys(env))}`);
+    assert.equal(providers[0].id, 'github');
+  }
+});
+
+test('full OIDC trio adds the OIDC provider with issuer-driven config', () => {
+  const providers = buildProviders(OIDC_ENV);
+  assert.equal(providers.length, 2);
+  assert.equal(providers[0].id, 'github');
+
+  const oidc = providers[1] as unknown as Record<string, unknown>;
+  assert.equal(oidc.id, OIDC_PROVIDER_ID);
+  assert.equal(oidc.type, 'oauth');
+  assert.equal(oidc.issuer, 'https://issuer.example.org');
+  assert.equal(oidc.wellKnown, 'https://issuer.example.org/.well-known/openid-configuration');
+  assert.equal(oidc.clientId, 'example-client-id');
+  assert.equal(oidc.clientSecret, 'example-client-secret');
+  // Discovery-based config: no hardcoded endpoint URLs.
+  assert.equal(oidc.name, 'SSO');
+});
+
+test('OIDC_PROVIDER_NAME sets the button label; trailing issuer slash is normalized', () => {
+  const providers = buildProviders({
+    ...OIDC_ENV,
+    OIDC_ISSUER: 'https://issuer.example.org/',
+    OIDC_PROVIDER_NAME: 'Example SSO',
+  });
+  const oidc = providers[1] as unknown as Record<string, unknown>;
+  assert.equal(oidc.name, 'Example SSO');
+  assert.equal(oidc.issuer, 'https://issuer.example.org');
+  assert.equal(oidc.wellKnown, 'https://issuer.example.org/.well-known/openid-configuration');
+});
+
+test('OIDC profile mapper follows standard claims with fallbacks', () => {
+  const providers = buildProviders(OIDC_ENV);
+  const oidc = providers[1] as unknown as {
+    profile: (p: Record<string, unknown>) => { id: string; name: unknown; email: unknown; image: unknown };
+  };
+
+  const full = oidc.profile({
+    sub: 'subject-1',
+    name: 'Full Name',
+    preferred_username: 'preferred',
+    email: 'user@example.org',
+    picture: 'https://issuer.example.org/avatar.png',
+  });
+  assert.deepEqual(full, {
+    id: 'subject-1',
+    name: 'Full Name',
+    email: 'user@example.org',
+    image: 'https://issuer.example.org/avatar.png',
+  });
+
+  const minimal = oidc.profile({ sub: 'subject-2' });
+  assert.deepEqual(minimal, { id: 'subject-2', name: 'subject-2', email: null, image: null });
+});
+
+test('oidcAccountKey is an issuer+subject composite that cannot collide with numeric ids', () => {
+  const key = oidcAccountKey('subject-1', 'https://issuer.example.org/');
+  assert.equal(key, 'oidc:https://issuer.example.org:subject-1');
+  assert.ok(!/^\d+$/.test(key));
+});
+
+test('normalizeIssuer strips only trailing slashes', () => {
+  assert.equal(normalizeIssuer('https://issuer.example.org//'), 'https://issuer.example.org');
+  assert.equal(normalizeIssuer('https://issuer.example.org/realms/a'), 'https://issuer.example.org/realms/a');
+});

--- a/src/lib/auth-providers.ts
+++ b/src/lib/auth-providers.ts
@@ -1,0 +1,102 @@
+// Auth provider construction — extracted from auth.ts so the provider list
+// is a pure function of the environment (and unit-testable without NextAuth
+// runtime wiring).
+//
+// Two providers:
+//   - GitHub: always present (the demo deployment's provider, unchanged).
+//   - Generic OIDC: present ONLY when OIDC_ISSUER, OIDC_CLIENT_ID, and
+//     OIDC_CLIENT_SECRET are all set. Any OIDC provider that supports
+//     standard discovery (/.well-known/openid-configuration) works; the
+//     optional OIDC_PROVIDER_NAME sets the sign-in button label.
+//
+// With none of the OIDC vars set, the provider list is exactly the
+// pre-existing GitHub-only list.
+
+import GithubProviderImport from 'next-auth/providers/github';
+import type { Provider } from 'next-auth/providers/index';
+import type { OAuthConfig } from 'next-auth/providers/oauth';
+
+// CJS/ESM interop: next-auth v4 providers are CJS with `exports.default`.
+// Bundlers resolve the default import to the function; plain Node (the unit
+// test runner) resolves it to the exports object with the function at
+// `.default`. Normalize so both paths get the function.
+type GithubProviderFn = typeof GithubProviderImport;
+const GithubProvider: GithubProviderFn =
+  (GithubProviderImport as unknown as { default?: GithubProviderFn }).default ?? GithubProviderImport;
+
+/** Provider id for the generic OIDC provider (route segment + account.provider). */
+export const OIDC_PROVIDER_ID = 'oidc';
+
+/** Minimal OIDC standard-claims shape used by the profile mapper. */
+export interface OidcProfile {
+  sub: string;
+  name?: string;
+  preferred_username?: string;
+  email?: string;
+  picture?: string;
+}
+
+/** The env vars the provider list depends on. */
+export interface AuthProviderEnv {
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
+  OIDC_ISSUER?: string;
+  OIDC_CLIENT_ID?: string;
+  OIDC_CLIENT_SECRET?: string;
+  OIDC_PROVIDER_NAME?: string;
+}
+
+/** Strip trailing slashes so issuer-derived URLs and keys are stable. */
+export function normalizeIssuer(issuer: string): string {
+  return issuer.replace(/\/+$/, '');
+}
+
+/**
+ * Stable per-user account key for OIDC sign-ins: issuer + subject composite.
+ * Stored in the users table's provider-account key column (`githubId`);
+ * the `oidc:` prefix guarantees no collision with numeric GitHub ids.
+ */
+export function oidcAccountKey(subject: string, issuer: string = process.env.OIDC_ISSUER || ''): string {
+  return `${OIDC_PROVIDER_ID}:${normalizeIssuer(issuer)}:${subject}`;
+}
+
+/**
+ * Build the NextAuth provider list from the environment. Pure: given the same
+ * env, returns the same list. Defaults to process.env.
+ */
+export function buildProviders(env: AuthProviderEnv | NodeJS.ProcessEnv = process.env): Provider[] {
+  const providers: Provider[] = [
+    GithubProvider({
+      clientId: env.GITHUB_CLIENT_ID || '',
+      clientSecret: env.GITHUB_CLIENT_SECRET || '',
+    }),
+  ];
+
+  if (env.OIDC_ISSUER && env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
+    const issuer = normalizeIssuer(env.OIDC_ISSUER);
+    const oidc: OAuthConfig<OidcProfile> = {
+      id: OIDC_PROVIDER_ID,
+      name: env.OIDC_PROVIDER_NAME || 'SSO',
+      type: 'oauth',
+      // Standard OIDC discovery off the issuer.
+      wellKnown: `${issuer}/.well-known/openid-configuration`,
+      issuer,
+      clientId: env.OIDC_CLIENT_ID,
+      clientSecret: env.OIDC_CLIENT_SECRET,
+      authorization: { params: { scope: 'openid profile email' } },
+      idToken: true,
+      checks: ['pkce', 'state'],
+      profile(profile) {
+        return {
+          id: profile.sub,
+          name: profile.name ?? profile.preferred_username ?? profile.email ?? profile.sub,
+          email: profile.email ?? null,
+          image: profile.picture ?? null,
+        };
+      },
+    };
+    providers.push(oidc);
+  }
+
+  return providers;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,22 +1,56 @@
 import type { NextAuthOptions } from 'next-auth';
-import GithubProvider from 'next-auth/providers/github';
+import { buildProviders, normalizeIssuer, oidcAccountKey, OIDC_PROVIDER_ID } from './auth-providers';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 
+/**
+ * Upsert a user row keyed by its provider-account key (the `githubId`
+ * column: GitHub numeric id for GitHub sign-ins, `oidc:{issuer}:{sub}`
+ * composite for OIDC sign-ins — the prefix cannot collide with numeric ids).
+ */
+async function upsertUser(accountKey: string, displayName: string, profileUrl: string) {
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.githubId, accountKey))
+    .limit(1);
+
+  if (existing.length === 0) {
+    await db.insert(users).values({
+      githubId: accountKey,
+      displayName,
+      githubProfileUrl: profileUrl,
+    });
+  } else {
+    // Update display name and profile URL in case they changed upstream
+    await db
+      .update(users)
+      .set({ displayName, githubProfileUrl: profileUrl })
+      .where(eq(users.githubId, accountKey));
+  }
+}
+
 export const authOptions: NextAuthOptions = {
-  providers: [
-    GithubProvider({
-      clientId: process.env.GITHUB_CLIENT_ID || '',
-      clientSecret: process.env.GITHUB_CLIENT_SECRET || '',
-    }),
-  ],
+  providers: buildProviders(),
   callbacks: {
-    async signIn({ user, profile }) {
+    async signIn({ user, account, profile }) {
       // Upsert user record in the database on every login.
       // Skip if DATABASE_URL is not configured (preserves existing behavior in dev).
       if (!process.env.DATABASE_URL) return true;
 
+      if (account?.provider === OIDC_PROVIDER_ID) {
+        // Generic OIDC sign-in: key by issuer + subject.
+        const subject = account.providerAccountId || user.id;
+        if (!subject) return true;
+        const displayName = user.name || user.email || 'Unknown';
+        // No provider-agnostic profile page exists; record the issuer origin.
+        const profileUrl = normalizeIssuer(process.env.OIDC_ISSUER || '');
+        await upsertUser(oidcAccountKey(subject), displayName, profileUrl);
+        return true;
+      }
+
+      // GitHub sign-in (the pre-existing path)
       const githubId = user.id;
       if (!githubId) return true;
 
@@ -24,25 +58,7 @@ export const authOptions: NextAuthOptions = {
       const displayName = user.name || ghProfile?.login || 'Unknown';
       const profileUrl = ghProfile?.html_url || `https://github.com/${ghProfile?.login || ''}`;
 
-      const existing = await db
-        .select()
-        .from(users)
-        .where(eq(users.githubId, githubId))
-        .limit(1);
-
-      if (existing.length === 0) {
-        await db.insert(users).values({
-          githubId,
-          displayName,
-          githubProfileUrl: profileUrl,
-        });
-      } else {
-        // Update display name and profile URL in case they changed on GitHub
-        await db
-          .update(users)
-          .set({ displayName, githubProfileUrl: profileUrl })
-          .where(eq(users.githubId, githubId));
-      }
+      await upsertUser(githubId, displayName, profileUrl);
 
       return true;
     },
@@ -63,12 +79,17 @@ export const authOptions: NextAuthOptions = {
         token.accessToken = account.access_token;
       }
 
-      // Look up the internal DB user ID on initial sign-in
+      // Look up the internal DB user ID on initial sign-in, by the same
+      // provider-account key the signIn upsert wrote.
       if (user?.id && process.env.DATABASE_URL) {
+        const accountKey =
+          account?.provider === OIDC_PROVIDER_ID
+            ? oidcAccountKey(account.providerAccountId || user.id)
+            : user.id;
         const dbUser = await db
           .select({ id: users.id })
           .from(users)
-          .where(eq(users.githubId, user.id))
+          .where(eq(users.githubId, accountKey))
           .limit(1);
         if (dbUser.length > 0) {
           token.dbUserId = dbUser[0].id;

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,19 +1,45 @@
 import { neon, type NeonQueryFunction } from '@neondatabase/serverless';
 import { drizzle, type NeonHttpDatabase } from 'drizzle-orm/neon-http';
+import { drizzle as drizzleNodePostgres } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
 import * as schema from './schema';
 
 let _db: NeonHttpDatabase<typeof schema> | null = null;
 
+/**
+ * Driver selection (DB_DRIVER env var):
+ *   - 'neon-http' (default): Neon serverless HTTP driver — the demo
+ *     deployment's behavior, unchanged when the var is unset.
+ *   - 'node-postgres': TCP via `pg` — works against any Postgres.
+ *
+ * Both drivers expose the same Drizzle query surface over the same schema, so
+ * the handle is typed once (as the default driver's type) and the 28 importers
+ * are driver-agnostic.
+ */
+function createDb(): NeonHttpDatabase<typeof schema> {
+  const driver = process.env.DB_DRIVER || 'neon-http';
+  if (driver === 'node-postgres') {
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    // Same Drizzle query-builder surface; cast keeps the exported handle's
+    // type (and every importer) identical across drivers.
+    return drizzleNodePostgres(pool, { schema }) as unknown as NeonHttpDatabase<typeof schema>;
+  }
+  if (driver !== 'neon-http') {
+    throw new Error(`Unsupported DB_DRIVER "${driver}" (expected "neon-http" or "node-postgres")`);
+  }
+  const sql: NeonQueryFunction<false, false> = neon(process.env.DATABASE_URL!);
+  return drizzle(sql, { schema });
+}
+
 function getDb(): NeonHttpDatabase<typeof schema> {
   if (!_db) {
-    const sql: NeonQueryFunction<false, false> = neon(process.env.DATABASE_URL!);
-    _db = drizzle(sql, { schema });
+    _db = createDb();
   }
   return _db;
 }
 
 /**
- * Lazily initialized Drizzle client for Neon PostgreSQL.
+ * Lazily initialized Drizzle client for PostgreSQL.
  * Only connects when first accessed — safe to import at module level
  * even when DATABASE_URL is not set (e.g., during Next.js build).
  */

--- a/src/lib/evidence/adversarial-eval.ts
+++ b/src/lib/evidence/adversarial-eval.ts
@@ -19,7 +19,7 @@
 // prompt-set version (SHA-256 of the rubric text, pinning the exact prompts),
 // evaluator model, scoring rubric identifier.
 
-import OpenAI from 'openai';
+import { createModelClient } from '@/lib/model-client';
 import { db } from '@/lib/db';
 import { attestationNodes } from '@/lib/db/schema';
 import { and, eq } from 'drizzle-orm';
@@ -60,10 +60,7 @@ export async function runAdversarialEval(
   pkg: EvidencePackage,
   opts: { apiKey: string; evaluatorModel: string },
 ): Promise<ParsedEvaluation> {
-  const openrouter = new OpenAI({
-    baseURL: 'https://openrouter.ai/api/v1',
-    apiKey: opts.apiKey,
-  });
+  const openrouter = createModelClient({ apiKey: opts.apiKey });
   const response = await openrouter.chat.completions.create({
     model: opts.evaluatorModel,
     messages: [

--- a/src/lib/model-client.ts
+++ b/src/lib/model-client.ts
@@ -1,0 +1,47 @@
+import OpenAI from 'openai';
+
+/**
+ * Model-client factory — the single place the chat-completions endpoint is
+ * configured. The app speaks the OpenAI-compatible API, so any
+ * OpenAI-compatible endpoint works: set MODEL_API_BASE_URL to point at it.
+ * Unset, the default below preserves the demo deployment's behavior
+ * (OpenRouter). The API key stays OPENROUTER_API_KEY in either case unless a
+ * per-call key is passed in (e.g. a user-supplied key on the replay/evaluate
+ * routes).
+ *
+ * Construction is lazy on purpose: no client is built at import time, so
+ * importing a module that uses the factory never requires the key to be
+ * present (e.g. during `next build`).
+ */
+
+const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
+
+/** Resolved chat-completions base URL (env override or the default above). */
+export function getModelApiBaseUrl(): string {
+  return process.env.MODEL_API_BASE_URL || DEFAULT_BASE_URL;
+}
+
+/**
+ * Build a new client against the configured endpoint. Pass `apiKey` to use a
+ * caller-supplied key; omitted, the key comes from OPENROUTER_API_KEY.
+ */
+export function createModelClient(opts: { apiKey?: string } = {}): OpenAI {
+  return new OpenAI({
+    baseURL: getModelApiBaseUrl(),
+    apiKey: opts.apiKey ?? process.env.OPENROUTER_API_KEY,
+  });
+}
+
+let defaultClient: OpenAI | null = null;
+
+/**
+ * Shared lazily-constructed client using the environment's key — the
+ * equivalent of the former module-level singletons, built on first use
+ * instead of at import.
+ */
+export function getModelClient(): OpenAI {
+  if (!defaultClient) {
+    defaultClient = createModelClient();
+  }
+  return defaultClient;
+}

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -1,5 +1,5 @@
-import OpenAI from 'openai';
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
+import { getModelClient } from './model-client';
 import { formatToolProgress, formatToolResult, generateToolReason, describeToolFailureForLlm, type PanelType, type ProgressPhase } from './streaming';
 import type { TraceBuilder } from './evidence/trace';
 import { hash as traceHash } from './evidence/trace';
@@ -16,11 +16,6 @@ export interface TraceContext {
    */
   resolveToolSource?: (toolName: string) => string | undefined;
 }
-
-const openrouter = new OpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: process.env.OPENROUTER_API_KEY,
-});
 
 export interface ProgressOpts {
   duration_ms?: number;
@@ -98,7 +93,7 @@ export async function queryWithoutMcpStreaming(
     }
     messages.push({ role: 'user', content: query });
 
-    const stream = await openrouter.chat.completions.create({
+    const stream = await getModelClient().chat.completions.create({
       model,
       messages,
       max_tokens: 4000,
@@ -161,7 +156,7 @@ export async function queryWithMcpStreaming(
       ...(trace.systemPromptHash ? { 'gen_ai.system_prompt_hash': trace.systemPromptHash } : {}),
       'gen_ai.inference_index': 0,
     });
-    let response = await openrouter.chat.completions.create({
+    let response = await getModelClient().chat.completions.create({
       model,
       messages,
       tools,
@@ -299,7 +294,7 @@ export async function queryWithMcpStreaming(
         'gen_ai.request.model': model,
         'gen_ai.inference_index': currentIteration,
       });
-      response = await openrouter.chat.completions.create({
+      response = await getModelClient().chat.completions.create({
         model,
         messages,
         tools,
@@ -346,7 +341,7 @@ export async function queryWithMcpStreaming(
       }
 
       // Make final streaming call without tools
-      const finalStream = await openrouter.chat.completions.create({
+      const finalStream = await getModelClient().chat.completions.create({
         model,
         messages: [
           ...messages,
@@ -440,7 +435,7 @@ export async function queryWithMcpStreaming(
       // No content - make a final streaming call
       callbacks.onProgress(panel, 'Synthesizing findings into response...', { phase: 'synthesize' });
 
-      const finalStream = await openrouter.chat.completions.create({
+      const finalStream = await getModelClient().chat.completions.create({
         model,
         messages,
         max_tokens: 4000,

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -1,10 +1,5 @@
-import OpenAI from 'openai';
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
-
-const openrouter = new OpenAI({
-  baseURL: 'https://openrouter.ai/api/v1',
-  apiKey: process.env.OPENROUTER_API_KEY,
-});
+import { getModelClient } from './model-client';
 
 export interface CompletionResult {
   content: string;
@@ -30,7 +25,7 @@ export async function queryWithoutMcp(
   }
   messages.push({ role: 'user', content: query });
 
-  const response = await openrouter.chat.completions.create({
+  const response = await getModelClient().chat.completions.create({
     model,
     messages,
     max_tokens: 2000,
@@ -64,7 +59,7 @@ export async function queryWithMcp(
   }
   messages.push({ role: 'user', content: query });
 
-  let response = await openrouter.chat.completions.create({
+  let response = await getModelClient().chat.completions.create({
     model,
     messages,
     tools,
@@ -107,7 +102,7 @@ export async function queryWithMcp(
     }
 
     // Get next response
-    response = await openrouter.chat.completions.create({
+    response = await getModelClient().chat.completions.create({
       model,
       messages,
       tools,
@@ -136,7 +131,7 @@ export async function queryWithMcp(
     }
 
     // Make final call without tools to force a text response
-    response = await openrouter.chat.completions.create({
+    response = await getModelClient().chat.completions.create({
       model,
       messages: [
         ...messages,
@@ -161,5 +156,3 @@ export async function queryWithMcp(
     tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
   };
 }
-
-export { openrouter };


### PR DESCRIPTION
Phase P2 of the S3b-core sprint (#171). Three portability seams as general interfaces; demo behavior unchanged when no new env var is set.

## What changed
- **Model endpoint:** new `src/lib/model-client.ts` factory — base URL from `MODEL_API_BASE_URL` (default OpenRouter), key stays `OPENROUTER_API_KEY`, per-call key passthrough. All six hardcoded `new OpenAI(...)` sites collapsed onto it; `grep -rn 'openrouter.ai' src/` now hits only the factory's default constant. Construction is lazy — the pre-existing `next build`-needs-a-key pain point (eager init) is dissolved.
- **Database:** driver choice inside `src/lib/db/index.ts` behind the existing lazy proxy — `DB_DRIVER=neon-http` (default, byte-identical construction) or `node-postgres` (`pg` + `drizzle-orm/node-postgres`); unknown values throw. All 28 `db`-handle importers untouched. No schema or migration changes.
- **Auth:** provider list extracted to a pure, tested `buildProviders(env)` — GitHub always (unchanged); a discovery-based generic-OIDC provider appears only when `OIDC_ISSUER`/`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET` are all set. Sign-in upsert keyed `oidc:{issuer}:{sub}` (collision-free with numeric GitHub ids); JWT lookup uses the same key. No invite gating.
- **Riders:** `.env.example` + `scripts/preflight-env.mjs` gain the six optional vars per existing conventions.

## Evidence
- Tests: 369 pass / 0 fail (361 baseline + 8 new provider-list tests) — verified independently by ORCH on the branch.
- Lint: the 4 known pre-existing warnings, 0 errors, no new. Build: green.
- node-postgres proof: `drizzle-kit migrate` + CRUD smoke (insert/select/delete via the app's `db` handle) against a disposable local `postgres:16` container under `DB_DRIVER=node-postgres` — passed; container removed after.
- Base-URL override verified end-to-end (`MODEL_API_BASE_URL` flows to `client.baseURL`).
- Diff: 15 files, +459/−82 (new lib modules + tests + lockfile for `pg`).

IMPL model: claude-fable-5 (per phase plan). Merging deploys production; `rollback/pre-s3b-p2` is tagged at `a6fa336`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)