### PR TITLE
S3b P4: notebook-executor driver seam — vercel-sandbox (default) + container runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,21 @@ BLOB_READ_WRITE_TOKEN=     # From Vercel Blob store settings
 # S3_FORCE_PATH_STYLE= # default: true when S3_ENDPOINT is set (MinIO), false otherwise
 # S3_PUBLIC_BASE_URL=  # public object URL base (default: <endpoint>/<bucket> path-style)
 
+# Notebook executor (executed-notebook pipeline)
+# Driver: vercel-sandbox (default) or container — the host container runtime
+# via the docker CLI, using the prebuilt image from docker/executor/Dockerfile
+# (build: docker build -t civic-notebook-executor:0.1.0 docker/executor)
+# EXECUTOR_DRIVER=
+# EXECUTOR_CONTAINER_IMAGE=  # default civic-notebook-executor:0.1.0 (container driver only)
+# Prebuilt Vercel Sandbox snapshot (npm run sandbox:build-snapshot); unset,
+# the vercel-sandbox driver falls back to a slow fresh boot + pip install
+# SANDBOX_SNAPSHOT_ID=
+# Vercel Sandbox auth for off-platform runs (on Vercel deploys auth is
+# OIDC-automatic; off-platform, set this token/team/project triple)
+# VERCEL_TOKEN=
+# VERCEL_TEAM_ID=
+# VERCEL_PROJECT_ID=
+
 # Evidence package signing (generate with: npx tsx scripts/generate-signing-key.ts)
 EVIDENCE_SIGNING_KEY=      # Base64-encoded Ed25519 private key (PKCS8 DER)
 EVIDENCE_KEY_ID=           # kid of the active signing key — must match the trust registry (unset = demo kid)

--- a/docker/executor/Dockerfile
+++ b/docker/executor/Dockerfile
@@ -1,0 +1,31 @@
+# Executor image for the `container` notebook-executor driver (S3b P4;
+# src/lib/sandbox/container.ts). The container-runtime equivalent of the
+# Vercel Sandbox snapshot built by scripts/build-sandbox-snapshot.ts:
+# python3.13 + the pinned scientific stack + jupyter/nbconvert prebuilt, so
+# per-run cost is container start + exec only.
+#
+# Build (once, and again after any pinned-version change):
+#
+#   docker build -t civic-notebook-executor:0.1.0 docker/executor
+#
+# PINNED VERSIONS ARE SINGLE-SOURCED: the `name==version` pins below MUST
+# match src/lib/notebook-author/prompt.ts (PINNED_LIBRARIES), and the FROM
+# line's python version MUST match PYTHON_RUNTIME_VERSION.
+# src/lib/sandbox/container.test.ts asserts this file against that table, so
+# drift here fails `npm test`.
+FROM python:3.13-slim-bookworm
+
+# Same package set the sandbox snapshot installs: the pinned scientific
+# stack + the notebook tooling (EXECUTOR_TOOLING_PACKAGES in
+# src/lib/sandbox/driver.ts).
+RUN pip install --no-cache-dir --no-input \
+    pandas==2.2.3 \
+    requests==2.32.3 \
+    numpy==2.1.3 \
+    matplotlib==3.9.2 \
+    jupyter ipykernel nbformat nbconvert
+
+# Warm matplotlib's font cache at build time so the first notebook run in a
+# fresh container does not emit the "building the font cache" notice into
+# cell stderr output (which would land in the executed-notebook bytes).
+RUN python -c "import matplotlib.pyplot"

--- a/scripts/build-sandbox-snapshot.ts
+++ b/scripts/build-sandbox-snapshot.ts
@@ -25,16 +25,13 @@
  * Run:   npm run sandbox:build-snapshot
  */
 import { Sandbox } from '@vercel/sandbox';
-
-// Keep this list mirrored with src/lib/notebook-author/prompt.ts:PINNED_LIBRARIES.
-// Versions chosen so every pin has a prebuilt CPython 3.13 wheel — no
-// compiler needed in the python3.13 sandbox image.
-const PINNED_LIBRARIES: Record<string, string> = {
-  pandas: '2.2.3',
-  requests: '2.32.3',
-  numpy: '2.1.3',
-  matplotlib: '3.9.2',
-};
+// Pinned versions are single-sourced from the notebook-author table (S3b P4):
+// this script, the sandbox pip fallback, the notebook's own pip-install cell,
+// and the container executor image (docker/executor/Dockerfile, test-enforced)
+// all derive from PINNED_LIBRARIES. Versions are chosen there so every pin
+// has a prebuilt CPython 3.13 wheel — no compiler needed in the sandbox image.
+import { PINNED_LIBRARIES } from '../src/lib/notebook-author/prompt.ts';
+import { EXECUTOR_TOOLING_PACKAGES } from '../src/lib/sandbox/driver.ts';
 
 const SNAPSHOT_BUILD_TIMEOUT_MS = 600_000; // 10 minutes — pip install + freeze
 const SNAPSHOT_EXPIRATION_MS = 0;          // 0 = never expire (operator controls cadence)
@@ -51,7 +48,7 @@ async function main(): Promise<void> {
     const pipArgs = [
       'install', '--no-input',
       ...Object.entries(PINNED_LIBRARIES).map(([n, v]) => `${n}==${v}`),
-      'jupyter', 'ipykernel', 'nbformat', 'nbconvert',
+      ...EXECUTOR_TOOLING_PACKAGES,
     ];
     // The python3.13 sandbox image expects the CA bundle at the Debian
     // path `/etc/ssl/certs/ca-certificates.crt`, but Amazon Linux 2023

--- a/scripts/executor-parity.mjs
+++ b/scripts/executor-parity.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Executor-driver parity harness (S3b P4).
+ *
+ * Executes a deterministic fixture notebook (scripts/fixtures/
+ * parity-notebook.ipynb — NO network calls, fixed inputs, seeded RNG) on a
+ * named notebook-executor driver and writes a NORMALIZED ExecutionResult
+ * JSON. Two normalized results from two drivers must be identical; the
+ * `compare` mode diffs them and exits non-zero on mismatch.
+ *
+ * The normalization list below is the explicit contract for what the two
+ * runtimes "inherently differ in" — everything else in the executed
+ * notebook bytes must match. MASKED FIELDS (each replaced with "[masked]"):
+ *
+ *   1. `.sandboxId`                — runtime instance id (Vercel sandbox id
+ *                                    vs container id; unique per run).
+ *   2. `.executionDuration_ms`     — wall-clock timing (varies per run).
+ *   3. `.pythonVersion`            — PATCH component only (both runtimes pin
+ *                                    python 3.13; the patch level is the
+ *                                    image's, e.g. "3.13.5" → "3.13.[masked]").
+ *   4. `.notebook.metadata.language_info.version`
+ *                                  — same patch-level normalization; nbformat
+ *                                    records the kernel's full version.
+ *   5. every `cell.metadata.execution`
+ *                                  — nbclient per-cell execution-timing
+ *                                    metadata (ISO timestamps of the
+ *                                    execute_request/reply messages).
+ *
+ * Nothing else is masked. Cell sources, stream outputs, execution_count,
+ * rich outputs (including the matplotlib PNG bytes — same pinned wheel,
+ * Agg backend, version chunk stripped in-fixture), and the pinned-library
+ * table must be byte-identical across drivers.
+ *
+ * Usage (container leg — needs a running container runtime + built image;
+ * see docker/executor/Dockerfile):
+ *
+ *   node --experimental-strip-types scripts/executor-parity.mjs run \
+ *     --driver container --out parity-container.json
+ *
+ * Usage (vercel-sandbox leg — needs Vercel Sandbox auth; run through the
+ * 1Password wrapper so the op:// references resolve; ONE command):
+ *
+ *   op run --env-file=.env.local -- node --experimental-strip-types \
+ *     scripts/executor-parity.mjs run --driver vercel-sandbox --out parity-vercel.json
+ *
+ * Compare (exit 0 = parity, exit 1 = mismatch, differences listed):
+ *
+ *   node --experimental-strip-types scripts/executor-parity.mjs compare \
+ *     parity-container.json parity-vercel.json
+ *
+ * Driver error-path and timeout proofs (container leg):
+ *
+ *   node --experimental-strip-types scripts/executor-parity.mjs run \
+ *     --driver container --fixture scripts/fixtures/error-notebook.ipynb --expect error
+ *   node --experimental-strip-types scripts/executor-parity.mjs run \
+ *     --driver container --fixture scripts/fixtures/timeout-notebook.ipynb \
+ *     --timeout-ms 20000 --expect timeout
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const DEFAULT_FIXTURE = 'scripts/fixtures/parity-notebook.ipynb';
+const MASKED = '[masked]';
+const DRIVERS = ['vercel-sandbox', 'container'];
+
+function usage(message) {
+  if (message) console.error(`error: ${message}\n`);
+  console.error(
+    [
+      'usage:',
+      '  executor-parity.mjs run --driver <vercel-sandbox|container> [--fixture <path>]',
+      '                          [--out <path>] [--timeout-ms <n>] [--expect <success|error|timeout>]',
+      '  executor-parity.mjs compare <a.json> <b.json>',
+      '',
+      'vercel-sandbox leg (auth via 1Password wrapper), one command:',
+      '  op run --env-file=.env.local -- node --experimental-strip-types \\',
+      '    scripts/executor-parity.mjs run --driver vercel-sandbox --out parity-vercel.json',
+    ].join('\n'),
+  );
+  process.exit(2);
+}
+
+/** Mask the patch component of a "major.minor.patch[...]" version string. */
+function maskPatchVersion(version) {
+  if (typeof version !== 'string') return version;
+  return version.replace(/^(\d+\.\d+)\.\S+$/, `$1.${MASKED}`);
+}
+
+/** Normalize an ExecutionResult per the masked-field contract in the header. */
+export function normalizeExecutionResult(result) {
+  const clone = structuredClone(result);
+  clone.sandboxId = MASKED; // (1) runtime instance id
+  clone.executionDuration_ms = MASKED; // (2) wall-clock timing
+  clone.pythonVersion = maskPatchVersion(clone.pythonVersion); // (3)
+  const nb = clone.notebook;
+  if (nb?.metadata?.language_info?.version !== undefined) {
+    nb.metadata.language_info.version = maskPatchVersion(nb.metadata.language_info.version); // (4)
+  }
+  for (const cell of nb?.cells ?? []) {
+    if (cell.metadata && 'execution' in cell.metadata) {
+      cell.metadata.execution = MASKED; // (5) nbclient per-cell timing metadata
+    }
+  }
+  return clone;
+}
+
+/** Deep structural diff; returns ["path: a-side vs b-side", …]. */
+function deepDiff(a, b, at = '$', diffs = [], limit = 25) {
+  if (diffs.length >= limit) return diffs;
+  if (Object.is(a, b)) return diffs;
+  const aType = Array.isArray(a) ? 'array' : typeof a;
+  const bType = Array.isArray(b) ? 'array' : typeof b;
+  if (aType !== bType || a === null || b === null || (aType !== 'object' && aType !== 'array')) {
+    const show = (v) => {
+      const s = JSON.stringify(v);
+      return s === undefined ? String(v) : s.length > 120 ? `${s.slice(0, 117)}…` : s;
+    };
+    diffs.push(`${at}: ${show(a)} vs ${show(b)}`);
+    return diffs;
+  }
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    if (!(key in a)) diffs.push(`${at}.${key}: (absent) vs present`);
+    else if (!(key in b)) diffs.push(`${at}.${key}: present vs (absent)`);
+    else deepDiff(a[key], b[key], `${at}.${key}`, diffs, limit);
+    if (diffs.length >= limit) break;
+  }
+  return diffs;
+}
+
+async function commandRun(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      driver: { type: 'string' },
+      fixture: { type: 'string', default: DEFAULT_FIXTURE },
+      out: { type: 'string' },
+      'timeout-ms': { type: 'string' },
+      expect: { type: 'string', default: 'success' },
+    },
+  });
+  const driver = values.driver;
+  if (!driver || !DRIVERS.includes(driver)) {
+    usage(`--driver must be one of: ${DRIVERS.join(', ')}`);
+  }
+  const expect = values.expect;
+  if (!['success', 'error', 'timeout'].includes(expect)) {
+    usage('--expect must be one of: success, error, timeout');
+  }
+  if (expect === 'success' && !values.out) {
+    usage('--out is required when expecting success (the normalized JSON is the artifact)');
+  }
+  const timeoutMs = values['timeout-ms'] ? Number(values['timeout-ms']) : undefined;
+  if (values['timeout-ms'] && !Number.isFinite(timeoutMs)) usage('--timeout-ms must be a number');
+
+  // Select the driver BEFORE the seam module loads its lazy singleton.
+  process.env.EXECUTOR_DRIVER = driver;
+  const { executeNotebook, NotebookExecutionError } = await import(
+    '../src/lib/sandbox/execute.ts'
+  );
+
+  const fixturePath = path.resolve(REPO_ROOT, values.fixture);
+  const notebook = JSON.parse(await readFile(fixturePath, 'utf8'));
+  console.log(`[parity] driver=${driver} fixture=${path.relative(REPO_ROOT, fixturePath)}`);
+
+  const startedAt = Date.now();
+  let result;
+  try {
+    result = await executeNotebook(notebook, {
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+  } catch (err) {
+    const elapsed = Date.now() - startedAt;
+    if (!(err instanceof NotebookExecutionError)) throw err;
+    if (expect === 'error') {
+      console.log('[parity] EXPECTED ERROR PATH — execution failed as intended:');
+      console.log(`         name=${err.name} exitCode=${err.exitCode}`);
+      console.log(`         message=${err.message}`);
+      const tail = (err.stderr ?? '').trim().split('\n').slice(-6).join('\n         ');
+      if (tail) console.log(`         stderr tail:\n         ${tail}`);
+      return;
+    }
+    if (expect === 'timeout') {
+      const cap = timeoutMs ?? 180_000;
+      const slack = 30_000; // boot + kill latency headroom
+      if (elapsed > cap + slack) {
+        console.error(
+          `[parity] FAIL: execution errored after ${elapsed}ms, past cap ${cap}ms + slack`,
+        );
+        process.exit(1);
+      }
+      console.log(
+        `[parity] EXPECTED TIMEOUT PATH — killed at wall-clock cap (elapsed ${elapsed}ms, cap ${cap}ms):`,
+      );
+      console.log(`         name=${err.name} exitCode=${err.exitCode} message=${err.message}`);
+      return;
+    }
+    console.error(`[parity] FAIL: execution errored (exitCode=${err.exitCode}): ${err.message}`);
+    if (err.stderr) console.error(err.stderr.trim().split('\n').slice(-10).join('\n'));
+    process.exit(1);
+  }
+
+  if (expect !== 'success') {
+    console.error(`[parity] FAIL: expected ${expect}, but execution succeeded`);
+    process.exit(1);
+  }
+
+  const normalized = normalizeExecutionResult(result);
+  const json = `${JSON.stringify(normalized, null, 2)}\n`;
+  const outPath = path.resolve(values.out);
+  await writeFile(outPath, json, 'utf8');
+  console.log(
+    `[parity] OK — ${normalized.notebook.cells.length} cells executed; normalized result → ${outPath}`,
+  );
+}
+
+async function commandCompare(argv) {
+  const [aPath, bPath] = argv;
+  if (!aPath || !bPath) usage('compare needs two normalized-result JSON paths');
+  const a = JSON.parse(await readFile(path.resolve(aPath), 'utf8'));
+  const b = JSON.parse(await readFile(path.resolve(bPath), 'utf8'));
+  const diffs = deepDiff(a, b);
+  if (diffs.length === 0) {
+    console.log(`[parity] PARITY OK — ${aPath} and ${bPath} are identical after normalization`);
+    return;
+  }
+  console.error(`[parity] PARITY FAIL — ${diffs.length}+ difference(s):`);
+  for (const diff of diffs) console.error(`  ${diff}`);
+  process.exit(1);
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  if (command === 'run') return commandRun(rest);
+  if (command === 'compare') return commandCompare(rest);
+  usage(`unknown command "${command ?? ''}"`);
+}
+
+main().catch((err) => {
+  console.error('[parity] FAILED:', err instanceof Error ? err.stack ?? err.message : err);
+  process.exit(1);
+});

--- a/scripts/fixtures/error-notebook.ipynb
+++ b/scripts/fixtures/error-notebook.ipynb
@@ -1,0 +1,28 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.13"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "id": "error-001",
+      "metadata": {},
+      "source": [
+        "print('about to fail')\n",
+        "raise ValueError('intentional-fixture-error: executor error-path test')"
+      ],
+      "outputs": [],
+      "execution_count": null
+    }
+  ]
+}

--- a/scripts/fixtures/parity-notebook.ipynb
+++ b/scripts/fixtures/parity-notebook.ipynb
@@ -1,0 +1,111 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.13"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "parity-000",
+      "metadata": {},
+      "source": [
+        "# Executor parity fixture\n",
+        "\n",
+        "Deterministic exercise of the pinned scientific stack — NO network calls,\n",
+        "fixed inputs, seeded RNG. Executed by `scripts/executor-parity.mjs` on each\n",
+        "notebook-executor driver; normalized results must match across drivers."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "id": "parity-001",
+      "metadata": {},
+      "source": [
+        "import logging\n",
+        "logging.getLogger('matplotlib').setLevel(logging.ERROR)  # suppress font-cache notice\n",
+        "import warnings\n",
+        "warnings.filterwarnings('ignore')\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import matplotlib\n",
+        "matplotlib.use('Agg')\n",
+        "import matplotlib.pyplot as plt\n",
+        "print('numpy', np.__version__)\n",
+        "print('pandas', pd.__version__)\n",
+        "print('matplotlib', matplotlib.__version__)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "id": "parity-002",
+      "metadata": {},
+      "source": [
+        "rng = np.random.default_rng(20260802)\n",
+        "values = rng.integers(0, 100, size=12)\n",
+        "print(values.tolist())\n",
+        "print(int(values.sum()), float(values.mean()))"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "id": "parity-003",
+      "metadata": {},
+      "source": [
+        "df = pd.DataFrame({\n",
+        "    'district': ['north', 'south', 'east', 'west'] * 3,\n",
+        "    'requests': values,\n",
+        "})\n",
+        "summary = df.groupby('district', sort=True)['requests'].agg(['count', 'sum', 'mean'])\n",
+        "print(summary.to_string())"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "id": "parity-004",
+      "metadata": {},
+      "source": [
+        "import hashlib, io\n",
+        "fig, ax = plt.subplots(figsize=(4, 3), dpi=100)\n",
+        "summary['sum'].plot.bar(ax=ax, color='#4477AA')\n",
+        "ax.set_title('requests by district (fixture)')\n",
+        "fig.tight_layout()\n",
+        "buf = io.BytesIO()\n",
+        "# metadata={'Software': None} drops the version-bearing PNG text chunk so\n",
+        "# the bytes depend only on the pinned matplotlib wheel's rendering.\n",
+        "fig.savefig(buf, format='png', metadata={'Software': None})\n",
+        "png_bytes = buf.getvalue()\n",
+        "print('png_sha256', hashlib.sha256(png_bytes).hexdigest())\n",
+        "print('png_len', len(png_bytes))"
+      ],
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "id": "parity-005",
+      "metadata": {},
+      "source": [
+        "from IPython.display import Image, display\n",
+        "display(Image(data=png_bytes))\n",
+        "plt.close(fig)"
+      ],
+      "outputs": [],
+      "execution_count": null
+    }
+  ]
+}

--- a/scripts/fixtures/timeout-notebook.ipynb
+++ b/scripts/fixtures/timeout-notebook.ipynb
@@ -1,0 +1,30 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.13"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "id": "timeout-001",
+      "metadata": {},
+      "source": [
+        "import time\n",
+        "print('sleeping past the wall-clock cap')\n",
+        "time.sleep(600)\n",
+        "print('never reached')"
+      ],
+      "outputs": [],
+      "execution_count": null
+    }
+  ]
+}

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -57,6 +57,14 @@ export const ENV_SPEC = [
   { name: 'S3_SECRET_ACCESS_KEY', tier: 'optional', purpose: 'S3 secret key (required when BLOB_DRIVER=s3)' },
   { name: 'S3_FORCE_PATH_STYLE', tier: 'optional', purpose: 'Path-style S3 addressing (default: on when S3_ENDPOINT is set — MinIO)', hasFallback: true },
   { name: 'S3_PUBLIC_BASE_URL', tier: 'optional', purpose: 'Public object URL base (default: endpoint/bucket path-style)', hasFallback: true },
+  // --- Notebook executor (S3b P4 driver seam; executed-notebook pipeline) ---
+  { name: 'EXECUTOR_DRIVER', tier: 'optional', purpose: "Notebook executor driver — 'vercel-sandbox' (default) or 'container' (host container runtime)", hasFallback: true },
+  { name: 'EXECUTOR_CONTAINER_IMAGE', tier: 'optional', purpose: 'Executor image tag (EXECUTOR_DRIVER=container only; default civic-notebook-executor:0.1.0)', hasFallback: true },
+  { name: 'SANDBOX_SNAPSHOT_ID', tier: 'recommended', purpose: 'Prebuilt sandbox snapshot — absent, the vercel-sandbox driver falls back to a slow fresh boot + pip install', hasFallback: true },
+  { name: 'VERCEL_TOKEN', tier: 'optional', purpose: 'Vercel Sandbox auth for off-platform runs (on-deploy auth is OIDC-automatic)' },
+  { name: 'VERCEL_TEAM_ID', tier: 'optional', purpose: 'Vercel Sandbox auth for off-platform runs (with VERCEL_TOKEN + VERCEL_PROJECT_ID)' },
+  { name: 'VERCEL_PROJECT_ID', tier: 'optional', purpose: 'Vercel Sandbox auth for off-platform runs (with VERCEL_TOKEN + VERCEL_TEAM_ID)' },
+
   { name: 'EVIDENCE_SIGNING_KEY', tier: 'required', purpose: 'Ed25519 private key — signs evidence packages' },
   { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry', hasFallback: true }, // signing.ts: `EVIDENCE_KEY_ID || DEFAULT_KEY_ID`; the default mirrors the registry's active kid
 

--- a/src/lib/sandbox/container.test.ts
+++ b/src/lib/sandbox/container.test.ts
@@ -1,0 +1,108 @@
+// Unit tests for the notebook-executor driver seam (S3b P4):
+//   1. Anti-drift: docker/executor/Dockerfile mirrors the single-sourced
+//      pinned-library table (src/lib/notebook-author/prompt.ts) and the
+//      notebook-tooling package set (src/lib/sandbox/driver.ts) — the
+//      container image cannot silently diverge from what the sandbox
+//      snapshot and the notebook's own pip-install cell pin.
+//   2. Pure helpers of the container driver (image resolution, docker exec
+//      env flags, shell quoting).
+//   3. Driver selection (EXECUTOR_DRIVER), matching the DB_DRIVER /
+//      BLOB_DRIVER register: default, explicit values, loud unknown-value
+//      failure.
+//
+// Driver behavior against a live container runtime is exercised separately
+// via scripts/executor-parity.mjs; these tests stay docker-free.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { PINNED_LIBRARIES, PYTHON_RUNTIME_VERSION } from '../notebook-author/prompt.ts';
+import { EXECUTOR_TOOLING_PACKAGES } from './driver.ts';
+import {
+  DEFAULT_CONTAINER_IMAGE,
+  buildDockerEnvFlags,
+  resolveContainerImage,
+  shellSingleQuote,
+} from './container.ts';
+import { resolveExecutorDriverName } from './execute.ts';
+
+const DOCKERFILE_PATH = fileURLToPath(
+  new URL('../../../docker/executor/Dockerfile', import.meta.url),
+);
+const dockerfile = readFileSync(DOCKERFILE_PATH, 'utf8');
+
+test('Dockerfile pins exactly the single-sourced PINNED_LIBRARIES table', () => {
+  const pinPattern = /([a-zA-Z0-9_-]+)==([0-9][0-9a-zA-Z.]*)/g;
+  const dockerfilePins: Record<string, string> = {};
+  for (const match of dockerfile.matchAll(pinPattern)) {
+    dockerfilePins[match[1]] = match[2];
+  }
+  // Exact equality both directions: no missing pins, no extra pins, no
+  // version drift. PINNED_LIBRARIES is the single source; the Dockerfile is
+  // a test-enforced mirror (Dockerfiles cannot import TypeScript).
+  assert.deepEqual(dockerfilePins, { ...PINNED_LIBRARIES });
+});
+
+test('Dockerfile FROM line matches PYTHON_RUNTIME_VERSION', () => {
+  const fromLines = dockerfile
+    .split('\n')
+    .filter((line) => line.startsWith('FROM '));
+  assert.equal(fromLines.length, 1);
+  assert.match(
+    fromLines[0],
+    new RegExp(`^FROM python:${PYTHON_RUNTIME_VERSION.replace('.', '\\.')}-`),
+    `executor image python version must match PYTHON_RUNTIME_VERSION (${PYTHON_RUNTIME_VERSION})`,
+  );
+});
+
+test('Dockerfile installs every notebook-tooling package', () => {
+  for (const pkg of EXECUTOR_TOOLING_PACKAGES) {
+    assert.match(
+      dockerfile,
+      new RegExp(`(^|[\\s\\\\])${pkg}([\\s\\\\]|$)`, 'm'),
+      `Dockerfile must install "${pkg}" (EXECUTOR_TOOLING_PACKAGES)`,
+    );
+  }
+});
+
+test('resolveContainerImage: default, override, and blank-value fallback', () => {
+  assert.equal(resolveContainerImage({}), DEFAULT_CONTAINER_IMAGE);
+  assert.equal(
+    resolveContainerImage({ EXECUTOR_CONTAINER_IMAGE: 'registry.example.org/executor:2' }),
+    'registry.example.org/executor:2',
+  );
+  assert.equal(resolveContainerImage({ EXECUTOR_CONTAINER_IMAGE: '   ' }), DEFAULT_CONTAINER_IMAGE);
+});
+
+test('buildDockerEnvFlags produces -e KEY=VALUE pairs in insertion order', () => {
+  assert.deepEqual(buildDockerEnvFlags({}), []);
+  assert.deepEqual(
+    buildDockerEnvFlags({ ALPHA: 'one', BETA: 'two=with=equals' }),
+    ['-e', 'ALPHA=one', '-e', 'BETA=two=with=equals'],
+  );
+});
+
+test('shellSingleQuote wraps and escapes embedded single quotes', () => {
+  assert.equal(shellSingleQuote('/tmp/notebook.ipynb'), `'/tmp/notebook.ipynb'`);
+  assert.equal(shellSingleQuote(`a'b`), `'a'\\''b'`);
+});
+
+test('resolveExecutorDriverName: default and explicit values', () => {
+  assert.equal(resolveExecutorDriverName({}), 'vercel-sandbox');
+  assert.equal(resolveExecutorDriverName({ EXECUTOR_DRIVER: '' }), 'vercel-sandbox');
+  assert.equal(
+    resolveExecutorDriverName({ EXECUTOR_DRIVER: 'vercel-sandbox' }),
+    'vercel-sandbox',
+  );
+  assert.equal(resolveExecutorDriverName({ EXECUTOR_DRIVER: 'container' }), 'container');
+});
+
+test('resolveExecutorDriverName: unknown value fails loudly with the value named', () => {
+  assert.throws(
+    () => resolveExecutorDriverName({ EXECUTOR_DRIVER: 'kubernetes' }),
+    /Unsupported EXECUTOR_DRIVER "kubernetes"/,
+  );
+});

--- a/src/lib/sandbox/container.ts
+++ b/src/lib/sandbox/container.ts
@@ -1,0 +1,193 @@
+/**
+ * Driver #2: local container runtime (S3b P4 — the portable executor).
+ *
+ * Runs the notebook via the host container runtime's `docker` CLI (any
+ * Docker-compatible runtime works). The prebuilt image at
+ * `docker/executor/Dockerfile` is the container equivalent of the Vercel
+ * Sandbox snapshot: python3.13 + the pinned scientific stack + jupyter/
+ * nbconvert baked in, so per-run cost is container start + exec only.
+ *
+ * Build the image once (and after any pinned-version change):
+ *
+ *   docker build -t civic-notebook-executor:0.1.0 docker/executor
+ *
+ * `src/lib/sandbox/container.test.ts` asserts the Dockerfile's pins against
+ * the single source (`src/lib/notebook-author/prompt.ts:PINNED_LIBRARIES`),
+ * so image/source drift fails `npm test`.
+ *
+ * Session shape mirrors the sandbox driver: `docker run -d … sleep infinity`
+ * boots an idle container (create), each step is a `docker exec` (exec/read),
+ * and `docker kill` tears it down (teardown). Timeout semantics match the
+ * sandbox driver's create-time cap: a wall-clock timer kills the container
+ * on overrun, which surfaces as a failed in-flight exec and maps into the
+ * same NotebookExecutionError shape upstream.
+ *
+ * The container joins the runtime's default network so notebook helper
+ * functions can reach civic-data endpoints, matching sandbox behavior.
+ */
+import { spawn } from 'node:child_process';
+import { NotebookExecutionError } from './driver.ts';
+import type {
+  CreateSessionOptions,
+  ExecutorCommand,
+  ExecutorCommandResult,
+  ExecutorSession,
+  NotebookExecutorDriver,
+} from './driver.ts';
+
+/** Default tag produced by `docker build -t … docker/executor`. */
+export const DEFAULT_CONTAINER_IMAGE = 'civic-notebook-executor:0.1.0';
+
+const ENV_CONTAINER_IMAGE = 'EXECUTOR_CONTAINER_IMAGE';
+
+/** Resolve the executor image tag (EXECUTOR_CONTAINER_IMAGE, else default). */
+export function resolveContainerImage(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const image = env[ENV_CONTAINER_IMAGE];
+  return image && image.trim().length > 0 ? image.trim() : DEFAULT_CONTAINER_IMAGE;
+}
+
+/** `-e K=V` flag pairs for `docker exec` from an env record. */
+export function buildDockerEnvFlags(env: Record<string, string>): string[] {
+  return Object.entries(env).flatMap(([key, value]) => ['-e', `${key}=${value}`]);
+}
+
+/** Single-quote a string for `sh -c` (used for in-container file paths). */
+export function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+interface DockerResult {
+  exitCode: number;
+  stdout: Buffer;
+  stderr: Buffer;
+}
+
+/**
+ * Run the docker CLI with array args (no shell interpolation). Rejects only
+ * on spawn failure (docker binary missing); CLI failures resolve with a
+ * non-zero exitCode so callers decide what is fatal.
+ */
+function runDocker(
+  args: string[],
+  opts: { stdin?: string; signal?: AbortSignal } = {},
+): Promise<DockerResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('docker', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+    child.on('error', (err) => {
+      reject(
+        new NotebookExecutionError(
+          'docker CLI unavailable — the container executor driver requires a running host container runtime',
+          { cause: err },
+        ),
+      );
+    });
+    child.on('close', (code) => {
+      resolve({
+        exitCode: code ?? -1,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+      });
+    });
+    child.stdin.end(opts.stdin ?? '');
+  });
+}
+
+export function createContainerDriver(): NotebookExecutorDriver {
+  return {
+    name: 'container',
+
+    async createSession(opts: CreateSessionOptions): Promise<ExecutorSession> {
+      const image = resolveContainerImage();
+      // `--rm` so a killed/stopped container removes itself; `sleep infinity`
+      // keeps it idle between execs (the create/exec/read/teardown shape).
+      const run = await runDocker(['run', '-d', '--rm', image, 'sleep', 'infinity']);
+      if (run.exitCode !== 0) {
+        throw new NotebookExecutionError(
+          `docker run failed (exit ${run.exitCode}) — is the container runtime up and the image "${image}" built? (docker build -t ${image} docker/executor)`,
+          { exitCode: run.exitCode, stderr: run.stderr.toString('utf8') },
+        );
+      }
+      const containerId = run.stdout.toString('utf8').trim();
+
+      // Wall-clock cap, mirroring the sandbox driver's create-time timeout:
+      // kill the container on overrun; any in-flight exec then fails and the
+      // orchestrator maps it into NotebookExecutionError.
+      let timedOut = false;
+      const killTimer = setTimeout(() => {
+        timedOut = true;
+        void runDocker(['kill', containerId]).catch(() => {
+          /* container already gone */
+        });
+      }, opts.timeoutMs);
+      killTimer.unref();
+
+      return {
+        id: containerId,
+        // The prebuilt image bakes the pinned stack (test-enforced), so the
+        // orchestrator never pip-installs here.
+        stackPreinstalled: true,
+
+        async runCommand(command: ExecutorCommand): Promise<ExecutorCommandResult> {
+          const envFlags = buildDockerEnvFlags(command.env ?? {});
+          const result = await runDocker(
+            ['exec', ...envFlags, containerId, command.cmd, ...command.args],
+            command.signal ? { signal: command.signal } : {},
+          );
+          return {
+            exitCode: result.exitCode,
+            stdout: async () => result.stdout.toString('utf8'),
+            stderr: async () => {
+              const text = result.stderr.toString('utf8');
+              return timedOut
+                ? `${text}\n[container-executor] wall-clock cap (${opts.timeoutMs}ms) exceeded — container killed`
+                : text;
+            },
+          };
+        },
+
+        async writeFiles(files, writeOpts) {
+          for (const file of files) {
+            const result = await runDocker(
+              ['exec', '-i', containerId, 'sh', '-c', `cat > ${shellSingleQuote(file.path)}`],
+              { stdin: file.content, ...(writeOpts?.signal ? { signal: writeOpts.signal } : {}) },
+            );
+            if (result.exitCode !== 0) {
+              throw new NotebookExecutionError(
+                `container write failed for ${file.path} (exit ${result.exitCode})`,
+                { exitCode: result.exitCode, stderr: result.stderr.toString('utf8') },
+              );
+            }
+          }
+        },
+
+        async readFileToBuffer(path: string): Promise<Buffer | null> {
+          const result = await runDocker(['exec', containerId, 'cat', path]);
+          if (result.exitCode !== 0) return null;
+          return result.stdout;
+        },
+
+        async stop(): Promise<void> {
+          clearTimeout(killTimer);
+          // --rm removes the container once killed; a second kill (after the
+          // cap fired) fails harmlessly and is swallowed by the caller.
+          const result = await runDocker(['kill', containerId]);
+          if (result.exitCode !== 0 && !timedOut) {
+            throw new NotebookExecutionError(
+              `docker kill failed (exit ${result.exitCode})`,
+              { exitCode: result.exitCode, stderr: result.stderr.toString('utf8') },
+            );
+          }
+        },
+      };
+    },
+  };
+}

--- a/src/lib/sandbox/driver.ts
+++ b/src/lib/sandbox/driver.ts
@@ -1,0 +1,118 @@
+/**
+ * Notebook-executor driver seam (S3b P4).
+ *
+ * Everything `executeNotebook` asks of an execution runtime goes through this
+ * interface: create a session (with a wall-clock cap), run commands in it,
+ * stage files, read the executed notebook back, and tear the runtime down.
+ * The surface mirrors what the pipeline actually used of `@vercel/sandbox`
+ * (Sandbox.create / runCommand / writeFiles / readFileToBuffer / stop) so the
+ * default driver is a relocation, not a redesign.
+ *
+ * Drivers sit BELOW notebook orchestration: they receive and return opaque
+ * bytes and command results. The executed-notebook bytes feed evidence
+ * packages, so a driver must not transform notebook content — differences
+ * between runtimes are limited to what the runtimes inherently differ in
+ * (instance ids, durations, python patch version, per-cell execution
+ * timestamps); `scripts/executor-parity.mjs` documents and enforces that
+ * list.
+ *
+ * Driver selection lives in `./execute.ts` (EXECUTOR_DRIVER env var,
+ * mirroring the DB_DRIVER / BLOB_DRIVER patterns in `src/lib/db/index.ts`
+ * and `src/lib/storage/index.ts`).
+ */
+
+/**
+ * Notebook tooling installed alongside the pinned scientific stack in every
+ * executor runtime (sandbox snapshot, fresh-sandbox pip fallback, container
+ * image). Unpinned by design — nbconvert executes the notebook but its
+ * version is not part of the notebook's reproducibility contract the way the
+ * scientific-stack pins (PINNED_LIBRARIES) are.
+ */
+export const EXECUTOR_TOOLING_PACKAGES = [
+  'jupyter',
+  'ipykernel',
+  'nbformat',
+  'nbconvert',
+] as const;
+
+/** A single command to run inside an executor session. */
+export interface ExecutorCommand {
+  cmd: string;
+  args: string[];
+  /**
+   * Env for this command. The driver merges its own runtime-specific base
+   * env on top (e.g. the vercel-sandbox driver's CA-bundle TLS paths);
+   * caller-provided keys win on collision.
+   */
+  env?: Record<string, string>;
+  /** AbortSignal for the caller's wrapping timeout. */
+  signal?: AbortSignal;
+}
+
+/** Result of a completed executor command (mirrors @vercel/sandbox's shape). */
+export interface ExecutorCommandResult {
+  exitCode: number;
+  stdout(): Promise<string>;
+  stderr(): Promise<string>;
+}
+
+/**
+ * A booted execution runtime: a Vercel Sandbox microVM or a local container.
+ * Sessions are single-use — one notebook execution, then `stop()`.
+ */
+export interface ExecutorSession {
+  /**
+   * Runtime instance id (sandbox id or container id). Carried through into
+   * `ExecutionResult.sandboxId` and from there into the execution-metadata
+   * stamp.
+   */
+  readonly id: string;
+  /**
+   * Whether the pinned scientific stack + notebook tooling are already
+   * present when the session boots. True for snapshot-booted sandboxes and
+   * for the prebuilt container image; false for a fresh sandbox, where the
+   * orchestrator pip-installs the stack inline.
+   */
+  readonly stackPreinstalled: boolean;
+  runCommand(command: ExecutorCommand): Promise<ExecutorCommandResult>;
+  writeFiles(
+    files: ReadonlyArray<{ path: string; content: string }>,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void>;
+  /** Read a file from the session filesystem; null when it does not exist. */
+  readFileToBuffer(path: string): Promise<Buffer | null>;
+  /** Tear the runtime down. Idempotent-enough: callers swallow errors. */
+  stop(): Promise<void>;
+}
+
+export interface CreateSessionOptions {
+  /**
+   * Wall-clock cap for the whole session (ms). The driver kills the runtime
+   * on overrun, which surfaces as a failed in-flight command.
+   */
+  timeoutMs: number;
+  /** Env visible to the executed notebook (data-portal tokens + caller extras). */
+  env: Record<string, string>;
+  /**
+   * vercel-sandbox driver only: snapshot to boot from. Ignored by the
+   * container driver, whose prebuilt image is the equivalent concept.
+   */
+  snapshotId?: string;
+}
+
+export interface NotebookExecutorDriver {
+  readonly name: string;
+  createSession(opts: CreateSessionOptions): Promise<ExecutorSession>;
+}
+
+export class NotebookExecutionError extends Error {
+  readonly stderr?: string;
+  readonly exitCode?: number;
+  constructor(message: string, opts: { stderr?: string; exitCode?: number; cause?: unknown } = {}) {
+    super(message);
+    this.name = 'NotebookExecutionError';
+    this.stderr = opts.stderr;
+    this.exitCode = opts.exitCode;
+    if (opts.cause) (this as { cause?: unknown }).cause = opts.cause;
+  }
+}

--- a/src/lib/sandbox/execute.ts
+++ b/src/lib/sandbox/execute.ts
@@ -1,63 +1,89 @@
 /**
- * Vercel Sandbox integration for the executed-notebook pipeline (ADR-0005
- * Phase C, project plan N4).
+ * Notebook execution for the executed-notebook pipeline (ADR-0005 Phase C,
+ * project plan N4) — driver-dispatching since S3b P4.
  *
- * Boots a python3.13 sandbox from a pre-built snapshot (sub-second cold
- * start per ADR-0005 Context), writes the notebook in, runs
- * `jupyter nbconvert --execute` against it, and reads the executed
- * notebook back as JSON. The snapshot embeds the pinned scientific stack
- * (pandas/requests/numpy/matplotlib) AND jupyter so cold start is fast;
- * the build script that produces the snapshot lives at
- * `scripts/build-sandbox-snapshot.ts` (project-plan N5).
+ * The orchestration is runtime-agnostic: boot an executor session, write the
+ * notebook in, run `jupyter nbconvert --execute` against it, and read the
+ * executed notebook back as JSON. Which runtime boots is a driver decision
+ * (`NotebookExecutorDriver` in `./driver.ts`):
  *
- * Auth is OIDC-automatic on Vercel deployments; local dev needs
- * `VERCEL_OIDC_TOKEN` (via `vercel link` + `vercel env pull`) OR the
- * VERCEL_TOKEN+VERCEL_TEAM_ID+VERCEL_PROJECT_ID triple.
+ *   - 'vercel-sandbox' (default): Vercel Sandbox microVM — the demo
+ *     deployment's behavior, unchanged when the var is unset
+ *     (`./vercel-sandbox.ts`).
+ *   - 'container': the host container runtime via the docker CLI, using the
+ *     prebuilt image from `docker/executor/Dockerfile` (`./container.ts`).
+ *
+ * Selection follows the DB_DRIVER / BLOB_DRIVER pattern (`src/lib/db/
+ * index.ts`, `src/lib/storage/index.ts`): EXECUTOR_DRIVER env var, lazy
+ * dynamic import so the non-selected driver's SDK never loads, loud failure
+ * on unknown values.
  */
-import { Sandbox } from '@vercel/sandbox';
 import type { Notebook } from '../notebook-author/cells.ts';
 import { PINNED_LIBRARIES, PYTHON_RUNTIME_VERSION } from '../notebook-author/prompt.ts';
+import { EXECUTOR_TOOLING_PACKAGES, NotebookExecutionError } from './driver.ts';
+import type { ExecutorSession, NotebookExecutorDriver } from './driver.ts';
+
+export { NotebookExecutionError } from './driver.ts';
 
 /**
- * Wall-clock timeout for a single sandbox execution. The notebook itself
- * may run for up to NOTEBOOK_TIMEOUT_S; the sandbox timeout adds headroom
+ * Wall-clock timeout for a single execution session. The notebook itself
+ * may run for up to NOTEBOOK_TIMEOUT_S; the session timeout adds headroom
  * for boot, writeFiles, and readback. Per ADR-0005 Risks: 90-120s timeout.
  */
 const SANDBOX_TIMEOUT_MS = 180_000;
 const NOTEBOOK_TIMEOUT_S = 120;
 
-/** Path inside the sandbox where the unexecuted notebook is written. */
+/** Path inside the session where the unexecuted notebook is written. */
 const NOTEBOOK_IN_PATH = '/tmp/notebook.ipynb';
-/** Path inside the sandbox where jupyter writes the executed notebook. */
+/** Path inside the session where jupyter writes the executed notebook. */
 const NOTEBOOK_OUT_PATH = '/tmp/executed.ipynb';
 
-/** Environment-variable names this module honors at module load time. */
+/** Environment-variable names this module honors. */
+const ENV_EXECUTOR_DRIVER = 'EXECUTOR_DRIVER';
 const ENV_SNAPSHOT_ID = 'SANDBOX_SNAPSHOT_ID';
 const ENV_SOCRATA_TOKEN = 'SOCRATA_APP_TOKEN';
 const ENV_DC_API_KEY = 'DC_API_KEY';
 
+export type ExecutorDriverName = 'vercel-sandbox' | 'container';
+
 /**
- * The python3.13 sandbox image (Amazon Linux 2023 base) expects its CA
- * bundle at `/etc/ssl/certs/ca-certificates.crt` but ships it only at
- * `/etc/pki/tls/certs/ca-bundle.crt`. Setting the standard openssl-family
- * env vars so pip + `requests` inside the executed notebook resolve PyPI
- * and HTTPS civic-data endpoints. Mirrors scripts/build-sandbox-snapshot.ts.
+ * Resolve the configured driver name. Exported for tests; the unknown-value
+ * throw is deliberately loud and lazy (first execution, not import time).
  */
-const AL2023_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt';
-const TLS_ENV: Record<string, string> = {
-  SSL_CERT_FILE: AL2023_CA_BUNDLE,
-  REQUESTS_CA_BUNDLE: AL2023_CA_BUNDLE,
-  PIP_CERT: AL2023_CA_BUNDLE,
-};
+export function resolveExecutorDriverName(
+  env: Record<string, string | undefined> = process.env,
+): ExecutorDriverName {
+  const driver = env[ENV_EXECUTOR_DRIVER] || 'vercel-sandbox';
+  if (driver === 'vercel-sandbox' || driver === 'container') return driver;
+  throw new Error(
+    `Unsupported EXECUTOR_DRIVER "${driver}" (expected "vercel-sandbox" or "container")`,
+  );
+}
+
+let _driver: NotebookExecutorDriver | null = null;
+
+async function getDriver(): Promise<NotebookExecutorDriver> {
+  if (!_driver) {
+    const name = resolveExecutorDriverName();
+    if (name === 'container') {
+      const { createContainerDriver } = await import('./container.ts');
+      _driver = createContainerDriver();
+    } else {
+      const { createVercelSandboxDriver } = await import('./vercel-sandbox.ts');
+      _driver = createVercelSandboxDriver();
+    }
+  }
+  return _driver;
+}
 
 export interface ExecuteNotebookOptions {
-  /** Snapshot to boot from. Defaults to env `SANDBOX_SNAPSHOT_ID`. */
+  /** Snapshot to boot from (vercel-sandbox driver only). Defaults to env `SANDBOX_SNAPSHOT_ID`. */
   snapshotId?: string;
-  /** Hard timeout for the whole sandbox session (ms). */
+  /** Hard timeout for the whole execution session (ms). */
   timeoutMs?: number;
   /** Timeout passed to `jupyter nbconvert --ExecutePreprocessor.timeout`. */
   notebookTimeoutS?: number;
-  /** Extra env vars passed to the sandbox. */
+  /** Extra env vars passed to the session. */
   extraEnv?: Record<string, string>;
   /** AbortSignal for the caller's wrapping timeout. */
   signal?: AbortSignal;
@@ -66,30 +92,19 @@ export interface ExecuteNotebookOptions {
 export interface ExecutionResult {
   /** Executed notebook (with output cells embedded). */
   notebook: Notebook;
-  /** Sandbox id; carried through into the execution-metadata stamp. */
+  /** Executor instance id (sandbox id or container id); carried through into
+   *  the execution-metadata stamp. */
   sandboxId: string;
-  /** Wall-clock duration from sandbox boot to readback (ms). */
+  /** Wall-clock duration from session boot to readback (ms). */
   executionDuration_ms: number;
-  /** Python version reported by the sandbox runtime. */
+  /** Python version reported by the session runtime. */
   pythonVersion: string;
-  /** Pinned library versions actually present inside the sandbox. */
+  /** Pinned library versions actually present inside the session. */
   libraries: Record<string, string>;
 }
 
-export class NotebookExecutionError extends Error {
-  readonly stderr?: string;
-  readonly exitCode?: number;
-  constructor(message: string, opts: { stderr?: string; exitCode?: number; cause?: unknown } = {}) {
-    super(message);
-    this.name = 'NotebookExecutionError';
-    this.stderr = opts.stderr;
-    this.exitCode = opts.exitCode;
-    if (opts.cause) (this as { cause?: unknown }).cause = opts.cause;
-  }
-}
-
-function buildSandboxEnv(extra?: Record<string, string>): Record<string, string> {
-  const env: Record<string, string> = { ...TLS_ENV };
+function buildNotebookEnv(extra?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
   const socrataToken = process.env[ENV_SOCRATA_TOKEN];
   if (socrataToken) env[ENV_SOCRATA_TOKEN] = socrataToken;
   const dcKey = process.env[ENV_DC_API_KEY];
@@ -102,40 +117,13 @@ function buildSandboxEnv(extra?: Record<string, string>): Record<string, string>
   return env;
 }
 
-interface SandboxCreateBase {
-  timeout: number;
-  env: Record<string, string>;
-}
-
-function createSandbox(
-  snapshotId: string | undefined,
-  base: SandboxCreateBase,
-): Promise<Sandbox> {
-  if (snapshotId) {
-    return Sandbox.create({
-      ...base,
-      source: { type: 'snapshot', snapshotId },
-    });
-  }
-  // No snapshot configured — boot a fresh python3.13 sandbox and install
-  // the pinned scientific stack inline. Slower (~10-30s cold start) and
-  // intended only for the snapshot-build script + local-dev smoke tests.
-  return Sandbox.create({
-    ...base,
-    runtime: 'python3.13',
-  });
-}
-
-async function ensureScientificStack(sandbox: Sandbox): Promise<void> {
+async function ensureScientificStack(session: ExecutorSession): Promise<void> {
   const pipArgs = [
     'install', '--quiet', '--no-input',
-    `pandas==${PINNED_LIBRARIES.pandas}`,
-    `requests==${PINNED_LIBRARIES.requests}`,
-    `numpy==${PINNED_LIBRARIES.numpy}`,
-    `matplotlib==${PINNED_LIBRARIES.matplotlib}`,
-    'jupyter', 'ipykernel', 'nbformat', 'nbconvert',
+    ...Object.entries(PINNED_LIBRARIES).map(([name, version]) => `${name}==${version}`),
+    ...EXECUTOR_TOOLING_PACKAGES,
   ];
-  const result = await sandbox.runCommand({ cmd: 'pip', args: pipArgs, env: TLS_ENV });
+  const result = await session.runCommand({ cmd: 'pip', args: pipArgs, env: {} });
   if (result.exitCode !== 0) {
     const stderr = await result.stderr();
     throw new NotebookExecutionError(
@@ -146,15 +134,16 @@ async function ensureScientificStack(sandbox: Sandbox): Promise<void> {
 }
 
 /**
- * Execute a notebook end-to-end in Vercel Sandbox.
+ * Execute a notebook end-to-end via the configured executor driver.
  *
  * The flow:
- *   1. Boot a sandbox (from `SANDBOX_SNAPSHOT_ID` snapshot when set, else a
- *      fresh python3.13 sandbox with inline pip install).
+ *   1. Boot a session (vercel-sandbox: from `SANDBOX_SNAPSHOT_ID` snapshot
+ *      when set, else a fresh python3.13 sandbox with inline pip install;
+ *      container: the prebuilt executor image).
  *   2. Write the notebook JSON to `/tmp/notebook.ipynb`.
  *   3. Run `jupyter nbconvert --to notebook --execute` against it.
  *   4. Read `/tmp/executed.ipynb` back and parse as JSON.
- *   5. Stop the sandbox (best-effort; errors are swallowed).
+ *   5. Stop the session (best-effort; errors are swallowed).
  *
  * Throws `NotebookExecutionError` when nbconvert exits non-zero or readback
  * fails. The caller (Phase D) is responsible for the comparison-cell append
@@ -167,19 +156,20 @@ export async function executeNotebook(
   const snapshotId = opts.snapshotId ?? process.env[ENV_SNAPSHOT_ID];
   const timeoutMs = opts.timeoutMs ?? SANDBOX_TIMEOUT_MS;
   const notebookTimeoutS = opts.notebookTimeoutS ?? NOTEBOOK_TIMEOUT_S;
-  const env = buildSandboxEnv(opts.extraEnv);
+  const env = buildNotebookEnv(opts.extraEnv);
   const startedAt = Date.now();
 
-  const sandbox = await createSandbox(snapshotId, { timeout: timeoutMs, env });
+  const driver = await getDriver();
+  const session = await driver.createSession({ timeoutMs, env, snapshotId });
   try {
-    // Without a snapshot, we still need the pinned scientific stack present.
-    if (!snapshotId) {
-      await ensureScientificStack(sandbox);
+    // Without a preinstalled stack (fresh sandbox), pip-install the pins.
+    if (!session.stackPreinstalled) {
+      await ensureScientificStack(session);
     }
 
-    // Stage the notebook on the sandbox filesystem.
+    // Stage the notebook on the session filesystem.
     const notebookJson = JSON.stringify(notebook);
-    await sandbox.writeFiles(
+    await session.writeFiles(
       [{ path: NOTEBOOK_IN_PATH, content: notebookJson }],
       opts.signal ? { signal: opts.signal } : undefined,
     );
@@ -187,7 +177,7 @@ export async function executeNotebook(
     // Execute the notebook in-place: nbconvert reads NOTEBOOK_IN_PATH, runs
     // every cell, and writes the executed copy to NOTEBOOK_OUT_PATH. Use a
     // generous per-cell timeout via --ExecutePreprocessor.timeout (seconds).
-    const convertResult = await sandbox.runCommand({
+    const convertResult = await session.runCommand({
       cmd: 'jupyter',
       args: [
         'nbconvert',
@@ -210,7 +200,7 @@ export async function executeNotebook(
     }
 
     // Read the executed notebook back as bytes, parse JSON.
-    const buffer = await sandbox.readFileToBuffer({ path: NOTEBOOK_OUT_PATH });
+    const buffer = await session.readFileToBuffer(NOTEBOOK_OUT_PATH);
     if (!buffer) {
       throw new NotebookExecutionError(`executed notebook not found at ${NOTEBOOK_OUT_PATH}`);
     }
@@ -221,18 +211,21 @@ export async function executeNotebook(
       throw new NotebookExecutionError('executed notebook JSON parse error', { cause: parseErr });
     }
 
-    // Capture runtime detail by asking the sandbox what python it has.
-    const versionResult = await sandbox.runCommand('python3', [
-      '-c',
-      'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")',
-    ]);
+    // Capture runtime detail by asking the session what python it has.
+    const versionResult = await session.runCommand({
+      cmd: 'python3',
+      args: [
+        '-c',
+        'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")',
+      ],
+    });
     const pythonVersion = versionResult.exitCode === 0
       ? (await versionResult.stdout()).trim() || PYTHON_RUNTIME_VERSION
       : PYTHON_RUNTIME_VERSION;
 
     return {
       notebook: executed,
-      sandboxId: sandbox.sandboxId,
+      sandboxId: session.id,
       executionDuration_ms: Date.now() - startedAt,
       pythonVersion,
       libraries: { ...PINNED_LIBRARIES },
@@ -241,7 +234,7 @@ export async function executeNotebook(
     // Best-effort cleanup; if the caller's signal aborted, stop() may also
     // throw — we swallow because the user already saw the abort.
     try {
-      await sandbox.stop();
+      await session.stop();
     } catch {
       /* ignore */
     }

--- a/src/lib/sandbox/vercel-sandbox.test.ts
+++ b/src/lib/sandbox/vercel-sandbox.test.ts
@@ -1,0 +1,81 @@
+// Unit tests for the vercel-sandbox driver's pure auth-params helper
+// (S3b P4 fix-on-top).
+//
+// Why this exists: `@vercel/sandbox` / `@vercel/oidc` read exactly ONE auth
+// variable from the environment — VERCEL_OIDC_TOKEN. The
+// VERCEL_TOKEN/VERCEL_TEAM_ID/VERCEL_PROJECT_ID triple is accepted only as
+// explicit Sandbox.create({ token, teamId, projectId }) parameters, and the
+// SDK's resolver THROWS on a partial triple (returning to the OIDC path only
+// when all three are absent). So the resolution rule is all-three-or-none,
+// and that rule is what these tests pin.
+//
+// No network, no SDK calls: the helper is pure and takes its env as an
+// argument. Fixture values below are obviously-fake placeholders — no
+// real-looking credentials.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveSandboxAuthParams } from './vercel-sandbox.ts';
+
+// Guard-safe fixture values: obviously fake, structurally unlike real
+// credentials, and never logged by the code under test.
+const FIXTURE_ENV = {
+  VERCEL_TOKEN: 'fixture-token-value-not-real',
+  VERCEL_TEAM_ID: 'fixture-team-id',
+  VERCEL_PROJECT_ID: 'fixture-project-id',
+};
+
+test('all three present → params returned verbatim (passed to Sandbox.create)', () => {
+  const params = resolveSandboxAuthParams(FIXTURE_ENV);
+  assert.deepEqual(params, {
+    token: 'fixture-token-value-not-real',
+    teamId: 'fixture-team-id',
+    projectId: 'fixture-project-id',
+  });
+});
+
+test('none present → null, so the on-platform OIDC path is untouched', () => {
+  // This is the demo/production case: no auth keys are passed to the SDK.
+  assert.equal(resolveSandboxAuthParams({}), null);
+});
+
+test('any one missing → null (never a partial triple, which the SDK rejects)', () => {
+  for (const omitted of ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID']) {
+    const env: Record<string, string | undefined> = { ...FIXTURE_ENV };
+    delete env[omitted];
+    assert.equal(
+      resolveSandboxAuthParams(env),
+      null,
+      `omitting ${omitted} must yield null, not a partial triple`,
+    );
+  }
+});
+
+test('empty and whitespace-only values count as absent', () => {
+  assert.equal(resolveSandboxAuthParams({ ...FIXTURE_ENV, VERCEL_TOKEN: '' }), null);
+  assert.equal(resolveSandboxAuthParams({ ...FIXTURE_ENV, VERCEL_TEAM_ID: '   ' }), null);
+});
+
+test('surrounding whitespace is trimmed off the resolved values', () => {
+  const params = resolveSandboxAuthParams({
+    VERCEL_TOKEN: '  fixture-token-value-not-real  ',
+    VERCEL_TEAM_ID: '\tfixture-team-id\n',
+    VERCEL_PROJECT_ID: ' fixture-project-id ',
+  });
+  assert.deepEqual(params, {
+    token: 'fixture-token-value-not-real',
+    teamId: 'fixture-team-id',
+    projectId: 'fixture-project-id',
+  });
+});
+
+test('the returned object has exactly the SDK credential keys (no extras, no undefineds)', () => {
+  const params = resolveSandboxAuthParams(FIXTURE_ENV);
+  assert.notEqual(params, null);
+  assert.deepEqual(Object.keys(params!).sort(), ['projectId', 'teamId', 'token']);
+  for (const value of Object.values(params!)) {
+    assert.equal(typeof value, 'string');
+  }
+});

--- a/src/lib/sandbox/vercel-sandbox.ts
+++ b/src/lib/sandbox/vercel-sandbox.ts
@@ -13,6 +13,17 @@
  * `VERCEL_OIDC_TOKEN` (via `vercel link` + `vercel env pull`) OR the
  * VERCEL_TOKEN+VERCEL_TEAM_ID+VERCEL_PROJECT_ID triple.
  *
+ * IMPORTANT — how that triple actually reaches the SDK: `@vercel/sandbox`
+ * and `@vercel/oidc` read exactly ONE auth variable from the environment,
+ * `VERCEL_OIDC_TOKEN`. The token/teamId/projectId triple is accepted *only*
+ * as explicit `Sandbox.create({ token, teamId, projectId })` parameters, so
+ * THIS MODULE reads the three variables and passes them through (see
+ * `resolveSandboxAuthParams`). Without that pass-through an off-platform run
+ * with the triple set still fails with `LocalOidcContextError` — and under a
+ * non-TTY wrapper (e.g. `op run`) the SDK's interactive-login fallback is
+ * disabled (`shouldPromptForCredentials()` requires a TTY), so it throws
+ * rather than prompting.
+ *
  * This module is the ONLY runtime importer of `@vercel/sandbox` — the seam
  * (`./execute.ts`) loads it lazily, so the container driver never touches
  * the SDK or its auth requirements.
@@ -48,24 +59,61 @@ interface SandboxCreateBase {
   env: Record<string, string>;
 }
 
+/** Environment-variable names for the off-platform auth triple. */
+const ENV_VERCEL_TOKEN = 'VERCEL_TOKEN';
+const ENV_VERCEL_TEAM_ID = 'VERCEL_TEAM_ID';
+const ENV_VERCEL_PROJECT_ID = 'VERCEL_PROJECT_ID';
+
+/** The SDK's `Credentials` shape — all three fields required, never partial. */
+export interface SandboxAuthParams {
+  token: string;
+  teamId: string;
+  projectId: string;
+}
+
+/**
+ * Resolve the off-platform auth triple from the environment.
+ *
+ * ALL THREE OR NONE, deliberately: the SDK's credential resolver treats a
+ * partial triple as a hard error (it throws "Missing credentials parameters
+ * to access the Vercel API") and falls through to the OIDC path only when
+ * all three are absent. Returning `null` unless the set is complete is what
+ * keeps the on-platform OIDC-automatic path untouched — production sets none
+ * of the three, so this returns null there and no auth keys are passed.
+ *
+ * SECRET HYGIENE: the returned token is passed straight to the SDK and is
+ * never logged, echoed, hashed, or included in an error message — not here
+ * and not in any caller. Pure function; exported for unit tests.
+ */
+export function resolveSandboxAuthParams(
+  env: Record<string, string | undefined> = process.env,
+): SandboxAuthParams | null {
+  const token = env[ENV_VERCEL_TOKEN]?.trim();
+  const teamId = env[ENV_VERCEL_TEAM_ID]?.trim();
+  const projectId = env[ENV_VERCEL_PROJECT_ID]?.trim();
+  if (token && teamId && projectId) return { token, teamId, projectId };
+  return null;
+}
+
 function createSandbox(
   snapshotId: string | undefined,
   base: SandboxCreateBase,
 ): Promise<Sandbox> {
-  if (snapshotId) {
-    return Sandbox.create({
-      ...base,
-      source: { type: 'snapshot', snapshotId },
-    });
-  }
-  // No snapshot configured — boot a fresh python3.13 sandbox; the
-  // orchestrator installs the pinned scientific stack inline. Slower
-  // (~10-30s cold start) and intended only for the snapshot-build script +
-  // local-dev smoke tests.
-  return Sandbox.create({
-    ...base,
-    runtime: 'python3.13',
-  });
+  const params = snapshotId
+    ? { ...base, source: { type: 'snapshot' as const, snapshotId } }
+    // No snapshot configured — boot a fresh python3.13 sandbox; the
+    // orchestrator installs the pinned scientific stack inline. Slower
+    // (~10-30s cold start) and intended only for the snapshot-build script +
+    // local-dev smoke tests.
+    : { ...base, runtime: 'python3.13' as const };
+
+  // Attach the auth triple ONLY when complete. Two distinct call shapes
+  // rather than a spread of possibly-undefined keys: an undefined-valued
+  // `token`/`teamId`/`projectId` would read to the SDK as a partial triple
+  // and throw. With the triple unset (the demo/production case) the call is
+  // byte-for-byte the pre-fix call and OIDC resolution is untouched.
+  const auth = resolveSandboxAuthParams();
+  return auth ? Sandbox.create({ ...params, ...auth }) : Sandbox.create(params);
 }
 
 export function createVercelSandboxDriver(): NotebookExecutorDriver {

--- a/src/lib/sandbox/vercel-sandbox.ts
+++ b/src/lib/sandbox/vercel-sandbox.ts
@@ -1,0 +1,119 @@
+/**
+ * Driver #1: Vercel Sandbox (the default; demo-instance behavior unchanged).
+ *
+ * Boots a python3.13 sandbox from a pre-built snapshot (sub-second cold
+ * start per ADR-0005 Context) when `SANDBOX_SNAPSHOT_ID` is configured, or a
+ * fresh python3.13 sandbox otherwise (the orchestrator then pip-installs the
+ * pinned stack inline). The snapshot embeds the pinned scientific stack
+ * (pandas/requests/numpy/matplotlib) AND jupyter so cold start is fast; the
+ * build script that produces the snapshot lives at
+ * `scripts/build-sandbox-snapshot.ts` (project-plan N5).
+ *
+ * Auth is OIDC-automatic on Vercel deployments; local dev needs
+ * `VERCEL_OIDC_TOKEN` (via `vercel link` + `vercel env pull`) OR the
+ * VERCEL_TOKEN+VERCEL_TEAM_ID+VERCEL_PROJECT_ID triple.
+ *
+ * This module is the ONLY runtime importer of `@vercel/sandbox` — the seam
+ * (`./execute.ts`) loads it lazily, so the container driver never touches
+ * the SDK or its auth requirements.
+ */
+import { Sandbox } from '@vercel/sandbox';
+import type {
+  CreateSessionOptions,
+  ExecutorCommand,
+  ExecutorCommandResult,
+  ExecutorSession,
+  NotebookExecutorDriver,
+} from './driver.ts';
+
+/**
+ * The python3.13 sandbox image (Amazon Linux 2023 base) expects its CA
+ * bundle at `/etc/ssl/certs/ca-certificates.crt` but ships it only at
+ * `/etc/pki/tls/certs/ca-bundle.crt`. Setting the standard openssl-family
+ * env vars so pip + `requests` inside the executed notebook resolve PyPI
+ * and HTTPS civic-data endpoints. Mirrors scripts/build-sandbox-snapshot.ts.
+ *
+ * These paths are an artifact of THIS runtime's image, which is why they
+ * live in the driver rather than in the orchestrator.
+ */
+const AL2023_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt';
+const TLS_ENV: Record<string, string> = {
+  SSL_CERT_FILE: AL2023_CA_BUNDLE,
+  REQUESTS_CA_BUNDLE: AL2023_CA_BUNDLE,
+  PIP_CERT: AL2023_CA_BUNDLE,
+};
+
+interface SandboxCreateBase {
+  timeout: number;
+  env: Record<string, string>;
+}
+
+function createSandbox(
+  snapshotId: string | undefined,
+  base: SandboxCreateBase,
+): Promise<Sandbox> {
+  if (snapshotId) {
+    return Sandbox.create({
+      ...base,
+      source: { type: 'snapshot', snapshotId },
+    });
+  }
+  // No snapshot configured — boot a fresh python3.13 sandbox; the
+  // orchestrator installs the pinned scientific stack inline. Slower
+  // (~10-30s cold start) and intended only for the snapshot-build script +
+  // local-dev smoke tests.
+  return Sandbox.create({
+    ...base,
+    runtime: 'python3.13',
+  });
+}
+
+export function createVercelSandboxDriver(): NotebookExecutorDriver {
+  return {
+    name: 'vercel-sandbox',
+
+    async createSession(opts: CreateSessionOptions): Promise<ExecutorSession> {
+      const sandbox = await createSandbox(opts.snapshotId, {
+        timeout: opts.timeoutMs,
+        env: { ...TLS_ENV, ...opts.env },
+      });
+
+      return {
+        id: sandbox.sandboxId,
+        stackPreinstalled: Boolean(opts.snapshotId),
+
+        async runCommand(command: ExecutorCommand): Promise<ExecutorCommandResult> {
+          const result = await sandbox.runCommand({
+            cmd: command.cmd,
+            args: command.args,
+            // Merge the image's TLS paths under the caller's env, exactly as
+            // the pre-seam module did for pip + nbconvert; a command with no
+            // env (the version probe) runs bare.
+            ...(command.env ? { env: { ...TLS_ENV, ...command.env } } : {}),
+            ...(command.signal ? { signal: command.signal } : {}),
+          });
+          return {
+            exitCode: result.exitCode,
+            stdout: () => result.stdout(),
+            stderr: () => result.stderr(),
+          };
+        },
+
+        async writeFiles(files, writeOpts) {
+          await sandbox.writeFiles(
+            files.map((f) => ({ path: f.path, content: f.content })),
+            writeOpts?.signal ? { signal: writeOpts.signal } : undefined,
+          );
+        },
+
+        async readFileToBuffer(path: string): Promise<Buffer | null> {
+          return sandbox.readFileToBuffer({ path });
+        },
+
+        async stop(): Promise<void> {
+          await sandbox.stop();
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
Phase P4 of the S3b-core sprint (#171) — the executor seam per ADR-0023 (companion PR on the hub repo). Demo behavior unchanged when `EXECUTOR_DRIVER` is unset.

## What changed
- **Interface** (`src/lib/sandbox/driver.ts`): `NotebookExecutorDriver`/`ExecutorSession` with create/exec/read/teardown semantics — the surface the pipeline actually used of the sandbox SDK. `executeNotebook` keeps its exact signature and dispatches on `EXECUTOR_DRIVER` (`vercel-sandbox` default | `container`), lazy dynamic import, loud failure on unknown values — the `DB_DRIVER`/`BLOB_DRIVER` register. Its one runtime caller is untouched (empty diff).
- **Driver #1 vercel-sandbox:** existing integration relocated verbatim (snapshot boot, fresh-boot pip fallback, timeouts, CA-bundle fixups now driver-internal).
- **Driver #2 container:** pinned image via the host `docker` CLI — idle-container create, `docker exec` per step, wall-clock timer kill at the same cap, same error mapping. Image from `docker/executor/Dockerfile` (python3.13 + pinned stack + notebook tooling — the snapshot concept's portable equivalent).
- **Pinned-libs single-sourcing:** `PINNED_LIBRARIES`/`PYTHON_RUNTIME_VERSION` in `notebook-author/prompt.ts` is the source; the snapshot script's hand-mirrored copy is deleted (imports now); the Dockerfile is a test-enforced mirror — `container.test.ts` parses its pins/FROM and asserts exact equality both directions.
- **Parity harness** (`scripts/executor-parity.mjs`): deterministic network-free fixture, normalized `ExecutionResult` (5 masked volatile fields documented in the header), `--compare` exits nonzero on mismatch. Container leg proven headlessly incl. cross-run determinism; the vercel-sandbox leg runs at the sprint gate via one owner-executed wrapped command (by the G0/Gate-3 decision, no live values in agent sessions).
- **Riders:** the preflight script gains the executor vars (driver selector, image tag, snapshot id, off-platform auth-variable names). The matching env-template section lands as a follow-up commit on this branch at the gate (the agent permission layer denies writes to env-template paths; comment-only change, no build impact).

## Evidence
- **Tests:** 384 pass / 0 fail (376 baseline + 8 new) — re-run independently by ORCH. **Lint:** the known 4 warnings, 0 errors. **Build:** green.
- **Container proof:** image builds clean (`civic-notebook-executor:0.1.0`); fixture executes with masks verified; timeout test killed at cap (exit 137 surfaced + annotated); error-path test maps a raise into `NotebookExecutionError` with traceback tail.
- **Parity:** container-vs-self compare passes; mutated copy fails nonzero with pinpointed path; second independent container run compared identical.
- **Greps:** `@vercel/sandbox` imported only by the vercel driver + snapshot script; caller diff empty.
- Diff: 12 files, +1094/−112.

IMPL model: claude-fable-5 (per phase plan). Merging deploys production; `rollback/pre-s3b-p4` is tagged at `90f0400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
