### PR TITLE
S3b P5: standalone output, application image, and compose stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Build-context exclusions for the application image (see Dockerfile).
+#
+# `.env*` is excluded FIRST and without exception: the build context is
+# copied wholesale into the builder stage, and anything copied there is
+# recoverable from the image layers. Configuration reaches a container at
+# RUN time (compose `environment:` / `--env-file`), never at build time.
+.env
+.env.*
+
+# Reinstalled inside the image for the image's own platform.
+node_modules
+
+# Rebuilt inside the image.
+.next
+out
+build
+
+# Not needed to build or run the server.
+.git
+.github
+.vercel
+.claude
+coverage
+*.tsbuildinfo
+npm-debug.log*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,84 @@
+# syntax=docker/dockerfile:1
+
+# Application image. Multi-stage: dependencies → standalone build → runtime.
+#
+# Targets:
+#   runner   (default) the Next.js standalone server — `node server.js`
+#   migrate            one-shot `drizzle-kit migrate` against DATABASE_URL
+#
+# Build:
+#   docker build -t civic-app:dev .
+#   docker build -t civic-app-migrate:dev --target migrate .
+#
+# Configuration is RUN-time only (see .dockerignore): no environment file
+# ever enters the build context.
+
+ARG NODE_IMAGE=node:22-bookworm-slim
+# Static docker CLI, copied into the runtime layer for EXECUTOR_DRIVER=container.
+ARG DOCKER_CLI_IMAGE=docker:29-cli
+
+# --- dependencies ----------------------------------------------------------
+# package.json engines require Node >=22; the base image pins the major.
+FROM ${NODE_IMAGE} AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# --- build -----------------------------------------------------------------
+FROM ${NODE_IMAGE} AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# `npm run build:standalone` = BUILD_STANDALONE=1 next build (which flips
+# next.config.ts to `output: 'standalone'`) followed by the runtime-read
+# asset check. The check is part of the build command on purpose: standalone
+# file tracing can drop node:fs-read files silently, and a successful build
+# that ships without them fails only later, in front of a user.
+RUN npm run build:standalone
+
+# --- migrate ---------------------------------------------------------------
+# The builder stage already carries drizzle-kit (a devDependency), the
+# drizzle/ migration folder, and drizzle.config.ts, so the migrator is that
+# stage with a different command. One-shot: applies pending migrations
+# against DATABASE_URL and exits.
+FROM builder AS migrate
+CMD ["npx", "drizzle-kit", "migrate"]
+
+# --- runtime ---------------------------------------------------------------
+FROM ${DOCKER_CLI_IMAGE} AS docker-cli
+
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# EXECUTOR_DRIVER=container shells out to `docker` (src/lib/sandbox/
+# container.ts). The CLI is inert on its own — it needs a daemon socket,
+# which the deployment decides to hand over or withhold. See the header of
+# docker-compose.yml for what handing it over costs.
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+
+# Standalone output carries its own traced node_modules and server.js.
+# `public/` and `.next/static` are copied explicitly per the Next.js
+# standalone contract (they are served from disk, not traced).
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+# ISR revalidation writes here at runtime.
+RUN mkdir -p .next/cache && chown -R node:node .next
+
+# sharp powers the image optimizer, which `images.remotePatterns` in
+# next.config.ts puts on the serving path. It arrives as a dependency of
+# next (not a direct one) and is carried in by standalone tracing — a chain
+# with two links that could break independently. Resolving AND running it
+# here turns a silent runtime degradation into a failed image build.
+RUN node -e "const s=require('sharp'); s({create:{width:8,height:8,channels:3,background:'#000'}}).png().toBuffer().then(b=>{if(!b.length)throw new Error('empty encode');console.log('sharp',s.versions.sharp,'libvips',s.versions.vips,'ok',b.length,'bytes')})"
+
+# Unprivileged by default. A deployment that mounts the docker socket must
+# override this (compose does, with the security note that goes with it).
+USER node
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,250 @@
+# Self-hosted deployment: application + Postgres + S3-compatible object
+# storage + a scheduler sidecar, wired onto the portability drivers
+# (DB_DRIVER=node-postgres, BLOB_DRIVER=s3, EXECUTOR_DRIVER=container).
+#
+# Bring-up:
+#   docker compose --profile build-only build executor-image   # once
+#   docker compose up --build
+#
+# ─── SECURITY: the app service mounts the host container-runtime socket ────
+# EXECUTOR_DRIVER=container executes notebooks by shelling out to `docker`
+# (src/lib/sandbox/container.ts), so the app container is given
+# /var/run/docker.sock and runs as root to use it. Be clear-eyed about the
+# cost: socket access is equivalent to root on the host. Anything able to
+# talk to that daemon can start a privileged container, bind-mount the host
+# filesystem, and step outside the container boundary — the isolation the
+# executor exists to provide does not extend to the app service itself.
+# Run this configuration only on a host you already trust the application
+# with, and do not expose the app's port to an untrusted network as-is.
+# The avoidance path is executor driver #3 (ADR-0023): an HTTP runner that
+# owns the runtime and exposes only "execute this notebook" over the
+# network, leaving the app with no socket at all. Until that exists, the
+# mount is the mechanism and this notice is the mitigation.
+# ───────────────────────────────────────────────────────────────────────────
+#
+# EXTERNAL BY DESIGN: the model endpoint and the MCP data endpoints are
+# network services, not containers here. Supply them by environment
+# (MODEL_API_BASE_URL / OPENROUTER_API_KEY, SOCRATA_MCP_URL,
+# DATA_COMMONS_MCP_URL / DATA_COMMONS_API_KEY).
+#
+# CONFIGURATION: every value written into this file is a neutral
+# local-development placeholder. Entries listed as a bare NAME are
+# pass-through — set in the container only when the caller's environment has
+# them, absent otherwise — so credentials and instance identity arrive from
+# your own environment file:
+#
+#   docker compose --env-file <your env file> up
+#
+# An instance that publishes signed evidence supplies EVIDENCE_SIGNING_KEY,
+# EVIDENCE_KEY_ID, and its own identity values; with none set the app runs
+# in the unsigned tier by design (ADR-0020) — publish stays gated off and
+# the running-unsigned banner shows. See docs/instance-setup.md.
+
+services:
+  postgres:
+    image: postgres:17-bookworm
+    restart: unless-stopped
+    # Placeholder credentials for a loopback-bound development database.
+    # Override all three from your own environment for anything else.
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-civic}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-localdev}
+      POSTGRES_DB: ${POSTGRES_DB:-civic}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-civic} -d ${POSTGRES_DB:-civic}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      # Loopback-bound: the app reaches Postgres over the compose network;
+      # this mapping is for your own psql/inspection only.
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
+
+  minio:
+    # Pin to a dated release tag for a deployment you intend to keep.
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    # Placeholder credentials, as above — these are also the S3_* credentials
+    # the app authenticates with, so the two stay in step by construction.
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID:-localminio}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY:-localminio}
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - miniodata:/data
+    ports:
+      - "127.0.0.1:${S3_PORT:-9000}:9000"
+      - "127.0.0.1:${S3_CONSOLE_PORT:-9001}:9001"
+
+  # One-shot: create the evidence bucket and give it public-read objects.
+  # Public read matches the object-URL semantics the app is written against
+  # (a stored package URL is fetchable); confidentiality of an uncommitted
+  # package rests on its unguessable random key, not on bucket ACLs
+  # (src/lib/storage/index.ts putCommittedPackage).
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        mc alias set local http://minio:9000 "$$MINIO_USER" "$$MINIO_PASSWORD"
+        mc mb --ignore-existing "local/$$BUCKET"
+        mc anonymous set download "local/$$BUCKET"
+        echo "[minio-init] bucket $$BUCKET ready"
+    environment:
+      MINIO_USER: ${S3_ACCESS_KEY_ID:-localminio}
+      MINIO_PASSWORD: ${S3_SECRET_ACCESS_KEY:-localminio}
+      BUCKET: ${S3_BUCKET:-evidence}
+    restart: "no"
+
+  # One-shot: apply pending Drizzle migrations, then exit. Built from the
+  # image's `migrate` target (the build stage, which still has drizzle-kit
+  # and the drizzle/ folder).
+  migrate:
+    build:
+      context: .
+      target: migrate
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-civic}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-civic}
+    restart: "no"
+
+  app:
+    build:
+      context: .
+      target: runner
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+      migrate:
+        condition: service_completed_successfully
+    # Root + socket: see the SECURITY note in this file's header. Both lines
+    # exist for EXECUTOR_DRIVER=container and are removable together on a
+    # deployment that does not execute notebooks.
+    user: "root"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      # Loopback by default, deliberately: the socket mount above makes this
+      # container's reachability a host-security decision. Publish it wider
+      # (APP_BIND=0.0.0.0, or a reverse proxy) only once that is considered.
+      - "${APP_BIND:-127.0.0.1}:${APP_PORT:-3000}:3000"
+    healthcheck:
+      # Dependency-free endpoint (reads env, returns a boolean). Probed with
+      # node because the runtime image ships no HTTP client of its own.
+      test:
+        - "CMD"
+        - "node"
+        - "-e"
+        - "fetch('http://127.0.0.1:3000/api/evidence/signing-status').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    environment:
+      # --- portability drivers (S3b) ---
+      DB_DRIVER: node-postgres
+      DATABASE_URL: postgres://${POSTGRES_USER:-civic}:${POSTGRES_PASSWORD:-localdev}@postgres:5432/${POSTGRES_DB:-civic}
+      BLOB_DRIVER: s3
+      S3_ENDPOINT: http://minio:9000
+      S3_BUCKET: ${S3_BUCKET:-evidence}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-localminio}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-localminio}
+      # Object URLs are handed to browsers, so the public base is the address
+      # a browser can reach — not the in-network endpoint above. Keep the
+      # last path segment equal to S3_BUCKET.
+      S3_PUBLIC_BASE_URL: ${S3_PUBLIC_BASE_URL:-http://localhost:9000/evidence}
+      EXECUTOR_DRIVER: container
+      EXECUTOR_CONTAINER_IMAGE: ${EXECUTOR_CONTAINER_IMAGE:-civic-notebook-executor:0.1.0}
+      # --- instance identity (ADR-0020; neutral local values) ---
+      EVIDENCE_SITE_ORIGIN: ${EVIDENCE_SITE_ORIGIN:-http://localhost:3000}
+      EVIDENCE_PUBLICATION_HOST: ${EVIDENCE_PUBLICATION_HOST:-localhost:3000}
+      EVIDENCE_SIGNER_BINDING_TIER: ${EVIDENCE_SIGNER_BINDING_TIER:-platform}
+      EVIDENCE_SIGNER_IDENTIFIER: ${EVIDENCE_SIGNER_IDENTIFIER:-platform:local-instance}
+      EVIDENCE_SIGNER_DISPLAY_NAME: ${EVIDENCE_SIGNER_DISPLAY_NAME:-Local Instance}
+      EVIDENCE_PLATFORM_AGENT_ID: ${EVIDENCE_PLATFORM_AGENT_ID:-local-instance}
+      EVIDENCE_PLATFORM_AGENT_TITLE: ${EVIDENCE_PLATFORM_AGENT_TITLE:-Local Instance}
+      # --- auth ---
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+      # --- pass-through (key with no value): set in the container only when
+      # present in the caller's environment, absent otherwise ---
+      #   EVIDENCE_SIGNING_KEY / EVIDENCE_KEY_ID  unset ⇒ unsigned tier
+      #   NEXTAUTH_SECRET                         unset ⇒ sign-in unavailable
+      #   CRON_SECRET                             unset ⇒ scheduler rejected (401)
+      # NEXT_PUBLIC_* values are not here: those are inlined into client
+      # bundles at build time, so they belong to the image build, not to run.
+      EVIDENCE_SIGNING_KEY:
+      EVIDENCE_KEY_ID:
+      NEXTAUTH_SECRET:
+      GITHUB_CLIENT_ID:
+      GITHUB_CLIENT_SECRET:
+      OIDC_ISSUER:
+      OIDC_CLIENT_ID:
+      OIDC_CLIENT_SECRET:
+      OIDC_PROVIDER_NAME:
+      OPENROUTER_API_KEY:
+      MODEL_API_BASE_URL:
+      SOCRATA_MCP_URL:
+      SOCRATA_APP_TOKEN:
+      DATA_COMMONS_MCP_URL:
+      DATA_COMMONS_API_KEY:
+      DC_API_KEY:
+      CRON_SECRET:
+      KV_REST_API_URL:
+      KV_REST_API_TOKEN:
+
+  # Periodic caller for the scheduler endpoint. The endpoint is a plain
+  # bearer-authenticated GET (src/app/api/cron/blob-gc/route.ts), so any
+  # scheduler can drive it — this sidecar is the portable one; the hosted
+  # deployment keeps its platform cron (vercel.json) unchanged.
+  gc-cron:
+    image: curlimages/curl:8.11.1
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
+    environment:
+      GC_ENDPOINT: ${GC_ENDPOINT:-http://app:3000/api/cron/blob-gc}
+      GC_INTERVAL_SECONDS: ${GC_INTERVAL_SECONDS:-86400}
+      # Same pass-through as the app: both sides must hold the same secret.
+      CRON_SECRET:
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "[gc-cron] every $${GC_INTERVAL_SECONDS}s → $${GC_ENDPOINT}"
+        while true; do
+          printf '[gc-cron] %s ' "$$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          curl -sS -w ' (http %{http_code})\n' \
+            -H "Authorization: Bearer $${CRON_SECRET}" \
+            "$${GC_ENDPOINT}" || echo '[gc-cron] request failed'
+          sleep "$${GC_INTERVAL_SECONDS}"
+        done
+
+  # Not started by `up`. Builds the notebook-executor image that the app's
+  # container driver runs on the HOST runtime through the mounted socket:
+  #
+  #   docker compose --profile build-only build executor-image
+  executor-image:
+    profiles: ["build-only"]
+    image: ${EXECUTOR_CONTAINER_IMAGE:-civic-notebook-executor:0.1.0}
+    build:
+      context: docker/executor
+
+volumes:
+  pgdata:
+  miniodata:

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,20 @@
 import type { NextConfig } from "next";
 
+/**
+ * Standalone output is opt-in via `BUILD_STANDALONE=1` (see `npm run
+ * build:standalone`). Unset — every existing build path, including the
+ * hosted one — is byte-for-byte the build this repo has always produced;
+ * set, `next build` additionally emits `.next/standalone/server.js` with a
+ * traced `node_modules`, which is what the container image runs.
+ *
+ * Standalone tracing is also where runtime-read non-JS assets can silently
+ * go missing (see `outputFileTracingIncludes` below), so a standalone build
+ * is only trustworthy together with `npm run check:standalone`.
+ */
+const standalone = process.env.BUILD_STANDALONE === '1';
+
 const nextConfig: NextConfig = {
+  ...(standalone ? { output: 'standalone' as const } : {}),
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:standalone": "BUILD_STANDALONE=1 next build && npm run check:standalone",
+    "check:standalone": "node scripts/check-standalone-assets.mjs",
     "start": "next start",
     "lint": "eslint",
     "test": "node --test --experimental-strip-types 'src/**/*.test.ts'",

--- a/scripts/check-standalone-assets.mjs
+++ b/scripts/check-standalone-assets.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Standalone-output asset check (S3b P5).
+ *
+ * `next build` with `output: 'standalone'` ships only what file tracing
+ * found. JavaScript imports are traced reliably; files read at RUNTIME
+ * through `node:fs` are not — they survive only because
+ * `outputFileTracingIncludes` in `next.config.ts` names them. When that
+ * declaration drifts (a moved directory, a renamed route entry, a bundler
+ * change), the build still SUCCEEDS and the missing file only surfaces as a
+ * 500 the first time a user hits the feature. This check closes that
+ * trapdoor: it fails loudly at build time instead.
+ *
+ * What is checked, for every asset in ASSETS below:
+ *   1. the file exists in the standalone output at the path the compiled
+ *      server resolves at runtime, and
+ *   2. its bytes are identical to the in-repo source (a truncated or stale
+ *      copy is as broken as a missing one).
+ *
+ * Runtime path derivation: the helper loader takes its directory from
+ * `import.meta.url` (src/lib/notebook-author/helpers/index.ts). The bundler
+ * rewrites that to a project-root-relative lookup, and `server.js` chdirs to
+ * the standalone root — so the runtime read lands on
+ * `<standalone>/src/lib/notebook-author/helpers/*.py`, which is exactly what
+ * `outputFileTracingIncludes` populates. Keep the two in step: if the loader
+ * stops deriving its path from the module URL, update ASSETS with it.
+ *
+ * Usage:
+ *   node scripts/check-standalone-assets.mjs                  # .next/standalone
+ *   node scripts/check-standalone-assets.mjs --dir <path>     # explicit root
+ *   node scripts/check-standalone-assets.mjs --source <path>  # explicit repo root
+ *
+ * Exit 0 = every asset present and byte-identical; exit 1 = missing,
+ * mismatched, or no standalone output at all.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const DEFAULT_STANDALONE_DIR = '.next/standalone';
+
+/**
+ * Repo-root-relative paths that must appear at the same relative path inside
+ * the standalone output. Each entry names why it is runtime-read, so a
+ * future reader knows what breaks when it goes missing.
+ */
+export const ASSETS = [
+  {
+    file: 'src/lib/notebook-author/helpers/fetch_socrata.py',
+    reason: 'inlined into executed notebooks (ADR-0005 §3); read via node:fs at runtime',
+  },
+  {
+    file: 'src/lib/notebook-author/helpers/fetch_data_commons.py',
+    reason: 'inlined into executed notebooks (ADR-0005 §3); read via node:fs at runtime',
+  },
+  {
+    file: 'src/lib/notebook-author/helpers/fetch_opencontext.py',
+    reason: 'inlined into executed notebooks (ADR-0005 §3); read via node:fs at runtime',
+  },
+];
+
+function sha256(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+/**
+ * Compare every ASSETS entry between a source tree and a standalone output.
+ * Pure and injectable so tests can point it at synthetic directories.
+ *
+ * @returns {{ ok: boolean, results: Array<{ file: string, status: 'ok'|'missing'|'mismatch', detail: string }> }}
+ */
+export function checkStandaloneAssets({ standaloneDir, sourceRoot = REPO_ROOT, assets = ASSETS }) {
+  const results = assets.map(({ file, reason }) => {
+    const target = path.join(standaloneDir, file);
+    if (!fs.existsSync(target)) {
+      return { file, status: 'missing', detail: `not found at ${target} — ${reason}` };
+    }
+    const sourcePath = path.join(sourceRoot, file);
+    const expected = sha256(sourcePath);
+    const actual = sha256(target);
+    if (expected !== actual) {
+      return {
+        file,
+        status: 'mismatch',
+        detail: `sha256 ${actual.slice(0, 12)}… in output vs ${expected.slice(0, 12)}… in source`,
+      };
+    }
+    return { file, status: 'ok', detail: `sha256 ${actual.slice(0, 12)}… (${fs.statSync(target).size} bytes)` };
+  });
+  return { ok: results.every((r) => r.status === 'ok'), results };
+}
+
+function parseArgs(argv) {
+  const opts = { dir: DEFAULT_STANDALONE_DIR, source: REPO_ROOT };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--dir') opts.dir = argv[++i];
+    else if (argv[i] === '--source') opts.source = argv[++i];
+    else {
+      console.error(`error: unknown argument "${argv[i]}"`);
+      console.error('usage: check-standalone-assets.mjs [--dir <standalone dir>] [--source <repo root>]');
+      process.exit(2);
+    }
+  }
+  return opts;
+}
+
+function main() {
+  const { dir, source } = parseArgs(process.argv.slice(2));
+  const standaloneDir = path.resolve(dir);
+  const sourceRoot = path.resolve(source);
+
+  if (!fs.existsSync(standaloneDir)) {
+    console.error(`[standalone-assets] FAIL: no standalone output at ${standaloneDir}`);
+    console.error('  Build one first:  BUILD_STANDALONE=1 npm run build');
+    process.exit(1);
+  }
+
+  const { ok, results } = checkStandaloneAssets({ standaloneDir, sourceRoot });
+  for (const r of results) {
+    const mark = r.status === 'ok' ? 'ok  ' : 'FAIL';
+    console.log(`[standalone-assets] ${mark} ${r.file}\n                        ${r.detail}`);
+  }
+
+  if (!ok) {
+    console.error('');
+    console.error('[standalone-assets] FAIL: the standalone output is missing runtime-read files.');
+    console.error('  These are read with node:fs at request time, so the server starts fine and');
+    console.error('  fails only when a user hits the feature. Fix the `outputFileTracingIncludes`');
+    console.error('  entry in next.config.ts (or the loader path it mirrors), rebuild, re-run.');
+    process.exit(1);
+  }
+  console.log(`[standalone-assets] OK — ${results.length} runtime-read asset(s) present and byte-identical`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/executor-parity.mjs
+++ b/scripts/executor-parity.mjs
@@ -40,7 +40,7 @@
  * Usage (vercel-sandbox leg — needs Vercel Sandbox auth; run through the
  * 1Password wrapper so the op:// references resolve; ONE command):
  *
- *   op run --env-file=.env.local -- node --experimental-strip-types \
+ *   op run --env-file=.env.parity.local -- node --experimental-strip-types \
  *     scripts/executor-parity.mjs run --driver vercel-sandbox --out parity-vercel.json
  *
  * Compare (exit 0 = parity, exit 1 = mismatch, differences listed):
@@ -77,7 +77,7 @@ function usage(message) {
       '  executor-parity.mjs compare <a.json> <b.json>',
       '',
       'vercel-sandbox leg (auth via 1Password wrapper), one command:',
-      '  op run --env-file=.env.local -- node --experimental-strip-types \\',
+      '  op run --env-file=.env.parity.local -- node --experimental-strip-types \\',
       '    scripts/executor-parity.mjs run --driver vercel-sandbox --out parity-vercel.json',
     ].join('\n'),
   );

--- a/src/lib/notebook-author/helpers/standalone-tracing.test.ts
+++ b/src/lib/notebook-author/helpers/standalone-tracing.test.ts
@@ -1,0 +1,108 @@
+// Standalone-tracing guard for the runtime-read Python helpers (S3b P5).
+//
+// The helpers in this directory are read with node:fs at request time, so
+// they reach a standalone build only through the `outputFileTracingIncludes`
+// declaration in next.config.ts. If that declaration ever stops covering
+// them, `next build` still succeeds and the failure surfaces as a 500 on the
+// executed-notebook route — a silent trapdoor.
+//
+// scripts/check-standalone-assets.mjs is the build-time gate. These tests
+// pin its contract without needing a real build:
+//
+//   - the asset list covers every .py file actually in this directory
+//     (adding a helper without registering it fails here);
+//   - next.config.ts still declares the tracing include that populates them;
+//   - the check PASSES on a complete synthetic output, and FAILS on a
+//     missing or byte-changed asset — including end-to-end through the CLI,
+//     which is what a build pipeline calls.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { ASSETS, checkStandaloneAssets } from '../../../../scripts/check-standalone-assets.mjs';
+
+const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HELPERS_DIR, '../../../..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts/check-standalone-assets.mjs');
+
+/** Copy the declared assets into a synthetic standalone root. */
+function buildSyntheticStandalone(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'standalone-assets-'));
+  for (const { file } of ASSETS) {
+    const target = path.join(dir, file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, file), target);
+  }
+  return dir;
+}
+
+test('asset list covers every runtime-read helper source in this directory', () => {
+  const onDisk = fs
+    .readdirSync(HELPERS_DIR)
+    .filter((f) => f.endsWith('.py'))
+    .sort();
+  const declared = ASSETS.map(({ file }: { file: string }) => path.basename(file)).sort();
+  assert.deepEqual(
+    declared,
+    onDisk,
+    'scripts/check-standalone-assets.mjs ASSETS is out of step with the helper sources on disk',
+  );
+});
+
+test('next.config.ts still declares the tracing include that ships them', () => {
+  const config = fs.readFileSync(path.join(REPO_ROOT, 'next.config.ts'), 'utf8');
+  assert.match(config, /outputFileTracingIncludes/);
+  assert.match(
+    config,
+    /\.\/src\/lib\/notebook-author\/helpers\/\*\.py/,
+    'the helpers glob vanished from outputFileTracingIncludes — standalone builds would ship without it',
+  );
+});
+
+test('check passes on a complete standalone output', () => {
+  const dir = buildSyntheticStandalone();
+  try {
+    const { ok, results } = checkStandaloneAssets({ standaloneDir: dir });
+    assert.equal(ok, true, JSON.stringify(results, null, 2));
+    assert.equal(results.length, ASSETS.length);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('check fails loudly when a traced asset is missing', () => {
+  const dir = buildSyntheticStandalone();
+  try {
+    const victim = path.join(dir, ASSETS[0].file);
+    fs.rmSync(victim);
+    const { ok, results } = checkStandaloneAssets({ standaloneDir: dir });
+    assert.equal(ok, false);
+    assert.equal(results[0].status, 'missing');
+
+    // And through the CLI, which is what a build pipeline invokes.
+    const run = spawnSync(process.execPath, [SCRIPT, '--dir', dir], { encoding: 'utf-8' });
+    assert.equal(run.status, 1, `expected exit 1, got ${run.status}\n${run.stdout}${run.stderr}`);
+    assert.match(run.stderr, /missing runtime-read files/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('check fails when a shipped asset drifts from its source bytes', () => {
+  const dir = buildSyntheticStandalone();
+  try {
+    const victim = path.join(dir, ASSETS[1].file);
+    fs.writeFileSync(victim, '# truncated by a bad copy\n');
+    const { ok, results } = checkStandaloneAssets({ standaloneDir: dir });
+    assert.equal(ok, false);
+    assert.equal(results[1].status, 'mismatch');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Phase P5 of the S3b-core sprint (#171) — the finale: standalone output, an application image, and a compose stack that runs the instance on the portability drivers P1–P4 shipped. Demo/hosted behavior unchanged.

## What changed
- **`output: 'standalone'` is opt-in** via `BUILD_STANDALONE=1` (`npm run build:standalone`). Unset — including the hosted build — the config is byte-for-byte what it always was, so this cannot perturb the production build path.
- **Dockerfile:** `node:22-bookworm-slim`, `deps` → `builder` → `migrate`/`runner`. Runner ships `.next/standalone` + `public` + `.next/static`, non-root `USER node`, writable ISR cache. Docker CLI copied in for the container executor driver. New `.dockerignore` excludes env files first, so no environment file can enter the build context.
- **`docker-compose.yml`:** Postgres + MinIO (+ bucket-init one-shot) + migrate one-shot + app + GC-cron sidecar, plus a profile-gated service that builds the executor image. App wired to `DB_DRIVER=node-postgres`, `BLOB_DRIVER=s3`, `EXECUTOR_DRIVER=container`. Model and MCP endpoints stay external by design. Ports bind to loopback by default.
- **Rider:** the parity harness now names its own credential env file in the printed usage line (string-only change).

## The four known wrinkles, handled as design requirements
1. **Standalone tracing silent-miss.** `scripts/check-standalone-assets.mjs` asserts each runtime-read `.py` helper exists in the standalone output *and* is byte-identical to source, exiting non-zero otherwise; it is chained into `build:standalone`, so the image build fails rather than shipping a server that breaks only when a user hits the feature. Five tests pin the asset list against the files actually on disk and exercise pass / missing / byte-drift.
2. **Container executor needs host runtime access.** The socket is mounted and the cost is stated plainly — a boxed security note in the compose header (socket access is equivalent to root on the host; the executor's isolation does not extend to the app service), repeated at the mount and in the Dockerfile, naming ADR-0023's HTTP-runner driver (#3) as the avoidance path.
3. **`sharp` at runtime.** No new dependency — it already arrives transitively and lands in the traced output. Because that is a chain that can break silently, the runner stage *executes* an encode probe at build time, so a missing or broken sharp fails the image build. Verified live: the optimizer served an actual resize through the running container.
4. **Neutral configuration.** `NEXTAUTH_URL`/site origin default to localhost; identity defaults are generic local-instance placeholders. No demo-instance identity value appears anywhere in the stack. Credentials are pass-through keys, set in the container only when present in the caller's environment.

## Evidence
- **Tests:** 395 pass / 0 fail (390 baseline + 5 new) — re-run independently by ORCH. **Lint:** the known 4 warnings, 0 errors. **Build:** non-standalone path green and emits no standalone output.
- **Standalone + trapdoor:** ORCH re-ran the standalone build (three helpers present, hashes matching) and independently verified the check exits 1 with a helper removed and 0 once restored.
- **Bring-up:** all four services healthy; 14 migrations applied against compose Postgres; pages and API routes served, including a route whose HTML proves the traced Python helpers resolve inside the standalone server.
- **Deterministic acceptance legs:** container executor driven through the mounted socket from inside the app container (create → exec → teardown, pinned stack versions confirmed); s3-driver round-trip against compose MinIO byte-identical, public read and delete confirmed; produce → store → retrieve → byte-parity → offline verification passing inside the built image; the instance-identity rehearsal passing; GC sidecar firing on schedule with 401s for missing and wrong bearer tokens.
- **Cleanup:** stack down, volumes and network removed; leftover image tags documented in the phase report.
- Diff: 8 files, +626/−2.

IMPL model: claude-opus-5 (session default changed mid-sprint; the plan had budgeted the session default for this phase). Merging deploys production; `rollback/pre-s3b-p5` is tagged at `af53784`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
