### PR TITLE
ADR-0016 sweep P1: accept-both prep (behaviorally inert)

### DIFF
--- a/drizzle/0014_add_sealed_public_visibility.sql
+++ b/drizzle/0014_add_sealed_public_visibility.sql
@@ -1,0 +1,27 @@
+-- M1 (EXPAND) of the ADR-0016 §A visibility-label rename: committed -> sealed,
+-- published -> public. This migration ONLY widens the enum. It rewrites no rows
+-- and does not touch the column default — the row flip and the default move are
+-- M2, a separate, separately-gated migration.
+--
+-- OWNER-RUN. Applied by hand via psql against production, ahead of the phase
+-- that starts writing the new labels. A downstream fork will apply this same
+-- file through an ordinary `drizzle-kit migrate`, so both paths must be safe on
+-- a database that may already hold the values: `IF NOT EXISTS` makes the
+-- statements idempotent by construction, and re-running the file is a no-op.
+-- (The earlier hand-authored ADD VALUE migrations here omit `IF NOT EXISTS`;
+-- this one needs it precisely because it has two application paths.)
+--
+-- VERIFY AFTER APPLYING — do not skip, and do not trust a tool's exit status:
+--
+--     \dT+ visibility
+--
+-- must list FOUR labels: published, committed, sealed, public. `drizzle-kit`
+-- can report success without having applied anything, so the catalog is the
+-- only acceptable evidence that this landed.
+--
+-- Note on transactions: `ALTER TYPE ... ADD VALUE` is safe inside a transaction
+-- block on PostgreSQL 12+, but the new label cannot be USED in the same
+-- transaction that adds it. Nothing here uses it, and the code that will is in
+-- a later deploy, so the ordering is fine either way.
+ALTER TYPE "public"."visibility" ADD VALUE IF NOT EXISTS 'sealed';--> statement-breakpoint
+ALTER TYPE "public"."visibility" ADD VALUE IF NOT EXISTS 'public';

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,817 @@
+{
+  "id": "6ccd2e6d-5fc0-450d-89f3-f7a9b2b83501",
+  "prevId": "bc495c2f-64d6-4403-a87f-039f8ff66d64",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_nodes": {
+      "name": "attestation_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rfc3161_timestamp": {
+          "name": "rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_entry_id": {
+          "name": "rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_inclusion_proof": {
+          "name": "rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer": {
+          "name": "signer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_nodes_creator_id_users_id_fk": {
+          "name": "attestation_nodes_creator_id_users_id_fk",
+          "tableFrom": "attestation_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_packages": {
+      "name": "attestation_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evidence_record_id": {
+          "name": "evidence_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attestation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_hash": {
+          "name": "package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references_base_hash": {
+          "name": "references_base_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_packages_evidence_record_id_evidence_records_id_fk": {
+          "name": "attestation_packages_evidence_record_id_evidence_records_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "evidence_records",
+          "columnsFrom": [
+            "evidence_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attestation_packages_creator_id_users_id_fk": {
+          "name": "attestation_packages_creator_id_users_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_approved_user_id_users_id_fk": {
+          "name": "device_codes_approved_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_records": {
+      "name": "evidence_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_visibility": {
+          "name": "prompt_visibility",
+          "type": "prompt_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_text'"
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_server": {
+          "name": "mcp_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civic_context": {
+          "name": "civic_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_hash": {
+          "name": "base_package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_storage_key": {
+          "name": "base_package_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_signature": {
+          "name": "base_package_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rfc3161_timestamp": {
+          "name": "base_package_rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_id": {
+          "name": "base_package_rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_inclusion_proof": {
+          "name": "base_package_rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_body": {
+          "name": "base_package_rekor_entry_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_method": {
+          "name": "capture_method",
+          "type": "capture_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_profile": {
+          "name": "content_profile",
+          "type": "content_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "consistency_classification": {
+          "name": "consistency_classification",
+          "type": "consistency_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_reason": {
+          "name": "withdrawn_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_signature": {
+          "name": "withdrawal_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_timestamp": {
+          "name": "withdrawal_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_reason": {
+          "name": "reinstated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_signature": {
+          "name": "reinstatement_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_timestamp": {
+          "name": "reinstatement_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidence_records_base_package_hash_idx": {
+          "name": "evidence_records_base_package_hash_idx",
+          "columns": [
+            {
+              "expression": "base_package_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidence_records_creator_id_users_id_fk": {
+          "name": "evidence_records_creator_id_users_id_fk",
+          "tableFrom": "evidence_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evidence_records_slug_unique": {
+          "name": "evidence_records_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attestation_type": {
+      "name": "attestation_type",
+      "schema": "public",
+      "values": [
+        "consistency",
+        "evaluation",
+        "re_evaluation",
+        "correction",
+        "expert_attestation"
+      ]
+    },
+    "public.capture_method": {
+      "name": "capture_method",
+      "schema": "public",
+      "values": [
+        "chat-flow-stream",
+        "claude-code-jsonl-readback",
+        "claude-code-self-report",
+        "datHere"
+      ]
+    },
+    "public.consistency_classification": {
+      "name": "consistency_classification",
+      "schema": "public",
+      "values": [
+        "highly_reproducible",
+        "moderately_stable",
+        "inconsistent"
+      ]
+    },
+    "public.content_profile": {
+      "name": "content_profile",
+      "schema": "public",
+      "values": [
+        "default",
+        "datHere"
+      ]
+    },
+    "public.prompt_visibility": {
+      "name": "prompt_visibility",
+      "schema": "public",
+      "values": [
+        "full_text",
+        "hash_only"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "consistency_tested",
+        "evaluated",
+        "fully_attested"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "published",
+        "committed",
+        "sealed",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1782929788389,
       "tag": "0013_add_base_package_hash_index",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1785931200000,
+      "tag": "0014_add_sealed_public_visibility",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/evidence/[slug]/page.tsx
+++ b/src/app/(app)/evidence/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
 import { resolveLifecycle } from '@/lib/evidence/lifecycle';
 import { sessionUserIsCreator } from '@/lib/evidence/committed-access';
+import { fromDbValue } from '@/lib/evidence/visibility';
 import { loadEvaluationViews } from '@/lib/evidence/adversarial-eval';
 import EvaluationAttestationsSection from '@/components/evidence/EvaluationAttestationsSection';
 import ProvenanceChain from '@/components/evidence/ProvenanceChain';
@@ -119,7 +120,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   // Committed records (civic-ai-tools#71): title/summary are content-derived
   // and creator-only — emit generic metadata regardless of viewer so nothing
   // content-bearing lands in OG tags, caches, or link previews.
-  if (data.record.visibility === 'committed') {
+  if (fromDbValue(data.record.visibility) === 'sealed') {
     return { title: 'Committed evidence record', robots: { index: false } };
   }
 
@@ -204,7 +205,7 @@ export default async function EvidencePage({ params }: PageProps) {
   // title, summary, notebook) does not exist for anyone else — 404, not 403,
   // so probing can't confirm the record. The public surface for a committed
   // claim is the redacted commitment sidecar.
-  const isCommitted = data.record.visibility === 'committed';
+  const isCommitted = fromDbValue(data.record.visibility) === 'sealed';
   if (isCommitted && !(await sessionUserIsCreator(data.record))) {
     notFound();
   }

--- a/src/app/api/evidence/[slug]/commitment/route.ts
+++ b/src/app/api/evidence/[slug]/commitment/route.ts
@@ -8,6 +8,7 @@ import { buildCommitmentView } from '@/lib/evidence/commitment';
 import { loadTrustRegistry } from '@/lib/evidence/verify';
 import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
 import { classifyIdentifier, commitmentAccessError } from '@/lib/evidence/identifier';
+import { fromDbValue } from '@/lib/evidence/visibility';
 
 /**
  * GET /api/evidence/[hash|slug]/commitment
@@ -154,7 +155,11 @@ export async function GET(
   // public — the hash is already on the transparency log — but the content
   // surface is not. Serve the view redacted of the capability URL, title, and
   // summary; never inline the package.
-  const isCommitted = record.visibility === 'committed';
+  // Keyed on the canonical state, so redaction holds for a row under EITHER
+  // label (legacy `committed` or ADR-0016 `sealed`). Note this decides only
+  // WHETHER to redact — the `visibility` value the view SERVES is the raw
+  // column, passed through unchanged by `buildCommitmentView`.
+  const isCommitted = fromDbValue(record.visibility) === 'sealed';
   const commitment = buildCommitmentView(record, creator, pkg, lifecycleAttestations, {
     redactContentSurface: isCommitted,
   });

--- a/src/app/api/evidence/[slug]/publish/route.ts
+++ b/src/app/api/evidence/[slug]/publish/route.ts
@@ -15,6 +15,8 @@ import {
   evaluateSealCommitGate,
   evaluateUnsignedRecordPublishGate,
 } from '@/lib/evidence/unsigned-tier';
+import { fromDbValue, toDbValue } from '@/lib/evidence/visibility';
+import { visibilityMatches } from '@/lib/evidence/visibility-sql';
 
 /**
  * POST /api/evidence/[slug]/publish
@@ -100,7 +102,9 @@ export async function POST(
     return NextResponse.json({ error: 'Evidence record not found' }, { status: 404 });
   }
 
-  if (record.visibility !== 'committed') {
+  // Precondition, keyed on the canonical state so a row holding EITHER label
+  // (legacy `committed` or ADR-0016 `sealed`) is still promotable.
+  if (fromDbValue(record.visibility) !== 'sealed') {
     return NextResponse.json({ error: 'Evidence is already published' }, { status: 400 });
   }
 
@@ -220,16 +224,22 @@ export async function POST(
     }
   }
 
-  // 2. Compare-and-set the visibility mirror committed→published. This is the
+  // 2. Compare-and-set the visibility mirror sealed→public. This is the
   //    concurrency guard: of two racing publishes, exactly one UPDATE matches
   //    the WHERE clause. The loser emits nothing and reports the conflict.
+  //
+  //    The compare side matches EITHER sealed-state label, so the guard keeps
+  //    working on rows still holding the legacy value — if it only matched one
+  //    spelling, a row on the other one would fail the CAS with a 409 and be
+  //    permanently unpublishable. The set side writes whatever `toDbValue`
+  //    currently persists, so the pre-check above and this update always agree.
   const won = await db
     .update(evidenceRecords)
-    .set({ visibility: 'published', updatedAt: new Date() })
+    .set({ visibility: toDbValue('public'), updatedAt: new Date() })
     .where(
       and(
         eq(evidenceRecords.id, record.id),
-        eq(evidenceRecords.visibility, 'committed' as const),
+        visibilityMatches(evidenceRecords.visibility, 'sealed'),
       ),
     )
     .returning({ id: evidenceRecords.id });
@@ -243,7 +253,7 @@ export async function POST(
   const revertToCommitted = async () => {
     await db
       .update(evidenceRecords)
-      .set({ visibility: 'committed', updatedAt: new Date() })
+      .set({ visibility: toDbValue('sealed'), updatedAt: new Date() })
       .where(eq(evidenceRecords.id, record.id));
   };
 

--- a/src/app/api/evidence/list/route.ts
+++ b/src/app/api/evidence/list/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { evidenceRecords, attestationPackages, users } from '@/lib/db/schema';
 import { eq, desc, asc, ilike, or, and, gte, isNull, isNotNull, sql } from 'drizzle-orm';
+import { visibilityMatches } from '@/lib/evidence/visibility-sql';
 
 const PAGE_SIZE = 20;
 
@@ -26,12 +27,17 @@ export async function GET(request: NextRequest) {
   const includeWithdrawn = params.get('withdrawn') === 'include';
   const page = Math.max(1, parseInt(params.get('page') || '1', 10));
 
-  // Build WHERE conditions. Committed records (civic-ai-tools#71) are never
+  // Build WHERE conditions. Sealed records (civic-ai-tools#71) are never
   // listed — their commitment is public via the commitment endpoint, but the
   // record itself is creator-only until published.
+  //
+  // The visibility filter is a SET-membership test over both public-state
+  // labels rather than equality against one (ADR-0016 §A; see
+  // `@/lib/evidence/visibility`). Equality against a single spelling would
+  // silently empty this listing the moment the row flip renames the rows.
   const conditions = [
     eq(evidenceRecords.isPublic, true),
-    eq(evidenceRecords.visibility, 'published' as const),
+    visibilityMatches(evidenceRecords.visibility, 'public'),
   ];
 
   // Exclude currently-withdrawn records by default.

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -11,6 +11,13 @@ import { type BlobRef } from '@/lib/evidence/blob-ref';
 import { resolveRequestUser, hasScope } from '@/lib/api-auth';
 import { emitPublicationPair } from '@/lib/evidence/publication';
 import { evaluateSealCommitGate } from '@/lib/evidence/unsigned-tier';
+import {
+  normalizeVisibility,
+  toDbValue,
+  ACCEPTED_VISIBILITY_INPUTS,
+  type Visibility,
+  type VisibilityDbValue,
+} from '@/lib/evidence/visibility';
 
 function slugify(text: string): string {
   return text
@@ -108,12 +115,17 @@ interface PublishRequest {
    *  ADR-0010 §5/§6) — an instruction to the registry, NOT an envelope field
    *  (the package JSON is byte-identical either way; visibility is the
    *  structural consequence of which attestations reference the node).
-   *  `"published"` (default, back-compat): store content-addressably, list
-   *  publicly, emit the publication pair. `"committed"`: register the
+   *  `"public"` (default, back-compat): store content-addressably, list
+   *  publicly, emit the publication pair. `"sealed"`: register the
    *  commitment (sign + timestamp + Rekor) but emit no publishes/locatedAt
    *  attestations, keep the record unlisted, and store the content under a
-   *  random non-hash-derivable key. */
-  visibility?: 'published' | 'committed';
+   *  random non-hash-derivable key.
+   *
+   *  Both vocabularies are accepted, indefinitely: `"committed"` is an alias of
+   *  `"sealed"` and `"published"` of `"public"` (ADR-0016 §A back-compat
+   *  SHOULD — already-shipped clients and the published skill send the legacy
+   *  pair). See `@/lib/evidence/visibility`. */
+  visibility?: VisibilityDbValue;
 }
 
 export async function POST(request: NextRequest) {
@@ -132,8 +144,8 @@ export async function POST(request: NextRequest) {
 
     // Unsigned-tier gate-off (S3a P3, #166; ADR-0020 Decisions B/C, G0-3).
     // Both request-level visibilities are persist actions this route signs:
-    // "committed" registers a commitment (sealed-family) and "published" is
-    // the public state — an unsigned package may reach NEITHER, so with no
+    // "sealed" registers a commitment and "public" is the disclosed
+    // state — an unsigned package may reach NEITHER, so with no
     // signing key configured the whole persist path is refused up front
     // rather than storing a record with a null signature.
     const gate = evaluateSealCommitGate();
@@ -185,15 +197,25 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate visibility (civic-ai-tools#71). Request-level instruction;
-    // absence is equivalent to "published" (backwards compatibility — every
-    // pre-Phase-2 publish was public).
-    if (body.visibility && body.visibility !== 'published' && body.visibility !== 'committed') {
+    // absence is equivalent to "public" (backwards compatibility — every
+    // pre-Phase-2 publish was public). Both the ADR-0016 §A vocabulary and the
+    // legacy one are accepted; everything downstream branches on the canonical
+    // value, and the single write goes through `toDbValue`.
+    const requestedVisibility = body.visibility === undefined
+      ? 'public'
+      : normalizeVisibility(body.visibility);
+    if (requestedVisibility === null) {
       return NextResponse.json(
-        { error: 'visibility, when provided, must be "published" or "committed".' },
+        {
+          error: `visibility, when provided, must be one of: ${ACCEPTED_VISIBILITY_INPUTS.map((v) => `"${v}"`).join(', ')}.`,
+        },
         { status: 400 },
       );
     }
-    const visibility: 'published' | 'committed' = body.visibility ?? 'published';
+    const visibility: Visibility = requestedVisibility;
+    // The label actually persisted, and the one echoed back to the caller. Both
+    // stay on the legacy vocabulary until the flip phase — see `toDbValue`.
+    const visibilityDbValue = toDbValue(visibility);
 
     // Validate captureMethod (ADR-0003/0011). Required for all publishes;
     // must be in the captureMethod vocabulary declared by the package's
@@ -269,7 +291,7 @@ export async function POST(request: NextRequest) {
     // non-hash-derivable key (Phase 2 hard requirement: the hash is public in
     // Rekor, so a hash-derived pathname would leak committed content); the
     // canonical hash-addressed key is claimed at publication time.
-    const blobUrl = visibility === 'committed'
+    const blobUrl = visibility === 'sealed'
       ? await putCommittedPackage(pkg as unknown as Record<string, unknown>)
       : await putPackage(packageHash, pkg as unknown as Record<string, unknown>);
 
@@ -319,7 +341,7 @@ export async function POST(request: NextRequest) {
       basePackageRekorEntryBody: rekorResult?.entryBody || null,
       captureMethod: body.captureMethod,
       contentProfile: body.contentProfile ?? null,
-      visibility,
+      visibility: visibilityDbValue,
     });
 
     // Published-mode packages get the publication pair at publish time
@@ -329,7 +351,7 @@ export async function POST(request: NextRequest) {
     // failure doesn't fail the publish (the content is public and listed; the
     // pair can be re-emitted by a future repair pass).
     let publicationPair: { publishesNodeId: string; locatedAtNodeId: string } | null = null;
-    if (visibility === 'published') {
+    if (visibility === 'public') {
       try {
         publicationPair = await emitPublicationPair({
           targetNodeId: packageHash,
@@ -343,17 +365,21 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Committed records return NO public url (the record is unlisted and the
+    // Sealed records return NO public url (the record is unlisted and the
     // content URL is undisclosed); the slug + packageHash are the creator's
     // handles for the later publish step.
+    //
+    // The echoed `visibility` is the PERSISTED label, not the canonical one:
+    // this response is a served surface, and changing what clients read is the
+    // flip phase's chartered change, not a side effect of accepting aliases.
     const response = NextResponse.json(
-      visibility === 'committed'
-        ? { slug, packageHash, visibility }
+      visibility === 'sealed'
+        ? { slug, packageHash, visibility: visibilityDbValue }
         : {
             slug,
             url: `/evidence/${slug}`,
             packageHash,
-            visibility,
+            visibility: visibilityDbValue,
             ...(publicationPair ?? {}),
           },
     );

--- a/src/components/PublishEvidenceDialog.tsx
+++ b/src/components/PublishEvidenceDialog.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import type { ToolCall, EvidenceTrace } from '@/hooks/useStreamingComparison';
 import { generateNotebook } from '@/lib/notebook';
 import type { Notebook } from '@/lib/notebook-author/cells';
+import { normalizeVisibility } from '@/lib/evidence/visibility';
 
 interface PublishEvidenceDialogProps {
   isOpen: boolean;
@@ -203,7 +204,12 @@ export default function PublishEvidenceDialog({
       // `url` is absent for committed-visibility responses; the slug-derived
       // page is creator-only until the record is published.
       setResultUrl(data.url ?? `/evidence/${data.slug}`);
-      setResultVisibility(data.visibility === 'committed' ? 'committed' : 'published');
+      // Read-side normalization only (ADR-0016 §A): the response may carry
+      // either vocabulary. The local state union and the request value it sends
+      // stay on the legacy labels in this phase.
+      setResultVisibility(
+        normalizeVisibility(data.visibility) === 'sealed' ? 'committed' : 'published',
+      );
       setDialogState('success');
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : 'Publishing failed');

--- a/src/components/dashboard/DashboardTabs.tsx
+++ b/src/components/dashboard/DashboardTabs.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, type CSSProperties } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { normalizeVisibility } from '@/lib/evidence/visibility';
 
 // --- Types ---
 
@@ -18,8 +19,10 @@ interface EvidenceRow {
   reinstatedAt: string | null;
   createdAt: string;
   attestationCount: number;
-  /** Visibility mirror (civic-ai-tools#71): committed records are unlisted +
-   *  creator-only until promoted via the publish flow. */
+  /** Visibility mirror (civic-ai-tools#71), as the raw DB label — either
+   *  vocabulary (ADR-0016 §A; normalized through `@/lib/evidence/visibility`).
+   *  Sealed records are unlisted + creator-only until promoted via the publish
+   *  flow. */
   visibility: string;
 }
 
@@ -292,7 +295,7 @@ function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signi
                   {r.title}
                 </Link>
                 <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'center' }}>
-                  {r.visibility === 'committed' && <StatusBadge status="committed" />}
+                  {normalizeVisibility(r.visibility) === 'sealed' && <StatusBadge status="committed" />}
                   {isCurrentlyWithdrawn
                     ? <StatusBadge status="withdrawn" />
                     : <StatusBadge status={r.verificationStatus} />
@@ -336,7 +339,7 @@ function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signi
                     <span style={{ color: 'var(--nyc-success)' }}>Reinstated {formatDate(r.reinstatedAt!)}</span>
                   </>
                 )}
-                {r.visibility === 'committed' && !isCurrentlyWithdrawn && (
+                {normalizeVisibility(r.visibility) === 'sealed' && !isCurrentlyWithdrawn && (
                   <>
                     <span>{'\u00b7'}</span>
                     {signingConfigured ? (

--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -7,6 +7,7 @@ import {
   summarizeIntegrity,
   resolveCaptureMethodLabel,
 } from '@/lib/evidence/trust-signal';
+import { normalizeVisibility } from '@/lib/evidence/visibility';
 import type {
   KeyTrustResult,
   BlobRefVerification,
@@ -28,10 +29,11 @@ interface EvidenceActionsProps {
    *  neutral informational label beside the signature verdict (#11,
    *  "signed ≠ verbatim"). */
   captureMethod: string | null;
-  /** Record visibility (`published` | `committed`). Gates the verify badge
+  /** Record visibility, as the raw DB label — either vocabulary (ADR-0016 §A;
+   *  normalized through `@/lib/evidence/visibility`). Gates the verify badge
    *  (#114): the delegated verifier resolves a package via its commitment
-   *  sidecar, which is redacted for committed records, so the badge is
-   *  published-only. */
+   *  sidecar, which is redacted for sealed records, so the badge is
+   *  public-state-only. */
   visibility: string;
   /** Absolute, publicly-fetchable commitment endpoint for this package
    *  (resolved server-side from the request host). The verify badge (#114)
@@ -278,7 +280,7 @@ export default function EvidenceActions({
             missing-content alarm. Rendered independent of the glance's load
             state — when our own check can't load, "verify it yourself" matters
             most. */}
-        {visibility === 'published' && <VerifyBadge commitmentUrl={commitmentUrl} />}
+        {normalizeVisibility(visibility) === 'public' && <VerifyBadge commitmentUrl={commitmentUrl} />}
       </div>
 
       {/* Actions */}

--- a/src/components/evidence/VerifyBadge.tsx
+++ b/src/components/evidence/VerifyBadge.tsx
@@ -15,11 +15,13 @@
  * shown ONLY there. The badge SVG (served by typedstandards.org) enforces this;
  * this component only points at it.
  *
- * CALLER GATE: render this ONLY for `visibility === 'published'` records. The
- * verifier resolves a package through its `/commitment` sidecar, and a committed
+ * CALLER GATE: render this ONLY for records in the PUBLIC visibility state —
+ * test it via `normalizeVisibility` (`@/lib/evidence/visibility`), never against
+ * a raw label, since the column carries either vocabulary (ADR-0016 §A). The
+ * verifier resolves a package through its `/commitment` sidecar, and a sealed
  * record's commitment is redacted of the package location (content is private),
- * so /verify would surface a missing-content alarm. Committed support is tracked
- * separately (arch-gated); until then the badge is published-only.
+ * so /verify would surface a missing-content alarm. Sealed support is tracked
+ * separately (arch-gated); until then the badge is public-state-only.
  *
  * `commitmentUrl` is the absolute, publicly-fetchable commitment endpoint for
  * this package, resolved server-side from the request host so it is correct on

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -92,9 +92,32 @@ export const contentProfileEnum = pgEnum('content_profile', [
 // mirror in the same pattern as the withdrawn/reinstated columns — the publish
 // flow dual-writes it alongside emitting the signed attestation pair. Legacy
 // rows backfill to 'published' (every pre-Phase-2 publish was public).
+//
+// ADR-0016 §A renames the two STATE labels — `committed` -> `sealed`,
+// `published` -> `public` — while the verb "Publish", the cryptographic
+// "commitment" noun, and `attestation/publishes/v1` all stay put. The rename
+// ships as expand -> flip -> keep-the-dead-values, so the enum carries all four
+// labels permanently (Postgres cannot drop an enum value without recreating the
+// type, and keeping the legacy pair makes every step reversible and every
+// historical dump readable).
+//
+// THIS DECLARATION RUNS AHEAD OF THE DATABASE. The `sealed` / `public` labels
+// reach the live enum only when the owner-run M1 expand migration
+// (drizzle/0014_add_sealed_public_visibility.sql) is applied. Declaring them
+// early is inert: a drizzle `pgEnum` is a compile-time type declaration plus a
+// migration-diff input — it emits no runtime validation — and the code in this
+// phase writes ONLY the legacy labels, because
+// `src/lib/evidence/visibility.ts#toDbValue` still maps the canonical values
+// back to `committed` / `published`. Order matches what `ALTER TYPE ... ADD
+// VALUE` produces: the new labels append after the existing two.
+//
+// The column DEFAULT stays `'published'` in this phase; moving it is part of
+// the later flip, alongside the row rewrite.
 export const visibilityEnum = pgEnum('visibility', [
   'published',
   'committed',
+  'sealed',
+  'public',
 ]);
 
 // --- Tables ---

--- a/src/lib/evidence/committed-access.ts
+++ b/src/lib/evidence/committed-access.ts
@@ -14,14 +14,21 @@ import { db } from '@/lib/db';
 import { users, type evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { resolveRequestUser } from '@/lib/api-auth';
+import { isSealedDbValue } from '@/lib/evidence/visibility';
 
 type VisibilityColumns = Pick<
   typeof evidenceRecords.$inferSelect,
   'visibility' | 'creatorId'
 >;
 
+/**
+ * True for the not-yet-disclosed state, under EITHER label — the row may hold
+ * the legacy `committed` or the ADR-0016 §A `sealed` (see
+ * `@/lib/evidence/visibility`). Historical rows keep the legacy label
+ * indefinitely, so this gate must never be keyed on one spelling.
+ */
 export function isCommittedRecord(record: VisibilityColumns): boolean {
-  return record.visibility === 'committed';
+  return isSealedDbValue(record.visibility);
 }
 
 /**

--- a/src/lib/evidence/visibility-sql.ts
+++ b/src/lib/evidence/visibility-sql.ts
@@ -1,0 +1,37 @@
+// Server-side SQL predicate for the visibility vocabulary (ADR-0016 §A).
+//
+// Split out of `visibility.ts` so that module stays dependency-free: three
+// CLIENT components normalize visibility labels, and pulling `drizzle-orm` into
+// their bundles to do it would be a real cost for no gain.
+
+import { sql, type SQL, type Column } from 'drizzle-orm';
+import {
+  SEALED_DB_VALUES,
+  PUBLIC_DB_VALUES,
+  type Visibility,
+} from './visibility.ts';
+
+/**
+ * Match a `visibility` enum column against every DB label that denotes
+ * `state` — both the legacy label and the ADR-0016 label — so a query keeps
+ * selecting the right rows on either side of the M2 row flip, and on a replica
+ * or fork that is part-way through the migration.
+ *
+ * WHY THE `::text` CAST. Comparing an enum column against a label the enum does
+ * not (yet) hold is a hard Postgres error at coercion time —
+ * `invalid input value for enum visibility: "public"` — not a non-match. Before
+ * the M1 expand migration runs, `sealed` and `public` are exactly that: labels
+ * the type does not hold. Casting the column to `text` makes both sides text,
+ * so the predicate is a plain string comparison that is valid at every point in
+ * the migration: it selects the same rows before M1 as `= '<legacy>'` did, and
+ * the same rows after M2 without a second edit. There is no index on
+ * `visibility` for the cast to defeat.
+ */
+export function visibilityMatches(column: Column, state: Visibility): SQL {
+  const labels: readonly string[] =
+    state === 'sealed' ? SEALED_DB_VALUES : PUBLIC_DB_VALUES;
+  return sql`${column}::text in (${sql.join(
+    labels.map((label) => sql`${label}`),
+    sql`, `,
+  )})`;
+}

--- a/src/lib/evidence/visibility.test.ts
+++ b/src/lib/evidence/visibility.test.ts
@@ -1,0 +1,236 @@
+// Tests for the ADR-0016 §A visibility vocabulary boundary (visibility.ts) and
+// for the property that makes the rename safe to ship in stages: a row written
+// under the LEGACY vocabulary keeps working, unchanged, at every surface that
+// reads it.
+//
+// Run with: npm test (Node 22+).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fromDbValue,
+  toDbValue,
+  normalizeVisibility,
+  isSealedDbValue,
+  SEALED_DB_VALUES,
+  PUBLIC_DB_VALUES,
+  ACCEPTED_VISIBILITY_INPUTS,
+  type Visibility,
+  type VisibilityDbValue,
+} from './visibility.ts';
+import { buildCommitmentView } from './commitment.ts';
+import { evidenceRecords, users } from '../db/schema.ts';
+import type { EvidencePackage } from './packager.ts';
+
+type EvidenceRecord = typeof evidenceRecords.$inferSelect;
+type UserRecord = typeof users.$inferSelect;
+
+const CREATOR_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+function makeRecord(overrides: Partial<EvidenceRecord> = {}): EvidenceRecord {
+  const base: EvidenceRecord = {
+    id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    slug: 'historical-analysis-eb1cad',
+    creatorId: CREATOR_ID,
+    title: 'Historical analysis',
+    summary: 'A summary captured before the vocabulary rename.',
+    model: 'claude-opus-4-8',
+    promptHash: 'sha256:promptdigest',
+    promptVisibility: 'full_text',
+    promptText: 'prompt text',
+    systemPromptHash: 'sha256:systemdigest',
+    mcpServer: 'https://socrata-mcp.civicaitools.org',
+    jurisdiction: 'NYC',
+    civicContext: 'civic context note',
+    basePackageHash:
+      'eb1cadfebadcaffeebeadfacedbeadedcabbadedeafdeedfeebfadedaccededa',
+    basePackageStorageKey:
+      'https://store.public.blob.vercel-storage.com/evidence-packages/committed/deadbeefcafefeedfacedbadcabbaded.json',
+    basePackageSignature: JSON.stringify({
+      signature: 'BASE64SIG',
+      publicKey: 'BASE64PUBKEY',
+      algorithm: 'Ed25519ph',
+      kid: 'platform:evidence-legacy',
+    }),
+    basePackageRfc3161Timestamp: 'BASE64TSTOKEN',
+    basePackageRekorEntryId: 'rekor-entry-legacy',
+    basePackageRekorInclusionProof: JSON.stringify({ logIndex: 'abc' }),
+    basePackageRekorEntryBody: 'eyJhcGlWZXJzaW9uIjoiMC4wLjEifQ==',
+    captureMethod: 'chat-flow-stream',
+    contentProfile: null,
+    verificationStatus: 'unverified',
+    consistencyClassification: null,
+    isPublic: true,
+    // The point of the fixture: the row holds the LEGACY label.
+    visibility: 'committed',
+    withdrawnAt: null,
+    withdrawnReason: null,
+    withdrawalSignature: null,
+    withdrawalTimestamp: null,
+    reinstatedAt: null,
+    reinstatedReason: null,
+    reinstatementSignature: null,
+    reinstatementTimestamp: null,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+  };
+  return { ...base, ...overrides };
+}
+
+function makeCreator(): UserRecord {
+  return {
+    id: CREATOR_ID,
+    githubId: 'octocat-id',
+    displayName: 'Octocat',
+    githubProfileUrl: 'https://github.com/octocat',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  };
+}
+
+// Only the envelope fields buildCommitmentView reads; cast keeps it small
+// (the full package shape is exercised in packager.test.ts).
+function makePkg(): EvidencePackage {
+  return {
+    producerProfile: 'analysis/socrata-civic/v1',
+    type: 'content/analysis/v1',
+    signer: {
+      bindingTier: 'platform',
+      identifier: 'platform:evidence-legacy',
+    },
+    contentHash: 'sha256:contentdigest',
+    contentCanonicalization: 'application/json+jcs',
+  } as unknown as EvidencePackage;
+}
+
+// --- Normalization: both vocabularies mean the same thing ---
+
+test('fromDbValue normalizes both vocabularies to the same canonical value', () => {
+  assert.equal(fromDbValue('committed'), 'sealed');
+  assert.equal(fromDbValue('sealed'), 'sealed');
+  assert.equal(fromDbValue('published'), 'public');
+  assert.equal(fromDbValue('public'), 'public');
+
+  // Stated as the property rather than four literals: each legacy label and its
+  // replacement are indistinguishable downstream.
+  assert.deepEqual(SEALED_DB_VALUES.map(fromDbValue), ['sealed', 'sealed']);
+  assert.deepEqual(PUBLIC_DB_VALUES.map(fromDbValue), ['public', 'public']);
+});
+
+test('fromDbValue refuses an unrecognized label instead of coercing it', () => {
+  assert.throws(
+    () => fromDbValue('unlisted' as VisibilityDbValue),
+    /Unrecognized visibility value/,
+  );
+});
+
+test('isSealedDbValue is true for both sealed-state labels and false for both public ones', () => {
+  for (const label of SEALED_DB_VALUES) assert.equal(isSealedDbValue(label), true, label);
+  for (const label of PUBLIC_DB_VALUES) assert.equal(isSealedDbValue(label), false, label);
+});
+
+// --- Input aliasing: legacy and new request bodies produce the same write ---
+
+test('normalizeVisibility accepts all four request literals and rejects everything else', () => {
+  assert.equal(ACCEPTED_VISIBILITY_INPUTS.length, 4);
+  for (const literal of ACCEPTED_VISIBILITY_INPUTS) {
+    assert.notEqual(normalizeVisibility(literal), null, literal);
+  }
+  for (const bad of ['Sealed', 'PUBLIC', 'private', 'withdrawn', '', null, undefined, 1, {}]) {
+    assert.equal(normalizeVisibility(bad), null, JSON.stringify(bad));
+  }
+});
+
+test('round trip: legacy input and new input produce an identical DB write', () => {
+  const write = (input: unknown): VisibilityDbValue => {
+    const canonical = normalizeVisibility(input);
+    assert.notEqual(canonical, null, `expected ${String(input)} to be accepted`);
+    return toDbValue(canonical as Visibility);
+  };
+
+  assert.equal(write('committed'), write('sealed'));
+  assert.equal(write('published'), write('public'));
+
+  // …and in this phase that identical write is the LEGACY label, so the merge
+  // changes nothing about what lands in the column. When the flip phase turns
+  // `toDbValue` into the identity, this pair of assertions is what changes —
+  // and it is the only place in the suite that has to.
+  assert.equal(write('sealed'), 'committed');
+  assert.equal(write('public'), 'published');
+});
+
+test('toDbValue output is always a value the canonical vocabulary round-trips', () => {
+  for (const canonical of ['sealed', 'public'] as const) {
+    assert.equal(fromDbValue(toDbValue(canonical)), canonical);
+  }
+});
+
+// --- Historical records are unharmed ---
+//
+// The acceptance criterion for shipping the vocabulary widening ahead of the
+// data: a row still holding `committed` reads, gates, and serves exactly as it
+// did before.
+
+test('historical record: a legacy "committed" row still reads as the sealed state', () => {
+  const record = makeRecord();
+  assert.equal(fromDbValue(record.visibility), 'sealed');
+});
+
+test('historical record: a legacy "committed" row still fails the public read gate', () => {
+  // `isCommittedRecord` in committed-access.ts is exactly this predicate applied
+  // to `record.visibility`; when it is true the route requires the requester to
+  // resolve to `record.creatorId`. A row on the legacy label must keep hitting
+  // that branch — if it stopped, the content surface of every pre-rename sealed
+  // record would become world-readable.
+  const legacy = makeRecord({ visibility: 'committed' });
+  const renamed = makeRecord({ visibility: 'sealed' });
+  assert.equal(isSealedDbValue(legacy.visibility), true);
+  assert.equal(isSealedDbValue(renamed.visibility), true);
+
+  // The disclosed state, under either label, needs no creator check.
+  assert.equal(isSealedDbValue(makeRecord({ visibility: 'published' }).visibility), false);
+  assert.equal(isSealedDbValue(makeRecord({ visibility: 'public' }).visibility), false);
+});
+
+test('historical record: a legacy "committed" row still produces a servable, redacted commitment view', () => {
+  const record = makeRecord({
+    title: 'CONFIDENTIAL question title',
+    summary: 'CONFIDENTIAL summary',
+  });
+
+  // The redaction decision is taken exactly the way the commitment route takes
+  // it — through the vocabulary boundary, not a string literal.
+  const view = buildCommitmentView(record, makeCreator(), makePkg(), undefined, {
+    redactContentSurface: isSealedDbValue(record.visibility),
+  });
+
+  // Content surface stays redacted for the legacy label.
+  const serialized = JSON.stringify(view);
+  assert.equal(serialized.includes('CONFIDENTIAL'), false, 'content strings leaked');
+  assert.ok(!('packageUrl' in view), 'capability URL leaked');
+  assert.ok(!('subjectTitle' in view));
+  assert.ok(!('subjectSummary' in view));
+
+  // The proofs — which ARE the commitment — are served.
+  assert.equal(view.packageHash, record.basePackageHash);
+  assert.ok(view.signature);
+  assert.equal(view.rfc3161Timestamp, 'BASE64TSTOKEN');
+  assert.equal(view.rekorEntryId, 'rekor-entry-legacy');
+
+  // SERVING SURFACE, deliberately unchanged: the commitment view passes the raw
+  // column through. An external verifier that already knows this record reads
+  // byte-identically to before the boundary module existed. Renaming what this
+  // field serves is the flip phase's chartered change, not a side effect here.
+  assert.equal(view.visibility, 'committed');
+});
+
+test('serving surface: a public-state row still serves its raw label unchanged', () => {
+  const view = buildCommitmentView(
+    makeRecord({ visibility: 'published', title: 'Open analysis', summary: 'Open summary' }),
+    makeCreator(),
+    makePkg(),
+  );
+  assert.equal(view.visibility, 'published');
+  assert.equal(view.subjectTitle, 'Open analysis');
+  assert.ok(view.packageUrl);
+});

--- a/src/lib/evidence/visibility.ts
+++ b/src/lib/evidence/visibility.ts
@@ -1,0 +1,156 @@
+// Visibility vocabulary boundary (ADR-0016 Decision A).
+//
+// ADR-0016 §A renames the two `visibility` STATE labels: the not-yet-disclosed
+// state `committed` -> `sealed`, and the disclosed state `published` ->
+// `public`. Deliberately NOT renamed by that ADR: the verb "Publish", the
+// cryptographic "commitment" noun (the `/commitment` endpoint, the commitment
+// view, the commitment bundle), and the `attestation/publishes/v1` sub-type.
+// Only the state label moves; the state MEANINGS are unchanged.
+//
+// ---------------------------------------------------------------------------
+// MIGRATION STRATEGY — expand, then flip, then keep the dead values
+// ---------------------------------------------------------------------------
+//
+//   M1  EXPAND   `ALTER TYPE visibility ADD VALUE 'sealed' / 'public'`
+//                (drizzle/0014_add_sealed_public_visibility.sql). The enum then
+//                carries all four labels. No row changes; no behavior changes.
+//
+//   M2  FLIP     Rewrite the rows onto the new labels and move the column
+//                default. Only after this does the database hold any
+//                new-vocabulary row. Paired with the code-side flip of
+//                `toDbValue` below.
+//
+//   ---  KEEP    The legacy labels `committed` / `published` are NEVER dropped.
+//                Postgres cannot remove an enum value without recreating the
+//                type, and leaving them in place costs nothing while keeping
+//                every step reversible, every historical dump readable, and
+//                every already-shipped client's request body valid.
+//
+// ---------------------------------------------------------------------------
+// THE TWO DIRECTIONS ARE ASYMMETRIC — that asymmetry is the point
+// ---------------------------------------------------------------------------
+//
+//   `fromDbValue` is PERMANENTLY total over all four labels. A row that was
+//   written before the flip keeps its legacy label forever, and the flip is not
+//   the only way a legacy label reaches this process: a restored backup, a
+//   downstream fork part-way through the migration, or a replica that has not
+//   run M2 all serve legacy labels. Reading must never assume the flip ran.
+//
+//   `toDbValue` is the SINGLE place that decides what gets WRITTEN. It is
+//   phase-gated (see its comment) so the flip is a one-line change instead of a
+//   second sweep across every write site.
+//
+// Read sites therefore normalize through `fromDbValue` / `normalizeVisibility`
+// and branch on the canonical vocabulary; write sites go through `toDbValue`.
+// No call site outside this module should compare a `visibility` value against
+// a raw string literal.
+
+/**
+ * The canonical, internal visibility vocabulary (ADR-0016 §A). Every branch in
+ * application code is keyed on THIS type — never on a raw DB label.
+ *
+ * - `sealed` — signed + RFC 3161-timestamped + transparency-log-logged; content
+ *   creator-only / unlisted / at a non-derivable key.
+ * - `public` — carries the `attestation/publishes/v1` + `attestation/locatedAt/v1`
+ *   pair; content served and listed.
+ */
+export type Visibility = 'sealed' | 'public';
+
+/**
+ * Every label the `visibility` Postgres enum can hold across the migration
+ * window: the two legacy labels plus the two ADR-0016 labels. The legacy pair
+ * is never dropped, so this union is the permanent shape of the column — not a
+ * transitional one.
+ */
+export type VisibilityDbValue = 'published' | 'committed' | 'sealed' | 'public';
+
+/** DB labels that denote the SEALED state. Legacy first, matching enum order. */
+export const SEALED_DB_VALUES = ['committed', 'sealed'] as const satisfies readonly VisibilityDbValue[];
+
+/** DB labels that denote the PUBLIC state. Legacy first, matching enum order. */
+export const PUBLIC_DB_VALUES = ['published', 'public'] as const satisfies readonly VisibilityDbValue[];
+
+/**
+ * Every literal the API boundary accepts for `visibility`, in the order the
+ * validation error lists them. Both vocabularies are accepted indefinitely
+ * (ADR-0016 §A back-compat SHOULD: already-shipped clients and the published
+ * skill keep sending the legacy labels).
+ */
+export const ACCEPTED_VISIBILITY_INPUTS = [
+  'sealed',
+  'public',
+  'committed',
+  'published',
+] as const satisfies readonly VisibilityDbValue[];
+
+/**
+ * Normalize a DB label to the canonical vocabulary. Total over all four labels
+ * and permanently so — see the asymmetry note above.
+ *
+ * The column is a `NOT NULL` enum, so the input domain is closed and the
+ * `default` branch is unreachable through the ORM. It throws rather than
+ * coercing anyway: a value outside the enum means the schema declaration and
+ * the database have diverged, and silently treating an unknown label as
+ * `public` would disclose content the row never authorized.
+ */
+export function fromDbValue(value: VisibilityDbValue): Visibility {
+  switch (value) {
+    case 'sealed':
+    case 'committed':
+      return 'sealed';
+    case 'public':
+    case 'published':
+      return 'public';
+    default: {
+      const unexpected: never = value;
+      throw new Error(`Unrecognized visibility value: ${String(unexpected)}`);
+    }
+  }
+}
+
+/**
+ * Does this DB label denote the sealed (not-yet-disclosed) state, under either
+ * vocabulary? This is the exact predicate the creator-only read gate keys on
+ * (`isCommittedRecord` in `committed-access.ts`), named here so it is
+ * directly exercisable — that module cannot be loaded by the test runner,
+ * which resolves no path aliases.
+ */
+export function isSealedDbValue(value: VisibilityDbValue): boolean {
+  return fromDbValue(value) === 'sealed';
+}
+
+/**
+ * ============================ THE FLIP POINT ============================
+ *
+ * PHASE P1 (this phase): returns the LEGACY label. The application continues
+ * to WRITE exactly what it writes today (`sealed` -> `'committed'`,
+ * `public` -> `'published'`), which is what makes P1's merge behaviorally
+ * inert — the new labels do not yet exist in the database.
+ *
+ * PHASE P2 (after the owner-run M1 expand migration lands): this function
+ * becomes the identity — `sealed` -> `'sealed'`, `public` -> `'public'` — and
+ * that is the ENTIRE code-side flip. Nothing else has to change, because no
+ * other module decides what a write puts in the column.
+ *
+ * =======================================================================
+ */
+export function toDbValue(value: Visibility): VisibilityDbValue {
+  return value === 'sealed' ? 'committed' : 'published';
+}
+
+/**
+ * Boundary normalizer: accepts any of the four labels (either vocabulary) from
+ * an untrusted source — a request body, or a JSON response being read by a
+ * client component — and returns the canonical value, or `null` for anything
+ * else. Callers turn `null` into their own rejection (a 400 listing
+ * `ACCEPTED_VISIBILITY_INPUTS`, or a safe default).
+ *
+ * Deliberately non-throwing and `unknown`-typed: unlike `fromDbValue`, whose
+ * domain is closed by the enum, this one's domain is whatever a caller sent.
+ */
+export function normalizeVisibility(value: unknown): Visibility | null {
+  if (typeof value !== 'string') return null;
+  if ((SEALED_DB_VALUES as readonly string[]).includes(value)) return 'sealed';
+  if ((PUBLIC_DB_VALUES as readonly string[]).includes(value)) return 'public';
+  return null;
+}


### PR DESCRIPTION
Phase P1 of the ADR-0016 Decision A sweep (anchor #182). **This merge is behaviorally inert** — the application writes the same values and serves the same values as today. All P1 does is make the code able to accept and understand both vocabularies, so P2's flip is a one-line change rather than a second sweep.

## What lands

- **Vocabulary boundary** (`src/lib/evidence/visibility.ts`) — canonical internal `sealed`/`public`, with `fromDbValue` accepting all four labels and `toDbValue` writing the legacy pair. `toDbValue` is the single flip point for P2 and is marked as such.
- **Input alias layer** — `POST /api/evidence` accepts `sealed | public | committed | published`. Legacy input keeps working indefinitely (ADR-0016 §A's SHOULD).
- **Read-path normalization at internal comparison sites only** — access gates, the publish precondition and its compare-and-set, the listing filter, and the render gates all key on the canonical state, so they keep working across the M2 row flip.
- **`drizzle/0014_add_sealed_public_visibility.sql`** — the M1 expand migration, hand-authored and idempotent (`ADD VALUE IF NOT EXISTS`). **Owner-run via psql; not applied by this merge.** Idempotence is load-bearing: production gets it by hand, a downstream fork gets the same file through an ordinary `drizzle-kit migrate`.
- **Widened enum declaration** in `schema.ts` — inert, since a drizzle `pgEnum` emits no runtime validation and P1 writes only legacy labels.

## Deliberately unchanged

The two serving surfaces — the documented read-back (`api/evidence/[slug]/route.ts:49`) and the commitment view (`lib/evidence/commitment.ts:209`) — still pass through the raw column value. `git diff` against these two files is empty. Flipping what external clients see is P2's separately-gated change.

Also untouched: all display strings, the Commit/Seal verb, badge labels, the column default, `docs/`, and the `isPublic`/`listed` question. Later phases.

## Two contract corrections found during implementation

1. **The listing filter and the publish CAS could not use `inArray`.** Comparing an enum column against a label the type does not yet hold is a hard Postgres coercion error, not a non-match — so the obvious implementation would have emptied the public listing and broken the publish guard the moment this merged, before M1 runs. Both now use a `::text`-cast set-membership predicate (`visibility-sql.ts`), verified through drizzle's dialect. No index on `visibility` for the cast to defeat.
2. **`POST /api/evidence` is a third serving surface** — its response echoes `visibility`. It now serves the persisted label, keeping the response byte-identical. Folded into P2's checklist, where it flips by design.

## Evidence

| Check | Result |
|---|---|
| `npm run test` | **405 pass / 0 fail** (baseline 395; +10 new) |
| `npm run lint` | 4 warnings, **0 introduced** — all pre-existing, in untouched files |
| `npm run build` | compiled clean, all routes emitted |
| Diff | 17 files, +1413 / −42 |

New coverage: a historical-record fixture (a row on the legacy label still reads, passes the creator-only gate, and produces a servable commitment view), round-trip equivalence between legacy and new input, and normalization parity across both DB vocabularies.

**Insert-path finding:** exactly one insert path into `evidence_records`, and it always supplies `visibility` explicitly. The M2 column-default change is therefore safe from the application side.

## Merge choreography

Merging this deploys inert code. **M1 runs after this deploys**, owner-run via psql, verified with `\dT+ visibility` showing four labels — never a tool's exit status.

Refs #182