### PR TITLE
ADR-0016 sweep P2: the flip — writes and serving surfaces read sealed/public

### DIFF
--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -16,7 +16,7 @@ This contract spans three repositories. If you're integrating, here's how they r
 
 Every ADR, `§`-reference, issue, and Q-number below is hyperlinked to its source — follow the link rather than guessing which repo it's in.
 
-_Last updated: 2026-08-02 — see the [change log](#change-log) for dated changes._
+_Last updated: 2026-08-05 — see the [change log](#change-log) for dated changes._
 
 **Status:** Schema version `0.1.0`. Fields may be added in a backwards-compatible way; breaking changes will bump the `schemaVersion` inside the package and be noted in the change log at the bottom of this document. The 2026-05-19 amendment introduces the `contentProfile` field per [ADR-0004](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0004-dathere-captureMethod-variant.md) and reverts the brief 2026-05-18 `datHere` captureMethod variant; both changes are additive — pre-ADR-0004 packages hash byte-identical with the new code.
 
@@ -107,7 +107,7 @@ Send exactly one auth header — when both are present, the `Authorization` head
 | `duration_ms`           | number             | no       | End-to-end analysis duration in milliseconds.                                                                                                           |
 | `skillMetadataOverride` | object             | no       | Override for the skill metadata normally extracted from the trace. Required when `trace` is a BlobRef. See [Blob references](#blob-references-phase-b6). |
 | `extensions`            | object             | no       | Implementation-specific artifacts keyed by reverse-DNS identifiers (e.g., `"org.civicaitools.notebook"`). Extensions are included in the canonical JSON and therefore covered by the package hash. |
-| `visibility`            | string             | no       | Request-level visibility instruction per [civic-ai-tools#71](https://github.com/npstorey/civic-ai-tools/issues/71): `"published"` (default) or `"committed"`. NOT an envelope field — the package JSON is identical either way. See [Committed-mode publishing](#committed-mode-publishing-live-since-2026-06-12). |
+| `visibility`            | string             | no       | Request-level visibility instruction per [civic-ai-tools#71](https://github.com/npstorey/civic-ai-tools/issues/71): `"public"` (default) or `"sealed"`. The legacy spellings `"published"` and `"committed"` are accepted as aliases indefinitely (deprecated, see below). NOT an envelope field — the package JSON is identical either way. See [Sealed-mode publishing](#sealed-mode-publishing-live-since-2026-06-12). |
 
 #### `toolCalls[]` entries
 
@@ -387,7 +387,7 @@ This section is the integration contract for the attest-by-default / publish-by-
 |---|---|
 | Withdrawal / reinstatement as signed `attestation/*` nodes | **Live** (`POST /api/evidence/:slug/withdraw`, `/reinstate`) |
 | Visibility expressed as attestation presence (spec semantics) | **Ratified** (spec §8.10, ADR-0010) — this is the normative model now |
-| Committed-mode publishing (`visibility: "committed"` request flag) | **Live** (Phase 2, 2026-06-12) |
+| Sealed-mode publishing (`visibility: "sealed"` request flag) | **Live** (Phase 2, 2026-06-12; renamed from `"committed"` 2026-08-05 per ADR-0016 §A — the legacy spelling still works) |
 | Publication-record creation (`POST /api/evidence/:slug/publish`) | **Live** (Phase 2, 2026-06-12) |
 | Adversarial-eval attestation as a signed `attestation/evaluates/v1` node + default-on publication gate | **Live** (Phase 3, 2026-06-12) — `runEvaluation` defaults to `true` on the publish route |
 | Host self-attestation (`requiresAdversarialEvalOnPublication`) | **Specified shape, reserved sub-type** — `content/host/v1` is reserved per ADR-0009 §7; the field shape below is the agreed v1 contract (Q22 / proposed-issue 008) |
@@ -400,10 +400,18 @@ The integration-arc issues were written before the unified-primitive consolidati
 |---|---|
 | `visibility: "committed"` envelope field | **Not a field.** A content node that is signed and transparency-logged but has **no `attestation/publishes/v1` and no public `attestation/locatedAt/v1`** referencing it. This is the zero-location base case (ADR-0010 §5, spec §8.10.2). |
 | `visibility: "published"` envelope field | **Not a field.** A content node referenced by an `attestation/publishes/v1` **and** at least one `attestation/locatedAt/v1` — publication is two coupled, independently Rekor-included signed nodes (ADR-0010 §6). |
-| `publication-record` claim type | **Is** the `attestation/publishes/v1` node (payload: `targetNodeId`, `publicationHost`, `releasedAt`), typically paired with the publisher's own `attestation/locatedAt/v1` (payload: `targetNodeId`, `uri`, `contentHash`, optional `contentLength`/`availability`). Multiple parties publishing the same committed claim each emit their own pair. |
+| `publication-record` claim type | **Is** the `attestation/publishes/v1` node (payload: `targetNodeId`, `publicationHost`, `releasedAt`), typically paired with the publisher's own `attestation/locatedAt/v1` (payload: `targetNodeId`, `uri`, `contentHash`, optional `contentLength`/`availability`). Multiple parties publishing the same sealed claim each emit their own pair. |
 | `visibility: "group"` (reserved) | Still reserved. No sub-type is minted; group-corroboration patterns are future work under Q20. |
 | Publication is irreversible; withdrawal is a meta-attestation | Preserved by construction: `attestation/withdraws/v1` is a separately-signed `publisher-only` node that reverses the publisher's *own* visibility commitment without erasing anything — retention asymmetry is normative (spec §8.10.3). |
 | `hostPointers` can be empty (point-to-point distribution) | Zero `attestation/locatedAt/v1` nodes — the recipient-distributed case under the zero-location base case. |
+
+The left column above quotes the **issues' original wording verbatim**, so that
+someone reading civic-ai-tools#71/#72 can find the ratified shape. It is not
+current vocabulary on two counts: those `visibility` values were never envelope
+fields, and the state labels themselves were subsequently renamed
+`committed` → `sealed` and `published` → `public` by
+[ADR-0016 §A](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0016-vcs-native-lifecycle-mapping.md)
+(see [Sealed-mode publishing](#sealed-mode-publishing-live-since-2026-06-12)).
 
 Why the envelope must not carry a visibility field: visibility changes over a node's life, and the envelope is content-addressed — a field flip would re-hash and re-sign the node, breaking the "publication adds attestations to the chain" property. ADR-0010's considered-and-rejected list records this decision; clients MUST NOT add a `visibility` key to package extensions to simulate it.
 
@@ -416,39 +424,78 @@ Withdrawal and reinstatement are shipped and emit conformant `attestation/*` nod
 
 Verifiers resolve lifecycle from the attestation chain first and fall back to the legacy columns only for pre-chain records (spec §8.10.4 dual-read). The bundle and commitment endpoints carry the signed lifecycle envelopes so third-party verifiers resolve the chain offline.
 
-### Committed-mode publishing (live since 2026-06-12)
+<a id="committed-mode-publishing-live-since-2026-06-12"></a>
+
+### Sealed-mode publishing (live since 2026-06-12)
 
 `POST /api/evidence` accepts an optional **request-level** `visibility` field — an instruction to the registry, not an envelope field (the package JSON is unchanged either way):
 
 | Value | Behavior |
 |---|---|
-| `"published"` (default) | Prior behavior, made explicit: the platform stores the package content-addressably, signs it, timestamps it, Rekor-includes it, lists it in the public registry, and emits the publication pair — `attestation/publishes/v1` + the platform's own `attestation/locatedAt/v1` — at publish time. Pair emission is best-effort (matching the signing posture); when it succeeds the response carries `publishesNodeId` + `locatedAtNodeId`. |
-| `"committed"` | The platform builds, signs, timestamps, and Rekor-includes the content node — the **commitment is publicly registered** — but emits **no** `attestation/publishes/v1` and **no** `attestation/locatedAt/v1`, does not list the record in the public registry index, and does not disclose a content URL. The content blob is stored under a **random, non-hash-derivable key** (the package hash is public in Rekor, so a hash-derived pathname would leak committed content). The publisher holds (or separately distributes) the bytes — the creator-only bundle export is the supported distribution artifact. |
+| `"public"` (default) | Prior behavior, made explicit: the platform stores the package content-addressably, signs it, timestamps it, Rekor-includes it, lists it in the public registry, and emits the publication pair — `attestation/publishes/v1` + the platform's own `attestation/locatedAt/v1` — at publish time. Pair emission is best-effort (matching the signing posture); when it succeeds the response carries `publishesNodeId` + `locatedAtNodeId`. |
+| `"sealed"` | The platform builds, signs, timestamps, and Rekor-includes the content node — the **commitment is publicly registered** — but emits **no** `attestation/publishes/v1` and **no** `attestation/locatedAt/v1`, does not list the record in the public registry index, and does not disclose a content URL. The content blob is stored under a **random, non-hash-derivable key** (the package hash is public in Rekor, so a hash-derived pathname would leak sealed content). The publisher holds (or separately distributes) the bytes — the creator-only bundle export is the supported distribution artifact. |
 
-The default is `"published"` for backwards compatibility — existing clients see no behavior change. The website publish dialog defaults its *UI choice* to **committed** per civic-ai-tools#71 scope item 7 (attest by default, publish by choice) and sends the flag explicitly; committed records are then promoted from the dashboard, where the publish step runs the default-on adversarial-eval gate. Note the asymmetry this creates deliberately: the dashboard promotion path always passes through the eval gate, while direct `visibility: "published"` publishes (API clients; the dialog's explicit "Publish now" choice) emit the publication pair without an evaluation — consistent with Q25's host-policy-not-protocol-mandatory posture.
+#### Accepted values and the legacy aliases
 
-Committed-mode response: `{ slug, packageHash, visibility: "committed" }` — no public `url` is returned. Published-mode response (additively extended): `{ slug, url, packageHash, visibility: "published", publishesNodeId?, locatedAtNodeId? }`.
+`visibility` is one of **four accepted input literals**, and will be indefinitely:
 
-What a committed record looks like from the outside:
+| Input literal | Means | Status |
+|---|---|---|
+| `"sealed"` | the not-yet-disclosed state | **Current** (ADR-0016 §A) |
+| `"public"` | the disclosed state | **Current** (ADR-0016 §A) |
+| `"committed"` | alias of `"sealed"` | **Deprecated**, accepted indefinitely |
+| `"published"` | alias of `"public"` | **Deprecated**, accepted indefinitely |
+
+The two vocabularies are indistinguishable once the value is accepted — the same
+record is produced either way, and the same bytes are signed. Anything else is
+rejected with `400`.
+
+There is **no removal date** for the deprecated pair, and none is planned:
+already-shipped clients and the published `publish-evidence` skill send it, and
+[ADR-0016 §A](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0016-vcs-native-lifecycle-mapping.md)
+makes back-compat a SHOULD. "Deprecated" here means only that new clients should
+write `"sealed"` / `"public"`.
+
+**What is SERVED, as of 2026-08-05, is always the current vocabulary.** Every
+response field that carries a visibility state — the `POST /api/evidence` echo,
+`GET /api/evidence/:slug`, and the `/commitment` sidecar — emits `"sealed"` or
+`"public"`, including for records created before the rename. A consumer that
+branches on the served value therefore needs to handle exactly two literals; a
+consumer reading a stored copy of an older response may still see the legacy
+pair and should treat the two vocabularies as synonymous.
+
+**What is renamed and what is not.** ADR-0016 §A moves the *state label* only.
+The verb stays **"Publish"** (and its mirror **"Seal"**), the relationship stays
+`attestation/publishes/v1` + `attestation/locatedAt/v1`, and the cryptographic
+**"commitment"** noun — the `/commitment` endpoint, the commitment view, the
+commitment bundle — is untouched. A sealed node and a public node BOTH carry a
+public transparency-log commitment; `visibility` describes whether the *content*
+is disclosed, never whether the node is on the ledger.
+
+The default is `"public"` for backwards compatibility — existing clients see no behavior change. The website publish dialog defaults its *UI choice* to **Seal** per civic-ai-tools#71 scope item 7 (attest by default, publish by choice) and sends the flag explicitly; sealed records are then promoted from the dashboard, where the publish step runs the default-on adversarial-eval gate. Note the asymmetry this creates deliberately: the dashboard promotion path always passes through the eval gate, while direct `visibility: "public"` publishes (API clients; the dialog's explicit "Publish now" choice) emit the publication pair without an evaluation — consistent with Q25's host-policy-not-protocol-mandatory posture.
+
+Sealed-mode response: `{ slug, packageHash, visibility: "sealed" }` — no public `url` is returned. Public-mode response (additively extended): `{ slug, url, packageHash, visibility: "public", publishesNodeId?, locatedAtNodeId? }`. The echoed `visibility` is the current vocabulary regardless of which spelling the request used.
+
+What a sealed record looks like from the outside:
 
 - **Not listed** in `/api/evidence/list` or the public registry index.
 - **Creator-only** (404 to everyone else, including probes) on every content-bearing surface: the detail page, `GET /api/evidence/:slug`, `/package`, `/bundle`, `/verify`, `/replay`, `/evaluate`, `/attestations`. The creator authenticates by session cookie or bearer token.
-- **Commitment publicly served, redacted**: `GET /api/evidence/:slug/commitment` (and the hash-addressed form) returns the proofs — `packageHash`, signature envelope, signer, envelope taxonomy fields, RFC 3161 token, Rekor entry + inclusion proof, lifecycle chain — plus `visibility: "committed"`, but **omits** `packageUrl`, `subjectTitle`, and `subjectSummary`, and never inlines the package (`?inline=1` inlines only the trust registry). A recipient holding creator-distributed bytes verifies them against this redacted commitment.
+- **Commitment publicly served, redacted**: `GET /api/evidence/:slug/commitment` (and the hash-addressed form) returns the proofs — `packageHash`, signature envelope, signer, envelope taxonomy fields, RFC 3161 token, Rekor entry + inclusion proof, lifecycle chain — plus `visibility: "sealed"`, but **omits** `packageUrl`, `subjectTitle`, and `subjectSummary`, and never inlines the package (`?inline=1` inlines only the trust registry). A recipient holding creator-distributed bytes verifies them against this redacted commitment.
 
 Two honesty notes integrating clients should know:
 
-1. **A public Rekor inclusion is itself a disclosure** — the envelope hash, timestamp, and signer identity become public records even for committed claims (spec §11.1; ADR-0010 §4). Truly-no-public-footprint flows require a private transparency-log substrate, which is design-permitted but not built (Xanadu-gated).
-2. **Content-URL non-derivability is implemented as a random storage key.** Committed blobs live at `evidence-packages/committed/<128-bit-random-hex>.json` — a capability URL the platform never discloses. At publication the content is re-homed to the canonical `evidence-packages/<hash>.json` key and the old capability URL is deleted.
+1. **A public Rekor inclusion is itself a disclosure** — the envelope hash, timestamp, and signer identity become public records even for sealed claims (spec §11.1; ADR-0010 §4). Truly-no-public-footprint flows require a private transparency-log substrate, which is design-permitted but not built (Xanadu-gated).
+2. **Content-URL non-derivability is implemented as a random storage key.** Sealed blobs live at `evidence-packages/committed/<128-bit-random-hex>.json` — a capability URL the platform never discloses. At publication the content is re-homed to the canonical `evidence-packages/<hash>.json` key and the old capability URL is deleted. (That path segment keeps its original spelling deliberately: it is a frozen storage literal, and every already-stored sealed package's capability URL contains it. It is not a state label and clients never see it.)
 
 ### Publication-record creation (live since 2026-06-12)
 
-A committed claim is promoted to published by creating the publication pair:
+A sealed claim is promoted to the public state by creating the publication pair:
 
-- **`POST /api/evidence/:slug/publish`** — authorization: publisher-only (the record's creator, via bearer token with `evidence:publish` scope or session cookie; delegated-publisher is a future ADR per Q20). Body: `{ "runEvaluation"?: boolean, "evaluatorModel"?: string }` — see [the publication gate](#the-publication-gate-live-since-2026-06-12) for the default-on adversarial evaluation that runs first. Flow: the adversarial eval runs and its signed node is emitted; the visibility transition is a compare-and-set (a concurrent second publish loses the race and gets `409`); then the content is re-homed from its random committed key to the canonical hash-addressed key and two independently signed + timestamped + Rekor-included nodes are emitted:
+- **`POST /api/evidence/:slug/publish`** — authorization: publisher-only (the record's creator, via bearer token with `evidence:publish` scope or session cookie; delegated-publisher is a future ADR per Q20). Body: `{ "runEvaluation"?: boolean, "evaluatorModel"?: string }` — see [the publication gate](#the-publication-gate-live-since-2026-06-12) for the default-on adversarial evaluation that runs first. Flow: the adversarial eval runs and its signed node is emitted; the visibility transition is a compare-and-set (a concurrent second publish loses the race and gets `409`); then the content is re-homed from its random sealed-mode capability key to the canonical hash-addressed key and two independently signed + timestamped + Rekor-included nodes are emitted:
   1. `attestation/publishes/v1` — payload `targetNodeId` (the package's envelope hash), `publicationHost` (`"civicaitools.org"`), `releasedAt`.
   2. `attestation/locatedAt/v1` — payload `targetNodeId`, `uri` (the now-public content URL), `targetContentHash` (multihash; matches the target's own `contentHash` — named `targetContentHash` rather than the §8.12.1 table's `contentHash` because that key is the attestation envelope's own fingerprint; registered as open-questions Q48), optional `contentLength`.
 
-  Returns `{ published: true, evaluationNodeId?, publishesNodeId, locatedAtNodeId, url }` (`evaluationNodeId` present unless `runEvaluation: false`). On pair-emission failure the canonical blob is rolled back, the visibility flip is reverted, and the record stays committed (`500`; retryable — never half-published; an already-emitted evaluation node survives harmlessly and counts for the retry).
+  Returns `{ published: true, evaluationNodeId?, publishesNodeId, locatedAtNodeId, url }` (`evaluationNodeId` present unless `runEvaluation: false`). On pair-emission failure the canonical blob is rolled back, the visibility flip is reverted, and the record stays sealed (`500`; retryable — never half-published; an already-emitted evaluation node survives harmlessly and counts for the retry).
 
 Publication is logically complete when both nodes are inclusion-proven (ADR-0010 §6); each is independently verifiable. Re-publishing an already-published record returns `400`, as does publishing a currently-withdrawn record (reinstate first — publishing content its own author has withdrawn would contradict the lifecycle chain). Publication is not reversible — a subsequent withdrawal is a new `attestation/withdraws/v1` in the chain, surfaced alongside any surviving third-party `locatedAt` copies per the retention-asymmetry rule.
 
@@ -526,7 +573,7 @@ Hosts express the eval requirement in their self-attestation — a `content/host
 | `403`  | `{ "error": "Token missing required scope: evidence:publish" }`   | Bearer token is valid but does not hold the `evidence:publish` scope.                           |
 | `403`  | `{ "error": "This instance is running unsigned …", "code": "unsigned_tier" }` | The instance holds no signing key (the ADR-0020 unsigned dev tier). Both request-level visibilities are refused: an unsigned package can reach neither the sealed nor the public state (Decision C), so nothing is persisted. Also returned by `POST /api/evidence/:slug/publish` on an unsigned instance. Configure signing per [docs/instance-setup.md](../instance-setup.md). |
 | `404`  | `{ "error": "User not found in database" }`                       | Session is valid but the user record has not been provisioned (can occur if `DATABASE_URL` was unset when the user first signed in — a re-sign-in fixes it). |
-| `409`  | `{ "error": "This record was persisted without a signature …", "code": "unsigned_package" }` | `POST /api/evidence/:slug/publish` only: the committed record predates the unsigned-tier gate and has no base-package signature — it cannot be promoted to `published` even on a signed instance (ADR-0020 Decision C is a property of the package). |
+| `409`  | `{ "error": "This record was persisted without a signature …", "code": "unsigned_package" }` | `POST /api/evidence/:slug/publish` only: the sealed record predates the unsigned-tier gate and has no base-package signature — it cannot be promoted to `public` even on a signed instance (ADR-0020 Decision C is a property of the package). |
 | `500`  | `{ "error": "<message>" }` with `<message>` from the thrown error | Database, blob storage, or evidence-package-building failure.                                    |
 
 RFC 3161 timestamp and Rekor submission are non-blocking. Failures for either are logged server-side but still return `200` — the resulting record will simply have `null` values for the corresponding database columns. Signing itself is **not** optional as of S3a P3: a missing key is refused up front with the `unsigned_tier` `403` above (previously the record persisted with a `null` signature), while a signing *failure* with a configured key still surfaces as `500`.
@@ -618,12 +665,35 @@ Returns the database row (truncated here for readability):
   "jurisdiction": null,
   "civicContext": null,
   "basePackageHash": "a1b2c3d4e5f6...",
+  "listed": true,
   "isPublic": true,
+  "visibility": "public",
   "createdAt": "2026-04-17T21:04:00.000Z",
   "updatedAt": "2026-04-17T21:04:00.000Z",
   "creator": { "displayName": "...", "githubProfileUrl": "..." }
 }
 ```
+
+Two things about that body are worth reading carefully:
+
+- **`listed` and `isPublic` are the same value.** `listed` is the canonical key;
+  `isPublic` is a read-back alias kept for already-shipped clients. Both are
+  emitted indefinitely. Prefer `listed`.
+- **`listed` and `visibility` are ORTHOGONAL, and may legitimately disagree.**
+  They are different dimensions in
+  [ADR-0016 §A.1](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0016-vcs-native-lifecycle-mapping.md):
+  `visibility` is the *content-disclosure* axis (`"sealed"` | `"public"`), while
+  `listed` is the *host-display* axis — whether **this host** shows the record in
+  its index, which is host policy rather than a property of the node. They are
+  separate columns. `{"visibility": "sealed", "listed": true}` is expressible and
+  is **not** a contradiction; in particular `listed` does **not** mean
+  "visibility == public". This is exactly why the boolean got a second, honest
+  name — read `visibility` when you want the disclosure state.
+
+  (The one place the two are entangled is `GET /api/evidence/list`, which ANDs
+  them: a record appears in that listing only if it is `listed` **and** its
+  visibility is the public state. That is a property of the listing endpoint, not
+  of the fields.)
 
 Open the detail page in a browser to see the rendered evidence, PROV-O graph, and signing metadata:
 
@@ -682,6 +752,8 @@ These are implementation details that may surprise an external client. None of t
 ---
 
 ## Change log
+
+- **2026-08-05** — **`visibility` state labels renamed `committed` → `sealed`, `published` → `public`** ([ADR-0016 §A](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0016-vcs-native-lifecycle-mapping.md)). The `visibility` field's values are now disclosure qualities rather than one quality and one act. **Input:** all four literals are accepted, indefinitely — `"committed"` is an alias of `"sealed"` and `"published"` of `"public"` — so no client has to change; the default is unchanged in meaning (`"public"`, formerly spelled `"published"`). **Output (the breaking-ish part, and the only behavior change):** every response field carrying a visibility state now emits the CURRENT vocabulary, including for records created before the rename — the `POST /api/evidence` echo, `GET /api/evidence/:slug`, and the `/commitment` sidecar. A consumer that string-compares a served `visibility` against `"published"` or `"committed"` must accept `"public"` / `"sealed"` instead; a consumer that treats the two vocabularies as synonymous needs no change. **Not renamed** (deliberately): the verb "Publish", the `attestation/publishes/v1` + `attestation/locatedAt/v1` relationship, and the cryptographic "commitment" noun — the `/commitment` endpoint, the commitment view, and the commitment bundle keep their names, because a node in EITHER visibility state carries a public transparency-log commitment. The `evidence-packages/committed/<random>.json` storage prefix also keeps its spelling: it is a frozen capability-URL literal, never a state label. UI copy follows the field: badges read "Sealed" / "Public" and the publish dialog's non-publishing action reads "Seal". Also on this revision: `GET /api/evidence/:slug` gains **`listed`** as the canonical name for the host-display boolean, with **`isPublic`** retained as an alias on the same value — `listed` and `visibility` are orthogonal dimensions (ADR-0016 §A.1) and may legitimately disagree. Database: the enum retains `published` and `committed` as documented dead values (Postgres cannot drop an enum value without a type rebuild, which was declined), and migration `0015_flip_visibility_to_sealed_public.sql` relabels existing rows and moves the column default.
 
 - **2026-08-02** — **Unsigned-tier gate-off** (S3a P3, [#166](https://github.com/npstorey/civic-ai-tools-website/issues/166); [ADR-0020](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0020-instance-key-custody.md) Decisions B/C, G0-3): on an instance with no `EVIDENCE_SIGNING_KEY`, `POST /api/evidence` (both request-level visibilities) and `POST /api/evidence/:slug/publish` are refused with `403 { code: "unsigned_tier" }` — an unsigned package can reach neither the sealed nor the public state, so nothing is persisted (previously the record persisted with a `null` signature and a `committed`/`published` visibility). The publish route additionally refuses a historical committed record that carries no base-package signature with `409 { code: "unsigned_package" }` (existing rows are not migrated or relabeled). New presence-only endpoint `GET /api/evidence/signing-status` returns `{ "signingConfigured": boolean }` for client affordances. Unsigned packages now render prominently (Attention-tier "Unsigned package — no cryptographic commitment" glance + detail-page banner), and a running-unsigned site banner shows outside dev environments.
 

--- a/drizzle/0015_flip_visibility_to_sealed_public.sql
+++ b/drizzle/0015_flip_visibility_to_sealed_public.sql
@@ -1,0 +1,65 @@
+-- M2 (FLIP) of the ADR-0016 §A visibility-label rename: committed -> sealed,
+-- published -> public. M1 (0014_add_sealed_public_visibility.sql) widened the
+-- enum to four labels and touched no rows. THIS migration rewrites the existing
+-- rows onto the new labels and moves the column default. It adds no enum value
+-- and drops none — the legacy pair stays declared forever (sprint decision
+-- G0-3: Postgres has no `ALTER TYPE ... DROP VALUE`, and the type rebuild that
+-- would be required was considered and declined; keeping the dead labels costs
+-- nothing and keeps historical dumps loadable).
+--
+-- ORDERING — this runs AFTER the code that writes the new labels is deployed,
+-- not before. In the window between that deploy and this migration the table
+-- holds BOTH vocabularies at once: historical rows on `committed`/`published`,
+-- new rows on `sealed`/`public`. That is safe by construction because every
+-- read path normalizes through `fromDbValue` and every query predicate is a
+-- `::text`-cast set-membership test over both labels of a state
+-- (`src/lib/evidence/visibility-sql.ts`), never an equality against one
+-- spelling. Running this migration early is also safe — it just has fewer rows
+-- to rewrite.
+--
+-- OWNER-RUN. Applied by hand via psql against production. A downstream fork
+-- applies this same file through an ordinary `drizzle-kit migrate`, so both
+-- paths must be safe on a database that has already been flipped: the `WHERE`
+-- clauses make the UPDATEs idempotent by construction (a second run matches
+-- zero rows) and `SET DEFAULT` is idempotent on its own. Re-running the whole
+-- file is a no-op. Keep it that way — do not add an unconditional UPDATE.
+--
+-- VERIFY BEFORE AND AFTER — do not skip, and do not trust a tool's exit status.
+-- Run this BEFORE applying and keep the output:
+--
+--     SELECT visibility::text AS label, count(*)
+--       FROM evidence_records
+--      GROUP BY 1
+--      ORDER BY 1;
+--
+-- Then apply, then run it again. Expected shape of the change:
+--
+--   * no row remains on `committed` or `published`;
+--   * the `sealed` count afterwards equals (`committed` + `sealed`) before;
+--   * the `public` count afterwards equals (`published` + `public`) before;
+--   * the GRAND TOTAL is unchanged.
+--
+-- A CHANGED TOTAL MEANS SOMETHING REWROTE ROWS IT SHOULD NOT HAVE — stop and
+-- investigate rather than proceeding; these statements only relabel, they
+-- neither insert nor delete. (Counts are deliberately not written into this
+-- file: they are a property of one database at one moment, and a stale literal
+-- in a tracked file is worse than no literal.)
+--
+-- Confirm the default moved with:
+--
+--     \d evidence_records
+--
+-- The `visibility` column must show `default 'public'::visibility`.
+--
+-- WHY THIS IS A SEPARATE FILE FROM 0014, and must stay one. `ALTER TYPE ... ADD
+-- VALUE` is transactional on PostgreSQL 12+, but a label added in a transaction
+-- cannot be USED in that same transaction. The statements below use `sealed`
+-- and `public`, so they must run in a transaction later than the one that added
+-- them. Two migration files = two transactions. Do not merge them.
+--
+-- REVERSIBILITY. The inverse is the same two UPDATEs with the labels swapped
+-- plus `SET DEFAULT 'published'`; it stays available precisely because the
+-- legacy labels were never dropped from the type.
+UPDATE "evidence_records" SET "visibility" = 'sealed' WHERE "visibility" = 'committed';--> statement-breakpoint
+UPDATE "evidence_records" SET "visibility" = 'public' WHERE "visibility" = 'published';--> statement-breakpoint
+ALTER TABLE "evidence_records" ALTER COLUMN "visibility" SET DEFAULT 'public';

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,817 @@
+{
+  "id": "7f1e0a3d-2c64-4b8e-9a05-1d3f6b8c2e94",
+  "prevId": "6ccd2e6d-5fc0-450d-89f3-f7a9b2b83501",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_nodes": {
+      "name": "attestation_nodes",
+      "schema": "",
+      "columns": {
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rfc3161_timestamp": {
+          "name": "rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_entry_id": {
+          "name": "rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rekor_inclusion_proof": {
+          "name": "rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signer": {
+          "name": "signer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_nodes_creator_id_users_id_fk": {
+          "name": "attestation_nodes_creator_id_users_id_fk",
+          "tableFrom": "attestation_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attestation_packages": {
+      "name": "attestation_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "evidence_record_id": {
+          "name": "evidence_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attestation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_hash": {
+          "name": "package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "references_base_hash": {
+          "name": "references_base_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attestation_packages_evidence_record_id_evidence_records_id_fk": {
+          "name": "attestation_packages_evidence_record_id_evidence_records_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "evidence_records",
+          "columnsFrom": [
+            "evidence_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attestation_packages_creator_id_users_id_fk": {
+          "name": "attestation_packages_creator_id_users_id_fk",
+          "tableFrom": "attestation_packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_user_id": {
+          "name": "approved_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_approved_user_id_users_id_fk": {
+          "name": "device_codes_approved_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence_records": {
+      "name": "evidence_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_visibility": {
+          "name": "prompt_visibility",
+          "type": "prompt_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_text'"
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_server": {
+          "name": "mcp_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civic_context": {
+          "name": "civic_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_hash": {
+          "name": "base_package_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_storage_key": {
+          "name": "base_package_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_signature": {
+          "name": "base_package_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rfc3161_timestamp": {
+          "name": "base_package_rfc3161_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_id": {
+          "name": "base_package_rekor_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_inclusion_proof": {
+          "name": "base_package_rekor_inclusion_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_package_rekor_entry_body": {
+          "name": "base_package_rekor_entry_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_method": {
+          "name": "capture_method",
+          "type": "capture_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_profile": {
+          "name": "content_profile",
+          "type": "content_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unverified'"
+        },
+        "consistency_classification": {
+          "name": "consistency_classification",
+          "type": "consistency_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_reason": {
+          "name": "withdrawn_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_signature": {
+          "name": "withdrawal_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_timestamp": {
+          "name": "withdrawal_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_at": {
+          "name": "reinstated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstated_reason": {
+          "name": "reinstated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_signature": {
+          "name": "reinstatement_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reinstatement_timestamp": {
+          "name": "reinstatement_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidence_records_base_package_hash_idx": {
+          "name": "evidence_records_base_package_hash_idx",
+          "columns": [
+            {
+              "expression": "base_package_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidence_records_creator_id_users_id_fk": {
+          "name": "evidence_records_creator_id_users_id_fk",
+          "tableFrom": "evidence_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evidence_records_slug_unique": {
+          "name": "evidence_records_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_profile_url": {
+          "name": "github_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attestation_type": {
+      "name": "attestation_type",
+      "schema": "public",
+      "values": [
+        "consistency",
+        "evaluation",
+        "re_evaluation",
+        "correction",
+        "expert_attestation"
+      ]
+    },
+    "public.capture_method": {
+      "name": "capture_method",
+      "schema": "public",
+      "values": [
+        "chat-flow-stream",
+        "claude-code-jsonl-readback",
+        "claude-code-self-report",
+        "datHere"
+      ]
+    },
+    "public.consistency_classification": {
+      "name": "consistency_classification",
+      "schema": "public",
+      "values": [
+        "highly_reproducible",
+        "moderately_stable",
+        "inconsistent"
+      ]
+    },
+    "public.content_profile": {
+      "name": "content_profile",
+      "schema": "public",
+      "values": [
+        "default",
+        "datHere"
+      ]
+    },
+    "public.prompt_visibility": {
+      "name": "prompt_visibility",
+      "schema": "public",
+      "values": [
+        "full_text",
+        "hash_only"
+      ]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": [
+        "unverified",
+        "consistency_tested",
+        "evaluated",
+        "fully_attested"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "published",
+        "committed",
+        "sealed",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1785931200000,
       "tag": "0014_add_sealed_public_visibility",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786190400000,
+      "tag": "0015_flip_visibility_to_sealed_public",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/evidence/[slug]/page.tsx
+++ b/src/app/(app)/evidence/[slug]/page.tsx
@@ -13,7 +13,7 @@ import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
 import { resolveLifecycle } from '@/lib/evidence/lifecycle';
-import { sessionUserIsCreator } from '@/lib/evidence/committed-access';
+import { sessionUserIsCreator } from '@/lib/evidence/sealed-access';
 import { fromDbValue } from '@/lib/evidence/visibility';
 import { loadEvaluationViews } from '@/lib/evidence/adversarial-eval';
 import EvaluationAttestationsSection from '@/components/evidence/EvaluationAttestationsSection';

--- a/src/app/(app)/evidence/[slug]/page.tsx
+++ b/src/app/(app)/evidence/[slug]/page.tsx
@@ -117,11 +117,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const data = await getEvidenceData(slug);
   if (!data) return { title: 'Evidence Not Found' };
 
-  // Committed records (civic-ai-tools#71): title/summary are content-derived
+  // Sealed records (civic-ai-tools#71): title/summary are content-derived
   // and creator-only — emit generic metadata regardless of viewer so nothing
   // content-bearing lands in OG tags, caches, or link previews.
   if (fromDbValue(data.record.visibility) === 'sealed') {
-    return { title: 'Committed evidence record', robots: { index: false } };
+    return { title: 'Sealed evidence record', robots: { index: false } };
   }
 
   const { record, creator } = data;
@@ -201,12 +201,12 @@ export default async function EvidencePage({ params }: PageProps) {
   const data = await getEvidenceData(slug);
   if (!data) notFound();
 
-  // Committed records are creator-only (civic-ai-tools#71): the page (content,
+  // Sealed records are creator-only (civic-ai-tools#71): the page (content,
   // title, summary, notebook) does not exist for anyone else — 404, not 403,
-  // so probing can't confirm the record. The public surface for a committed
+  // so probing can't confirm the record. The public surface for a sealed
   // claim is the redacted commitment sidecar.
-  const isCommitted = fromDbValue(data.record.visibility) === 'sealed';
-  if (isCommitted && !(await sessionUserIsCreator(data.record))) {
+  const isSealed = fromDbValue(data.record.visibility) === 'sealed';
+  if (isSealed && !(await sessionUserIsCreator(data.record))) {
     notFound();
   }
 
@@ -296,12 +296,12 @@ export default async function EvidencePage({ params }: PageProps) {
           </div>
         )}
 
-        {/* Committed banner (civic-ai-tools#71) — creator-only view of a
-            committed-not-published record. The commitment (hash + signature +
+        {/* Sealed banner (civic-ai-tools#71) — creator-only view of a
+            sealed-not-published record. The commitment (hash + signature +
             timestamp + Rekor) is publicly registered; the content is not.
             The proof sentence is signature-conditional: a historical unsigned
             row registered no commitment, and the banner must not claim one. */}
-        {isCommitted && (
+        {isSealed && (
           <div style={{
             padding: '16px 20px', marginBottom: '24px',
             backgroundColor: 'rgba(16, 63, 239, 0.05)',
@@ -309,7 +309,7 @@ export default async function EvidencePage({ params }: PageProps) {
             borderRadius: '6px',
           }}>
             <div style={{ fontSize: '15px', fontWeight: 600, color: 'var(--nyc-blue)', marginBottom: '6px' }}>
-              Committed — not published
+              Sealed — not published
             </div>
             <div style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>
               {isUnsignedRecord ? (

--- a/src/app/api/evidence/[slug]/attestations/route.ts
+++ b/src/app/api/evidence/[slug]/attestations/route.ts
@@ -45,7 +45,7 @@ export async function GET(
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
-  // Committed records are creator-only (civic-ai-tools#71).
+  // Sealed records are creator-only (civic-ai-tools#71).
   if (!(await canReadRecord(request, records[0]))) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
@@ -122,7 +122,7 @@ export async function POST(
   }
   const record = records[0];
 
-  // Committed records are creator-only (civic-ai-tools#71).
+  // Sealed records are creator-only (civic-ai-tools#71).
   if (!(await canReadRecord(request, record))) {
     return NextResponse.json({ error: 'Evidence record not found' }, { status: 404 });
   }

--- a/src/app/api/evidence/[slug]/attestations/route.ts
+++ b/src/app/api/evidence/[slug]/attestations/route.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
-import { canReadRecord } from '@/lib/evidence/committed-access';
+import { canReadRecord } from '@/lib/evidence/sealed-access';
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { evidenceRecords, attestationPackages, users } from '@/lib/db/schema';

--- a/src/app/api/evidence/[slug]/bundle/route.ts
+++ b/src/app/api/evidence/[slug]/bundle/route.ts
@@ -125,7 +125,7 @@ export async function GET(
   }
   const record = records[0];
 
-  // Committed records' bundle (the full content, packaged for sharing) is
+  // Sealed records' bundle (the full content, packaged for sharing) is
   // creator-only (civic-ai-tools#71) — the creator exports it to distribute
   // to chosen recipients; it is not a public surface until publication.
   if (!(await canReadRecord(request, record))) {

--- a/src/app/api/evidence/[slug]/bundle/route.ts
+++ b/src/app/api/evidence/[slug]/bundle/route.ts
@@ -6,7 +6,7 @@ import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
 import { loadCarriedLifecycleAttestations } from '@/lib/evidence/lifecycle';
 import { buildCommitmentView } from '@/lib/evidence/commitment';
-import { canReadRecord } from '@/lib/evidence/committed-access';
+import { canReadRecord } from '@/lib/evidence/sealed-access';
 // Instance-identity config (ADR-0020): the cell-0 reader affordance carries
 // this instance's detail URL, host label, and trust-registry pointer — the
 // same values the embedded commitment view resolves; demo defaults when no

--- a/src/app/api/evidence/[slug]/commitment/route.ts
+++ b/src/app/api/evidence/[slug]/commitment/route.ts
@@ -151,17 +151,17 @@ export async function GET(
     ? await loadCarriedLifecycleAttestations(record.basePackageHash)
     : [];
 
-  // Committed records (civic-ai-tools#71, ADR-0010 §5): the commitment IS
+  // Sealed records (civic-ai-tools#71, ADR-0010 §5): the commitment IS
   // public — the hash is already on the transparency log — but the content
   // surface is not. Serve the view redacted of the capability URL, title, and
   // summary; never inline the package.
   // Keyed on the canonical state, so redaction holds for a row under EITHER
-  // label (legacy `committed` or ADR-0016 `sealed`). Note this decides only
-  // WHETHER to redact — the `visibility` value the view SERVES is the raw
-  // column, passed through unchanged by `buildCommitmentView`.
-  const isCommitted = fromDbValue(record.visibility) === 'sealed';
+  // label (legacy `committed` or ADR-0016 `sealed`). As of the P2 flip the
+  // `visibility` value the view SERVES is also canonical — `buildCommitmentView`
+  // normalizes the column rather than passing it through.
+  const isSealed = fromDbValue(record.visibility) === 'sealed';
   const commitment = buildCommitmentView(record, creator, pkg, lifecycleAttestations, {
-    redactContentSurface: isCommitted,
+    redactContentSurface: isSealed,
   });
 
   // `?inline=1` → self-contained bundle (#119 Q15a): inline the package + the stamped
@@ -170,7 +170,7 @@ export async function GET(
   // route trusts (the build-time-bundled, generatedAt-stamped `/.well-known` file). When
   // the blob couldn't be fetched (`pkg === null`), `package` is simply omitted — the
   // bundle then falls back to `packageUrl` rather than serving a hollow inline field.
-  // Committed records never inline the package (content is creator-distributed only).
+  // Sealed records never inline the package (content is creator-distributed only).
   const inlineParam = request.nextUrl.searchParams.get('inline');
   const inline = inlineParam !== null && inlineParam !== '0' && inlineParam !== 'false';
   let body: Record<string, unknown> = commitment;
@@ -178,7 +178,7 @@ export async function GET(
     const registry = await loadTrustRegistry();
     body = {
       ...commitment,
-      ...(pkg && !isCommitted ? { package: pkg } : {}),
+      ...(pkg && !isSealed ? { package: pkg } : {}),
       ...(registry ? { trustRegistry: registry } : {}),
     };
   }

--- a/src/app/api/evidence/[slug]/evaluate/route.ts
+++ b/src/app/api/evidence/[slug]/evaluate/route.ts
@@ -56,7 +56,7 @@ export async function POST(
   }
   const record = records[0];
 
-  // Committed records are creator-only on this content-bearing surface
+  // Sealed records are creator-only on this content-bearing surface
   // (civic-ai-tools#71).
   if (!(await canReadRecord(request, record))) {
     return NextResponse.json({ error: 'Evidence record not found' }, { status: 404 });

--- a/src/app/api/evidence/[slug]/evaluate/route.ts
+++ b/src/app/api/evidence/[slug]/evaluate/route.ts
@@ -6,7 +6,7 @@ import { db } from '@/lib/db';
 import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
-import { canReadRecord } from '@/lib/evidence/committed-access';
+import { canReadRecord } from '@/lib/evidence/sealed-access';
 import type { EvidencePackage } from '@/lib/evidence/packager';
 // Rubric, prompt builder, and response parsing are shared with the
 // publication gate (civic-ai-tools#72 Phase 3) via the adversarial-eval lib.

--- a/src/app/api/evidence/[slug]/package/route.ts
+++ b/src/app/api/evidence/[slug]/package/route.ts
@@ -3,7 +3,7 @@ import { db } from '@/lib/db';
 import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
-import { canReadRecord } from '@/lib/evidence/committed-access';
+import { canReadRecord } from '@/lib/evidence/sealed-access';
 
 export async function GET(
   request: NextRequest,

--- a/src/app/api/evidence/[slug]/package/route.ts
+++ b/src/app/api/evidence/[slug]/package/route.ts
@@ -25,7 +25,7 @@ export async function GET(
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 
-  // Committed records' content is creator-only (civic-ai-tools#71).
+  // Sealed records' content is creator-only (civic-ai-tools#71).
   if (!(await canReadRecord(request, records[0]))) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }

--- a/src/app/api/evidence/[slug]/publish/route.ts
+++ b/src/app/api/evidence/[slug]/publish/route.ts
@@ -21,7 +21,7 @@ import { visibilityMatches } from '@/lib/evidence/visibility-sql';
 /**
  * POST /api/evidence/[slug]/publish
  *
- * Promotes a COMMITTED record to PUBLISHED (civic-ai-tools#71; spec §8.10,
+ * Promotes a SEALED record to PUBLIC (civic-ai-tools#71; spec §8.10,
  * ADR-0010 §6), gated by a default-on adversarial evaluation
  * (civic-ai-tools#72; Q25 option (b)+(c): host-policy + default-on at the
  * publisher tool — NOT protocol-mandatory).
@@ -39,14 +39,14 @@ import { visibilityMatches } from '@/lib/evidence/visibility-sql';
  *      axis. An eval FAILURE (evaluator unreachable / invalid response) aborts
  *      the publish with an explicit 502 — never a silent skip; the caller can
  *      retry or pass runEvaluation:false to publish without an eval.
- *   2. Compare-and-set visibility committed→published (the concurrency guard:
+ *   2. Compare-and-set visibility sealed→public (the concurrency guard:
  *      two racing publishes can both pass the pre-check, but only one wins the
  *      conditional UPDATE; the loser gets 409 and emits nothing).
- *   3. Re-home the content from its random committed key to the canonical
+ *   3. Re-home the content from its random sealed-mode key to the canonical
  *      hash-addressed key; emit the publication pair (attestation/publishes/v1
  *      + attestation/locatedAt/v1, one atomic insert); point the record at the
  *      canonical blob; retire the old capability URL.
- *      On failure: visibility reverts to committed and the canonical blob is
+ *      On failure: visibility reverts to sealed and the canonical blob is
  *      deleted — a failed publish is retryable, never half-published. (A
  *      surviving evaluation node from step 1 is harmless: evals target the
  *      content node and remain valid for the retry.)
@@ -78,7 +78,7 @@ export async function POST(
   }
 
   // Unsigned-tier gate-off (S3a P3, #166; ADR-0020 Decisions B/C, G0-3): the
-  // committed→published promotion emits SIGNED publication attestations — an
+  // sealed→public promotion emits SIGNED publication attestations — an
   // instance with no signing key cannot back them, and an unsigned package
   // may reach neither sealed nor public. Refused before any lookup.
   const gate = evaluateSealCommitGate();
@@ -97,29 +97,31 @@ export async function POST(
   const record = records[0];
 
   // Publisher-only (§8.12.3): only the creator can publish. 404 (not 403) for
-  // non-creators so a committed record's existence isn't confirmed by probing.
+  // non-creators so a sealed record's existence isn't confirmed by probing.
   if (record.creatorId !== auth.userId) {
     return NextResponse.json({ error: 'Evidence record not found' }, { status: 404 });
   }
 
   // Precondition, keyed on the canonical state so a row holding EITHER label
-  // (legacy `committed` or ADR-0016 `sealed`) is still promotable.
+  // (legacy `committed` or ADR-0016 `sealed`) is still promotable. This is the
+  // mixed-state property in its sharpest form: between this deploy and the M2
+  // backfill the table holds both spellings at once.
   if (fromDbValue(record.visibility) !== 'sealed') {
     return NextResponse.json({ error: 'Evidence is already published' }, { status: 400 });
   }
 
   // Per-record form of the same gate: a historical row persisted WITHOUT a
-  // signature (pre-gate unsigned-committed) cannot be promoted to public even
+  // signature (pre-gate unsigned-sealed) cannot be promoted to public even
   // on a signed instance — the base package has no signature to back a public
   // state (ADR-0020 Decision C is a property of the package). The row itself
-  // is not migrated or relabeled; it stays committed and renders with the
+  // is not migrated or relabeled; it stays sealed and renders with the
   // prominent unsigned labeling.
   const recordGate = evaluateUnsignedRecordPublishGate(record.basePackageSignature);
   if (recordGate) {
     return NextResponse.json(recordGate.body, { status: recordGate.status });
   }
 
-  // A withdrawn committed claim must be reinstated before it can publish —
+  // A withdrawn sealed claim must be reinstated before it can publish —
   // publishing content whose own author has withdrawn it would assert a
   // visibility the lifecycle chain contradicts. Resolved from the signed
   // attestation chain first (§8.10.4 dual-read) rather than the legacy column
@@ -155,7 +157,7 @@ export async function POST(
     // Empty / non-JSON body is fine; defaults apply.
   }
 
-  // Fetch the committed package from its random-key blob.
+  // Fetch the sealed package from its random-key blob.
   const pkg = (await getPackage(record.basePackageStorageKey)) as EvidencePackage | null;
   if (!pkg) {
     return NextResponse.json(
@@ -250,7 +252,7 @@ export async function POST(
     );
   }
 
-  const revertToCommitted = async () => {
+  const revertToSealed = async () => {
     await db
       .update(evidenceRecords)
       .set({ visibility: toDbValue('sealed'), updatedAt: new Date() })
@@ -274,15 +276,15 @@ export async function POST(
       creatorId: record.creatorId,
     });
   } catch (err) {
-    // Roll back: content out of public reach, visibility back to committed.
+    // Roll back: content out of public reach, visibility back to sealed.
     // The publish is retryable; a step-1 evaluation node survives harmlessly.
     if (publicUrl) await deletePackageBlob(publicUrl);
-    await revertToCommitted().catch((revertErr) =>
+    await revertToSealed().catch((revertErr) =>
       console.error('[api/evidence/publish] visibility revert failed:', revertErr),
     );
     console.error('[api/evidence/publish] pair emission failed:', err);
     return NextResponse.json(
-      { error: 'Publication failed; the record remains committed' },
+      { error: 'Publication failed; the record remains sealed' },
       { status: 500 },
     );
   }

--- a/src/app/api/evidence/[slug]/replay/route.ts
+++ b/src/app/api/evidence/[slug]/replay/route.ts
@@ -71,7 +71,7 @@ export async function POST(
   }
   const record = records[0];
 
-  // Committed records are creator-only on this content-bearing surface
+  // Sealed records are creator-only on this content-bearing surface
   // (civic-ai-tools#71).
   if (!(await canReadRecord(request, record))) {
     return NextResponse.json({ error: 'Evidence record not found' }, { status: 404 });

--- a/src/app/api/evidence/[slug]/replay/route.ts
+++ b/src/app/api/evidence/[slug]/replay/route.ts
@@ -7,7 +7,7 @@ import { db } from '@/lib/db';
 import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
-import { canReadRecord } from '@/lib/evidence/committed-access';
+import { canReadRecord } from '@/lib/evidence/sealed-access';
 import { mcpTools } from '@/lib/mcp/tools';
 import { callMcpTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';

--- a/src/app/api/evidence/[slug]/route.ts
+++ b/src/app/api/evidence/[slug]/route.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/db';
 import { evidenceRecords, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { canReadRecord } from '@/lib/evidence/sealed-access';
+import { buildRecordReadback } from '@/lib/evidence/readback';
 
 export async function GET(
   request: NextRequest,
@@ -22,8 +23,8 @@ export async function GET(
 
   const record = records[0];
 
-  // Committed records are creator-only (civic-ai-tools#71). 404 (not 403) so
-  // probing can't confirm a committed record's existence.
+  // Sealed records are creator-only (civic-ai-tools#71). 404 (not 403) so
+  // probing can't confirm a sealed record's existence.
   if (!(await canReadRecord(request, record))) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
@@ -33,22 +34,7 @@ export async function GET(
     .where(eq(users.id, record.creatorId))
     .limit(1);
 
-  return NextResponse.json({
-    slug: record.slug,
-    title: record.title,
-    summary: record.summary,
-    model: record.model,
-    promptHash: record.promptHash,
-    promptVisibility: record.promptVisibility,
-    verificationStatus: record.verificationStatus,
-    consistencyClassification: record.consistencyClassification,
-    jurisdiction: record.jurisdiction,
-    civicContext: record.civicContext,
-    basePackageHash: record.basePackageHash,
-    isPublic: record.isPublic,
-    visibility: record.visibility,
-    createdAt: record.createdAt,
-    updatedAt: record.updatedAt,
-    creator: creator[0] || null,
-  });
+  // The body shape (including the `listed` / `isPublic` pair and the canonical
+  // `visibility`) lives in `@/lib/evidence/readback` so it is unit-testable.
+  return NextResponse.json(buildRecordReadback(record, creator[0] || null));
 }

--- a/src/app/api/evidence/[slug]/route.ts
+++ b/src/app/api/evidence/[slug]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { evidenceRecords, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
-import { canReadRecord } from '@/lib/evidence/committed-access';
+import { canReadRecord } from '@/lib/evidence/sealed-access';
 
 export async function GET(
   request: NextRequest,

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -18,7 +18,7 @@ import {
 } from '@/lib/evidence/verify-core';
 import { loadTrustRegistry } from '@/lib/evidence/verify';
 import { resolveLifecycle } from '@/lib/evidence/lifecycle';
-import { canReadRecord } from '@/lib/evidence/committed-access';
+import { canReadRecord } from '@/lib/evidence/sealed-access';
 
 export async function GET(
   request: NextRequest,

--- a/src/app/api/evidence/[slug]/verify/route.ts
+++ b/src/app/api/evidence/[slug]/verify/route.ts
@@ -38,8 +38,8 @@ export async function GET(
 
   const record = records[0];
 
-  // Committed records are creator-only on this surface (civic-ai-tools#71);
-  // public verification of a committed claim goes through the redacted
+  // Sealed records are creator-only on this surface (civic-ai-tools#71);
+  // public verification of a sealed claim goes through the redacted
   // commitment sidecar instead.
   if (!(await canReadRecord(request, record))) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -213,8 +213,10 @@ export async function POST(request: NextRequest) {
       );
     }
     const visibility: Visibility = requestedVisibility;
-    // The label actually persisted, and the one echoed back to the caller. Both
-    // stay on the legacy vocabulary until the flip phase — see `toDbValue`.
+    // The label actually persisted. Since the P2 flip `toDbValue` is the
+    // identity, so this equals the canonical value — but the write still goes
+    // through the boundary, because that function is the one place that decides
+    // what lands in the column.
     const visibilityDbValue = toDbValue(visibility);
 
     // Validate captureMethod (ADR-0003/0011). Required for all publishes;
@@ -287,9 +289,9 @@ export async function POST(request: NextRequest) {
 
     const { pkg, hash: packageHash } = buildEvidencePackage(packageInput);
 
-    // Store package in Vercel Blob. Committed packages use a random,
+    // Store package in Vercel Blob. Sealed packages use a random,
     // non-hash-derivable key (Phase 2 hard requirement: the hash is public in
-    // Rekor, so a hash-derived pathname would leak committed content); the
+    // Rekor, so a hash-derived pathname would leak sealed content); the
     // canonical hash-addressed key is claimed at publication time.
     const blobUrl = visibility === 'sealed'
       ? await putCommittedPackage(pkg as unknown as Record<string, unknown>)
@@ -369,17 +371,22 @@ export async function POST(request: NextRequest) {
     // content URL is undisclosed); the slug + packageHash are the creator's
     // handles for the later publish step.
     //
-    // The echoed `visibility` is the PERSISTED label, not the canonical one:
-    // this response is a served surface, and changing what clients read is the
-    // flip phase's chartered change, not a side effect of accepting aliases.
+    // The echoed `visibility` is the CANONICAL value (ADR-0016 §A, P2) — the
+    // same vocabulary every other serving surface emits — not the raw persisted
+    // label. It happens to equal `visibilityDbValue` now that `toDbValue` is
+    // the identity, but it is written as the canonical value on purpose: what a
+    // client reads must not be coupled to what the column happens to store.
+    // A legacy request body (`"committed"` / `"published"`) is still accepted
+    // and still means the same thing; the echo tells the caller the state in
+    // one vocabulary.
     const response = NextResponse.json(
       visibility === 'sealed'
-        ? { slug, packageHash, visibility: visibilityDbValue }
+        ? { slug, packageHash, visibility }
         : {
             slug,
             url: `/evidence/${slug}`,
             packageHash,
-            visibility: visibilityDbValue,
+            visibility,
             ...(publicationPair ?? {}),
           },
     );

--- a/src/components/PublishEvidenceDialog.tsx
+++ b/src/components/PublishEvidenceDialog.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import type { ToolCall, EvidenceTrace } from '@/hooks/useStreamingComparison';
 import { generateNotebook } from '@/lib/notebook';
 import type { Notebook } from '@/lib/notebook-author/cells';
-import { normalizeVisibility } from '@/lib/evidence/visibility';
+import { normalizeVisibility, type Visibility } from '@/lib/evidence/visibility';
 
 interface PublishEvidenceDialogProps {
   isOpen: boolean;
@@ -62,12 +62,17 @@ export default function PublishEvidenceDialog({
   const [summaryLoading, setSummaryLoading] = useState(false);
   const [userEditedSummary, setUserEditedSummary] = useState(false);
   const [promptVisibility, setPromptVisibility] = useState<'full_text' | 'hash_only'>('full_text');
-  // Visibility choice (civic-ai-tools#71 scope item 7): COMMITTED is the
+  // Visibility choice (civic-ai-tools#71 scope item 7): SEALED is the
   // default — attest by default, publish by choice. The request-level flag is
-  // sent explicitly either way (the API's own default stays "published" for
+  // sent explicitly either way (the API's own default is the public state for
   // client back-compat; the UI default is the product decision).
-  const [visibility, setVisibility] = useState<'committed' | 'published'>('committed');
-  const [resultVisibility, setResultVisibility] = useState<'committed' | 'published'>('published');
+  //
+  // Both unions are on the ADR-0016 §A canonical vocabulary. The request value
+  // sent below is one of these literals, and the API accepts it directly (the
+  // legacy pair remains accepted as an alias, indefinitely — this client just
+  // no longer sends it).
+  const [visibility, setVisibility] = useState<Visibility>('sealed');
+  const [resultVisibility, setResultVisibility] = useState<Visibility>('public');
   const [dialogState, setDialogState] = useState<DialogState>('form');
   const [resultUrl, setResultUrl] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -201,15 +206,16 @@ export default function PublishEvidenceDialog({
       }
 
       const data = await response.json();
-      // `url` is absent for committed-visibility responses; the slug-derived
+      // `url` is absent for sealed-visibility responses; the slug-derived
       // page is creator-only until the record is published.
       setResultUrl(data.url ?? `/evidence/${data.slug}`);
-      // Read-side normalization only (ADR-0016 §A): the response may carry
-      // either vocabulary. The local state union and the request value it sends
-      // stay on the legacy labels in this phase.
-      setResultVisibility(
-        normalizeVisibility(data.visibility) === 'sealed' ? 'committed' : 'published',
-      );
+      // Still normalized on read (ADR-0016 §A): this instance's API now echoes
+      // the canonical value, but the dialog must not assume the server it is
+      // talking to has flipped — a fork mid-migration can still answer with a
+      // legacy label. `normalizeVisibility` returns null only for a value that
+      // is neither vocabulary; treat that as the public state, which is the
+      // API's own default when the field is absent.
+      setResultVisibility(normalizeVisibility(data.visibility) ?? 'public');
       setDialogState('success');
     } catch (err) {
       setErrorMessage(err instanceof Error ? err.message : 'Publishing failed');
@@ -235,7 +241,7 @@ export default function PublishEvidenceDialog({
   // #86 (published path) — "let me share this" without leaving: native share
   // sheet where available (mobile), clipboard + toast otherwise (desktop). A
   // dismissed share sheet is a no-op (no surprise copy). Only ever wired for a
-  // PUBLISHED result — a committed record is private, so Share is meaningless.
+  // PUBLIC result — a sealed record is private, so Share is meaningless.
   const handleShare = async () => {
     const fullUrl = `${window.location.origin}${resultUrl}`;
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
@@ -417,12 +423,12 @@ export default function PublishEvidenceDialog({
                     <input
                       type="radio"
                       name="visibility"
-                      checked={visibility === 'committed'}
-                      onChange={() => setVisibility('committed')}
+                      checked={visibility === 'sealed'}
+                      onChange={() => setVisibility('sealed')}
                       style={{ marginTop: '3px' }}
                     />
                     <span>
-                      Commit (default)
+                      Seal (default)
                       <span style={{ display: 'block', fontSize: '12px', color: 'var(--text-muted)' }}>
                         Signed, timestamped, and registered on the public transparency
                         log — but the content stays private to you. Publish later from
@@ -434,8 +440,8 @@ export default function PublishEvidenceDialog({
                     <input
                       type="radio"
                       name="visibility"
-                      checked={visibility === 'published'}
-                      onChange={() => setVisibility('published')}
+                      checked={visibility === 'public'}
+                      onChange={() => setVisibility('public')}
                       style={{ marginTop: '3px' }}
                     />
                     <span>
@@ -450,7 +456,7 @@ export default function PublishEvidenceDialog({
               </div>
 
               {/* Unsigned-tier gate-off (ADR-0020, S3a P3): with no signing
-                  key, neither Commit (sealed) nor Publish (public) is
+                  key, neither Seal (sealed) nor Publish (public) is
                   reachable — the action renders disabled with an explanation,
                   mirroring the server-side gate. */}
               {signingConfigured === false && (
@@ -467,7 +473,7 @@ export default function PublishEvidenceDialog({
                   <strong style={{ color: 'var(--text-primary)' }}>
                     This instance is running unsigned.
                   </strong>{' '}
-                  No signing key is configured, so evidence cannot be committed
+                  No signing key is configured, so evidence cannot be sealed
                   or published — an unsigned package can reach neither the
                   sealed nor the public state. The analysis itself still works;
                   an operator enables signing via the instance setup guide.
@@ -492,7 +498,7 @@ export default function PublishEvidenceDialog({
               >
                 {signingConfigured === false
                   ? 'Unavailable (running unsigned)'
-                  : visibility === 'committed' ? 'Commit' : 'Publish'}
+                  : visibility === 'sealed' ? 'Seal' : 'Publish'}
               </button>
             </>
           )}
@@ -532,18 +538,18 @@ export default function PublishEvidenceDialog({
                   <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 1 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z" />
                 </svg>
                 <span style={{ fontSize: '16px', fontWeight: 600 }}>
-                  {resultVisibility === 'committed' ? 'Committed' : 'Published'}
+                  {resultVisibility === 'sealed' ? 'Sealed' : 'Public'}
                 </span>
               </div>
 
-              {resultVisibility === 'committed' ? (
-                /* COMMITTED — a private record. Preserve the creator-only copy +
+              {resultVisibility === 'sealed' ? (
+                /* SEALED — a private record. Preserve the creator-only copy +
                    the URL box (the creator's own handle to open / re-open it);
                    no public "Share" affordance, because the content is private
                    and a shared link is meaningless to anyone else (#86). */
                 <>
                   <p style={{ fontSize: '14px', color: 'var(--text-secondary)', margin: '0 0 12px' }}>
-                    Your evidence is committed — signed and registered, content private to you.
+                    Your evidence is sealed — signed and registered, content private to you.
                     Only you can open this page; publish it anytime from your dashboard:
                   </p>
 
@@ -609,7 +615,7 @@ export default function PublishEvidenceDialog({
                   </button>
                 </>
               ) : (
-                /* PUBLISHED — a public record. Two distinct affordances instead
+                /* PUBLIC — a public record. Two distinct affordances instead
                    of a raw URL to parse (#86): primary "View" (navigates) +
                    secondary "Share" (copy / native share). The raw URL stays
                    reachable via Share and the destination URL bar; closing the

--- a/src/components/dashboard/DashboardTabs.tsx
+++ b/src/components/dashboard/DashboardTabs.tsx
@@ -61,7 +61,7 @@ interface DashboardTabsProps {
   activity: ActivityRow[];
   tokens: TokenRow[];
   /** Whether this instance holds a signing key (ADR-0020, S3a P3): with no
-   *  key the committed→published promotion is gated off server-side, so the
+   *  key the sealed→public promotion is gated off server-side, so the
    *  Publish affordance renders disabled-with-explanation instead of a dead
    *  button that errors. */
   signingConfigured?: boolean;
@@ -89,7 +89,7 @@ function StatusBadge({ status }: { status: string }) {
     evaluated: { bg: 'rgba(0, 183, 3, 0.1)', text: 'var(--nyc-success)' },
     fully_attested: { bg: 'rgba(0, 183, 3, 0.15)', text: 'var(--nyc-success)' },
     withdrawn: { bg: 'rgba(236, 19, 30, 0.08)', text: 'var(--nyc-error)' },
-    committed: { bg: 'rgba(16, 63, 239, 0.08)', text: 'var(--nyc-blue)' },
+    sealed: { bg: 'rgba(16, 63, 239, 0.08)', text: 'var(--nyc-blue)' },
   };
   const c = colors[status] || colors.unverified;
   return (
@@ -230,7 +230,7 @@ function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signi
     }
   }, [reinstateTarget, reinstateReason, router]);
 
-  // Committed → published promotion (civic-ai-tools#71/#72 Phase 5). Runs the
+  // Sealed → public promotion (civic-ai-tools#71/#72 Phase 5). Runs the
   // default-on adversarial eval unless the user unchecks it; irreversible.
   const [publishTarget, setPublishTarget] = useState<EvidenceRow | null>(null);
   const [publishRunEval, setPublishRunEval] = useState(true);
@@ -295,7 +295,7 @@ function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signi
                   {r.title}
                 </Link>
                 <div style={{ display: 'flex', gap: '6px', flexShrink: 0, alignItems: 'center' }}>
-                  {normalizeVisibility(r.visibility) === 'sealed' && <StatusBadge status="committed" />}
+                  {normalizeVisibility(r.visibility) === 'sealed' && <StatusBadge status="sealed" />}
                   {isCurrentlyWithdrawn
                     ? <StatusBadge status="withdrawn" />
                     : <StatusBadge status={r.verificationStatus} />
@@ -393,7 +393,7 @@ function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signi
         })}
       </div>
 
-      {/* Publish (committed → published) confirmation dialog */}
+      {/* Publish (sealed → public) confirmation dialog */}
       {publishTarget && (
         <div
           style={{

--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -274,9 +274,9 @@ export default function EvidenceActions({
         )}
 
         {/* Verify-independently badge (#114) — the host-side entry point to the
-            neutral verifier (ADR-0013 / Q46). Published-only: the verifier
+            neutral verifier (ADR-0013 / Q46). Public-state-only: the verifier
             resolves a package through its commitment sidecar, which is redacted
-            for committed records (content private), so /verify would show a
+            for sealed records (content private), so /verify would show a
             missing-content alarm. Rendered independent of the glance's load
             state — when our own check can't load, "verify it yourself" matters
             most. */}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -86,33 +86,44 @@ export const contentProfileEnum = pgEnum('content_profile', [
 
 // visibility mirrors the package's lifecycle visibility for query convenience
 // (list filtering, dashboard labels). The CANONICAL representation is the
-// attestation chain (spec §8.10, ADR-0010): a node is published iff an
+// attestation chain (spec §8.10, ADR-0010): a node is public iff an
 // `attestation/publishes/v1` (+ ≥1 `attestation/locatedAt/v1`) references it;
-// committed = zero-location base case. This column is a denormalized status
+// sealed = zero-location base case. This column is a denormalized status
 // mirror in the same pattern as the withdrawn/reinstated columns — the publish
 // flow dual-writes it alongside emitting the signed attestation pair. Legacy
-// rows backfill to 'published' (every pre-Phase-2 publish was public).
+// rows backfill to the public state (every pre-Phase-2 publish was public).
 //
 // ADR-0016 §A renames the two STATE labels — `committed` -> `sealed`,
 // `published` -> `public` — while the verb "Publish", the cryptographic
 // "commitment" noun, and `attestation/publishes/v1` all stay put. The rename
 // ships as expand -> flip -> keep-the-dead-values, so the enum carries all four
-// labels permanently (Postgres cannot drop an enum value without recreating the
-// type, and keeping the legacy pair makes every step reversible and every
-// historical dump readable).
+// labels permanently.
 //
-// THIS DECLARATION RUNS AHEAD OF THE DATABASE. The `sealed` / `public` labels
-// reach the live enum only when the owner-run M1 expand migration
-// (drizzle/0014_add_sealed_public_visibility.sql) is applied. Declaring them
-// early is inert: a drizzle `pgEnum` is a compile-time type declaration plus a
-// migration-diff input — it emits no runtime validation — and the code in this
-// phase writes ONLY the legacy labels, because
-// `src/lib/evidence/visibility.ts#toDbValue` still maps the canonical values
-// back to `committed` / `published`. Order matches what `ALTER TYPE ... ADD
-// VALUE` produces: the new labels append after the existing two.
+// DEAD VALUES, DELIBERATELY RETAINED (sprint decision G0-3). `published` and
+// `committed` are no longer WRITTEN by any code path — `toDbValue` in
+// `src/lib/evidence/visibility.ts` is the identity, and the 0015 migration
+// rewrites every existing row — but they stay declared here and in the live
+// Postgres type. Dropping an enum value requires recreating the type (Postgres
+// has no `ALTER TYPE ... DROP VALUE`), which means rewriting every dependent
+// column under a lock; that rebuild was considered and DECLINED. Keeping the
+// pair costs nothing and buys three things: every step of the rename stays
+// reversible, every historical dump and restored backup remains loadable, and a
+// downstream fork part-way through the migration keeps working. Reads must
+// therefore treat all four labels as live forever — `fromDbValue` is total over
+// them by design.
 //
-// The column DEFAULT stays `'published'` in this phase; moving it is part of
-// the later flip, alongside the row rewrite.
+// Enum ORDER matches what `ALTER TYPE ... ADD VALUE` produced in migration
+// 0014: the new labels append after the original two. It is the physical sort
+// order of the type, not a statement about which are current.
+//
+// SCHEMA-VS-DATABASE ASYMMETRY ON THE DEFAULT. The declaration below says
+// `'public'` as of this phase, but the DB-side `DEFAULT` moves in migration
+// 0015 (`ALTER COLUMN visibility SET DEFAULT 'public'`), which the owner runs
+// AFTER this code deploys. In the window between the two, the declaration and
+// the live column disagree — harmlessly, because every INSERT this application
+// makes supplies `visibility` explicitly (see `src/app/api/evidence/route.ts`),
+// so the column default is never exercised by the write path. It matters only
+// for hand-written SQL and for `drizzle-kit`'s diff.
 export const visibilityEnum = pgEnum('visibility', [
   'published',
   'committed',
@@ -167,12 +178,16 @@ export const evidenceRecords = pgTable('evidence_records', {
     .notNull()
     .default('unverified'),
   consistencyClassification: consistencyClassificationEnum('consistency_classification'),
+  // Host-display axis (ADR-0016 §A.1) — does this host index the record? A
+  // SEPARATE dimension from `visibility` below, and orthogonal to it: the two
+  // may legitimately disagree. Served as `listed` (canonical key) with
+  // `isPublic` as a back-compat alias on `GET /api/evidence/[slug]`.
   isPublic: boolean('is_public').notNull().default(true),
-  // Visibility mirror (see visibilityEnum above). 'committed' records are
-  // creator-only on every content-bearing surface; their commitment (hash,
-  // signature, timestamp, Rekor proof) stays publicly served, redacted of
-  // content and location, via the commitment endpoint.
-  visibility: visibilityEnum('visibility').notNull().default('published'),
+  // Content-disclosure axis / visibility mirror (see visibilityEnum above).
+  // Sealed records are creator-only on every content-bearing surface; their
+  // commitment (hash, signature, timestamp, Rekor proof) stays publicly served,
+  // redacted of content and location, via the commitment endpoint.
+  visibility: visibilityEnum('visibility').notNull().default('public'),
   withdrawnAt: timestamp('withdrawn_at', { withTimezone: true }),
   withdrawnReason: text('withdrawn_reason'),
   withdrawalSignature: text('withdrawal_signature'),

--- a/src/lib/evidence/commitment.test.ts
+++ b/src/lib/evidence/commitment.test.ts
@@ -358,9 +358,9 @@ test('SECURITY: only intended-public keys are emitted (no PII / internal IDs / p
   );
 });
 
-// --- Committed-record redaction (civic-ai-tools#71 Phase 2, ADR-0010 §5) ---
+// --- Sealed-record redaction (civic-ai-tools#71 Phase 2, ADR-0010 §5) ---
 
-test('committed redaction: capability URL, title, and summary never leave the server', () => {
+test('sealed redaction: capability URL, title, and summary never leave the server', () => {
   const record = makeRecord({
     visibility: 'committed',
     basePackageStorageKey:
@@ -380,8 +380,10 @@ test('committed redaction: capability URL, title, and summary never leave the se
   assert.ok(!('subjectTitle' in view));
   assert.ok(!('subjectSummary' in view));
 
-  // The commitment itself — the proofs — is served unredacted.
-  assert.equal(view.visibility, 'committed');
+  // The commitment itself — the proofs — is served unredacted. `visibility` is
+  // served CANONICAL as of the ADR-0016 §A P2 flip: this fixture's row still
+  // holds the legacy `committed` label and the view emits `sealed`.
+  assert.equal(view.visibility, 'sealed');
   assert.equal(view.packageHash, record.basePackageHash);
   assert.ok(view.signature, 'signature envelope should be served');
   assert.equal(view.rfc3161Timestamp, 'BASE64TSTOKEN');
@@ -393,9 +395,11 @@ test('committed redaction: capability URL, title, and summary never leave the se
   }
 });
 
-test('published records carry visibility "published" and stay unredacted', () => {
+test('public records carry visibility "public" and stay unredacted', () => {
+  // The base fixture's row holds the legacy `published` label; the view serves
+  // the canonical `public` (ADR-0016 §A, P2).
   const view = buildCommitmentView(makeRecord(), makeCreator(), makePkg());
-  assert.equal(view.visibility, 'published');
+  assert.equal(view.visibility, 'public');
   assert.ok(view.packageUrl);
   assert.equal(view.subjectTitle, 'Sample analysis');
 });

--- a/src/lib/evidence/commitment.ts
+++ b/src/lib/evidence/commitment.ts
@@ -10,6 +10,7 @@ import {
   DEMO_TRUST_REGISTRY_CANONICAL_URL,
   DEMO_TRUST_REGISTRY_LEGACY_URL,
 } from '../site-config.ts';
+import { fromDbValue } from './visibility.ts';
 
 /**
  * Proof sidecar ("commitment view") builder — spec §9.2.1.
@@ -20,7 +21,7 @@ import {
  * per-publisher configuration — never a core constant). What stays HERE is
  * the implementation-side adapter (ADR-0021 §B): mapping the evidence DB row
  * + creator row onto the neutral input, parsing the stored signature JSON,
- * deriving the lifecycle summary from the row's columns, the COMMITTED-record
+ * deriving the lifecycle summary from the row's columns, the SEALED-record
  * redaction decision, and resolving THIS instance's trust-registry URLs from
  * config (ADR-0020 — see `src/lib/site-config.ts`).
  *
@@ -150,11 +151,11 @@ export function buildCommitmentView(
    *  `verifyLifecycleChain` — no reference-impl dependency (#119 P3). Omitted when the
    *  package has no signed lifecycle chain (it then stays at STATE / legacy columns). */
   lifecycleAttestations?: CarriedLifecycleAttestation[],
-  /** COMMITTED-record redaction (civic-ai-tools#71, ADR-0010 §5): the commitment
+  /** SEALED-record redaction (civic-ai-tools#71, ADR-0010 §5): the commitment
    *  is public by design (the hash is already on the transparency log), but the
    *  content's location and content-derived strings are not. When set, the view
    *  omits `packageUrl` (the non-derivable capability URL must not be disclosed),
-   *  `subjectTitle`, and `subjectSummary`, and carries `visibility: "committed"`
+   *  `subjectTitle`, and `subjectSummary`, and carries `visibility: "sealed"`
    *  so verifiers can render the zero-location state honestly. Proof-side fields
    *  (hash, signature, signer, envelope taxonomy, timestamps, Rekor, lifecycle)
    *  are served unredacted — they ARE the commitment. */
@@ -199,14 +200,25 @@ export function buildCommitmentView(
     // the raw column value verbatim (`"packageHash": null` on a hashless
     // row), and the pass-through preserves that.
     packageHash: record.basePackageHash as unknown as string,
-    // The committed-mode storage key is a non-derivable capability URL; the
+    // The sealed-mode storage key is a non-derivable capability URL; the
     // core never emits it on a redacted view (Phase 2 hard requirement). The
     // cast preserves the historical pass-through of a null column.
     packageUrl: record.basePackageStorageKey as unknown as string | undefined,
-    // Visibility state (ADR-0010): lets a verifier render "committed — content
+    // Visibility state (ADR-0010): lets a verifier render "sealed — content
     // not publicly located" instead of treating a missing packageUrl as an
-    // error. The core defaults absent → 'published'.
-    visibility: record.visibility ?? undefined,
+    // error. (The core defaults an ABSENT value to 'published'; the column is
+    // `NOT NULL`, so that branch is unreachable from this adapter — the
+    // fallback exists for callers whose row shape predates the column.)
+    //
+    // SERVED CANONICAL (ADR-0016 §A, P2). The row's raw label is normalized
+    // through the vocabulary boundary before it is emitted, so a historical row
+    // still holding `committed` serves `sealed` and one holding `published`
+    // serves `public`. This is the chartered externally-visible change of the
+    // flip phase: the commitment view is the offline-bundle surface, and a
+    // third-party verifier reading it must see ONE vocabulary regardless of
+    // which spelling the row happens to carry — otherwise the same record read
+    // before and after the M2 backfill would appear to change state.
+    visibility: record.visibility ? fromDbValue(record.visibility) : undefined,
     captureMethod: record.captureMethod,
     // Generalized for all packages (WS1): sourced from the row, not hardcoded
     // 'datHere'. The core defaults an absent column to 'default' (legacy /
@@ -242,7 +254,7 @@ export function buildCommitmentView(
     trustRegistryUrl: registry.canonical,
     trustRegistryUrlLegacy: registry.legacy,
     // Title and summary are content-derived (titles are typically the user's
-    // question verbatim) — redacted for committed records.
+    // question verbatim) — redacted for sealed records.
     subjectTitle: record.title,
     subjectSummary: record.summary,
     redactContentSurface: opts?.redactContentSurface,

--- a/src/lib/evidence/identifier.ts
+++ b/src/lib/evidence/identifier.ts
@@ -59,7 +59,7 @@ export function classifyIdentifier(identifier: string): ResolvedIdentifier {
  * This is the load-bearing authorization invariant of the hash-lookup fix:
  * addressing a record by hash grants NO more access than addressing it by slug.
  * A record with no published base package, or one that is not public (private /
- * unlisted), is unreachable by EITHER form. Committed-visibility redaction is
+ * unlisted), is unreachable by EITHER form. Sealed-visibility redaction is
  * handled separately by the route (the commitment is public by design — the hash
  * is already on the transparency log — but content and location are redacted).
  */

--- a/src/lib/evidence/publication.ts
+++ b/src/lib/evidence/publication.ts
@@ -3,8 +3,8 @@
 // A publication is two coupled, independently-verifiable signed nodes, each
 // with its own nodeId, signature, RFC 3161 timestamp, and Rekor inclusion:
 //
-//   1. `attestation/publishes/v1`  — the visibility transition (committed →
-//      published) asserted by the publisher. Authorization: publisher-only;
+//   1. `attestation/publishes/v1`  — the visibility transition (sealed →
+//      public) asserted by the publisher. Authorization: publisher-only;
 //      the platform signs on the author's behalf (§8.5), exactly as the
 //      withdraw/reinstate routes do.
 //   2. `attestation/locatedAt/v1`  — the publisher's own public pointer to the

--- a/src/lib/evidence/readback.ts
+++ b/src/lib/evidence/readback.ts
@@ -1,0 +1,79 @@
+// The `GET /api/evidence/[slug]` read-back projection.
+//
+// Extracted from the route so the two properties the ADR-0016 §A sweep put on
+// this surface are directly exercisable by the test runner (which resolves no
+// path aliases, and cannot load a route module):
+//
+//   1. `visibility` is served CANONICAL, not raw — a row on either vocabulary
+//      reads out as `sealed` / `public`;
+//   2. `listed` and `isPublic` are both emitted, from the same column.
+//
+// Nothing here touches the database; the route does the lookups and the
+// authorization, then hands the rows to this pure function.
+
+import type { evidenceRecords, users } from '../db/schema.ts';
+import { fromDbValue } from './visibility.ts';
+
+type EvidenceRecord = typeof evidenceRecords.$inferSelect;
+
+/** The creator projection the route selects — public GitHub identity only. */
+export type ReadbackCreator = Pick<
+  typeof users.$inferSelect,
+  'displayName' | 'githubProfileUrl'
+>;
+
+/**
+ * Build the read-back body for one evidence record.
+ *
+ * `createdAt` / `updatedAt` are passed through as `Date`s; `NextResponse.json`
+ * serializes them to ISO-8601 strings, exactly as the route did inline.
+ */
+export function buildRecordReadback(
+  record: EvidenceRecord,
+  creator: ReadbackCreator | null,
+): Record<string, unknown> {
+  return {
+    slug: record.slug,
+    title: record.title,
+    summary: record.summary,
+    model: record.model,
+    promptHash: record.promptHash,
+    promptVisibility: record.promptVisibility,
+    verificationStatus: record.verificationStatus,
+    consistencyClassification: record.consistencyClassification,
+    jurisdiction: record.jurisdiction,
+    civicContext: record.civicContext,
+    basePackageHash: record.basePackageHash,
+    // `listed` and `visibility` are ORTHOGONAL and may legitimately disagree
+    // (ADR-0016 §A.1; sprint decision G0-6):
+    //
+    //   - `visibility` is the CONTENT-DISCLOSURE axis: `sealed` | `public`.
+    //   - `listed` is the HOST-DISPLAY axis — does THIS host show the record in
+    //     its index? — which §A.1 names as a separate dimension, resolved by
+    //     host policy rather than by the node itself.
+    //
+    // They are separate columns (`visibility` and `is_public`), and a record can
+    // be `public` but unlisted — a host declining to index content it still
+    // serves. Emitting only `isPublic` invited reading
+    // `{visibility: "sealed", isPublic: true}` as a contradiction, or worse as
+    // "visibility == public"; `listed` names what the boolean actually is.
+    // `isPublic` stays as a read-back ALIAS — same column, same value — because
+    // already-shipped clients read it. Both are emitted indefinitely.
+    //
+    // (`GET /api/evidence/list` ANDs the two: a record appears there only if
+    // `is_public` AND its visibility is the public state. That entanglement is
+    // existing behavior of the LISTING endpoint — documented accurately here,
+    // not changed.)
+    listed: record.isPublic,
+    isPublic: record.isPublic,
+    // SERVED CANONICAL (ADR-0016 §A, P2): normalized through the vocabulary
+    // boundary, so a historical row still holding `committed` / `published`
+    // reads out as `sealed` / `public` like every other row. One vocabulary on
+    // the wire, whichever spelling the column happens to carry — see
+    // `./visibility.ts`.
+    visibility: fromDbValue(record.visibility),
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    creator: creator ?? null,
+  };
+}

--- a/src/lib/evidence/sealed-access.ts
+++ b/src/lib/evidence/sealed-access.ts
@@ -1,6 +1,6 @@
-// Creator-only read gate for committed records (civic-ai-tools#71 Phase 2).
+// Creator-only read gate for sealed records (civic-ai-tools#71 Phase 2).
 //
-// A committed record's COMMITMENT (hash, signature, timestamp, Rekor proof) is
+// A sealed record's COMMITMENT (hash, signature, timestamp, Rekor proof) is
 // public by design — it sits on a public transparency log. Its CONTENT, title,
 // summary, and location are not: every content-bearing surface ([slug] read-back,
 // package, bundle, verify, evaluate, replay, attestations, the detail page) is
@@ -27,13 +27,13 @@ type VisibilityColumns = Pick<
  * `@/lib/evidence/visibility`). Historical rows keep the legacy label
  * indefinitely, so this gate must never be keyed on one spelling.
  */
-export function isCommittedRecord(record: VisibilityColumns): boolean {
+export function isSealedRecord(record: VisibilityColumns): boolean {
   return isSealedDbValue(record.visibility);
 }
 
 /**
- * Route-layer gate. Published records are readable by anyone (true without an
- * auth lookup). Committed records require the requester to resolve — via
+ * Route-layer gate. Public records are readable by anyone (true without an
+ * auth lookup). Sealed records require the requester to resolve — via
  * bearer token or session cookie (`resolveRequestUser` handles both) — to the
  * record's creator.
  */
@@ -41,7 +41,7 @@ export async function canReadRecord(
   request: NextRequest,
   record: VisibilityColumns,
 ): Promise<boolean> {
-  if (!isCommittedRecord(record)) return true;
+  if (!isSealedRecord(record)) return true;
   const auth = await resolveRequestUser(request).catch(() => null);
   return !!auth && auth.userId === record.creatorId;
 }

--- a/src/lib/evidence/unsigned-tier.ts
+++ b/src/lib/evidence/unsigned-tier.ts
@@ -48,8 +48,8 @@ export interface SealCommitGateRefusal {
  * Guard 1 (instance form): the seal/commit action is unreachable in the
  * unsigned tier. Returns `null` when signing is configured (the action may
  * proceed) and a refusal otherwise. Wired server-side into the publish/commit
- * routes so an unsigned run cannot persist a `committed`- or
- * `published`-labeled record — per Decision C an unsigned package may reach
+ * routes so an unsigned run cannot persist a `sealed`- or
+ * `public`-labeled record — per Decision C an unsigned package may reach
  * neither state, so the whole persist action is gated, not just one
  * visibility value.
  */
@@ -62,7 +62,7 @@ export function evaluateSealCommitGate(
     body: {
       error:
         'This instance is running unsigned — no signing key is configured. ' +
-        'Committing or publishing evidence requires a signature: an unsigned ' +
+        'Sealing or publishing evidence requires a signature: an unsigned ' +
         'package can reach neither the sealed nor the public state (ADR-0020). ' +
         'Analyses still run and can be inspected locally; an operator enables ' +
         'signing via docs/instance-setup.md.',
@@ -73,8 +73,8 @@ export function evaluateSealCommitGate(
 
 /**
  * Guard 1 (per-record form): a record persisted WITHOUT a signature (a
- * historical unsigned-committed row, predating this gate) cannot be promoted
- * to `published` — even on an instance that has since configured signing. The
+ * historical unsigned-sealed row, predating this gate) cannot be promoted
+ * to `public` — even on an instance that has since configured signing. The
  * base package has no signature to back a public state; per Decision C it can
  * reach neither `sealed` nor `public`. The row itself is NOT migrated or
  * relabeled — the gate is on the action going forward, and the record keeps

--- a/src/lib/evidence/visibility.test.ts
+++ b/src/lib/evidence/visibility.test.ts
@@ -177,7 +177,7 @@ test('historical record: a legacy "committed" row still reads as the sealed stat
 });
 
 test('historical record: a legacy "committed" row still fails the public read gate', () => {
-  // `isCommittedRecord` in committed-access.ts is exactly this predicate applied
+  // `isSealedRecord` in sealed-access.ts is exactly this predicate applied
   // to `record.visibility`; when it is true the route requires the requester to
   // resolve to `record.creatorId`. A row on the legacy label must keep hitting
   // that branch — if it stopped, the content surface of every pre-rename sealed

--- a/src/lib/evidence/visibility.test.ts
+++ b/src/lib/evidence/visibility.test.ts
@@ -1,7 +1,16 @@
-// Tests for the ADR-0016 §A visibility vocabulary boundary (visibility.ts) and
-// for the property that makes the rename safe to ship in stages: a row written
-// under the LEGACY vocabulary keeps working, unchanged, at every surface that
-// reads it.
+// Tests for the ADR-0016 §A visibility vocabulary boundary (visibility.ts), the
+// read-back projection (readback.ts), and the property that makes the rename
+// safe to ship in stages: a row written under the LEGACY vocabulary keeps
+// working at every surface that reads it, in the mixed state where the table
+// holds BOTH vocabularies at once.
+//
+// Two things changed at the P2 flip and are asserted as such below:
+//   - writes now emit `sealed` / `public` only (legacy input still ACCEPTED,
+//     it just no longer round-trips to a legacy DB label);
+//   - the serving surfaces emit the CANONICAL value, so a row still holding
+//     `committed` serves `sealed`. That is the deliberate, chartered delta —
+//     the alternative would be an external consumer watching a record appear to
+//     change state when the M2 backfill rewrites its label.
 //
 // Run with: npm test (Node 22+).
 
@@ -20,6 +29,7 @@ import {
   type VisibilityDbValue,
 } from './visibility.ts';
 import { buildCommitmentView } from './commitment.ts';
+import { buildRecordReadback } from './readback.ts';
 import { evidenceRecords, users } from '../db/schema.ts';
 import type { EvidencePackage } from './packager.ts';
 
@@ -148,15 +158,36 @@ test('round trip: legacy input and new input produce an identical DB write', () 
     return toDbValue(canonical as Visibility);
   };
 
+  // Back-compat, permanent (ADR-0016 §A): an already-shipped client sending the
+  // legacy literal and a new client sending the ADR literal are indistinguishable
+  // by the time the value reaches the column.
   assert.equal(write('committed'), write('sealed'));
   assert.equal(write('published'), write('public'));
 
-  // …and in this phase that identical write is the LEGACY label, so the merge
-  // changes nothing about what lands in the column. When the flip phase turns
-  // `toDbValue` into the identity, this pair of assertions is what changes —
-  // and it is the only place in the suite that has to.
-  assert.equal(write('sealed'), 'committed');
-  assert.equal(write('public'), 'published');
+  // …and after the P2 flip that identical write is the NEW label. Legacy input
+  // is still accepted; it just no longer round-trips to a legacy DB value.
+  assert.equal(write('sealed'), 'sealed');
+  assert.equal(write('public'), 'public');
+  assert.equal(write('committed'), 'sealed');
+  assert.equal(write('published'), 'public');
+});
+
+test('writes emit ONLY the ADR-0016 vocabulary — no legacy label can be persisted', () => {
+  // The whole point of routing every write through one function: enumerate its
+  // range and there is nothing else to audit. If a legacy label ever reappears
+  // in the column, it did not come from this application.
+  const emitted = new Set((['sealed', 'public'] as const).map(toDbValue));
+  assert.deepEqual([...emitted].sort(), ['public', 'sealed']);
+
+  // Stated the other way round, so a partial revert fails loudly rather than
+  // half-flipping one state.
+  for (const legacy of ['committed', 'published'] as const) {
+    assert.equal(
+      emitted.has(legacy),
+      false,
+      `toDbValue must never emit the dead label "${legacy}"`,
+    );
+  }
 });
 
 test('toDbValue output is always a value the canonical vocabulary round-trips', () => {
@@ -217,20 +248,89 @@ test('historical record: a legacy "committed" row still produces a servable, red
   assert.equal(view.rfc3161Timestamp, 'BASE64TSTOKEN');
   assert.equal(view.rekorEntryId, 'rekor-entry-legacy');
 
-  // SERVING SURFACE, deliberately unchanged: the commitment view passes the raw
-  // column through. An external verifier that already knows this record reads
-  // byte-identically to before the boundary module existed. Renaming what this
-  // field serves is the flip phase's chartered change, not a side effect here.
-  assert.equal(view.visibility, 'committed');
+  // SERVING SURFACE — the deliberate P2 delta. The commitment view no longer
+  // passes the raw column through: it normalizes, so this legacy `committed`
+  // row now serves `sealed`. That is the chartered externally-visible change of
+  // the flip phase. A verifier reading the offline bundle sees ONE vocabulary
+  // whichever spelling the row carries, so the same record does not appear to
+  // change state when the M2 backfill later rewrites it.
+  assert.equal(view.visibility, 'sealed');
 });
 
-test('serving surface: a public-state row still serves its raw label unchanged', () => {
+test('serving surface: a legacy "published" row serves the canonical "public"', () => {
   const view = buildCommitmentView(
     makeRecord({ visibility: 'published', title: 'Open analysis', summary: 'Open summary' }),
     makeCreator(),
     makePkg(),
   );
-  assert.equal(view.visibility, 'published');
+  assert.equal(view.visibility, 'public');
   assert.equal(view.subjectTitle, 'Open analysis');
   assert.ok(view.packageUrl);
+});
+
+test('serving surface: both spellings of a state serve the SAME value', () => {
+  // The mixed-state property as an equality, not two literals: during the window
+  // between this deploy and the M2 backfill the table holds both vocabularies at
+  // once, and a consumer must not be able to tell which row is which.
+  const seal = (v: VisibilityDbValue) =>
+    buildCommitmentView(makeRecord({ visibility: v }), makeCreator(), makePkg(), undefined, {
+      redactContentSurface: true,
+    }).visibility;
+  assert.equal(seal('committed'), seal('sealed'));
+  assert.equal(seal('committed'), 'sealed');
+
+  const pub = (v: VisibilityDbValue) =>
+    buildCommitmentView(makeRecord({ visibility: v }), makeCreator(), makePkg()).visibility;
+  assert.equal(pub('published'), pub('public'));
+  assert.equal(pub('published'), 'public');
+});
+
+// --- The `[slug]` read-back projection (sprint decision G0-6) ---
+
+test('read-back: visibility is served canonical for a row on either vocabulary', () => {
+  for (const [raw, served] of [
+    ['committed', 'sealed'],
+    ['sealed', 'sealed'],
+    ['published', 'public'],
+    ['public', 'public'],
+  ] as const) {
+    const body = buildRecordReadback(makeRecord({ visibility: raw }), null);
+    assert.equal(body.visibility, served, `${raw} should serve ${served}`);
+  }
+});
+
+test('read-back: `listed` and `isPublic` both serialize, from the same column', () => {
+  for (const flag of [true, false]) {
+    const body = buildRecordReadback(makeRecord({ isPublic: flag }), null);
+    assert.ok('listed' in body, '`listed` (the canonical key) must be present');
+    assert.ok('isPublic' in body, '`isPublic` (the read-back alias) must be present');
+    assert.equal(body.listed, flag);
+    assert.equal(body.isPublic, flag);
+    assert.equal(body.listed, body.isPublic, 'the alias must never drift');
+  }
+});
+
+test('read-back: `listed` and `visibility` are orthogonal — they may disagree', () => {
+  // ADR-0016 §A.1: host display and content disclosure are different dimensions.
+  // `{visibility: "sealed", listed: true}` is expressible and is NOT a
+  // contradiction — which is exactly why the boolean needed its own honest name.
+  const sealedButFlagged = buildRecordReadback(
+    makeRecord({ visibility: 'sealed', isPublic: true }),
+    null,
+  );
+  assert.equal(sealedButFlagged.visibility, 'sealed');
+  assert.equal(sealedButFlagged.listed, true);
+
+  const publicButUnlisted = buildRecordReadback(
+    makeRecord({ visibility: 'public', isPublic: false }),
+    null,
+  );
+  assert.equal(publicButUnlisted.visibility, 'public');
+  assert.equal(publicButUnlisted.listed, false);
+});
+
+test('read-back: the creator projection is null-safe', () => {
+  assert.equal(buildRecordReadback(makeRecord(), null).creator, null);
+  const creator = { displayName: 'Octocat', githubProfileUrl: 'https://github.com/octocat' };
+  assert.deepEqual(buildRecordReadback(makeRecord(), creator).creator, creator);
 });

--- a/src/lib/evidence/visibility.ts
+++ b/src/lib/evidence/visibility.ts
@@ -111,7 +111,7 @@ export function fromDbValue(value: VisibilityDbValue): Visibility {
 /**
  * Does this DB label denote the sealed (not-yet-disclosed) state, under either
  * vocabulary? This is the exact predicate the creator-only read gate keys on
- * (`isCommittedRecord` in `committed-access.ts`), named here so it is
+ * (`isSealedRecord` in `sealed-access.ts`), named here so it is
  * directly exercisable — that module cannot be loaded by the test runner,
  * which resolves no path aliases.
  */

--- a/src/lib/evidence/visibility.ts
+++ b/src/lib/evidence/visibility.ts
@@ -15,10 +15,25 @@
 //                (drizzle/0014_add_sealed_public_visibility.sql). The enum then
 //                carries all four labels. No row changes; no behavior changes.
 //
-//   M2  FLIP     Rewrite the rows onto the new labels and move the column
-//                default. Only after this does the database hold any
-//                new-vocabulary row. Paired with the code-side flip of
-//                `toDbValue` below.
+//   P2  FLIP     `toDbValue` becomes the identity, so every NEW row lands on
+//                `sealed` / `public`, and the three serving surfaces start
+//                emitting the canonical value. This deploys BEFORE M2.
+//
+//   M2  BACKFILL Rewrite the existing rows onto the new labels and move the
+//                column default (drizzle/0015_flip_visibility_to_sealed_public
+//                .sql). Run by the owner AFTER the P2 deploy.
+//
+//   THE MIXED-STATE WINDOW between P2 and M2 is the load-bearing case: the
+//   table holds BOTH vocabularies simultaneously — historical rows on
+//   `committed` / `published`, rows written since the deploy on `sealed` /
+//   `public`. Every read path normalizes through `fromDbValue`, and every
+//   query predicate is a SET-MEMBERSHIP test over both labels for a state
+//   (`visibility-sql.ts#visibilityMatches`), never an equality against one
+//   spelling. An equality test would empty the public listing and break the
+//   publish compare-and-set the moment this phase deployed. The window is not
+//   the only time this matters: a restored backup or a fork that never runs M2
+//   holds legacy labels forever, so the property is permanent, not
+//   transitional.
 //
 //   ---  KEEP    The legacy labels `committed` / `published` are NEVER dropped.
 //                Postgres cannot remove an enum value without recreating the
@@ -36,9 +51,9 @@
 //   downstream fork part-way through the migration, or a replica that has not
 //   run M2 all serve legacy labels. Reading must never assume the flip ran.
 //
-//   `toDbValue` is the SINGLE place that decides what gets WRITTEN. It is
-//   phase-gated (see its comment) so the flip is a one-line change instead of a
-//   second sweep across every write site.
+//   `toDbValue` is the SINGLE place that decides what gets WRITTEN. Because it
+//   is the only such place, the flip was a one-line change instead of a second
+//   sweep across every write site.
 //
 // Read sites therefore normalize through `fromDbValue` / `normalizeVisibility`
 // and branch on the canonical vocabulary; write sites go through `toDbValue`.
@@ -120,22 +135,24 @@ export function isSealedDbValue(value: VisibilityDbValue): boolean {
 }
 
 /**
- * ============================ THE FLIP POINT ============================
+ * The single place that decides what a write puts in the `visibility` column.
+ * It is the IDENTITY: the canonical vocabulary and the persisted vocabulary are
+ * now the same two labels (`sealed`, `public`), so every new row lands on the
+ * ADR-0016 §A spelling.
  *
- * PHASE P1 (this phase): returns the LEGACY label. The application continues
- * to WRITE exactly what it writes today (`sealed` -> `'committed'`,
- * `public` -> `'published'`), which is what makes P1's merge behaviorally
- * inert — the new labels do not yet exist in the database.
+ * The flip happened in P2, after the owner-run M1 expand migration
+ * (drizzle/0014_add_sealed_public_visibility.sql) put `sealed` and `public` on
+ * the live enum. It was a one-line change precisely because no other module
+ * decides what a write persists.
  *
- * PHASE P2 (after the owner-run M1 expand migration lands): this function
- * becomes the identity — `sealed` -> `'sealed'`, `public` -> `'public'` — and
- * that is the ENTIRE code-side flip. Nothing else has to change, because no
- * other module decides what a write puts in the column.
- *
- * =======================================================================
+ * IT STAYS A FUNCTION, not an inlined cast. Writing is a policy decision — if a
+ * future instance ever has to emit a different label (a downstream fork pinned
+ * to the legacy vocabulary, a rollback window), this is the one line that
+ * changes. `fromDbValue`'s permanent four-label totality is what keeps that
+ * reversible.
  */
 export function toDbValue(value: Visibility): VisibilityDbValue {
-  return value === 'sealed' ? 'committed' : 'published';
+  return value;
 }
 
 /**

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -54,12 +54,20 @@ export async function putPackage(
 }
 
 /**
- * Store a COMMITTED evidence package blob under a random, non-hash-derivable
+ * Store a SEALED evidence package blob under a random, non-hash-derivable
  * key (Phase 2 hard requirement, civic-ai-tools#71): the package hash is
  * public in the Rekor log, so a hash-derived pathname would let anyone with
- * the commitment fetch committed content. 128 bits of randomness make the
+ * the commitment fetch sealed content. 128 bits of randomness make the
  * URL a capability held by the creator (and whoever they hand it to) until
  * publication moves the content to the canonical hash-addressed key.
+ *
+ * DELIBERATELY NOT RENAMED by the ADR-0016 §A sweep: the `committed/` path
+ * segment below is a FROZEN STORAGE LITERAL, not a state label. Every
+ * already-stored sealed package lives at that prefix and its capability URL is
+ * recorded on the row (`base_package_storage_key`); changing the segment would
+ * strand them. The function name tracks the path it writes so the two cannot
+ * drift apart. The state label that used to spell this word now reads `sealed`
+ * everywhere it is a state label — see `src/lib/evidence/visibility.ts`.
  */
 export async function putCommittedPackage(
   data: Record<string, unknown>
@@ -75,7 +83,7 @@ export async function putCommittedPackage(
 
 /**
  * Best-effort delete of a blob by URL. Used when publication re-homes a
- * committed package to its canonical hash-addressed key — the old random-key
+ * sealed package to its canonical hash-addressed key — the old random-key
  * blob is removed so the capability URL stops working. Failures are swallowed
  * (the canonical copy is already live; a stale duplicate is a cleanup concern,
  * not a correctness one).


### PR DESCRIPTION
Phase P2 of the ADR-0016 Decision A sweep (anchor #182), following P1 (#184) and the owner-run, psql-verified M1 expand migration.

**Read-path owner gate is closed** — the follow-up heads-up carrying the specific string-matching ask has been sent.

## What lands

- **The write direction flips.** `toDbValue` becomes identity; new rows land on `sealed` / `public`.
- **All three serving surfaces now serve canonical values** — the documented read-back, the commitment view (the offline-bundle surface), and the `POST /api/evidence` response echo. A row still holding `committed` serves `sealed`.
- **UI string sweep** — badges read "Sealed" / "Public", the submit verb is "Seal". "Publish" stays "Publish" wherever it is the verb, the act, or the attestation.
- **`committed-access.ts` → `sealed-access.ts`** (isolated first commit, no logic change), `isCommittedRecord` → `isSealedRecord`.
- **`drizzle/0015_flip_visibility_to_sealed_public.sql`** — the M2 row flip plus the column-default move. **Owner-run via psql; not applied by this merge.** Idempotent by construction, with a before/after count-verification protocol in the header.
- **`listed` joins `isPublic` on the read-back** (sprint decision G0-6), same value, with the orthogonality documented: `visibility` is the content-disclosure axis, `listed` is the host-display axis, and a record can legitimately be `public` but unlisted.
- **`docs/api/evidence-publish.md`** — the fork-facing contract, swept and documenting the alias layer.

## The mixed-state window

This deploys **before** M2, so the table briefly holds both vocabularies at once — historical rows on the legacy pair, new rows on the new one. That is safe by construction: every read gate normalizes through `fromDbValue`, and both SQL predicates remain `::text`-cast set-membership tests over both labels of a state. No equality against a single spelling survives anywhere.

The sharpest case is the publish compare-and-set: its pre-check accepts either spelling, so if the CAS matched only one, a row on the other would pass the pre-check, fail the `UPDATE`'s `WHERE`, and return a misleading 409 — permanently unpublishable. Set membership keeps the two in agreement across all four labels.

## Two razor calls worth review

1. **The `evidence-packages/committed/<random>.json` storage path is NOT renamed.** It is a frozen capability-URL literal recorded on `base_package_storage_key` for every existing sealed row; renaming the segment would strand them. It is not a state label and no client sees it. `putCommittedPackage` keeps its name so it tracks the path it writes, with the reasoning in its JSDoc.
2. **The issue-vocabulary mapping table's left column is NOT renamed** — it quotes civic-ai-tools#71/#72 verbatim under a heading telling integrators to read it as a lookup. Renaming it would destroy the mapping it exists to provide; it now carries a note that the quoted wording is doubly non-current. Historical change-log entries are likewise left intact per the append-only convention, with a new dated entry added instead.

The renamed `Sealed-mode publishing` heading keeps an explicit anchor at its old fragment so external deep links into this contract keep landing.

## What an external client sees change

Exactly one field, on three surfaces: `visibility` now serves `"sealed"` / `"public"` on the commitment view (and the `org.civicaitools.evidence` block in `/bundle`), the `[slug]` read-back, and the `POST /api/evidence` response. Plus one purely additive field, `listed`.

Input still accepts all four literals indefinitely. No field removed or renamed, no status code changed, and **the package JSON is byte-identical** — `visibility` was never an envelope field, which is why historical records keep verifying.

## Evidence

| Check | Result |
|---|---|
| `npm run test` | **411 pass / 0 fail** (baseline 405; +6 net) |
| `npm run lint` | 4 warnings, **0 introduced** — byte-identical to the documented pre-existing set |
| `npm run build` | compiled clean |
| Diff | 29 files, +1416 / −219, 4 commits |

The file count is wider than the literal inventory because the module rename fans out through the seven route modules that import `canReadRecord`; those changes are import lines and comment prose.

## Merge choreography

**Merge, pull, then run M2** — the migration file only exists locally after main is pulled. M2 is owner-run via psql and verified arithmetically: no rows left on the legacy pair, each new count equal to the sum of its pair, and the grand total unchanged. A changed total means something rewrote rows it should not have.

Refs #182