### PR TITLE
Correct the ADR-0016 storage-path freeze rationale

### DIFF
--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -62,12 +62,19 @@ export async function putPackage(
  * publication moves the content to the canonical hash-addressed key.
  *
  * DELIBERATELY NOT RENAMED by the ADR-0016 §A sweep: the `committed/` path
- * segment below is a FROZEN STORAGE LITERAL, not a state label. Every
- * already-stored sealed package lives at that prefix and its capability URL is
- * recorded on the row (`base_package_storage_key`); changing the segment would
- * strand them. The function name tracks the path it writes so the two cannot
- * drift apart. The state label that used to spell this word now reads `sealed`
- * everywhere it is a state label — see `src/lib/evidence/visibility.ts`.
+ * segment below is a FROZEN STORAGE LITERAL, not a state label.
+ *
+ * Renaming it would NOT strand existing packages — every consumer reads the
+ * stored key off the row (`base_package_storage_key`) and hands it to
+ * `getPackage()`, and the GC selects stored keys from the database; nothing
+ * reconstructs the path from visibility state. What renaming would actually
+ * produce is a split storage layout for no benefit, plus a hazard for future
+ * code that DOES try to derive the path. The freeze is worth keeping for a
+ * simpler reason: a stored capability URL is a value someone already holds.
+ *
+ * The function name tracks the path it writes so the two cannot drift apart.
+ * The state label that used to spell this word now reads `sealed` everywhere
+ * it is a state label — see `src/lib/evidence/visibility.ts`.
  */
 export async function putCommittedPackage(
   data: Record<string, unknown>


### PR DESCRIPTION
Comment-only. Follow-up to #185.

The P2 JSDoc on `putCommittedPackage` justified freezing the `evidence-packages/committed/` path segment by claiming a rename would strand existing sealed packages. **That claim was wrong and I had not checked it before writing it into both the PR body and the phase report.**

Verified now: all 19 consumers of `basePackageStorageKey` read the stored key off the row and hand it to `getPackage()`, and the GC cron selects stored keys from the database rather than reasoning about the segment. Nothing reconstructs the path from visibility state. The only `committed/` path constructions outside the writer are test fixtures. A rename would have produced a **split storage layout, not data loss.**

The freeze itself still stands, for the accurate reason now recorded in the comment: a stored capability URL is a value someone already holds, and renaming its generator buys nothing while leaving a hazard for future code that *does* try to derive the path.

`npm run test`: 411 pass / 0 fail (unchanged — comment-only).

Refs #182