### PR TITLE
S5 P1: fail fast when the model credential is missing or rejected

### DIFF
--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -7,8 +7,15 @@ import { callMcpTool, routeTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
 import { headers } from 'next/headers';
-import { encodeSSE, type PanelType, type StreamEvent } from '@/lib/streaming';
+import { encodeSSE, type ModelErrorCode, type PanelType, type StreamEvent } from '@/lib/streaming';
+import { getMissingModelCredentialError } from '@/lib/model-client';
 import { TraceBuilder, hash } from '@/lib/evidence/trace';
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  'Connection': 'keep-alive',
+} as const;
 
 interface CompareRequest {
   query: string;
@@ -28,6 +35,29 @@ export async function POST(request: NextRequest) {
         JSON.stringify({ error: 'Query and model are required' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
+    }
+
+    // Fail fast when the instance has no model credential (#178). Checked
+    // before rate limiting (a misconfigured instance must not burn quota) and
+    // before any upstream work (skill fetch, MCP init). Surfaced as typed SSE
+    // error events — the channel the client already renders — plus a server
+    // log line for the operator.
+    const credentialError = getMissingModelCredentialError();
+    if (credentialError) {
+      console.error('[compare-stream]', credentialError.message);
+      const encoder = new TextEncoder();
+      const panels: PanelType[] = mcpOnly ? ['withMcp'] : ['withoutMcp', 'withMcp'];
+      const body = panels
+        .map((panel) =>
+          encodeSSE({
+            type: 'error',
+            panel,
+            message: credentialError.message,
+            code: credentialError.code,
+          } as StreamEvent & { message: string; code: ModelErrorCode })
+        )
+        .join('');
+      return new Response(encoder.encode(body), { headers: SSE_HEADERS });
     }
 
     // Get session and identifier for rate limiting
@@ -96,8 +126,13 @@ Be honest if you don't have access to current or real-time data.`;
       onComplete: (panel: PanelType, result) => {
         writeEvent({ type: 'complete', panel, data: result });
       },
-      onError: (panel: PanelType, message: string) => {
-        writeEvent({ type: 'error', panel, message } as StreamEvent & { message: string });
+      onError: (panel: PanelType, message: string, code?: ModelErrorCode) => {
+        writeEvent({
+          type: 'error',
+          panel,
+          message,
+          ...(code ? { code } : {}),
+        } as StreamEvent & { message: string; code?: ModelErrorCode });
       },
     };
 
@@ -156,13 +191,7 @@ Be honest if you don't have access to current or real-time data.`;
     runQueries();
 
     // Return the readable stream as SSE
-    return new Response(stream.readable, {
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        'Connection': 'keep-alive',
-      },
-    });
+    return new Response(stream.readable, { headers: SSE_HEADERS });
   } catch (error) {
     console.error('Compare stream API error:', error);
     return new Response(

--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -6,6 +6,7 @@ import { mcpTools } from '@/lib/mcp/tools';
 import { callMcpTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
+import { getMissingModelCredentialError, classifyModelError } from '@/lib/model-client';
 import { headers } from 'next/headers';
 
 interface CompareRequest {
@@ -24,6 +25,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Query and model are required' },
         { status: 400 }
+      );
+    }
+
+    // Fail fast when the instance has no model credential (#178) — same shared
+    // guard as the streaming route, before rate limiting or any upstream call.
+    const credentialError = getMissingModelCredentialError();
+    if (credentialError) {
+      console.error('[compare]', credentialError.message);
+      return NextResponse.json(
+        { error: credentialError.message, code: credentialError.code },
+        { status: 503 }
       );
     }
 
@@ -83,6 +95,15 @@ Be honest if you don't have access to current or real-time data.`;
     });
   } catch (error) {
     console.error('Compare API error:', error);
+    // Distinguish an upstream auth rejection (configured but refused key)
+    // from other failures so the operator gets a typed, actionable response.
+    const code = classifyModelError(error);
+    if (code) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Model credential error', code },
+        { status: code === 'model_not_configured' ? 503 : 502 }
+      );
+    }
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Internal server error' },
       { status: 500 }

--- a/src/components/ComparisonDisplay.tsx
+++ b/src/components/ComparisonDisplay.tsx
@@ -29,6 +29,7 @@ interface StreamingPanelState {
   completion_tokens?: number;
   token_limit_exceeded?: boolean;
   tools_called?: ToolCall[];
+  error?: string;
 }
 
 interface ComparisonDisplayProps {
@@ -112,6 +113,7 @@ export default function ComparisonDisplay({
       tools_called={isStreaming ? streamingWithMcp?.tools_called : withMcp?.tools_called}
       isLoading={isLoading && !isStreaming}
       variant="with-mcp"
+      error={isStreaming ? streamingWithMcp?.error : undefined}
       isStreaming={isStreaming}
       progressLog={streamingWithMcp?.progressLog}
       progressGroups={streamingWithMcp?.progressGroups}
@@ -134,6 +136,7 @@ export default function ComparisonDisplay({
       tokens_used={isStreaming ? streamingWithoutMcp?.tokens_used : withoutMcp?.tokens_used}
       isLoading={isLoading && !isStreaming}
       variant="without-mcp"
+      error={isStreaming ? streamingWithoutMcp?.error : undefined}
       isStreaming={isStreaming}
       progressLog={streamingWithoutMcp?.progressLog}
       progressGroups={streamingWithoutMcp?.progressGroups}

--- a/src/components/ResponsePanel.tsx
+++ b/src/components/ResponsePanel.tsx
@@ -18,6 +18,8 @@ interface ResponsePanelProps {
   tools_called?: ToolCall[];
   isLoading?: boolean;
   variant: 'without-mcp' | 'with-mcp';
+  /** Friendly error copy for this panel (already mapped via friendlyStreamError). */
+  error?: string;
   // Streaming props
   progressLog?: ProgressLogEntry[];
   progressGroups?: ProgressGroup[];
@@ -43,6 +45,7 @@ export default function ResponsePanel({
   tools_called,
   isLoading,
   variant,
+  error,
   progressLog,
   progressGroups,
   isStreaming,
@@ -56,12 +59,31 @@ export default function ResponsePanel({
 }: ResponsePanelProps) {
   const isMcp = variant === 'with-mcp';
 
-  // Without-MCP display state
+  // Without-MCP display state. An error suppresses the in-progress affordances
+  // (spinners, "answering from training data" note) so the panel reads as
+  // failed, not still working (#178).
   const hasProgressLog = isStreaming && progressLog && progressLog.length > 0;
   const hasGroups = isStreaming && progressGroups && progressGroups.length > 0;
-  const showProgressLog = !isMcp && (hasProgressLog || hasGroups) && !content;
+  const showProgressLog = !isMcp && (hasProgressLog || hasGroups) && !content && !error;
   const showStreamingContent = !isMcp && isStreaming && !!content;
   const showStaticContent = !isMcp && !isStreaming && !isLoading && !!content;
+
+  const errorBox = error ? (
+    <div
+      role="alert"
+      style={{
+        padding: '12px 16px',
+        backgroundColor: 'rgba(236, 19, 30, 0.1)',
+        color: 'var(--nyc-error)',
+        borderRadius: '4px',
+        border: '1px solid var(--nyc-error)',
+        fontSize: '14px',
+        marginBottom: '16px',
+      }}
+    >
+      {error}
+    </div>
+  ) : null;
 
   const markdownContent = (text: string, showCursor?: boolean) => (
     <div className="response-markdown">
@@ -122,7 +144,10 @@ export default function ResponsePanel({
         </p>
       </div>
 
-      {/* MCP variant: delegate to shared component */}
+      {/* MCP variant: delegate to shared component (error box above it) */}
+      {isMcp && errorBox && (
+        <div style={{ padding: '16px 24px 0' }}>{errorBox}</div>
+      )}
       {isMcp && (
         <McpResponseDisplay
           content={content}
@@ -136,7 +161,7 @@ export default function ResponsePanel({
           completion_tokens={completion_tokens}
           token_limit_exceeded={token_limit_exceeded}
           isComplete={isStreaming ? !!duration_ms : !!content}
-          isActive={!!isStreaming && !duration_ms}
+          isActive={!!isStreaming && !duration_ms && !error}
           showFooter={!isLoading && !!(duration_ms || tokens_used)}
           portal={portal}
           model={model}
@@ -204,6 +229,9 @@ export default function ResponsePanel({
               </div>
             )}
 
+            {/* Typed failure (e.g. no model credential configured) */}
+            {errorBox}
+
             {/* Streaming progress log */}
             {showProgressLog && hasGroups && (
               <ProgressLog
@@ -214,7 +242,7 @@ export default function ResponsePanel({
               />
             )}
             {/* Without-MCP contextual label during streaming */}
-            {isStreaming && !content && (
+            {isStreaming && !content && !error && (
               <div
                 style={{
                   borderLeft: '3px solid var(--nyc-caution)',

--- a/src/hooks/useLiveTrace.ts
+++ b/src/hooks/useLiveTrace.ts
@@ -63,6 +63,10 @@ export function useLiveTrace(): UseLiveTraceReturn {
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const cascadeTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const receivedCompleteRef = useRef(false);
+  // Tracks a typed `error` event in a ref (statusRef lags a render behind), so
+  // onComplete's connection-lost fallback can't overwrite the real error when
+  // the stream closes immediately after erroring.
+  const receivedErrorRef = useRef(false);
 
   // Keep statusRef in sync
   useEffect(() => {
@@ -94,6 +98,7 @@ export function useLiveTrace(): UseLiveTraceReturn {
     setToolsCalled([]);
     eventIndexRef.current = 0;
     receivedCompleteRef.current = false;
+    receivedErrorRef.current = false;
     traceCaptureRef.current = null;
   }, [clearTimers]);
 
@@ -261,6 +266,7 @@ export function useLiveTrace(): UseLiveTraceReturn {
     setToolsCalled([]);
     eventIndexRef.current = 0;
     receivedCompleteRef.current = false;
+    receivedErrorRef.current = false;
 
     const abortController = new AbortController();
     abortRef.current = abortController;
@@ -402,7 +408,11 @@ export function useLiveTrace(): UseLiveTraceReturn {
         }
 
         if (type === 'error') {
-          setError(friendlyStreamError(eventData.message));
+          // Pass the whole event: a typed `code` (e.g. model_not_configured)
+          // selects operator-actionable copy; otherwise the message text is
+          // classified as before.
+          receivedErrorRef.current = true;
+          setError(friendlyStreamError(eventData));
           setStatus('error');
           clearTimers();
         }
@@ -422,7 +432,7 @@ export function useLiveTrace(): UseLiveTraceReturn {
 
           if (receivedCompleteRef.current) {
             setStatus('complete');
-          } else {
+          } else if (!receivedErrorRef.current) {
             // Stream ended without a complete event — likely a connection drop
             setError('Connection lost before the query finished. Partial results may be shown.');
             setStatus('error');

--- a/src/hooks/useStreamingComparison.ts
+++ b/src/hooks/useStreamingComparison.ts
@@ -474,15 +474,31 @@ function handleEvent(
       break;
 
     case 'error':
-      setState(prev => ({
-        ...prev,
-        [panel]: {
-          ...prev[panel],
-          error: friendlyStreamError(event.message),
+      setState(prev => {
+        // Stop the spinners: without this, a panel that errors before any
+        // content arrives keeps its in-flight progress entries animating
+        // forever — the silent-hang symptom of #178.
+        const newLog = prev[panel].progressLog.map(entry => ({ ...entry, isComplete: true }));
+        const newGroups = prev[panel].progressGroups.map(g => ({
+          ...g,
           isComplete: true,
-          progress: null,
-        },
-      }));
+          entries: g.entries.map(e => ({ ...e, isComplete: true })),
+        }));
+        return {
+          ...prev,
+          [panel]: {
+            ...prev[panel],
+            // Pass the whole event: a typed `code` (e.g. model_not_configured)
+            // selects operator-actionable copy; otherwise the message text is
+            // classified as before.
+            error: friendlyStreamError(event),
+            isComplete: true,
+            progress: null,
+            progressLog: newLog,
+            progressGroups: newGroups,
+          },
+        };
+      });
       break;
   }
 }

--- a/src/lib/mcp/client-unreachable.test.ts
+++ b/src/lib/mcp/client-unreachable.test.ts
@@ -1,0 +1,43 @@
+// Rider evidence for #178: unlike the model-credential path, a missing or
+// unreachable MCP endpoint does NOT hang the request path. The MCP client
+// fails loudly and bounded on its own — connection failures reject
+// immediately, unresponsive servers hit the 45s AbortError timeout with a
+// clear message, and `classifyStreamError` already maps both shapes to
+// friendly copy. This test pins the connection-refused case.
+//
+// The registry captures env at module load, so the unreachable URL is set
+// before `client.ts` is imported (node --test runs each file in its own
+// process, so this cannot leak into other tests).
+//
+// Run with: npm test   (or: node --test --experimental-strip-types src/lib/mcp/client-unreachable.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Port 1 (tcpmux) on loopback: nothing listens there, so connections are
+// refused immediately — a deterministic "unreachable endpoint" fixture.
+process.env.SOCRATA_MCP_URL = 'http://127.0.0.1:1';
+
+const { callMcpTool } = await import('./client.ts');
+const { classifyStreamError } = await import('../streaming.ts');
+
+test('callMcpTool against an unreachable MCP endpoint rejects promptly with a classifiable error', async () => {
+  const t0 = Date.now();
+  let caught: unknown;
+  try {
+    await callMcpTool('get_data', { type: 'catalog', query: 'test', portal: 'data.cityofnewyork.us' });
+    assert.fail('expected callMcpTool to reject');
+  } catch (error) {
+    caught = error;
+  }
+  const elapsed = Date.now() - t0;
+
+  // Bounded: connection refusal surfaces immediately, far inside the client's
+  // own 45s worst-case AbortError timeout.
+  assert.ok(elapsed < 5_000, `bounded time: took ${elapsed}ms`);
+  assert.ok(caught instanceof Error);
+
+  // The existing error-copy layer already classifies this shape as an MCP
+  // availability failure — the request path surfaces it, it does not hang.
+  assert.equal(classifyStreamError(caught), 'mcp_unavailable');
+});

--- a/src/lib/model-client.test.ts
+++ b/src/lib/model-client.test.ts
@@ -1,0 +1,96 @@
+// Tests for the request-path model-credential guard (#178).
+//
+// A fresh instance with no model API key must fail fast and typed — never
+// hang. The factory stays lazy (no import-time validation); these tests cover
+// the guard check, the typed construction failure (including the empty-string
+// key the SDK constructor would otherwise silently accept), and error
+// classification. All key values are obviously fake fixtures.
+//
+// Run with: npm test   (or: node --test --experimental-strip-types src/lib/model-client.test.ts)
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ModelConfigurationError,
+  getMissingModelCredentialError,
+  createModelClient,
+  getModelClient,
+  classifyModelError,
+  _resetDefaultModelClientForTests,
+} from './model-client.ts';
+
+const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ['OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'MODEL_API_BASE_URL'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+test('guard returns a typed error when the key is unset', () => {
+  const err = getMissingModelCredentialError();
+  assert.ok(err instanceof ModelConfigurationError);
+  assert.equal(err!.code, 'model_not_configured');
+  assert.match(err!.message, /OPENROUTER_API_KEY/);
+});
+
+test('guard returns a typed error when the key is empty or whitespace', () => {
+  process.env.OPENROUTER_API_KEY = '';
+  assert.ok(getMissingModelCredentialError() instanceof ModelConfigurationError);
+  process.env.OPENROUTER_API_KEY = '   ';
+  assert.ok(getMissingModelCredentialError() instanceof ModelConfigurationError);
+});
+
+test('guard returns null when a key is present', () => {
+  process.env.OPENROUTER_API_KEY = FAKE_KEY;
+  assert.equal(getMissingModelCredentialError(), null);
+});
+
+test('createModelClient throws the typed error when no key resolves', () => {
+  assert.throws(() => createModelClient(), ModelConfigurationError);
+  // Empty string: the SDK constructor would accept this and send a blank
+  // bearer token upstream — the typed throw must catch it too.
+  process.env.OPENROUTER_API_KEY = '';
+  assert.throws(() => createModelClient(), ModelConfigurationError);
+});
+
+test('createModelClient accepts a per-call key even when the env is empty', () => {
+  const client = createModelClient({ apiKey: FAKE_KEY });
+  assert.ok(client);
+});
+
+test('getModelClient throws typed when unconfigured, builds once configured', () => {
+  assert.throws(() => getModelClient(), ModelConfigurationError);
+  process.env.OPENROUTER_API_KEY = FAKE_KEY;
+  _resetDefaultModelClientForTests();
+  assert.ok(getModelClient());
+});
+
+test('classifyModelError distinguishes not-configured from auth-rejected', () => {
+  assert.equal(classifyModelError(new ModelConfigurationError('x')), 'model_not_configured');
+  // The SDK constructor's own message shape (belt and braces).
+  assert.equal(
+    classifyModelError(new Error('Missing credentials. Please pass an `apiKey`.')),
+    'model_not_configured',
+  );
+  // Upstream auth rejections carry a status on the SDK's APIError.
+  assert.equal(classifyModelError({ status: 401, message: '401 Invalid API key' }), 'model_auth_rejected');
+  assert.equal(classifyModelError({ status: 403, message: 'Forbidden' }), 'model_auth_rejected');
+  // Everything else keeps its existing handling.
+  assert.equal(classifyModelError({ status: 500, message: 'Internal' }), null);
+  assert.equal(classifyModelError(new Error('fetch failed')), null);
+  assert.equal(classifyModelError(null), null);
+});

--- a/src/lib/model-client.ts
+++ b/src/lib/model-client.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import type { ModelErrorCode } from './streaming.ts';
 
 /**
  * Model-client factory — the single place the chat-completions endpoint is
@@ -11,10 +12,74 @@ import OpenAI from 'openai';
  *
  * Construction is lazy on purpose: no client is built at import time, so
  * importing a module that uses the factory never requires the key to be
- * present (e.g. during `next build`).
+ * present (e.g. during `next build`). Credential validation therefore lives on
+ * the request path: routes call `getMissingModelCredentialError()` up front,
+ * and `createModelClient` throws a typed `ModelConfigurationError` (instead of
+ * the SDK's generic constructor error) the first time a request actually needs
+ * the missing key. See issue #178 — a fresh instance with an incomplete env
+ * file must fail loudly, not hang.
  */
 
 const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
+
+/**
+ * Typed, operator-actionable configuration failure: the environment has no
+ * usable model credential. Distinct from an upstream auth rejection (a key
+ * that exists but the endpoint refuses) — see `classifyModelError`.
+ */
+export class ModelConfigurationError extends Error {
+  readonly code: ModelErrorCode = 'model_not_configured';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ModelConfigurationError';
+  }
+}
+
+const MISSING_CREDENTIAL_MESSAGE =
+  'No model API key is configured: OPENROUTER_API_KEY is missing or empty in the server environment. ' +
+  'Set it (any OpenAI-compatible endpoint configured via MODEL_API_BASE_URL still reads its key from OPENROUTER_API_KEY) and restart the server.';
+
+/**
+ * Request-path guard: returns a typed `ModelConfigurationError` when the
+ * environment holds no usable model credential (missing or empty
+ * OPENROUTER_API_KEY), or null when a credential is present. Detectable before
+ * any upstream call — routes use this to fail fast instead of opening the
+ * model pipeline. Deliberately a check-and-return (not a throw) so routes can
+ * shape their own response (SSE error event vs. JSON status).
+ */
+export function getMissingModelCredentialError(): ModelConfigurationError | null {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key || key.trim() === '') {
+    return new ModelConfigurationError(MISSING_CREDENTIAL_MESSAGE);
+  }
+  return null;
+}
+
+/**
+ * Classify a request-path model failure into a typed, operator-actionable
+ * code, or null for anything else (network errors, rate limits, model errors —
+ * those keep their existing handling).
+ *
+ * - `model_not_configured`: our typed guard error, or the SDK's own
+ *   missing-credentials constructor error (belt and braces — the guard should
+ *   fire first).
+ * - `model_auth_rejected`: the configured endpoint answered 401/403 (or an
+ *   equivalent auth rejection), i.e. a credential exists but was refused
+ *   upstream. Shape-based (`status` on the SDK's APIError) rather than
+ *   instanceof so it survives SDK class-identity quirks and stays unit-testable.
+ */
+export function classifyModelError(error: unknown): ModelErrorCode | null {
+  if (error instanceof ModelConfigurationError) return 'model_not_configured';
+  if (error instanceof Error && /missing credentials/i.test(error.message)) {
+    return 'model_not_configured';
+  }
+  if (error !== null && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status?: unknown }).status;
+    if (status === 401 || status === 403) return 'model_auth_rejected';
+  }
+  return null;
+}
 
 /** Resolved chat-completions base URL (env override or the default above). */
 export function getModelApiBaseUrl(): string {
@@ -24,11 +89,20 @@ export function getModelApiBaseUrl(): string {
 /**
  * Build a new client against the configured endpoint. Pass `apiKey` to use a
  * caller-supplied key; omitted, the key comes from OPENROUTER_API_KEY.
+ *
+ * Throws a typed `ModelConfigurationError` when no usable key resolves. This
+ * replaces two silent-failure shapes: the SDK's generic constructor error for
+ * an unset key, and — worse — an empty-string key, which the SDK constructor
+ * accepts and then sends as a blank bearer token upstream.
  */
 export function createModelClient(opts: { apiKey?: string } = {}): OpenAI {
+  const apiKey = opts.apiKey ?? process.env.OPENROUTER_API_KEY;
+  if (!apiKey || apiKey.trim() === '') {
+    throw new ModelConfigurationError(MISSING_CREDENTIAL_MESSAGE);
+  }
   return new OpenAI({
     baseURL: getModelApiBaseUrl(),
-    apiKey: opts.apiKey ?? process.env.OPENROUTER_API_KEY,
+    apiKey,
   });
 }
 
@@ -44,4 +118,9 @@ export function getModelClient(): OpenAI {
     defaultClient = createModelClient();
   }
   return defaultClient;
+}
+
+/** Test support: drop the cached default client so env changes take effect. */
+export function _resetDefaultModelClientForTests(): void {
+  defaultClient = null;
 }

--- a/src/lib/openrouter-streaming.test.ts
+++ b/src/lib/openrouter-streaming.test.ts
@@ -1,0 +1,159 @@
+// Acceptance tests for #178: a submitted query must fail fast and typed on
+// the streaming request path when the model credential is missing (no
+// upstream call at all) or rejected upstream (401/403) — never hang.
+//
+// The rejected case runs against a local mock HTTP server; no live endpoint
+// is ever contacted and all key values are obviously fake fixtures.
+//
+// Run with: npm test   (or: node --test --experimental-strip-types src/lib/openrouter-streaming.test.ts)
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { queryWithoutMcpStreaming, queryWithMcpStreaming, type StreamCallbacks } from './openrouter-streaming.ts';
+import { _resetDefaultModelClientForTests } from './model-client.ts';
+import type { ModelErrorCode, PanelType } from './streaming.ts';
+
+const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
+
+// A promptly-failing path should resolve well inside this bound; the
+// pre-#178 behavior this guards against surfaced no signal at all.
+const BOUNDED_MS = 5_000;
+
+interface RecordedError {
+  panel: PanelType;
+  message: string;
+  code?: ModelErrorCode;
+}
+
+function makeCallbacks(errors: RecordedError[]): StreamCallbacks {
+  return {
+    onProgress: () => {},
+    onToken: () => {},
+    onComplete: () => {
+      assert.fail('query must not complete without a working credential');
+    },
+    onError: (panel, message, code) => {
+      errors.push({ panel, message, code });
+    },
+  };
+}
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ['OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'MODEL_API_BASE_URL'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+// --- Case 1: not configured — fails before any upstream call ---------------
+
+test('queryWithoutMcpStreaming: missing credential yields typed onError in bounded time', async () => {
+  const errors: RecordedError[] = [];
+  const t0 = Date.now();
+  await queryWithoutMcpStreaming('test question', 'fake/model', undefined, makeCallbacks(errors));
+  const elapsed = Date.now() - t0;
+
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].panel, 'withoutMcp');
+  assert.equal(errors[0].code, 'model_not_configured');
+  assert.match(errors[0].message, /OPENROUTER_API_KEY/);
+  assert.ok(elapsed < BOUNDED_MS, `bounded time: took ${elapsed}ms`);
+});
+
+test('queryWithMcpStreaming: missing credential yields typed onError in bounded time', async () => {
+  const errors: RecordedError[] = [];
+  const t0 = Date.now();
+  await queryWithMcpStreaming(
+    'test question',
+    'fake/model',
+    [],
+    async () => {
+      assert.fail('no tool call should ever run without a credential');
+    },
+    undefined,
+    makeCallbacks(errors),
+  );
+  const elapsed = Date.now() - t0;
+
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].panel, 'withMcp');
+  assert.equal(errors[0].code, 'model_not_configured');
+  assert.ok(elapsed < BOUNDED_MS, `bounded time: took ${elapsed}ms`);
+});
+
+// --- Case 2: configured but rejected upstream (mocked 401) ------------------
+
+function startAuthRejectingServer(): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((_req, res) => {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: { message: 'Invalid API key (test fixture)', code: 401 } }));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/v1` });
+    });
+  });
+}
+
+test('queryWithoutMcpStreaming: upstream 401 yields typed model_auth_rejected onError', async () => {
+  const { server, url } = await startAuthRejectingServer();
+  try {
+    process.env.OPENROUTER_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    const errors: RecordedError[] = [];
+    const t0 = Date.now();
+    await queryWithoutMcpStreaming('test question', 'fake/model', undefined, makeCallbacks(errors));
+    const elapsed = Date.now() - t0;
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].panel, 'withoutMcp');
+    assert.equal(errors[0].code, 'model_auth_rejected');
+    assert.ok(elapsed < BOUNDED_MS, `bounded time: took ${elapsed}ms`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('queryWithMcpStreaming: upstream 401 yields typed model_auth_rejected onError', async () => {
+  const { server, url } = await startAuthRejectingServer();
+  try {
+    process.env.OPENROUTER_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    const errors: RecordedError[] = [];
+    await queryWithMcpStreaming(
+      'test question',
+      'fake/model',
+      [],
+      async () => {
+        assert.fail('no tool call should run when the credential is rejected');
+      },
+      undefined,
+      makeCallbacks(errors),
+    );
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].panel, 'withMcp');
+    assert.equal(errors[0].code, 'model_auth_rejected');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -1,9 +1,9 @@
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
-import { getModelClient } from './model-client';
-import { formatToolProgress, formatToolResult, generateToolReason, describeToolFailureForLlm, type PanelType, type ProgressPhase } from './streaming';
-import type { TraceBuilder } from './evidence/trace';
-import { hash as traceHash } from './evidence/trace';
-import { deriveOperationType } from './mcp/operation-types';
+import { getModelClient, classifyModelError } from './model-client.ts';
+import { formatToolProgress, formatToolResult, generateToolReason, describeToolFailureForLlm, type PanelType, type ProgressPhase, type ModelErrorCode } from './streaming.ts';
+import type { TraceBuilder } from './evidence/trace.ts';
+import { hash as traceHash } from './evidence/trace.ts';
+import { deriveOperationType } from './mcp/operation-types.ts';
 
 export interface TraceContext {
   builder: TraceBuilder;
@@ -28,7 +28,19 @@ export interface StreamCallbacks {
   onProgress: (panel: PanelType, message: string, opts?: ProgressOpts) => void;
   onToken: (panel: PanelType, content: string) => void;
   onComplete: (panel: PanelType, result: CompletionResult) => void;
-  onError: (panel: PanelType, error: string) => void;
+  /** `code` is set for typed model-credential failures (#178); undefined otherwise. */
+  onError: (panel: PanelType, error: string, code?: ModelErrorCode) => void;
+}
+
+/**
+ * Shared failure tail for both streaming query functions: classify the error,
+ * log it server-side (previously this path was silent — the error only went to
+ * the SSE callback), and forward message + typed code to the caller.
+ */
+function reportStreamFailure(panel: PanelType, error: unknown, callbacks: StreamCallbacks): void {
+  const code = classifyModelError(error) ?? undefined;
+  console.error(`[stream:${panel}] query failed${code ? ` (${code})` : ''}:`, error);
+  callbacks.onError(panel, error instanceof Error ? error.message : 'Unknown error', code);
 }
 
 export interface CompletionResult {
@@ -123,7 +135,7 @@ export async function queryWithoutMcpStreaming(
       tokens_used: tokensUsed,
     });
   } catch (error) {
-    callbacks.onError(panel, error instanceof Error ? error.message : 'Unknown error');
+    reportStreamFailure(panel, error, callbacks);
   }
 }
 
@@ -484,6 +496,6 @@ export async function queryWithMcpStreaming(
       });
     }
   } catch (error) {
-    callbacks.onError(panel, error instanceof Error ? error.message : 'Unknown error');
+    reportStreamFailure(panel, error, callbacks);
   }
 }

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -1,5 +1,5 @@
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
-import { getModelClient } from './model-client';
+import { getModelClient } from './model-client.ts';
 
 export interface CompletionResult {
   content: string;

--- a/src/lib/streaming.test.ts
+++ b/src/lib/streaming.test.ts
@@ -89,3 +89,47 @@ test('describeToolFailureForLlm distinguishes unavailable from generic', () => {
   assert.match(unavailable, /temporarily unavailable/i);
   assert.match(generic, /could not be completed/i);
 });
+
+// --- Typed model-credential failures (#178) --------------------------------
+//
+// The server stamps `code` on SSE error events for the two credential
+// failures. Classification must honor the code without parsing message text,
+// and the copy must be operator-actionable (it names the env var — these
+// errors only appear on self-hosted instances with a broken configuration).
+
+test('classifyStreamError honors a typed code before any message parsing', () => {
+  assert.equal(
+    classifyStreamError({ code: 'model_not_configured', message: 'whatever' }),
+    'model_not_configured',
+  );
+  assert.equal(
+    classifyStreamError({ code: 'model_auth_rejected', message: 'whatever' }),
+    'model_auth_rejected',
+  );
+  // An unknown code falls through to message classification.
+  assert.equal(classifyStreamError({ code: 'bogus', message: 'rate limit exceeded' }), 'rate_limit');
+});
+
+test('classifyStreamError falls back to message shape for credential failures', () => {
+  // The guard's own message (non-streaming route JSON path).
+  assert.equal(
+    classifyStreamError('No model API key is configured: OPENROUTER_API_KEY is missing or empty in the server environment.'),
+    'model_not_configured',
+  );
+  // The SDK's constructor message (belt and braces).
+  assert.equal(classifyStreamError('Missing credentials. Please pass an `apiKey`.'), 'model_not_configured');
+  // A typical upstream 401 body message.
+  assert.equal(classifyStreamError('401 Invalid API key provided'), 'model_auth_rejected');
+});
+
+test('friendlyStreamError gives distinct, operator-actionable copy for the two credential failures', () => {
+  const notConfigured = friendlyStreamError({ code: 'model_not_configured' });
+  const rejected = friendlyStreamError({ code: 'model_auth_rejected' });
+  assert.notEqual(notConfigured, rejected);
+  // Both name the env var so the operator knows exactly what to fix.
+  assert.match(notConfigured, /OPENROUTER_API_KEY/);
+  assert.match(rejected, /OPENROUTER_API_KEY/);
+  // Distinguishing language: absent vs rejected.
+  assert.match(notConfigured, /no AI model API key configured/i);
+  assert.match(rejected, /rejected/i);
+});

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -37,9 +37,21 @@ export interface CompleteEvent extends StreamEvent {
   };
 }
 
+/**
+ * Machine-readable code for model-credential failures (issue #178). Set by the
+ * server on `error` events so the client can render distinct,
+ * operator-actionable copy without parsing message strings:
+ * - `model_not_configured` — no credential in the environment; detected before
+ *   any upstream call.
+ * - `model_auth_rejected` — a credential exists but the model endpoint refused
+ *   it (401/403).
+ */
+export type ModelErrorCode = 'model_not_configured' | 'model_auth_rejected';
+
 export interface ErrorEvent extends StreamEvent {
   type: 'error';
   message: string;
+  code?: ModelErrorCode;
 }
 
 // --- Friendly error copy -----------------------------------------------------
@@ -52,7 +64,14 @@ export interface ErrorEvent extends StreamEvent {
 // implementation jargon; no new trust/status vocabulary). They are the single
 // place error-to-copy mapping lives, consumed by every SSE-consuming hook.
 
-export type StreamErrorKind = 'rate_limit' | 'mcp_timeout' | 'mcp_unavailable' | 'connection' | 'generic';
+export type StreamErrorKind =
+  | 'rate_limit'
+  | 'model_not_configured'
+  | 'model_auth_rejected'
+  | 'mcp_timeout'
+  | 'mcp_unavailable'
+  | 'connection'
+  | 'generic';
 
 /** Pull a lowercased message string out of any error-ish input. */
 function errorMessageOf(input: unknown): string {
@@ -67,11 +86,17 @@ function errorMessageOf(input: unknown): string {
 
 /**
  * Classify an error (an `Error`, an SSEError-like object with `status`, a raw
- * message string, or an SSE `error`-event message) into a `StreamErrorKind`.
- * Order matters: rate-limit first (status or text), then the more specific MCP
- * timeout before the broader MCP-unavailable, then generic connection.
+ * message string, or an SSE `error`-event object) into a `StreamErrorKind`.
+ * Order matters: an explicit typed `code` first (server-declared, never
+ * guessed from text), then rate-limit (status or text), then the more specific
+ * MCP timeout before the broader MCP-unavailable, then generic connection.
  */
 export function classifyStreamError(input: unknown): StreamErrorKind {
+  if (input !== null && typeof input === 'object' && 'code' in input) {
+    const code = (input as { code?: unknown }).code;
+    if (code === 'model_not_configured' || code === 'model_auth_rejected') return code;
+  }
+
   const status =
     input !== null && typeof input === 'object' && 'status' in input
       ? (input as { status?: unknown }).status
@@ -82,6 +107,10 @@ export function classifyStreamError(input: unknown): StreamErrorKind {
   if (!m) return 'generic';
 
   if (m.includes('rate limit') || m.includes('429')) return 'rate_limit';
+  // Message-shape fallback for the two credential failures, for paths that
+  // carry only a message (e.g. the non-streaming route's JSON error).
+  if (m.includes('no model api key') || m.includes('missing credentials')) return 'model_not_configured';
+  if (m.includes('invalid api key') || m.includes('incorrect api key')) return 'model_auth_rejected';
   if (m.includes('timed out') || m.includes('timeout') || m.includes('did not respond within')) return 'mcp_timeout';
   if (
     m.includes('unavailable') ||
@@ -110,6 +139,13 @@ export function classifyStreamError(input: unknown): StreamErrorKind {
 
 const FRIENDLY_STREAM_COPY: Record<StreamErrorKind, string> = {
   rate_limit: 'You’ve reached today’s request limit. Sign in for more requests, or try again tomorrow.',
+  // The two credential kinds are deliberately operator-actionable (they name
+  // the env var): they only appear on self-hosted instances with a broken
+  // configuration, where the reader is the person who can fix it (#178).
+  model_not_configured:
+    'This server has no AI model API key configured, so queries can’t run. If you operate this instance, set OPENROUTER_API_KEY in the server environment and restart.',
+  model_auth_rejected:
+    'The AI model service rejected this server’s API key, so the query couldn’t run. If you operate this instance, check that OPENROUTER_API_KEY is valid for the configured endpoint.',
   mcp_timeout:
     'The live data source took too long to respond, so this query couldn’t finish. Try again in a moment, or narrow the question (for example, add a date range).',
   mcp_unavailable:


### PR DESCRIPTION
Phase P1 of the S5 pre-deployment-hardening sprint (#183). Issue: #178.

A fresh instance with no model credential hung silently on query submit — no UI error, no server log, spinners forever. Every other misconfiguration in the stack fails loudly; this was the outlier, and it is the first thing an incomplete environment file produces.

## Diagnosis
The failure was a swallowed error rendered as a hang, in three stacked layers: (1) the SDK's constructor error was caught in the streaming query functions and forwarded to `onError` with **no server-side log**; (2) the SSE `error` event reached the browser but `ComparisonDisplay`/`ResponsePanel` had no `error` field and never rendered it; (3) the error branch never finalized in-flight progress entries, so the spinners animated indefinitely. Worse variant: an empty-string `OPENROUTER_API_KEY` (the typical incomplete env file) was *accepted* by the SDK constructor and sent upstream as a blank bearer token.

## What changed
- **`src/lib/model-client.ts`** — typed `ModelConfigurationError`; `getMissingModelCredentialError()` request-path guard (missing *or* empty/whitespace key); `createModelClient` throws typed; `classifyModelError()` distinguishes `model_not_configured` from `model_auth_rejected` (401/403, shape-based). Factory stays lazy — nothing runs at import.
- **`src/lib/streaming.ts`** — `ModelErrorCode` on `ErrorEvent`; two new `StreamErrorKind`s; code-first classification (server-declared, never guessed from text) with message-shape fallback; distinct operator-actionable copy naming the env var (these errors only appear on misconfigured self-hosted instances, where the reader is the operator).
- **Routes** — `compare-stream`: guard immediately after input validation, before rate-limit increment and any upstream work; returns typed SSE error events per panel + server log line. `compare`: same shared guard (503 + code); catch classifies upstream auth rejections (502 + code).
- **Client** — `useStreamingComparison` finalizes progress on error (spinners stop) and threads `code`; `ComparisonDisplay`/`ResponsePanel` gain and render the `error` field (`role="alert"`); `useLiveTrace` guards a pre-existing race where the "Connection lost" fallback could overwrite the typed error.
- **`src/lib/openrouter-streaming.ts`** — shared failure tail: `console.error` (the previously missing server log) + classify + forward code via `onError(panel, message, code?)`.

## Chartered rider: MCP endpoint — does NOT hang
A missing/unreachable MCP endpoint already fails loudly and bounded: immediate rejection on connection refusal, clear 45s abort otherwise, skill prompt degrades to fallback, tool failures narrated to the model. Pinned by new test `src/lib/mcp/client-unreachable.test.ts` (unreachable endpoint → rejection in <5s → classified `mcp_unavailable`). No change to `mcp/client.ts`.

## Evidence
- **Tests:** 426 pass / 0 fail (re-run independently by ORCH). New: `model-client.test.ts`, `openrouter-streaming.test.ts` (mock 401 upstream — no live calls; obviously-fake fixture key), `client-unreachable.test.ts`; `streaming.test.ts` extended.
- **Acceptance:** credential unset → typed `model_not_configured` SSE error in bounded time (test-asserted <5s, measured ~3ms; end-to-end curl 0.638s incl. route compile); bad credential → distinguishable `model_auth_rejected` (mock 401). Both logged server-side.
- **Lint:** 0 errors, the 4 known pre-existing warnings. **Build:** green.
- Diff: 14 files, +616/−40.

IMPL model: claude-fable-5 (per phase plan). Merging deploys production; `rollback/pre-s5-p1` is tagged at `93923e8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
