### PR TITLE
Docs-tail P2: README as install/quick-start front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,144 @@
 # Civic AI Tools Website
 
-A demo website showcasing the value of [Model Context Protocol (MCP)](https://modelcontextprotocol.io) by displaying side-by-side LLM responses with and without MCP integration for civic data queries.
+The reference implementation of an evidence-publishing platform for AI-assisted
+analysis of civic open data. Ask a plain-language question about public data;
+the app answers it against live sources through
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers, can
+re-run the analysis as an executed notebook, and packages the result as a
+**signed evidence package** anyone can verify independently.
+
+Side-by-side comparison of a model answering with and without live data access
+is one of the surfaces this app offers — the thing it publishes is the evidence.
 
 > **Integrating?** Start at [`docs/api/evidence-publish.md`](docs/api/evidence-publish.md) — the evidence-publish contract, including the "Repositories & layers" orientation and the integration-contract section.
 
-**Live demo:** [civic-ai-tools-website.vercel.app](https://civic-ai-tools-website.vercel.app/)
+> **Running your own instance?** [`docs/deploy.md`](docs/deploy.md) is the guide, from `git clone` to a configured instance.
 
-## What it does
+**Reference deployment:** [civicaitools.org](https://civicaitools.org)
 
-Users enter a question about civic data (e.g., "What are the most common 311 complaints in Brooklyn?") and see two responses:
+## What's in it
 
-- **Without MCP:** LLM responds using only training data (often outdated or vague)
-- **With MCP:** LLM connects to live Socrata open data portals via [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) and returns real, current data
+| Surface | What it does |
+| --- | --- |
+| Home | Ask a question; see the answer with and without live data access, side by side. |
+| Explore | The same query as an animated BPMN process diagram — live, or replayed from recorded traces. |
+| Directory | A browsable inventory of MCP servers for civic data and the open-data portals they cover. |
+| Evidence | The published registry, and a detail page per analysis carrying its signature, timestamp, and provenance. |
+| Learn / About / Project / Roadmap | Educational and project prose. |
+| Dashboard | A signed-in publisher's own evidence records and API tokens. |
 
-## Tech Stack
+An analysis becomes evidence in two states: **`sealed`** — signed, timestamped,
+transparency-logged, unlisted — and **`public`**, which adds the publication
+attestation and served content. An instance with no signing key configured runs
+in the **unsigned tier**: analyses run and packages can be produced and
+inspected, but neither state is reachable and the app says so on every page.
+That is the intended first-run state, not a failure; signing is a deliberate
+later step ([`docs/instance-setup.md`](docs/instance-setup.md)).
 
-- **Frontend:** Next.js 16+ (App Router), Tailwind CSS
-- **LLM API:** OpenRouter (supports GPT-4o, Claude, etc.)
-- **MCP Server:** socrata-mcp-server (Socrata data access)
-- **Auth:** NextAuth.js with GitHub OAuth
-- **Rate Limiting:** Upstash Redis via @vercel/kv
-- **Hosting:** Vercel
+Built with Next.js (App Router) and React in TypeScript, with Postgres via
+Drizzle, Ed25519 signing backed by an RFC 3161 timestamp and a public
+transparency log, and three swappable driver seams — database, blob storage, and notebook executor —
+so the same code runs on a managed platform or on your own hardware
+([`docs/deploy.md`](docs/deploy.md#the-three-driver-decisions)).
 
-## Local Development
+## Quick start (local development)
+
+Node.js ≥ 22 (`.nvmrc` pins 22).
 
 ```bash
-# Install dependencies
+git clone https://github.com/npstorey/civic-ai-tools-website.git
+cd civic-ai-tools-website
 npm install
-
-# Set up environment variables (see .env.example or CLAUDE.md)
-cp .env.example .env.local
-
-# Start dev server
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000)
+Open <http://localhost:3000>. A checkout with **nothing configured** starts and
+serves every page — initialization is lazy throughout — so the first run works
+before any setup. What it cannot do yet is answer questions — queries fail
+immediately with an error naming the variable to set.
 
-## Environment Variables
+Configuration goes in `.env.local`, which the dev server loads automatically
+(never commit it). The minimum for working queries is one variable:
 
-Required:
-```
-OPENROUTER_API_KEY=sk-or-...
-SOCRATA_MCP_URL=https://socrata-mcp-server.onrender.com
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-NEXTAUTH_SECRET=        # openssl rand -base64 32
-NEXTAUTH_URL=http://localhost:3000
+```bash
+OPENROUTER_API_KEY=<your model API key>
 ```
 
-For persistent rate limiting (optional locally, required in production):
+Any OpenAI-compatible chat-completions endpoint works via `MODEL_API_BASE_URL`;
+the key stays in `OPENROUTER_API_KEY` either way. Publishing evidence
+additionally needs a database, object storage, sign-in, and a signing key —
+don't guess that set. The executable authority is the preflight, which checks
+the **presence** (never the value) of every variable the app reads and tiers
+each one against your instance's drivers:
+
+```bash
+node scripts/preflight-env.mjs
 ```
-KV_REST_API_URL=
-KV_REST_API_TOKEN=
+
+A fresh checkout **fails** the preflight by design: the FAIL list is the
+remaining go-to-production to-do list, not a broken install. The tier-by-tier
+reference is
+[`docs/deploy.md`](docs/deploy.md#environment-reference-tier-by-tier).
+
+Other useful scripts: `npm test` (unit tests), `npm run lint`, `npm run build`.
+
+## Self-hosting
+
+The repository ships a [`docker-compose.yml`](docker-compose.yml) that wires the
+whole self-hosted profile — app, Postgres, S3-compatible object storage with
+bucket init, a one-shot migration runner, and a scheduler sidecar:
+
+```bash
+docker compose --profile build-only build executor-image   # once
+docker compose up --build
 ```
 
-## Rate Limits
+That brings up an unsigned-tier instance, with no key material at all, on
+`http://localhost:3000` — loopback-bound deliberately. Read [`docs/deploy.md`](docs/deploy.md) before going further:
+it covers the driver decisions, the environment tier by tier, sign-in with your
+own OAuth application, migrations, object storage, the scheduler, and a
+**security note about the executor's socket mount** that anyone exposing this
+stack to a network needs to have read.
 
-- Anonymous users: 10 requests/day
-- Signed-in users (GitHub): 25 requests/day
+## Integrating
 
-## API documentation
+External clients — CLIs, CI jobs, publish skills — talk to the same publish
+endpoint the website's own UI uses. The contract, the OAuth 2.0 device flow for
+bearer tokens, the request schema, and a worked example are in
+[`docs/api/evidence-publish.md`](docs/api/evidence-publish.md); the read-only
+proof sidecar that lets a third party verify a package without trusting this
+host is in
+[`docs/api/evidence-commitment.md`](docs/api/evidence-commitment.md).
 
-- [`POST /api/evidence`](docs/api/evidence-publish.md) — publish an evidence package (request/response schema, auth pattern, worked curl example for external clients)
+## Documentation
 
-## Contact / express-interest links
-
-All "get in touch" links on the site (home positioning band, `/about`) read from
-`EXPRESS_INTEREST_URL` in [`src/lib/site-config.ts`](src/lib/site-config.ts).
-Re-pointing them to a different destination is a one-line change to that constant.
-
-## Contributing
-
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+| Document | What it covers |
+| --- | --- |
+| [`docs/deploy.md`](docs/deploy.md) | Self-hosted deployment end to end: bring-up, driver seams, environment reference, sign-in, migrations, storage, scheduler, managed-platform notes. |
+| [`docs/instance-setup.md`](docs/instance-setup.md) | Instance identity and signing — keygen, trust registry, identity variables. The go-to-production step. |
+| [`docs/key-rotation.md`](docs/key-rotation.md) | Signing-key rotation runbook, preventive and incident-response. |
+| [`docs/api/evidence-publish.md`](docs/api/evidence-publish.md) | The publish API contract and integrator entry point. |
+| [`docs/api/evidence-commitment.md`](docs/api/evidence-commitment.md) | The public proof sidecar served for each published package. |
+| [`docs/design-principles.md`](docs/design-principles.md) | UX and data-model principles for AI-output and provenance surfaces. |
+| [`civic-ai-tools/docs/architecture/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/architecture) | Canonical architecture in the hub repo: ADRs, spec drafts, and the open-questions registry. |
 
 ## Related
 
-- [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) - Starter project for querying civic data with MCP servers
-- [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) - The MCP server for Socrata open data portals
-- [Model Context Protocol](https://modelcontextprotocol.io) - Official MCP documentation
+- [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) — the hub repo: architecture decisions, spec drafts, MCP server configs, and the local starter project
+- [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) — the MCP server for Socrata open data portals
+- [typedstandards](https://github.com/npstorey/typedstandards) — the standard's home: `@typedstandards/verify-core` and [typedstandards.org](https://typedstandards.org)
+- [Model Context Protocol](https://modelcontextprotocol.io) — official MCP documentation
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[code of conduct](CODE_OF_CONDUCT.md).
 
 ## Disclaimer
 
-This is a personal project and is not affiliated with, endorsed by, or representative of any employer or organization.
+This is a personal project and is not affiliated with, endorsed by, or
+representative of any employer or organization.
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
 ## Disclaimer
 
 This is a personal project and is not affiliated with, endorsed by, or
-representative of any employer or organization.
+representative of any employer.
 
 ## License
 


### PR DESCRIPTION
Docs-tail sprint phase P2 (anchor #189): `README.md` rewritten as an install/quick-start front door, per program decision D2 — the README is what this is + quick start + pointers; `docs/deploy.md` (merged in #196) is the guide.

What changed:

- **Identity brought current.** The demo-era description ("a demo website showcasing MCP value") is replaced by the current reality: the reference implementation of an evidence-publishing platform for AI-assisted civic data analysis, with the side-by-side MCP comparison as one of its surfaces. A surface table matches the shipped page inventory; a short paragraph states the `sealed`/`public` states and the unsigned tier.
- **Canonical URL.** The stale platform-subdomain live-demo link is replaced by the canonical origin the code itself declares (`src/lib/site-config.ts` `DEMO_SITE_ORIGIN`), verified live.
- **Quick start, verified in a pristine worktree:** clone → install → dev; an unconfigured checkout boots and serves every page (lazy initialization), queries fail fast naming `OPENROUTER_API_KEY`; the one-variable minimum; then preflight as the executable environment authority and the deploy guide's tier-by-tier reference. The stale env-var blocks are gone — no second authority.
- **Self-hosting section** = the two compose commands plus the pointer to `docs/deploy.md`, flagging the executor socket-mount security note.
- **Integrator pointer kept** (evidence-publish contract, commitment sidecar) and a documentation pointer table added (deploy, instance-setup, key-rotation, both API docs, design principles, hub architecture).
- **Related repos refreshed:** `typedstandards` added (now public); a listed repo that no longer resolves dropped; rate-limit and contact sections cut (owned elsewhere).
- **Disclaimer narrowed to employers** (owner-directed at the merge gate): the site displays a fiscal-sponsorship acknowledgment, which the "or organization" clause contradicted.

Evidence: every command in the README was run before being written (fresh `npm install` + `npm run dev` in a detached pristine worktree; page and API probes against the unconfigured server; preflight; tests 426/426; lint clean); all 11 relative link targets and both deep anchors verified; vocabulary scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
