### PR TITLE
Docs-tail P3: riders and consistency sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A demo website showcasing MCP (Model Context Protocol) value by displaying side-by-side LLM responses with and without MCP integration for civic data queries. Built with Next.js 16+ on Vercel, it connects to OpenRouter for LLM access and socrata-mcp-server for live Socrata civic data.
 
-**Production URL:** https://civic-ai-tools-website.vercel.app/
+**Production URL:** https://civicaitools.org/
 
 ## Strategic context — what not to include in this repo
 
@@ -39,6 +39,7 @@ Each page has a distinct purpose. Use this framing to decide where new features 
 | **Home** | `/` | The result content | "Show me why MCP matters" |
 | **Explore** | `/explore` | The process | "Show me how this works" |
 | **About** | `/about` | The prose | "Explain this to me" |
+| **Project** | `/project` | Mission + proof | "What is this project, and does it work?" |
 | **Learn** | `/learn` | Educational content | "Teach me the concepts" |
 | **Evidence index** | `/evidence` | The published registry | "Show me what's been published" |
 | **Evidence detail** | `/evidence/[slug]` | One signed analysis | "Let me scrutinize this analysis" |
@@ -331,7 +332,6 @@ Active work is organized into lightweight sprints in [`/sprints/`](sprints/).
 |------|---------|
 | [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) | MCP server configs, skill docs, setup scripts |
 | [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) | The MCP server itself (Socrata/OpenGov data) |
-| [socrata-mcp-server-vercel-nextjs](https://github.com/npstorey/socrata-mcp-server-vercel-nextjs) | Vercel deployment wrapper for the MCP server |
 
 ## Design Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in contributing! This is the demo website for the ci
 ## Getting started
 
 1. Fork the repo and clone your fork
-2. Copy `.env.example` to `.env.local` and fill in the required values (see README)
+2. Copy `.env.example` to `.env.local` and fill in the values — `node scripts/preflight-env.mjs` reports what your setup requires, and [`docs/deploy.md`](docs/deploy.md#environment-reference-tier-by-tier)'s "Environment reference, tier by tier" section explains what each variable does
 3. Run `npm install && npm run dev`
 4. Create a branch for your changes
 5. Submit a pull request

--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -12,7 +12,7 @@ This contract spans three repositories. If you're integrating, here's how they r
 |---|---|---|
 | [`civic-ai-tools-website`](https://github.com/npstorey/civic-ai-tools-website) | Reference implementation | The civicaitools.org endpoints you call, this contract (`docs/api/evidence-publish.md`), and implementation issues (e.g. [#112](https://github.com/npstorey/civic-ai-tools-website/issues/112)). |
 | [`civic-ai-tools`](https://github.com/npstorey/civic-ai-tools) | Protocol decisions + spec source | The ADRs, the open-questions registry (Q-numbers), the integration-arc issues [#71](https://github.com/npstorey/civic-ai-tools/issues/71) / [#72](https://github.com/npstorey/civic-ai-tools/issues/72), and the [Typed Standards Specification](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/typed-standards-specification.md) itself — the source of the `§8.x` section numbers. |
-| [`typedstandards`](https://github.com/npstorey/typedstandards) | The standard's public home | `@typedstandards/verify-core` and the standalone verifier; the specification's public home from the July RFC. (The repo is private pre-launch; until publication the spec source is the `civic-ai-tools` link above.) |
+| [`typedstandards`](https://github.com/npstorey/typedstandards) | The standard's public home | `@typedstandards/verify-core` and the standalone verifier; the specification's public home from the July RFC. (The repo is public; the spec's live home is [typedstandards.org](https://typedstandards.org).) |
 
 Every ADR, `§`-reference, issue, and Q-number below is hyperlinked to its source — follow the link rather than guessing which repo it's in.
 
@@ -366,7 +366,7 @@ External clients that want to verify packages offline should fetch both the pack
 
 ### Signing-side env vars
 
-Callers publishing through `POST /api/evidence` do not set these themselves — the platform server supplies them. They are listed here so developers running a private fork or the dev server know what drives the signing path:
+Callers publishing through `POST /api/evidence` do not set these themselves — the platform server supplies them. They are listed here so developers running a private instance or the dev server know what drives the signing path:
 
 | Env var                        | Purpose                                                                 |
 |--------------------------------|-------------------------------------------------------------------------|
@@ -479,7 +479,7 @@ Sealed-mode response: `{ slug, packageHash, visibility: "sealed" }` — no publi
 What a sealed record looks like from the outside:
 
 - **Not listed** in `/api/evidence/list` or the public registry index.
-- **Creator-only** (404 to everyone else, including probes) on every content-bearing surface: the detail page, `GET /api/evidence/:slug`, `/package`, `/bundle`, `/verify`, `/replay`, `/evaluate`, `/attestations`. The creator authenticates by session cookie or bearer token.
+- **Creator-only** (404 to everyone else, including probes) on every content-bearing surface: the detail page, `GET /api/evidence/:slug`, `/package`, `/bundle`, `/verify`, `/replay`, `/evaluate`. The creator authenticates by session cookie or bearer token.
 - **Commitment publicly served, redacted**: `GET /api/evidence/:slug/commitment` (and the hash-addressed form) returns the proofs — `packageHash`, signature envelope, signer, envelope taxonomy fields, RFC 3161 token, Rekor entry + inclusion proof, lifecycle chain — plus `visibility: "sealed"`, but **omits** `packageUrl`, `subjectTitle`, and `subjectSummary`, and never inlines the package (`?inline=1` inlines only the trust registry). A recipient holding creator-distributed bytes verifies them against this redacted commitment.
 
 Two honesty notes integrating clients should know:


### PR DESCRIPTION
Docs-tail sprint phase P3 (anchor #189) — the riders and final consistency pass. Six lines across three files:

- **`docs/api/evidence-publish.md`**: "private fork" → "private instance" in the signing-side env-vars intro; the `typedstandards` repo description updated from "private pre-launch" to its public reality (repo public, spec live at typedstandards.org); and the **F3 rider** (#173's interim measure) — the legacy `/attestations` endpoint removed from the sealed-record surface list, so fork-facing docs no longer point integrators at the surface whose fold-in decision is pending.
- **`CONTRIBUTING.md`**: the env-setup step no longer points at a README env list that no longer exists — it now cites the driver-aware preflight and the deploy guide's tier-by-tier reference (the env-template refresh itself is tracked in #198).
- **`CLAUDE.md`**: production URL corrected to the canonical origin; the missing `/project` row added to the information-architecture table (phrased from the shipped page); the related-repos row for a repository that no longer resolves removed.

Sweeps, both clean: the ADR-0016 vocabulary sweep found no legacy visibility label presented as a current state anywhere in `docs/` + `README.md` + `CONTRIBUTING.md` (every remaining occurrence is migration explanation, an explicitly deprecated-marked table, an input-alias compatibility note, or a dated changelog entry); the `/attestations` sweep found exactly one fork-facing mention (fixed above), with the remaining hits confined to UX-rationale memos and planning docs discussing the collision itself.

Closes the docs-tail sprint's phase work; G1 close-outs (#180, #190) follow the cold-reader pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
