### PR TITLE
App front-door P2: sign-in allowlist gate, app chrome, app-tier rate limit, provider gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,3 +100,12 @@ KV_URL=
 KV_REST_API_URL=
 KV_REST_API_TOKEN=
 KV_REST_API_READ_ONLY_TOKEN=
+
+# Sign-in gate (app front door): provider-account keys permitted to sign in.
+# GitHub = the numeric account id; OIDC = oidc:{issuer}:{sub}.
+# Comma/whitespace separated. Unset or empty = open sign-in (the default).
+SIGN_IN_ALLOWLIST=
+
+# Per-day query limit for signed-in users of a gated instance.
+# Default: AUTHENTICATED_RATE_LIMIT - unset changes nothing.
+APP_TIER_RATE_LIMIT=

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -395,9 +395,12 @@ doesn't):
 `EVIDENCE_PUBLICATION_HOST`, the registry-URL overrides — with none set,
 the demo deployment's values are emitted; see
 [`docs/instance-setup.md`](instance-setup.md)), `OIDC_PROVIDER_NAME`
-(button label), rate-limit and token-budget tuning knobs
+(button label), `SIGN_IN_ALLOWLIST` (unset or empty = open sign-in,
+exactly the pre-allowlist behavior; see the sign-in section),
+rate-limit and token-budget tuning knobs
 (`ANONYMOUS_RATE_LIMIT`, `AUTHENTICATED_RATE_LIMIT`,
-`TOKEN_LIMIT_PER_REQUEST`, `MAX_TOOL_RESULT_CHARS`),
+`APP_TIER_RATE_LIMIT`, `TOKEN_LIMIT_PER_REQUEST`,
+`MAX_TOOL_RESULT_CHARS`),
 `S3_REGION` / `S3_FORCE_PATH_STYLE` / `S3_PUBLIC_BASE_URL` (coded
 defaults described in the storage section), and analytics
 (`NEXT_PUBLIC_GA_MEASUREMENT_ID`).
@@ -430,7 +433,11 @@ authorization callback URL to:
 <your origin>/api/auth/callback/github
 ```
 
-and supply `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`.
+and supply `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`. The provider
+appears only when both are set — with either half absent, the GitHub
+button is simply not rendered rather than rendered broken, and preflight
+demotes the pair from required to optional once the OIDC triple below is
+complete (an instance needs *a* working provider, not this one).
 
 **Generic OIDC provider.** Any provider that supports standard OIDC
 discovery (`/.well-known/openid-configuration`) works — an enterprise
@@ -444,6 +451,21 @@ the client with redirect URI:
 ```
 
 The flow requests `openid profile email` scopes and uses PKCE + state.
+
+**Restricting who may sign in (optional allowlist).** By default any
+account the active provider authenticates may sign in. To gate an
+instance, set `SIGN_IN_ALLOWLIST` to the permitted provider-account
+keys — the same strings the users table stores: the GitHub numeric
+account id for GitHub sign-ins, `oidc:{issuer}:{sub}` for OIDC
+sign-ins. Entries are separated by commas and/or whitespace, so a
+multi-line value in a secret manager works as well as a one-line list.
+Unset or empty means open — an instance that has never heard of the
+variable behaves exactly as before the gate existed. A refused account
+gets NextAuth's built-in Access Denied page and leaves no user row
+behind. On a gated instance, signed-in users draw their daily quota
+from `APP_TIER_RATE_LIMIT` instead of `AUTHENTICATED_RATE_LIMIT`; its
+default is the authenticated limit itself, so leaving it unset changes
+nothing.
 
 Before any browser test, check what the instance advertises:
 

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -84,14 +84,36 @@ export const DRIVER_SEAMS = {
  *   - `requiredWhen: { <seam>: '<driver>' }` — tier becomes 'required' under
  *     that driver; otherwise the declared `tier` stands.
  *
- * CONSTRAINT: both fields must leave the default profile untouched. With no
- * selector set (or every selector set to its default) the resolved spec is
- * identical to the declared one, so the report is byte-identical to the
- * pre-driver-awareness output. That is why the S3_* knobs stay listed under
- * the Vercel Blob profile rather than being suppressed as not-applicable —
- * the suppression only runs in the direction that the frozen default output
- * does not cover.
+ * A third conditional field expresses ALTERNATIVES rather than drivers — the
+ * case where two variable sets satisfy the same need and an instance picks
+ * one:
+ *   - `requiredUnlessAllPresent: ['A', 'B', ...]` — the entry's declared
+ *     'required' tier is DEMOTED TO 'optional' when every named variable is
+ *     present. Used for the sign-in providers: an instance needs *a* provider,
+ *     and a complete OIDC triple satisfies that need without GitHub. Demoted
+ *     to 'optional' rather than 'recommended' on purpose — for an OIDC-only
+ *     instance an absent GitHub pair is a deliberate configuration choice, not
+ *     a degraded feature, and 'recommended' would emit a "feature(s) will
+ *     degrade" nag. Same no-nagging principle as `onlyWhen`; the entry stays
+ *     listed so the operator can still see the option exists.
+ *
+ * CONSTRAINT: all three fields must leave the default profile untouched. With
+ * no selector set (or every selector set to its default) and no alternative
+ * set complete, the resolved spec is identical to the declared one, so the
+ * report is byte-identical to the pre-driver-awareness output. That is why the
+ * S3_* knobs stay listed under the Vercel Blob profile rather than being
+ * suppressed as not-applicable — the suppression only runs in the direction
+ * that the frozen default output does not cover. The same holds for the
+ * GitHub pair: the demotion fires only when the OIDC triple is complete, which
+ * the frozen default output does not cover either.
  */
+/**
+ * The generic-OIDC provider set. A complete triple is a full substitute for a
+ * GitHub OAuth app, which is what the GitHub pair's `requiredUnlessAllPresent`
+ * condition below is asserting. Named once so the two sides cannot drift.
+ */
+export const OIDC_PROVIDER_SET = ['OIDC_ISSUER', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET'];
+
 export const ENV_SPEC = [
   // --- Core query path (every demo query depends on these) ---
   { name: 'OPENROUTER_API_KEY', tier: 'required', purpose: 'LLM access — every query (no fallback)' },
@@ -138,14 +160,23 @@ export const ENV_SPEC = [
   // --- Sign-in path (the rate-limit headroom option; OAuth) ---
   { name: 'NEXTAUTH_SECRET', tier: 'required', purpose: 'NextAuth session encryption' },
   { name: 'NEXTAUTH_URL', tier: 'required', purpose: 'OAuth callback base URL (must match the deploy origin)' },
-  { name: 'GITHUB_CLIENT_ID', tier: 'required', purpose: 'GitHub sign-in (raises the per-user rate limit)' },
-  { name: 'GITHUB_CLIENT_SECRET', tier: 'required', purpose: 'GitHub sign-in (raises the per-user rate limit)' },
+  // The GitHub pair now GATES its provider (auth-providers.ts): with either
+  // half absent the button is not rendered at all, rather than rendered
+  // broken. That is what makes an honest retier possible — the pair is
+  // required unless the OIDC triple is complete, because an instance needs at
+  // least one working sign-in provider and OIDC is a full substitute.
+  { name: 'GITHUB_CLIENT_ID', tier: 'required', purpose: 'GitHub sign-in — the pair gates the provider (required unless the OIDC triple is complete)', requiredUnlessAllPresent: OIDC_PROVIDER_SET },
+  { name: 'GITHUB_CLIENT_SECRET', tier: 'required', purpose: 'GitHub sign-in — the pair gates the provider (required unless the OIDC triple is complete)', requiredUnlessAllPresent: OIDC_PROVIDER_SET },
   // Generic OIDC sign-in (optional — active only when ISSUER + CLIENT_ID +
   // CLIENT_SECRET are all present; unset, sign-in is GitHub only).
   { name: 'OIDC_ISSUER', tier: 'optional', purpose: 'Generic OIDC sign-in — issuer URL (discovery-based)' },
   { name: 'OIDC_CLIENT_ID', tier: 'optional', purpose: 'Generic OIDC sign-in — client id' },
   { name: 'OIDC_CLIENT_SECRET', tier: 'optional', purpose: 'Generic OIDC sign-in — client secret' },
   { name: 'OIDC_PROVIDER_NAME', tier: 'optional', purpose: 'OIDC sign-in button label (default "SSO")', hasFallback: true },
+  // Sign-in gate (app front door). Unset/empty = open sign-in, i.e. exactly
+  // the behavior before the gate existed — so it is a pure override with a
+  // coded default, never load-bearing for an instance that does not want it.
+  { name: 'SIGN_IN_ALLOWLIST', tier: 'optional', purpose: 'Allowlist of provider-account keys permitted to sign in (unset/empty = open)', hasFallback: true },
 
   // --- Rate limiting (durable counter; without it, falls back to per-instance memory) ---
   // hasFallback, not a hard miss: rate-limit.ts:53-63 tests both vars and takes
@@ -186,6 +217,10 @@ export const ENV_SPEC = [
   //     reads them but runs on built-in defaults when absent) ---
   { name: 'ANONYMOUS_RATE_LIMIT', tier: 'optional', purpose: 'Anonymous per-day query limit (default 10)', hasFallback: true },
   { name: 'AUTHENTICATED_RATE_LIMIT', tier: 'optional', purpose: 'Authenticated per-day query limit (default 25)', hasFallback: true },
+  // Applies only on a gated instance (SIGN_IN_ALLOWLIST populated), and its
+  // coded fallback is the authenticated limit itself — so unset it is not
+  // merely defaulted, it is identical to the authenticated tier.
+  { name: 'APP_TIER_RATE_LIMIT', tier: 'optional', purpose: 'Per-day query limit for signed-in users of a gated instance (default: AUTHENTICATED_RATE_LIMIT)', hasFallback: true },
   { name: 'TOKEN_LIMIT_PER_REQUEST', tier: 'optional', purpose: 'Streaming token budget per request (coded default)', hasFallback: true },
   { name: 'MAX_TOOL_RESULT_CHARS', tier: 'optional', purpose: 'Tool-result truncation budget (coded default)', hasFallback: true },
   { name: 'NEXT_PUBLIC_CAPTURE_TRACES', tier: 'optional', purpose: 'Dev-only BPMN trace capture toggle', hasFallback: true },
@@ -234,18 +269,34 @@ function conditionMet(condition, drivers) {
 }
 
 /**
+ * True when every named variable is present in `env`. Presence only — the
+ * same non-empty-after-trim test `evaluateEnv` uses, and no value is read
+ * beyond that boolean.
+ */
+function allPresent(names, env) {
+  return names.every((name) => {
+    const raw = env[name];
+    return typeof raw === 'string' && raw.trim().length > 0;
+  });
+}
+
+/**
  * Resolve the declared spec against an instance profile: drop entries the
- * profile will never read, and promote entries the profile makes load-bearing.
+ * profile will never read, promote entries the profile makes load-bearing, and
+ * demote entries whose need another present variable set already satisfies.
  *
- * With every selector at its default this is the identity transform on
- * ENV_SPEC (see the CONSTRAINT note on ENV_SPEC), which is what keeps the
- * default profile's report byte-identical.
+ * With every selector at its default and no alternative set complete this is
+ * the identity transform on ENV_SPEC (see the CONSTRAINT note on ENV_SPEC),
+ * which is what keeps the default profile's report byte-identical. `env`
+ * therefore defaults to `{}`: a caller that passes only drivers gets exactly
+ * the driver-aware behavior it got before alternatives existed.
  *
  * @param {Record<string, string>} drivers
  * @param {typeof ENV_SPEC} [spec]
+ * @param {Record<string, string | undefined>} [env]
  * @returns {{ applicable: typeof ENV_SPEC, notApplicable: typeof ENV_SPEC }}
  */
-export function resolveSpec(drivers, spec = ENV_SPEC) {
+export function resolveSpec(drivers, spec = ENV_SPEC, env = {}) {
   const applicable = [];
   const notApplicable = [];
   for (const s of spec) {
@@ -254,7 +305,14 @@ export function resolveSpec(drivers, spec = ENV_SPEC) {
       continue;
     }
     const promoted = s.requiredWhen && conditionMet(s.requiredWhen, drivers);
-    applicable.push(promoted ? { ...s, tier: 'required' } : s);
+    if (promoted) {
+      applicable.push({ ...s, tier: 'required' });
+      continue;
+    }
+    // An alternative set covers this variable's need: demote rather than
+    // suppress, so the option stays visible without being nagged about.
+    const demoted = s.requiredUnlessAllPresent && allPresent(s.requiredUnlessAllPresent, env);
+    applicable.push(demoted ? { ...s, tier: 'optional' } : s);
   }
   return { applicable, notApplicable };
 }
@@ -270,7 +328,7 @@ export function resolveSpec(drivers, spec = ENV_SPEC) {
  */
 export function evaluateEnv(env, spec = ENV_SPEC) {
   const { drivers, errors: driverErrors, isDefault } = resolveDrivers(env);
-  const { applicable, notApplicable } = resolveSpec(drivers, spec);
+  const { applicable, notApplicable } = resolveSpec(drivers, spec, env);
 
   const rows = applicable.map((s) => {
     const raw = env[s.name];

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -14,6 +14,7 @@ import {
   resolveSpec,
   ENV_SPEC,
   DRIVER_SEAMS,
+  OIDC_PROVIDER_SET,
 } from './preflight-env.mjs';
 
 const REQUIRED = ENV_SPEC.filter((s) => s.tier === 'required').map((s) => s.name);
@@ -261,6 +262,130 @@ test('an unrecognized selector value fails the run and is never echoed', () => {
   const report = renderReport(result);
   assert.ok(!report.includes('SENTINEL'), 'the offending value is never echoed');
   assert.match(report, /BLOB_DRIVER \(expected one of: vercel-blob, s3\)/);
+});
+
+// --- Alternative sets (sign-in providers; #193) -----------------------------
+
+/** The pair that gates the GitHub provider in src/lib/auth-providers.ts. */
+const GITHUB_PAIR = ['GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET'];
+
+/** Env with a complete generic-OIDC provider triple. */
+function withOidcProvider(env) {
+  const out = { ...env };
+  for (const name of OIDC_PROVIDER_SET) out[name] = 'present';
+  return out;
+}
+
+test('every requiredUnlessAllPresent names variables the spec itself declares', () => {
+  const declared = new Set(ENV_SPEC.map((s) => s.name));
+  for (const s of ENV_SPEC) {
+    if (!s.requiredUnlessAllPresent) continue;
+    assert.ok(Array.isArray(s.requiredUnlessAllPresent), `${s.name}.requiredUnlessAllPresent is a list`);
+    assert.ok(s.requiredUnlessAllPresent.length > 0, `${s.name}.requiredUnlessAllPresent is non-empty`);
+    // Demotion only makes sense from 'required' — anything else is a no-op
+    // that would silently mislead a reader of the spec.
+    assert.equal(s.tier, 'required', `${s.name} declares 'required' so the demotion is meaningful`);
+    for (const name of s.requiredUnlessAllPresent) {
+      assert.ok(declared.has(name), `${s.name} names a declared variable (${name})`);
+    }
+  }
+});
+
+test('the GitHub pair carries the OIDC alternative condition', () => {
+  for (const name of GITHUB_PAIR) {
+    const entry = ENV_SPEC.find((s) => s.name === name);
+    assert.deepEqual(entry.requiredUnlessAllPresent, OIDC_PROVIDER_SET);
+  }
+});
+
+test('REGRESSION: an incomplete OIDC triple leaves the GitHub pair required', () => {
+  // Every strict subset of the triple, plus none of it at all.
+  const partials = [
+    {},
+    { OIDC_ISSUER: 'present' },
+    { OIDC_ISSUER: 'present', OIDC_CLIENT_ID: 'present' },
+    { OIDC_CLIENT_ID: 'present', OIDC_CLIENT_SECRET: 'present' },
+  ];
+  for (const partial of partials) {
+    const env = { ...envWithAllRequired(), ...partial };
+    for (const name of GITHUB_PAIR) delete env[name];
+    const result = evaluateEnv(env);
+    const which = JSON.stringify(Object.keys(partial));
+    for (const name of GITHUB_PAIR) {
+      assert.equal(tierOf(result.rows, name), 'required', `${name} stays required for ${which}`);
+    }
+    assert.equal(result.ok, false, `an instance with no working provider fails for ${which}`);
+    assert.deepEqual(result.missingRequired.map((r) => r.name).sort(), [...GITHUB_PAIR].sort());
+  }
+});
+
+test('a complete OIDC triple demotes the GitHub pair to optional and passes without it', () => {
+  const env = withOidcProvider(envWithAllRequired());
+  for (const name of GITHUB_PAIR) delete env[name];
+
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, true, 'an OIDC-only instance has a working provider and must pass');
+  for (const name of GITHUB_PAIR) {
+    assert.equal(tierOf(result.rows, name), 'optional', `${name} is optional for an OIDC-only instance`);
+  }
+  // Demoted to 'optional', NOT 'recommended': an absent GitHub pair on an
+  // OIDC-only instance is a configuration choice, not a degraded feature, so
+  // it must not appear in the "feature(s) will degrade" note.
+  assert.ok(!result.missingRecommended.some((r) => GITHUB_PAIR.includes(r.name)));
+  const report = renderReport(result);
+  // The degrade note exists (other recommended vars are absent in this env);
+  // what matters is that neither GitHub variable is named inside it.
+  const degradeNote = report.slice(report.indexOf('will degrade'));
+  for (const name of GITHUB_PAIR) {
+    assert.ok(!degradeNote.includes(name), `${name} is not nagged about as a degraded feature`);
+  }
+  // Still listed in the table, so the operator can see GitHub remains
+  // available to add alongside OIDC.
+  assert.match(report, /GITHUB_CLIENT_ID/);
+});
+
+test('the demotion is presence-driven, not order-driven: whitespace-only OIDC vars do not count', () => {
+  const env = { ...envWithAllRequired(), ...withOidcProvider({}) };
+  env.OIDC_CLIENT_SECRET = '   '; // present-but-blank is absent everywhere else too
+  for (const name of GITHUB_PAIR) delete env[name];
+
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false);
+  for (const name of GITHUB_PAIR) {
+    assert.equal(tierOf(result.rows, name), 'required');
+  }
+});
+
+test('REGRESSION: resolveSpec without an env argument never demotes (identity preserved)', () => {
+  const { drivers } = resolveDrivers({});
+  const { applicable } = resolveSpec(drivers); // no env passed
+  assert.deepEqual(applicable, ENV_SPEC);
+});
+
+// --- The app front door's two new knobs -------------------------------------
+
+test('the sign-in gate and app-tier knobs are optional with coded fallbacks', () => {
+  // Both reproduce today's behavior when unset — SIGN_IN_ALLOWLIST leaves
+  // sign-in open, APP_TIER_RATE_LIMIT falls back to the authenticated limit —
+  // so neither may ever fail or nag a run.
+  for (const name of ['SIGN_IN_ALLOWLIST', 'APP_TIER_RATE_LIMIT']) {
+    const entry = ENV_SPEC.find((s) => s.name === name);
+    assert.ok(entry, `${name} is enumerated`);
+    assert.equal(entry.tier, 'optional', `${name} is optional`);
+    assert.equal(entry.hasFallback, true, `${name} has a coded fallback`);
+  }
+  const result = evaluateEnv(envWithAllRequired()); // both absent
+  assert.equal(result.ok, true);
+  assert.ok(!result.missingRecommended.some((r) => r.name === 'SIGN_IN_ALLOWLIST'));
+  assert.ok(!result.missingRecommended.some((r) => r.name === 'APP_TIER_RATE_LIMIT'));
+});
+
+test('a configured allowlist is never echoed — only the variable name', () => {
+  const env = { ...envWithAllRequired(), SIGN_IN_ALLOWLIST: '4242,oidc:https://idp.example.org:SENTINEL' };
+  const report = renderReport(evaluateEnv(env));
+  assert.ok(!report.includes('SENTINEL'), 'allowlist entries are identities — never printed');
+  assert.ok(!report.includes('4242'));
+  assert.ok(report.includes('SIGN_IN_ALLOWLIST'));
 });
 
 test('the durable rate-limit counter is soft: absent, the run still passes', () => {

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,7 +1,34 @@
+import AppChrome from '@/components/AppChrome';
+
+/**
+ * Layout for the `(app)` route group — the gated app surface's shell
+ * (app front-door v0.1.0, P2). Was a bare passthrough.
+ *
+ * DELIBERATELY NOT AN AUTH BOUNDARY. There is no `getServerSession` call, no
+ * redirect, and no blanket enforcement here, and adding one would be a
+ * regression rather than a hardening: `/evidence` and `/evidence/[slug]` live
+ * in this group and are PUBLIC pages on the apex today, linked from the
+ * marketing nav — a layout-level gate would take the published evidence
+ * registry offline for everyone who is not signed in. Two other reasons the
+ * boundary does not belong here: the sprint's gate is at sign-in
+ * (`SIGN_IN_ALLOWLIST` in `callbacks.signIn`), and host separation — which
+ * routes are served where — arrives with P3's middleware. Routes that DO need
+ * a session keep enforcing it themselves, as `/dashboard` already does.
+ *
+ * So this layout is chrome only: it composes `AppChrome` above the group's
+ * pages, on top of the site header and footer the root layout already
+ * provides. `AppChrome` renders nothing at all for a signed-out visitor, so
+ * the public evidence pages are untouched.
+ */
 export default function AppLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return children;
+  return (
+    <>
+      <AppChrome />
+      {children}
+    </>
+  );
 }

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+
+/**
+ * App-surface chrome — the slim context strip for the `(app)` route group
+ * (app front-door v0.1.0, P2).
+ *
+ * WHAT IT ADDS, and why it is not a second header. `(app)` pages already
+ * inherit the full site chrome from the root layout: `Header` (brand, nav,
+ * signed-in avatar + user menu with Dashboard and Sign out) and the site
+ * footer. Duplicating any of that here would be the "parallel version"
+ * mistake the repo conventions call out. This strip composes with it,
+ * answering the three questions the app surface owes a signed-in user that
+ * the marketing header does not:
+ *
+ *   1. WHO AM I — identity stated in the page body, not hidden behind an
+ *      avatar menu, because on the app surface "which account is this?" is a
+ *      question you must be able to answer at a glance before publishing
+ *      anything under it.
+ *   2. WHERE IS MY WORK — a direct Dashboard link, current-page aware.
+ *   3. HOW DO I GET OUT — an explicit exit to the public site.
+ *
+ * CLIENT COMPONENT ON PURPOSE. It reads the session through `useSession()`
+ * (the provider is already mounted in the root layout) rather than
+ * `getServerSession()`. A server-side session read in the `(app)` layout
+ * would opt every route in the group into dynamic rendering — including the
+ * public evidence pages, which are not this phase's to change.
+ *
+ * SIGNED OUT ⇒ RENDERS NOTHING. This is load-bearing, not a cosmetic choice:
+ * `/evidence` and `/evidence/[slug]` live in `(app)` and are public pages on
+ * the apex today, linked from the marketing nav. An anonymous visitor to a
+ * published evidence page must see exactly what they saw before this phase.
+ * All three items above are signed-in concerns anyway — there is no identity
+ * to state, and the dashboard would only bounce a signed-out visitor home.
+ *
+ * NOT A GATE. This component decides what to DISPLAY; it never decides who
+ * may READ. The sprint's gate is at sign-in (`SIGN_IN_ALLOWLIST`, checked in
+ * `callbacks.signIn`); host separation arrives in P3.
+ */
+export default function AppChrome() {
+  const { data: session, status } = useSession();
+  const pathname = usePathname();
+
+  // `loading` renders nothing too — a strip that flashes in on hydration and
+  // out again for anonymous visitors is worse than one that arrives late.
+  if (status !== 'authenticated' || !session?.user) return null;
+
+  const displayName = session.user.name || session.user.email || 'your account';
+  const onDashboard = pathname === '/dashboard';
+
+  return (
+    <div
+      style={{
+        borderBottom: '1px solid var(--border-color)',
+        backgroundColor: 'var(--card-background)',
+        padding: '8px 24px',
+        fontSize: '13px',
+        lineHeight: 1.5,
+        color: 'var(--text-secondary)',
+      }}
+    >
+      <div
+        className="max-w-6xl mx-auto"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '16px',
+          flexWrap: 'wrap',
+        }}
+      >
+        <span>
+          Signed in as{' '}
+          <strong style={{ color: 'var(--text-primary)', fontWeight: 600 }}>{displayName}</strong>
+        </span>
+        <span style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          {onDashboard ? (
+            <span aria-current="page" style={{ color: 'var(--text-muted)' }}>
+              Dashboard
+            </span>
+          ) : (
+            <Link href="/dashboard" style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
+              Dashboard
+            </Link>
+          )}
+          {/* The way out. Relative on purpose: on a single host `/` is the
+              public site, and when P3 splits the hosts this one href is the
+              single place that becomes the apex origin. */}
+          <Link href="/" style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
+            Public site
+            <span aria-hidden="true" style={{ marginLeft: '4px', color: 'var(--text-muted)' }}>
+              &#8599;
+            </span>
+          </Link>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth-allowlist.test.ts
+++ b/src/lib/auth-allowlist.test.ts
@@ -1,0 +1,163 @@
+// Tests for the sign-in allowlist — the app front door's gate (P2).
+//
+// These cover the exact expression `callbacks.signIn` evaluates:
+//
+//     isSignInAllowed(providerAccountKey(account, user), <SIGN_IN_ALLOWLIST>)
+//
+// so what is asserted here is the gate decision itself, not a paraphrase of
+// it. Every function takes its env as a parameter, so no process.env mutation
+// and no NextAuth or database wiring is involved.
+//
+// The three acceptance properties, by name:
+//   (a) an off-list account is refused        → the "refuses" tests
+//   (b) an on-list account is admitted        → the "admits" tests
+//   (c) an unset allowlist reproduces today's behavior exactly
+//                                             → the "open by default" tests
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseAllowlist, isSignInAllowed, isSignInGateEnabled } from './auth-allowlist.ts';
+import { providerAccountKey, oidcAccountKey, OIDC_PROVIDER_ID } from './auth-providers.ts';
+
+/** A GitHub sign-in as NextAuth hands it to the callback. */
+const githubSignIn = (id: string) => ({
+  account: { provider: 'github', providerAccountId: id },
+  user: { id },
+});
+
+/** An OIDC sign-in as NextAuth hands it to the callback. */
+const oidcSignIn = (subject: string) => ({
+  account: { provider: OIDC_PROVIDER_ID, providerAccountId: subject },
+  user: { id: subject },
+});
+
+/** The gate exactly as auth.ts composes it. */
+function gate(
+  signIn: { account: { provider: string; providerAccountId: string }; user: { id: string } },
+  allowlist: string | undefined,
+): boolean {
+  return isSignInAllowed(providerAccountKey(signIn.account, signIn.user), allowlist);
+}
+
+const ISSUER = 'https://idp.example.org';
+const OIDC_KEY = oidcAccountKey('subject-1', ISSUER);
+
+// --- (c) Unset ⇒ open: today's behavior, exactly -----------------------------
+
+test('(c) an unset allowlist admits every account — both key families', () => {
+  assert.equal(gate(githubSignIn('4242'), undefined), true);
+  assert.equal(gate(oidcSignIn('subject-1'), undefined), true);
+});
+
+test('(c) an empty or whitespace-only allowlist is treated as unset (open)', () => {
+  for (const raw of ['', '   ', '\n', '\t\n  ', ',', ' , , ', ',,\n,']) {
+    assert.equal(gate(githubSignIn('4242'), raw), true, `expected open for ${JSON.stringify(raw)}`);
+    assert.equal(isSignInGateEnabled(raw), false, `gate is off for ${JSON.stringify(raw)}`);
+  }
+});
+
+test('(c) with the gate off, even an underivable account key is admitted', () => {
+  // The pre-gate callback returned true for a keyless sign-in; that must not
+  // change on an instance that never configured an allowlist.
+  assert.equal(isSignInAllowed(null, undefined), true);
+  assert.equal(isSignInAllowed(undefined, ''), true);
+});
+
+// --- (b) On-list accounts are admitted ---------------------------------------
+
+test('(b) a listed GitHub numeric id is admitted', () => {
+  assert.equal(gate(githubSignIn('4242'), '4242'), true);
+  assert.equal(gate(githubSignIn('4242'), '1,4242,9'), true);
+});
+
+test('(b) a listed OIDC issuer+subject composite is admitted', () => {
+  assert.equal(isSignInAllowed(OIDC_KEY, OIDC_KEY), true);
+  assert.equal(isSignInAllowed(OIDC_KEY, `4242,${OIDC_KEY}`), true);
+});
+
+test('(b) the two key families compose in one list', () => {
+  const raw = `4242, ${OIDC_KEY}`;
+  assert.equal(gate(githubSignIn('4242'), raw), true);
+  assert.equal(isSignInAllowed(OIDC_KEY, raw), true);
+  // ...and a third party matching neither is still refused.
+  assert.equal(gate(githubSignIn('7777'), raw), false);
+});
+
+// --- (a) Off-list accounts are refused ---------------------------------------
+
+test('(a) an unlisted GitHub id is refused', () => {
+  assert.equal(gate(githubSignIn('7777'), '4242'), false);
+});
+
+test('(a) an unlisted OIDC subject is refused', () => {
+  assert.equal(isSignInAllowed(oidcAccountKey('intruder', ISSUER), OIDC_KEY), false);
+});
+
+test('(a) the same subject from a DIFFERENT issuer is refused', () => {
+  // The composite key is what makes this true: an allowlist entry authorizes
+  // an identity at one issuer, not a subject string anywhere.
+  const otherIssuer = oidcAccountKey('subject-1', 'https://other-idp.example.org');
+  assert.notEqual(otherIssuer, OIDC_KEY);
+  assert.equal(isSignInAllowed(otherIssuer, OIDC_KEY), false);
+});
+
+test('(a) matching is exact — no prefix, substring, or case-insensitive matches', () => {
+  assert.equal(isSignInAllowed('42', '4242'), false, 'no prefix match');
+  assert.equal(isSignInAllowed('4242', '424'), false, 'no substring match');
+  assert.equal(isSignInAllowed('42421', '4242'), false, 'no extension match');
+  assert.equal(
+    isSignInAllowed(oidcAccountKey('SUBJECT-1', ISSUER), OIDC_KEY),
+    false,
+    'OIDC subjects are case-sensitive',
+  );
+});
+
+test('(a) with the gate on, an underivable account key is refused', () => {
+  assert.equal(isSignInAllowed(null, '4242'), false);
+  assert.equal(isSignInAllowed(undefined, '4242'), false);
+  assert.equal(isSignInAllowed('', '4242'), false);
+});
+
+// --- Whitespace and separator handling ---------------------------------------
+
+test('parseAllowlist splits on commas, whitespace, and newlines alike', () => {
+  const expected = ['4242', '7777', OIDC_KEY];
+  assert.deepEqual(parseAllowlist(`4242,7777,${OIDC_KEY}`), expected);
+  assert.deepEqual(parseAllowlist(`4242 7777 ${OIDC_KEY}`), expected);
+  assert.deepEqual(parseAllowlist(`4242\n7777\n${OIDC_KEY}`), expected);
+  assert.deepEqual(parseAllowlist(`  4242 ,\n  7777,\n${OIDC_KEY}  `), expected);
+});
+
+test('parseAllowlist tolerates trailing separators and blank lines', () => {
+  assert.deepEqual(parseAllowlist('4242,'), ['4242']);
+  assert.deepEqual(parseAllowlist(',4242,,7777,'), ['4242', '7777']);
+  assert.deepEqual(parseAllowlist('\n\n4242\n\n'), ['4242']);
+});
+
+test('parseAllowlist de-duplicates', () => {
+  assert.deepEqual(parseAllowlist('4242, 4242, 7777'), ['4242', '7777']);
+});
+
+test('parseAllowlist returns an empty list for unset/empty values', () => {
+  assert.deepEqual(parseAllowlist(undefined), []);
+  assert.deepEqual(parseAllowlist(null), []);
+  assert.deepEqual(parseAllowlist(''), []);
+  assert.deepEqual(parseAllowlist('   \n  '), []);
+});
+
+test('surrounding whitespace on a listed entry does not break the match', () => {
+  assert.equal(gate(githubSignIn('4242'), '  4242  '), true);
+  assert.equal(gate(githubSignIn('4242'), '\n 4242 \n'), true);
+  assert.equal(isSignInAllowed(OIDC_KEY, `\t${OIDC_KEY}\n`), true);
+});
+
+test('isSignInGateEnabled is true only for a populated list', () => {
+  assert.equal(isSignInGateEnabled(undefined), false);
+  assert.equal(isSignInGateEnabled(''), false);
+  assert.equal(isSignInGateEnabled('  '), false);
+  assert.equal(isSignInGateEnabled('4242'), true);
+  assert.equal(isSignInGateEnabled(OIDC_KEY), true);
+});

--- a/src/lib/auth-allowlist.ts
+++ b/src/lib/auth-allowlist.ts
@@ -1,0 +1,72 @@
+// Sign-in allowlist — the app front door's gate.
+//
+// An instance can restrict who is allowed to sign in by listing permitted
+// PROVIDER-ACCOUNT KEYS in SIGN_IN_ALLOWLIST. A provider-account key is the
+// same string the users table stores and `providerAccountKey()` in
+// auth-providers.ts derives — there is exactly one derivation, shared by the
+// gate, the upsert, and the JWT lookup:
+//
+//   - GitHub sign-in:  the GitHub numeric account id, e.g. `12345678`
+//   - OIDC sign-in:    `oidc:{normalized-issuer}:{sub}`,
+//                      e.g. `oidc:https://idp.example.org:a1b2c3`
+//
+// SEAM CONVENTION (load-bearing): unset or empty ⇒ OPEN. An instance that has
+// never heard of this variable behaves exactly as it did before the gate
+// existed — the allowlist adds a restriction, it never relaxes one.
+//
+// Pure and env-injectable throughout, so the gate is unit-testable without
+// NextAuth or a database. Run: npm test
+
+/** The env var carrying the allowlist. Named here so callers never re-spell it. */
+export const SIGN_IN_ALLOWLIST_ENV = 'SIGN_IN_ALLOWLIST';
+
+/**
+ * Parse the raw allowlist value into normalized entries.
+ *
+ * Entries are separated by commas and/or any whitespace (so a multi-line
+ * value in a secret manager works as well as a one-line comma list), trimmed,
+ * and de-duplicated. Empty segments are dropped, which is what makes trailing
+ * commas and stray blank lines harmless.
+ *
+ * Matching is exact and case-sensitive: OIDC subject claims are
+ * case-sensitive, and GitHub account ids are digits, so no case folding is
+ * safe to apply.
+ */
+export function parseAllowlist(raw: string | undefined | null): string[] {
+  if (!raw) return [];
+  const entries = raw
+    .split(/[\s,]+/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return [...new Set(entries)];
+}
+
+/**
+ * Is the gate active on this instance? False when the variable is unset,
+ * empty, whitespace-only, or contains only separators — every one of which
+ * means "no allowlist configured", i.e. open sign-in.
+ */
+export function isSignInGateEnabled(
+  raw: string | undefined | null = process.env[SIGN_IN_ALLOWLIST_ENV],
+): boolean {
+  return parseAllowlist(raw).length > 0;
+}
+
+/**
+ * The gate itself: may this provider-account key sign in?
+ *
+ * - Gate off (allowlist unset/empty) ⇒ always true. Today's behavior exactly.
+ * - Gate on ⇒ true only for an exact match on a listed key.
+ * - Gate on and the key could not be derived (null/empty) ⇒ false. An
+ *   account we cannot name cannot be on a list of names, and the safe
+ *   direction for a deliberately-configured gate is to refuse.
+ */
+export function isSignInAllowed(
+  accountKey: string | null | undefined,
+  raw: string | undefined | null = process.env[SIGN_IN_ALLOWLIST_ENV],
+): boolean {
+  const allowlist = parseAllowlist(raw);
+  if (allowlist.length === 0) return true;
+  if (!accountKey) return false;
+  return allowlist.includes(accountKey);
+}

--- a/src/lib/auth-providers.test.ts
+++ b/src/lib/auth-providers.test.ts
@@ -12,6 +12,7 @@ import {
   buildProviders,
   normalizeIssuer,
   oidcAccountKey,
+  providerAccountKey,
   OIDC_PROVIDER_ID,
 } from './auth-providers.ts';
 
@@ -21,17 +22,20 @@ const OIDC_ENV = {
   OIDC_CLIENT_SECRET: 'example-client-secret',
 };
 
-test('provider list without OIDC env is GitHub only (demo default)', () => {
-  const providers = buildProviders({});
+/** The GitHub pair, complete — the reference deployment's configuration. */
+const GITHUB_ENV = {
+  GITHUB_CLIENT_ID: 'example-github-id',
+  GITHUB_CLIENT_SECRET: 'example-github-secret',
+};
+
+test('provider list with the GitHub pair and no OIDC env is GitHub only (demo default)', () => {
+  const providers = buildProviders(GITHUB_ENV);
   assert.equal(providers.length, 1);
   assert.equal(providers[0].id, 'github');
 });
 
 test('GitHub env alone does not add the OIDC provider', () => {
-  const providers = buildProviders({
-    GITHUB_CLIENT_ID: 'example-github-id',
-    GITHUB_CLIENT_SECRET: 'example-github-secret',
-  });
+  const providers = buildProviders(GITHUB_ENV);
   assert.equal(providers.length, 1);
   assert.equal(providers[0].id, 'github');
 });
@@ -43,14 +47,54 @@ test('partial OIDC env (any of the three missing) stays GitHub only', () => {
     { OIDC_CLIENT_ID: OIDC_ENV.OIDC_CLIENT_ID, OIDC_CLIENT_SECRET: OIDC_ENV.OIDC_CLIENT_SECRET },
   ];
   for (const env of partials) {
-    const providers = buildProviders(env);
+    const providers = buildProviders({ ...GITHUB_ENV, ...env });
     assert.equal(providers.length, 1, `expected GitHub only for ${JSON.stringify(Object.keys(env))}`);
     assert.equal(providers[0].id, 'github');
   }
 });
 
-test('full OIDC trio adds the OIDC provider with issuer-driven config', () => {
+// --- The GitHub provider gate (#193) ----------------------------------------
+
+test('an incomplete GitHub pair produces NO GitHub provider (not a broken one)', () => {
+  const partials = [
+    {},
+    { GITHUB_CLIENT_ID: GITHUB_ENV.GITHUB_CLIENT_ID },
+    { GITHUB_CLIENT_SECRET: GITHUB_ENV.GITHUB_CLIENT_SECRET },
+  ];
+  for (const env of partials) {
+    const providers = buildProviders(env);
+    assert.equal(
+      providers.length,
+      0,
+      `expected no providers for ${JSON.stringify(Object.keys(env))}`,
+    );
+  }
+});
+
+test('an OIDC-only instance advertises exactly one provider, and it is not GitHub', () => {
   const providers = buildProviders(OIDC_ENV);
+  assert.equal(providers.length, 1);
+  assert.equal(providers[0].id, OIDC_PROVIDER_ID);
+  assert.ok(!providers.some((p) => p.id === 'github'), 'no silently-broken GitHub button');
+});
+
+test('a configured GitHub provider carries the real credentials, never an empty string', () => {
+  // next-auth v4 provider factories return their defaults plus the caller's
+  // options under `.options`; the top-level merge happens later, in
+  // parseProviders. The credentials the gate feeds in live there.
+  const gh = buildProviders(GITHUB_ENV)[0] as unknown as {
+    options: { clientId?: string; clientSecret?: string };
+  };
+  assert.equal(gh.options.clientId, GITHUB_ENV.GITHUB_CLIENT_ID);
+  assert.equal(gh.options.clientSecret, GITHUB_ENV.GITHUB_CLIENT_SECRET);
+  // The `|| ''` fallbacks are gone: an empty string can no longer reach a
+  // rendered provider, because an incomplete pair renders no provider at all.
+  assert.notEqual(gh.options.clientId, '');
+  assert.notEqual(gh.options.clientSecret, '');
+});
+
+test('full OIDC trio adds the OIDC provider with issuer-driven config', () => {
+  const providers = buildProviders({ ...GITHUB_ENV, ...OIDC_ENV });
   assert.equal(providers.length, 2);
   assert.equal(providers[0].id, 'github');
 
@@ -67,6 +111,7 @@ test('full OIDC trio adds the OIDC provider with issuer-driven config', () => {
 
 test('OIDC_PROVIDER_NAME sets the button label; trailing issuer slash is normalized', () => {
   const providers = buildProviders({
+    ...GITHUB_ENV,
     ...OIDC_ENV,
     OIDC_ISSUER: 'https://issuer.example.org/',
     OIDC_PROVIDER_NAME: 'Example SSO',
@@ -78,7 +123,7 @@ test('OIDC_PROVIDER_NAME sets the button label; trailing issuer slash is normali
 });
 
 test('OIDC profile mapper follows standard claims with fallbacks', () => {
-  const providers = buildProviders(OIDC_ENV);
+  const providers = buildProviders({ ...GITHUB_ENV, ...OIDC_ENV });
   const oidc = providers[1] as unknown as {
     profile: (p: Record<string, unknown>) => { id: string; name: unknown; email: unknown; image: unknown };
   };
@@ -110,4 +155,43 @@ test('oidcAccountKey is an issuer+subject composite that cannot collide with num
 test('normalizeIssuer strips only trailing slashes', () => {
   assert.equal(normalizeIssuer('https://issuer.example.org//'), 'https://issuer.example.org');
   assert.equal(normalizeIssuer('https://issuer.example.org/realms/a'), 'https://issuer.example.org/realms/a');
+});
+
+// --- The single provider-account key derivation ------------------------------
+//
+// One implementation feeds the allowlist gate, the users-table upsert, and the
+// JWT's DB lookup. These tests pin the shapes those three agree on.
+
+test('providerAccountKey returns the GitHub numeric id for a GitHub sign-in', () => {
+  assert.equal(providerAccountKey({ provider: 'github', providerAccountId: '4242' }, { id: '4242' }), '4242');
+  // The GitHub path keys on user.id (what the upsert has always written),
+  // not on providerAccountId.
+  assert.equal(providerAccountKey({ provider: 'github', providerAccountId: '9999' }, { id: '4242' }), '4242');
+});
+
+test('providerAccountKey returns the issuer+subject composite for an OIDC sign-in', () => {
+  const key = providerAccountKey(
+    { provider: OIDC_PROVIDER_ID, providerAccountId: 'subject-1' },
+    { id: 'ignored-when-subject-present' },
+  );
+  assert.equal(key, oidcAccountKey('subject-1'));
+  assert.match(key as string, /^oidc:/);
+});
+
+test('providerAccountKey falls back to user.id as the OIDC subject', () => {
+  const key = providerAccountKey({ provider: OIDC_PROVIDER_ID }, { id: 'subject-2' });
+  assert.equal(key, oidcAccountKey('subject-2'));
+});
+
+test('providerAccountKey returns null when no key can be derived', () => {
+  assert.equal(providerAccountKey({ provider: 'github' }, {}), null);
+  assert.equal(providerAccountKey({ provider: OIDC_PROVIDER_ID }, {}), null);
+  assert.equal(providerAccountKey(undefined, undefined), null);
+  assert.equal(providerAccountKey(null, { id: '' }), null);
+});
+
+test('an absent account object takes the GitHub (pre-existing) path', () => {
+  // NextAuth omits `account` on some flows; the old inline derivation treated
+  // that as the GitHub branch, and this one must too.
+  assert.equal(providerAccountKey(undefined, { id: '4242' }), '4242');
 });

--- a/src/lib/auth-providers.ts
+++ b/src/lib/auth-providers.ts
@@ -2,15 +2,21 @@
 // is a pure function of the environment (and unit-testable without NextAuth
 // runtime wiring).
 //
-// Two providers:
-//   - GitHub: always present (the demo deployment's provider, unchanged).
+// Two providers, each gated on its own env set being complete:
+//   - GitHub: present ONLY when GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are
+//     both set. Previously pushed unconditionally with `|| ''` fallbacks,
+//     which rendered a sign-in button that redirected with an empty client id
+//     on an instance that had never configured a GitHub OAuth app — silently
+//     broken rather than absent (#193).
 //   - Generic OIDC: present ONLY when OIDC_ISSUER, OIDC_CLIENT_ID, and
 //     OIDC_CLIENT_SECRET are all set. Any OIDC provider that supports
 //     standard discovery (/.well-known/openid-configuration) works; the
 //     optional OIDC_PROVIDER_NAME sets the sign-in button label.
 //
-// With none of the OIDC vars set, the provider list is exactly the
-// pre-existing GitHub-only list.
+// With the GitHub pair set and none of the OIDC vars set, the provider list is
+// exactly the pre-existing GitHub-only list — the reference deployment's shape,
+// unchanged. `/api/auth/providers` is the runtime answer to "what does this
+// instance actually offer": a half-configured provider is simply absent there.
 
 import GithubProviderImport from 'next-auth/providers/github';
 import type { Provider } from 'next-auth/providers/index';
@@ -61,16 +67,46 @@ export function oidcAccountKey(subject: string, issuer: string = process.env.OID
 }
 
 /**
+ * THE provider-account key derivation — one implementation, three consumers:
+ * the sign-in allowlist gate, the users-table upsert, and the JWT's DB-user
+ * lookup (all in auth.ts). Keeping it here, beside `oidcAccountKey`, is what
+ * stops a parallel derivation from drifting into existence.
+ *
+ * Returns the key stored in the users table's provider-account key column:
+ * the GitHub numeric account id for GitHub sign-ins, the
+ * `oidc:{issuer}:{sub}` composite for OIDC sign-ins. Returns null when no key
+ * can be derived (no subject and no user id) — callers decide what that means
+ * for them.
+ */
+export function providerAccountKey(
+  account: { provider?: string; providerAccountId?: string | null } | null | undefined,
+  user: { id?: string | null } | null | undefined,
+): string | null {
+  if (account?.provider === OIDC_PROVIDER_ID) {
+    const subject = account.providerAccountId || user?.id;
+    return subject ? oidcAccountKey(subject) : null;
+  }
+  return user?.id || null;
+}
+
+/**
  * Build the NextAuth provider list from the environment. Pure: given the same
  * env, returns the same list. Defaults to process.env.
  */
 export function buildProviders(env: AuthProviderEnv | NodeJS.ProcessEnv = process.env): Provider[] {
-  const providers: Provider[] = [
-    GithubProvider({
-      clientId: env.GITHUB_CLIENT_ID || '',
-      clientSecret: env.GITHUB_CLIENT_SECRET || '',
-    }),
-  ];
+  const providers: Provider[] = [];
+
+  // Gated on the full pair, mirroring the OIDC gate below: an incomplete pair
+  // can only produce a broken authorization redirect, so the honest render is
+  // no GitHub button at all (#193).
+  if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
+    providers.push(
+      GithubProvider({
+        clientId: env.GITHUB_CLIENT_ID,
+        clientSecret: env.GITHUB_CLIENT_SECRET,
+      }),
+    );
+  }
 
   if (env.OIDC_ISSUER && env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET) {
     const issuer = normalizeIssuer(env.OIDC_ISSUER);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import type { NextAuthOptions } from 'next-auth';
-import { buildProviders, normalizeIssuer, oidcAccountKey, OIDC_PROVIDER_ID } from './auth-providers';
+import { buildProviders, normalizeIssuer, providerAccountKey, OIDC_PROVIDER_ID } from './auth-providers';
+import { isSignInAllowed } from './auth-allowlist';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
@@ -35,30 +36,46 @@ export const authOptions: NextAuthOptions = {
   providers: buildProviders(),
   callbacks: {
     async signIn({ user, account, profile }) {
+      // One derivation for both provider families (GitHub numeric ids and
+      // `oidc:{issuer}:{sub}` composites) — the same key the users table is
+      // keyed on and the JWT callback looks up.
+      const accountKey = providerAccountKey(account, user);
+
+      // THE GATE (app front-door v0.1.0). Checked first: before the database
+      // is consulted and before any row is written, so a refused account
+      // leaves no trace. With SIGN_IN_ALLOWLIST unset or empty this is
+      // unconditionally true and the whole callback behaves exactly as it did
+      // before the gate existed.
+      //
+      // REFUSAL UX (deliberate, v0.1.0): returning false hands the request to
+      // NextAuth's built-in AccessDenied flow — HTTP 403 at
+      // /api/auth/error?error=AccessDenied, reading "Access Denied — You do
+      // not have permission to sign in." with a link back to the sign-in page
+      // (`pages.signIn`, i.e. `/`). No custom error page is configured: the
+      // built-in copy is already accurate and unblamed, and a bespoke page
+      // would be new public surface for no gain at this tier.
+      if (!isSignInAllowed(accountKey)) return false;
+
       // Upsert user record in the database on every login.
       // Skip if DATABASE_URL is not configured (preserves existing behavior in dev).
       if (!process.env.DATABASE_URL) return true;
+      if (!accountKey) return true;
 
       if (account?.provider === OIDC_PROVIDER_ID) {
-        // Generic OIDC sign-in: key by issuer + subject.
-        const subject = account.providerAccountId || user.id;
-        if (!subject) return true;
+        // Generic OIDC sign-in: keyed by issuer + subject.
         const displayName = user.name || user.email || 'Unknown';
         // No provider-agnostic profile page exists; record the issuer origin.
         const profileUrl = normalizeIssuer(process.env.OIDC_ISSUER || '');
-        await upsertUser(oidcAccountKey(subject), displayName, profileUrl);
+        await upsertUser(accountKey, displayName, profileUrl);
         return true;
       }
 
       // GitHub sign-in (the pre-existing path)
-      const githubId = user.id;
-      if (!githubId) return true;
-
       const ghProfile = profile as { login?: string; html_url?: string } | undefined;
       const displayName = user.name || ghProfile?.login || 'Unknown';
       const profileUrl = ghProfile?.html_url || `https://github.com/${ghProfile?.login || ''}`;
 
-      await upsertUser(githubId, displayName, profileUrl);
+      await upsertUser(accountKey, displayName, profileUrl);
 
       return true;
     },
@@ -82,10 +99,7 @@ export const authOptions: NextAuthOptions = {
       // Look up the internal DB user ID on initial sign-in, by the same
       // provider-account key the signIn upsert wrote.
       if (user?.id && process.env.DATABASE_URL) {
-        const accountKey =
-          account?.provider === OIDC_PROVIDER_ID
-            ? oidcAccountKey(account.providerAccountId || user.id)
-            : user.id;
+        const accountKey = providerAccountKey(account, user) as string;
         const dbUser = await db
           .select({ id: users.id })
           .from(users)

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -7,7 +7,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveLimit, checkRateLimit } from './rate-limit.ts';
+import { resolveLimit, selectLimit, checkRateLimit } from './rate-limit.ts';
 
 test('resolveLimit: unset (undefined) falls back to the default', () => {
   assert.equal(resolveLimit(undefined, 10), 10);
@@ -30,6 +30,57 @@ test('resolveLimit: non-numeric falls back to the default (the || guard)', () =>
 
 test('resolveLimit: zero falls back to the default (|| guard treats 0 as unset)', () => {
   assert.equal(resolveLimit('0', 10), 10);
+});
+
+// --- Tier selection, including the app tier (app front door P2) -------------
+
+/** The default numbers, named so the intent of each case is readable. */
+const TIERS = { anonymous: 10, authenticated: 25, appTier: 40 };
+
+test('selectLimit: anonymous requests take the anonymous limit, gated or not', () => {
+  assert.equal(selectLimit({ ...TIERS, isAuthenticated: false, gated: false }), 10);
+  assert.equal(selectLimit({ ...TIERS, isAuthenticated: false, gated: true }), 10);
+});
+
+test('selectLimit: on an UNGATED instance, a signed-in user takes the authenticated limit', () => {
+  // The reference deployment today. This is the byte-identical-behavior case:
+  // no allowlist configured means the app tier is never consulted, whatever
+  // APP_TIER_RATE_LIMIT happens to say.
+  assert.equal(selectLimit({ ...TIERS, isAuthenticated: true, gated: false }), 25);
+  assert.equal(
+    selectLimit({ ...TIERS, appTier: 999, isAuthenticated: true, gated: false }),
+    25,
+    'an app-tier value set on an ungated instance is inert',
+  );
+});
+
+test('selectLimit: on a GATED instance, a signed-in user takes the app tier', () => {
+  // On a gated instance every authenticated identity is an allowlisted one —
+  // the gate is at sign-in — so "authenticated + gated" is the app tier.
+  assert.equal(selectLimit({ ...TIERS, isAuthenticated: true, gated: true }), 40);
+});
+
+test('selectLimit: an unset app tier resolves to the authenticated limit (identity, not a default)', () => {
+  // resolveLimit(undefined, AUTHENTICATED_LIMIT) is how the module wires it,
+  // so an instance that sets an allowlist but no app-tier number sees exactly
+  // its authenticated numbers.
+  const appTier = resolveLimit(undefined, 25);
+  assert.equal(appTier, 25);
+  assert.equal(selectLimit({ ...TIERS, appTier, isAuthenticated: true, gated: true }), 25);
+});
+
+test('selectLimit: the app tier inherits a lifted authenticated limit when unset', () => {
+  // AUTHENTICATED_RATE_LIMIT=100 with APP_TIER_RATE_LIMIT unset ⇒ app tier 100.
+  const authenticated = resolveLimit('100', 25);
+  const appTier = resolveLimit(undefined, authenticated);
+  assert.equal(appTier, 100);
+  assert.equal(selectLimit({ ...TIERS, authenticated, appTier, isAuthenticated: true, gated: true }), 100);
+});
+
+test('selectLimit: an app tier may be set below the authenticated limit', () => {
+  // Nothing forces the gated tier upward — an instance may deliberately run a
+  // tighter per-user budget on its gated surface.
+  assert.equal(selectLimit({ ...TIERS, appTier: 5, isAuthenticated: true, gated: true }), 5);
 });
 
 test('default wiring: with no env overrides, the limits are 10 (anon) and 25 (auth)', async () => {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,4 +1,8 @@
 import { kv } from '@vercel/kv';
+// Explicit .ts extension: this module is unit-tested under the plain-Node
+// runner, which does not do extensionless resolution (same convention as
+// src/lib/evidence/*).
+import { isSignInGateEnabled } from './auth-allowlist.ts';
 
 /**
  * Resolve a per-request quota from an optional env override, falling back to
@@ -14,6 +18,65 @@ export function resolveLimit(envValue: string | undefined, fallback: number): nu
 
 const ANONYMOUS_LIMIT = resolveLimit(process.env.ANONYMOUS_RATE_LIMIT, 10);
 const AUTHENTICATED_LIMIT = resolveLimit(process.env.AUTHENTICATED_RATE_LIMIT, 25);
+
+/**
+ * The app tier: the quota for signed-in users of a GATED instance.
+ *
+ * Note the fallback — it is the authenticated limit, not a fresh number. An
+ * instance that never sets APP_TIER_RATE_LIMIT resolves the app tier to
+ * exactly whatever its authenticated tier already is, so the variable's
+ * absence is not merely "a default" but literal identity with today's
+ * behavior. Combined with the gate check in `selectLimit`, an instance with
+ * neither new variable set is byte-identical to the pre-P2 module.
+ */
+const APP_TIER_LIMIT = resolveLimit(process.env.APP_TIER_RATE_LIMIT, AUTHENTICATED_LIMIT);
+
+/** Resolved once at module load, like the limits themselves. */
+const SIGN_IN_GATED = isSignInGateEnabled();
+
+/**
+ * Pick the ceiling for a request. Pure — every input is a parameter — so the
+ * tier selection is testable without mutating process.env or reloading the
+ * module. `checkRateLimit`/`incrementRateLimit` call it with the module
+ * constants above.
+ *
+ * WHERE THE APP TIER APPLIES (v0.1.0 reading, deliberately conservative):
+ * a signed-in request on an instance whose sign-in allowlist is populated.
+ * On a gated instance the two populations coincide by construction — the gate
+ * is at sign-in, so *every* authenticated identity is an allowlisted one, and
+ * "authenticated on a gated instance" is the honest available proxy for
+ * "user of the gated app surface" until the host split lands.
+ *
+ * WHERE IT DOES NOT APPLY YET: host awareness (P3's middleware) and the
+ * signed-in `(app)` query mount (P4). Until those land there is no request
+ * attribute that distinguishes an app-host query from an apex query, so no
+ * call site passes a host or surface hint. The seam is here and resolved;
+ * narrowing it to the app host is a P3/P4 change to this one function.
+ *
+ * Ungated instance (allowlist unset/empty) ⇒ the authenticated limit, exactly
+ * as before. That is the reference deployment today.
+ */
+export function selectLimit(opts: {
+  isAuthenticated: boolean;
+  gated: boolean;
+  anonymous: number;
+  authenticated: number;
+  appTier: number;
+}): number {
+  if (!opts.isAuthenticated) return opts.anonymous;
+  return opts.gated ? opts.appTier : opts.authenticated;
+}
+
+/** The module's own wiring of `selectLimit` — one place, both entry points. */
+function limitFor(isAuthenticated: boolean): number {
+  return selectLimit({
+    isAuthenticated,
+    gated: SIGN_IN_GATED,
+    anonymous: ANONYMOUS_LIMIT,
+    authenticated: AUTHENTICATED_LIMIT,
+    appTier: APP_TIER_LIMIT,
+  });
+}
 
 // In-memory fallback for local development without Vercel KV
 const memoryStore = new Map<string, number>();
@@ -44,7 +107,7 @@ export async function checkRateLimit(
   identifier: string,
   isAuthenticated: boolean
 ): Promise<RateLimitInfo> {
-  const limit = isAuthenticated ? AUTHENTICATED_LIMIT : ANONYMOUS_LIMIT;
+  const limit = limitFor(isAuthenticated);
   const key = getRateLimitKey(identifier);
 
   let count = 0;
@@ -75,7 +138,7 @@ export async function incrementRateLimit(
   identifier: string,
   isAuthenticated: boolean
 ): Promise<RateLimitInfo> {
-  const limit = isAuthenticated ? AUTHENTICATED_LIMIT : ANONYMOUS_LIMIT;
+  const limit = limitFor(isAuthenticated);
   const key = getRateLimitKey(identifier);
 
   let count = 0;


### PR DESCRIPTION
Phase 2 of the app-front-door v0.1.0 sprint (#191): the sign-in allowlist gate, real `(app)` chrome, the app-tier rate limit, and the folded #193 provider gating. Every new variable is inert when unset — an instance that has never heard of them is byte-identical to pre-P2.

## The four legs

**Allowlist gate.** `SIGN_IN_ALLOWLIST` (new `src/lib/auth-allowlist.ts`, pure and env-injectable) is checked in `callbacks.signIn` before the database is consulted — a refused account leaves no row. Unset/empty ⇒ open, exactly pre-gate behavior. A new shared `providerAccountKey()` derivation (in `auth-providers.ts`, beside `oidcAccountKey`) now feeds the gate, the users-table upsert, and the JWT lookup — one derivation, three consumers, both provider-key families (GitHub numeric ids, `oidc:{issuer}:{sub}` composites). Refusal UX: NextAuth's built-in AccessDenied flow, deliberately unchanged — a custom error page would be new public surface on the acceptance-protected apex.

**App chrome.** `(app)/layout.tsx` composes a new `AppChrome` strip above the group's pages: signed-in identity stated in the page body, a current-page-aware Dashboard link, an explicit exit to the public site. Client component via `useSession()` (a server-side read would opt the whole group into dynamic rendering); renders nothing signed-out or loading — anonymous visitors to the public `/evidence` pages see exactly the pre-phase page. Deliberately NOT an auth boundary; the layout carries a comment explaining why one does not belong there.

**App-tier rate limit.** `APP_TIER_RATE_LIMIT` resolves through the existing `resolveLimit()` with fallback = the authenticated limit itself. A new pure `selectLimit()` picks the tier; the app tier applies when authenticated ∧ gated (on a gated instance every authenticated identity is allowlisted by construction). Host-narrowing is deferred to P3/P4 and is a change to this one function.

**#193 provider gating + retier.** `buildProviders()` now pushes GitHub only when both env vars are present, mirroring the OIDC gate — no more silently broken button on an OIDC-only instance. Preflight gains `requiredUnlessAllPresent` (alternatives, vs the driver-keyed conditionals): the GitHub pair demotes to `optional` when the OIDC triple is complete. `resolveSpec()` gained an `env` parameter defaulting to `{}`, keeping the frozen default-profile output byte-identical.

## Env single-authority rider

`SIGN_IN_ALLOWLIST` and `APP_TIER_RATE_LIMIT` land in the preflight inventory (both `optional` + `hasFallback` — never load-bearing for an instance that doesn't want them) and `docs/deploy.md` (sign-in section + tuning-knob list). The env-example entries arrive as a follow-up commit on this branch — the file is permission-fenced for agent sessions, so the append is owner-run.

## Acceptance mapping

- **Off-list refused / on-list admitted / unset ⇒ open:** unit-tested in `auth-allowlist.test.ts` (both key families, unset/empty/whitespace-only/populated, separators, dedup, underivable-key-refused-when-gated) and gate-order-tested via the callback. Live OAuth round-trips are the owner's G1 smoke.
- **Evidence:** `npm test` 457/457 (31 new tests) · preflight test 29/29 · lint 0 errors (4 pre-existing warnings) · build clean, route table unchanged.

IMPL ran on Opus (three infrastructure stalls, resumed each time — the stall culprit was the permission-fenced env-example file); the doc-rider tail and evidence runs were completed by ORCH.

Closes #193. Part of #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
