### PR TITLE
App front-door P3: host topology — routing proxy, apex withholding, app-only mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,3 +109,17 @@ SIGN_IN_ALLOWLIST=
 # Per-day query limit for signed-in users of a gated instance.
 # Default: AUTHENTICATED_RATE_LIMIT - unset changes nothing.
 APP_TIER_RATE_LIMIT=
+
+# --- Host topology (app front-door P3; all optional - unset = single host, no withholding) ---
+# Split-host deployment: set both. Requests on APP_HOST serve the gated app
+# surface (/ temporarily 307s to /evidence; marketing pages 404); requests on
+# MARKETING_HOST serve the public face and 404 the app-private routes
+# (/dashboard, /auth/device, /dev/notebook-preview). /evidence and /api/* serve
+# on both. Hosts that match neither variable are untouched (previews stay
+# whole). Values are hostnames (app.example.org); a full origin also works;
+# matching is case-, port-, and www-insensitive.
+APP_HOST=
+MARKETING_HOST=
+# App-only instance (no marketing site): 1/true serves the gated surface on
+# every host; APP_HOST/MARKETING_HOST are ignored.
+APP_ONLY=

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -23,15 +23,17 @@ The guide is ordered the way a first deployment actually proceeds:
    overrides a default.
 5. [Sign-in configuration](#sign-in-configuration) — your own OAuth
    application.
-6. [Database and migrations](#database-and-migrations) — including the
+6. [Host topology](#host-topology-optional) — optional: split the
+   public face from the gated app surface, or run app-only.
+7. [Database and migrations](#database-and-migrations) — including the
    fork/existing-database path.
-7. [Instance identity and signing](#instance-identity-and-signing-go-to-production)
+8. [Instance identity and signing](#instance-identity-and-signing-go-to-production)
    — the go-to-production step (linked, not duplicated).
-8. [Object storage: configuration and rehearsal](#object-storage-configuration-and-rehearsal)
-9. [Scheduler and background jobs](#scheduler-and-background-jobs)
-10. [Managed-platform deployment](#managed-platform-deployment)
-11. [Vocabulary notes for integrators](#vocabulary-notes-for-integrators)
-12. [Appendix A: first-time S3 on a public cloud](#appendix-a-first-time-s3-on-a-public-cloud)
+9. [Object storage: configuration and rehearsal](#object-storage-configuration-and-rehearsal)
+10. [Scheduler and background jobs](#scheduler-and-background-jobs)
+11. [Managed-platform deployment](#managed-platform-deployment)
+12. [Vocabulary notes for integrators](#vocabulary-notes-for-integrators)
+13. [Appendix A: first-time S3 on a public cloud](#appendix-a-first-time-s3-on-a-public-cloud)
 
 ## Before you start
 
@@ -397,6 +399,9 @@ the demo deployment's values are emitted; see
 [`docs/instance-setup.md`](instance-setup.md)), `OIDC_PROVIDER_NAME`
 (button label), `SIGN_IN_ALLOWLIST` (unset or empty = open sign-in,
 exactly the pre-allowlist behavior; see the sign-in section),
+the host-topology set (`APP_HOST`, `MARKETING_HOST`, `APP_ONLY` — with
+none set, every route serves on every host, exactly the single-host
+behavior; see [Host topology](#host-topology-optional)),
 rate-limit and token-budget tuning knobs
 (`ANONYMOUS_RATE_LIMIT`, `AUTHENTICATED_RATE_LIMIT`,
 `APP_TIER_RATE_LIMIT`, `TOKEN_LIMIT_PER_REQUEST`,
@@ -485,6 +490,51 @@ Then verify by completing a sign-in round-trip in a browser against your
 deployed origin — a misconfigured `NEXTAUTH_URL` typically surfaces as a
 callback-URL mismatch error from the provider. Signed-in users are
 recorded in the instance's own database on first sign-in.
+
+## Host topology (optional)
+
+By default an instance is a single host and every route serves on it —
+nothing in this section is required, and with none of the three
+variables set the routing middleware passes every request through
+untouched. Set them to split the public face from the gated app
+surface, or to run an app-only instance with no public face at all.
+The decision logic lives in `src/lib/host-routing.ts` (unit-tested;
+`src/middleware.ts` is a thin adapter over it).
+
+| Variable | Meaning |
+| --- | --- |
+| `APP_HOST` | The host that serves the gated app surface. On it, `/` temporarily redirects to `/evidence` (a later release mounts the signed-in query surface at `/`; the dashboard is not the target because it bounces signed-out visitors back to `/`, which would loop), the marketing pages return 404, and the dashboard, device pairing, and evidence routes all serve. |
+| `MARKETING_HOST` | The host that serves the public face. On it, the marketing pages and the public evidence registry serve exactly as on a single host, and the app-private routes — `/dashboard`, `/auth/device`, `/dev/notebook-preview` — return 404. |
+| `APP_ONLY` | `1` or `true`: an app-only instance. Every request on every host gets the app-surface behavior above; `APP_HOST`/`MARKETING_HOST` are ignored. For operators deploying only the gated surface, with no marketing site. |
+
+Values are host names (`app.example.org`); a full origin
+(`http://localhost:3000`) is also accepted, and matching is
+case-, port-, and `www.`-insensitive. Three properties worth
+internalizing:
+
+- **Roles are claimed, never assumed.** A request on a host matching
+  neither variable — a preview deployment, a health check by IP, an
+  alias you have not named — is served exactly as if no topology were
+  configured. That makes the rollout incremental: set `APP_HOST` first
+  and verify the app host, then set `MARKETING_HOST` to switch on the
+  withholding.
+- **The evidence registry is dual-served on purpose.** `/evidence` and
+  `/evidence/<slug>` are public product surface; published links must
+  keep resolving on the public face, and the app surface serves them
+  too. `/api/*`, `/.well-known/*`, and static assets likewise serve on
+  every host.
+- **Withholding is topology, not security.** The 404s shape which host
+  presents which surface; access control is sign-in
+  (`SIGN_IN_ALLOWLIST`) and the per-route session checks, which apply
+  identically on every host.
+
+Two split-host interactions to plan for: `NEXTAUTH_URL` can point at
+only one host, and sessions are per-host cookies — decide which host
+users sign in on (for a gated app surface, normally the app host) and
+point `NEXTAUTH_URL` and your OAuth callback URLs there. The
+device-pairing URL the API hands to CLI clients already follows
+`APP_HOST` when it is set, since `/auth/device` is withheld on the
+marketing host.
 
 ## Database and migrations
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -499,7 +499,7 @@ variables set the routing middleware passes every request through
 untouched. Set them to split the public face from the gated app
 surface, or to run an app-only instance with no public face at all.
 The decision logic lives in `src/lib/host-routing.ts` (unit-tested;
-`src/middleware.ts` is a thin adapter over it).
+`src/proxy.ts` is a thin adapter over it).
 
 | Variable | Meaning |
 | --- | --- |

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -178,6 +178,15 @@ export const ENV_SPEC = [
   // coded default, never load-bearing for an instance that does not want it.
   { name: 'SIGN_IN_ALLOWLIST', tier: 'optional', purpose: 'Allowlist of provider-account keys permitted to sign in (unset/empty = open)', hasFallback: true },
 
+  // --- Host topology (app front door P3; src/lib/host-routing.ts). All three
+  //     are pure opt-ins whose coded default is "no host routing": with none
+  //     set the middleware passes every request through and every route keeps
+  //     serving on every host, exactly the pre-topology behavior — so none is
+  //     ever load-bearing for a single-host instance. ---
+  { name: 'APP_HOST', tier: 'optional', purpose: 'Split-host: host serving the gated app surface (unset = no host routing)', hasFallback: true },
+  { name: 'MARKETING_HOST', tier: 'optional', purpose: 'Split-host: host serving the marketing site — withholds the app-private routes there (unset = no withholding)', hasFallback: true },
+  { name: 'APP_ONLY', tier: 'optional', purpose: 'App-only instance: every host serves the gated surface; marketing routes 404 (unset = off)', hasFallback: true },
+
   // --- Rate limiting (durable counter; without it, falls back to per-instance memory) ---
   // hasFallback, not a hard miss: rate-limit.ts:53-63 tests both vars and takes
   // an in-process memory store when either is absent — the instance runs, the

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -380,6 +380,24 @@ test('the sign-in gate and app-tier knobs are optional with coded fallbacks', ()
   assert.ok(!result.missingRecommended.some((r) => r.name === 'APP_TIER_RATE_LIMIT'));
 });
 
+test('the host-topology trio is optional with coded fallbacks (unset = single host, no withholding)', () => {
+  // All three reproduce today's behavior when unset — the middleware passes
+  // every request through — so none may ever fail or nag a run (the P3 seam
+  // convention, same shape as the sign-in gate above).
+  for (const name of ['APP_HOST', 'MARKETING_HOST', 'APP_ONLY']) {
+    const entry = ENV_SPEC.find((s) => s.name === name);
+    assert.ok(entry, `${name} is enumerated`);
+    assert.equal(entry.tier, 'optional', `${name} is optional`);
+    assert.equal(entry.hasFallback, true, `${name} has a coded fallback`);
+  }
+  const result = evaluateEnv(envWithAllRequired()); // all three absent
+  assert.equal(result.ok, true);
+  for (const name of ['APP_HOST', 'MARKETING_HOST', 'APP_ONLY']) {
+    assert.ok(!result.missingRequired.some((r) => r.name === name));
+    assert.ok(!result.missingRecommended.some((r) => r.name === name));
+  }
+});
+
 test('a configured allowlist is never echoed — only the variable name', () => {
   const env = { ...envWithAllRequired(), SIGN_IN_ALLOWLIST: '4242,oidc:https://idp.example.org:SENTINEL' };
   const report = renderReport(evaluateEnv(env));

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import AppChrome from '@/components/AppChrome';
+import { resolvePublicSiteHref } from '@/lib/host-routing';
 
 /**
  * Layout for the `(app)` route group — the gated app surface's shell
@@ -19,6 +20,13 @@ import AppChrome from '@/components/AppChrome';
  * pages, on top of the site header and footer the root layout already
  * provides. `AppChrome` renders nothing at all for a signed-out visitor, so
  * the public evidence pages are untouched.
+ *
+ * The "Public site" exit link is resolved HERE (a server component) from
+ * the host-topology env vars and passed down as a plain prop — AppChrome is
+ * a client component and non-NEXT_PUBLIC env never reaches the browser
+ * bundle. Unset topology resolves to `/`, today's exact link. For routes
+ * prerendered at build time the value freezes at build, the same semantics
+ * an inlined NEXT_PUBLIC var would have.
  */
 export default function AppLayout({
   children,
@@ -27,7 +35,7 @@ export default function AppLayout({
 }>) {
   return (
     <>
-      <AppChrome />
+      <AppChrome publicSiteHref={resolvePublicSiteHref(process.env)} />
       {children}
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import Link from 'next/link';
 import Providers from '@/components/Providers';
 import Header from '@/components/Header';
+import { resolveDashboardHref } from '@/lib/host-routing';
 import RunningUnsignedBanner from '@/components/RunningUnsignedBanner';
 import SponsorLine from '@/components/SponsorLine';
 
@@ -70,7 +71,10 @@ export default function RootLayout({
       <body className={`${spaceGrotesk.variable} ${notoSans.variable}`}>
         <Providers>
           <div className="flex flex-col">
-            <Header />
+            {/* Env-driven (P3): on a split-host topology the marketing host
+                withholds /dashboard, so the signed-in menu must carry the
+                app origin. Unset topology resolves to '/dashboard'. */}
+            <Header dashboardHref={resolveDashboardHref(process.env)} />
             {/* ADR-0020: running-unsigned indicator — renders only when this
                 instance has no signing key AND is outside a dev environment. */}
             <RunningUnsignedBanner />

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -38,9 +38,19 @@ import { useSession } from 'next-auth/react';
  *
  * NOT A GATE. This component decides what to DISPLAY; it never decides who
  * may READ. The sprint's gate is at sign-in (`SIGN_IN_ALLOWLIST`, checked in
- * `callbacks.signIn`); host separation arrives in P3.
+ * `callbacks.signIn`); host separation lives in `src/middleware.ts` (P3).
+ *
+ * `publicSiteHref` is resolved server-side by the `(app)` layout via
+ * `resolvePublicSiteHref()` (src/lib/host-routing.ts): `/` on a single
+ * host, the marketing origin on a split-host deployment, and null on an
+ * app-only instance — null hides the link entirely, because an app-only
+ * instance HAS no public marketing site to exit to.
  */
-export default function AppChrome() {
+export default function AppChrome({
+  publicSiteHref = '/',
+}: {
+  publicSiteHref?: string | null;
+}) {
   const { data: session, status } = useSession();
   const pathname = usePathname();
 
@@ -86,15 +96,19 @@ export default function AppChrome() {
               Dashboard
             </Link>
           )}
-          {/* The way out. Relative on purpose: on a single host `/` is the
-              public site, and when P3 splits the hosts this one href is the
-              single place that becomes the apex origin. */}
-          <Link href="/" style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
-            Public site
-            <span aria-hidden="true" style={{ marginLeft: '4px', color: 'var(--text-muted)' }}>
-              &#8599;
-            </span>
-          </Link>
+          {/* The way out. Env-driven (P3): relative `/` on a single host,
+              the marketing origin when MARKETING_HOST splits the hosts,
+              absent entirely on an APP_ONLY instance. next/link treats an
+              absolute cross-origin href as a plain anchor navigation, so
+              one element covers both shapes. */}
+          {publicSiteHref !== null && (
+            <Link href={publicSiteHref} style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
+              Public site
+              <span aria-hidden="true" style={{ marginLeft: '4px', color: 'var(--text-muted)' }}>
+                &#8599;
+              </span>
+            </Link>
+          )}
         </span>
       </div>
     </div>

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -38,7 +38,7 @@ import { useSession } from 'next-auth/react';
  *
  * NOT A GATE. This component decides what to DISPLAY; it never decides who
  * may READ. The sprint's gate is at sign-in (`SIGN_IN_ALLOWLIST`, checked in
- * `callbacks.signIn`); host separation lives in `src/middleware.ts` (P3).
+ * `callbacks.signIn`); host separation lives in `src/proxy.ts` (P3).
  *
  * `publicSiteHref` is resolved server-side by the `(app)` layout via
  * `resolvePublicSiteHref()` (src/lib/host-routing.ts): `/` on a single

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,18 @@ const DROPDOWN_ITEM_STYLE: React.CSSProperties = {
   fontWeight: 500,
 };
 
-export default function Header() {
+/**
+ * `dashboardHref` is env-driven (app front-door P3): the root layout passes
+ * `resolveDashboardHref()` so that on a split-host deployment — where the
+ * marketing host withholds `/dashboard` — the signed-in menu points at the
+ * app host instead of a 404. Default (and unset topology) is today's
+ * relative href, byte-identical.
+ */
+export default function Header({
+  dashboardHref = '/dashboard',
+}: {
+  dashboardHref?: string;
+}) {
   const { data: session, status } = useSession();
   const headerRef = useRef<HTMLElement>(null);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -313,7 +324,7 @@ export default function Header() {
                   }}
                 >
                   <Link
-                    href="/dashboard"
+                    href={dashboardHref}
                     onClick={() => setUserMenuOpen(false)}
                     style={DROPDOWN_ITEM_STYLE}
                     onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'var(--card-background)'; }}
@@ -516,7 +527,7 @@ export default function Header() {
                 Your account
               </span>
               <Link
-                href="/dashboard"
+                href={dashboardHref}
                 onClick={() => setMobileMenuOpen(false)}
                 style={{
                   color: 'var(--text-secondary)',

--- a/src/lib/device-flow.ts
+++ b/src/lib/device-flow.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { resolveAppOrigin } from './host-routing';
 
 /**
  * Device authorization grant primitives (RFC 8628).
@@ -62,11 +63,17 @@ export function normalizeUserCode(input: string): string {
 }
 
 /**
- * Returns the base URL for this deployment. Prefers `NEXTAUTH_URL` (set
- * per-environment in Vercel); falls back to the request origin when
- * called with one.
+ * Returns the base URL the device-flow verification URIs are built on —
+ * the pairing page `/auth/device` lives under it. Host topology (P3): on a
+ * split-host deployment the pairing page is served on the app host and
+ * WITHHELD on the marketing host, so a configured `APP_HOST` wins over
+ * `NEXTAUTH_URL` (which stays pointed at the OAuth-callback host). With no
+ * topology configured: `NEXTAUTH_URL` (set per-environment in Vercel),
+ * then the request origin when called with one — unchanged.
  */
 export function getBaseUrl(request?: Request): string {
+  const appOrigin = resolveAppOrigin(process.env);
+  if (appOrigin) return appOrigin;
   const fromEnv = process.env.NEXTAUTH_URL;
   if (fromEnv) return fromEnv.replace(/\/+$/, '');
   if (request) {

--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -1,0 +1,289 @@
+// Tests for the host-topology decision logic (app front-door v0.1.0, P3).
+//
+// The core property, matching the seam convention everywhere else in this
+// codebase: with none of APP_HOST / MARKETING_HOST / APP_ONLY set, every
+// (host, path) pair resolves to `serve` — no withholding, no rewrites,
+// anywhere. The full matrix (two-host split × every route class, app-only ×
+// every route class, unmatched hosts, partial configuration) is pinned below.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyPath,
+  decideRoute,
+  normalizeHost,
+  originFromHostValue,
+  parseBooleanFlag,
+  readHostRoutingConfig,
+  resolveAppOrigin,
+  resolveDashboardHref,
+  resolveHostRole,
+  resolvePublicSiteHref,
+  APP_PRIVATE_PATHS,
+  MARKETING_PATHS,
+} from './host-routing.ts';
+
+// --- Fixtures ----------------------------------------------------------------
+
+const SPLIT = readHostRoutingConfig({
+  APP_HOST: 'app.example.org',
+  MARKETING_HOST: 'example.org',
+});
+const APP_ONLY = readHostRoutingConfig({ APP_ONLY: '1' });
+const UNSET = readHostRoutingConfig({});
+
+// One representative per route class, plus depth and edge variants.
+const ROOT = '/';
+const MARKETING_SAMPLES = ['/about', '/explore', '/learn', '/project', '/roadmap', '/directory', '/explore/deep/link'];
+const APP_PRIVATE_SAMPLES = ['/dashboard', '/dashboard/settings', '/auth/device', '/dev/notebook-preview'];
+const DUAL_SAMPLES = ['/evidence', '/evidence/some-published-slug'];
+const OTHER_SAMPLES = [
+  '/api/rate-limit', // matcher-excluded in prod, but the function must serve it regardless
+  '/_next/static/chunk.js',
+  '/.well-known/typed-publisher.json',
+  '/bpmn/mcp-query-flow.bpmn',
+  '/talks/some-deck.pdf',
+  '/file.svg',
+  '/no-such-page',
+  '/authors', // prefix-collision guard: not /auth/device
+  '/dashboard-widgets', // prefix-collision guard: not /dashboard
+];
+const EVERY_PATH = [ROOT, ...MARKETING_SAMPLES, ...APP_PRIVATE_SAMPLES, ...DUAL_SAMPLES, ...OTHER_SAMPLES];
+
+// --- Rule zero: unset config is a universal pass-through ---------------------
+
+test('unset config: every route class on every host passes through', () => {
+  const hosts = ['example.org', 'app.example.org', 'localhost:3000', 'preview-abc.vercel.app', null];
+  for (const host of hosts) {
+    for (const path of EVERY_PATH) {
+      assert.deepEqual(
+        decideRoute(host, path, UNSET),
+        { kind: 'serve' },
+        `unset config must serve ${path} on host ${host}`,
+      );
+    }
+  }
+});
+
+// --- Split-host: the marketing host ------------------------------------------
+
+test('split: the marketing host withholds exactly the app-private routes', () => {
+  for (const path of APP_PRIVATE_SAMPLES) {
+    assert.deepEqual(decideRoute('example.org', path, SPLIT), { kind: 'withhold' }, path);
+  }
+});
+
+test('split: the marketing host serves root, marketing, evidence, and everything else', () => {
+  for (const path of [ROOT, ...MARKETING_SAMPLES, ...DUAL_SAMPLES, ...OTHER_SAMPLES]) {
+    assert.deepEqual(decideRoute('example.org', path, SPLIT), { kind: 'serve' }, path);
+  }
+});
+
+test('split: every declared app-private prefix is withheld on the marketing host, nested too', () => {
+  for (const prefix of APP_PRIVATE_PATHS) {
+    assert.deepEqual(decideRoute('example.org', prefix, SPLIT), { kind: 'withhold' }, prefix);
+    assert.deepEqual(decideRoute('example.org', `${prefix}/nested`, SPLIT), { kind: 'withhold' }, `${prefix}/nested`);
+  }
+});
+
+// --- Split-host: the app host -------------------------------------------------
+
+test('split: the app host redirects / into the app group (interim P4 seam)', () => {
+  // /evidence, not /dashboard: the dashboard bounces signed-out visitors
+  // back to /, so /dashboard here would loop for anyone without a session.
+  assert.deepEqual(decideRoute('app.example.org', ROOT, SPLIT), {
+    kind: 'redirect',
+    destination: '/evidence',
+  });
+});
+
+test('split: the app host withholds every marketing route', () => {
+  for (const path of MARKETING_SAMPLES) {
+    assert.deepEqual(decideRoute('app.example.org', path, SPLIT), { kind: 'withhold' }, path);
+  }
+  for (const prefix of MARKETING_PATHS) {
+    assert.deepEqual(decideRoute('app.example.org', prefix, SPLIT), { kind: 'withhold' }, prefix);
+  }
+});
+
+test('split: the app host serves the full (app) group, evidence included', () => {
+  for (const path of [...APP_PRIVATE_SAMPLES, ...DUAL_SAMPLES]) {
+    assert.deepEqual(decideRoute('app.example.org', path, SPLIT), { kind: 'serve' }, path);
+  }
+});
+
+test('split: the app host passes through assets, API paths, and unknown URLs', () => {
+  for (const path of OTHER_SAMPLES) {
+    assert.deepEqual(decideRoute('app.example.org', path, SPLIT), { kind: 'serve' }, path);
+  }
+});
+
+// --- Split-host: hosts that match neither variable ---------------------------
+
+test('split: an unmatched host (preview, IP, unnamed alias) is untouched everywhere', () => {
+  for (const host of ['preview-abc.vercel.app', '127.0.0.1:3000', 'staging.example.net']) {
+    for (const path of EVERY_PATH) {
+      assert.deepEqual(decideRoute(host, path, SPLIT), { kind: 'serve' }, `${host} ${path}`);
+    }
+  }
+});
+
+test('a missing Host header is passthrough, never a role', () => {
+  assert.deepEqual(decideRoute(null, '/dashboard', SPLIT), { kind: 'serve' });
+  assert.deepEqual(decideRoute(undefined, '/', SPLIT), { kind: 'serve' });
+});
+
+// --- Partial configuration ----------------------------------------------------
+
+test('APP_HOST alone: app role on that host, NO withholding anywhere else', () => {
+  const config = readHostRoutingConfig({ APP_HOST: 'app.example.org' });
+  // The app host takes its role...
+  assert.deepEqual(decideRoute('app.example.org', '/about', config), { kind: 'withhold' });
+  assert.deepEqual(decideRoute('app.example.org', '/', config), { kind: 'redirect', destination: '/evidence' });
+  // ...and every other host keeps today's behavior — withholding on the
+  // marketing face starts only when MARKETING_HOST is set (incremental
+  // rollout: stand up the app host first, flip the apex second).
+  for (const path of EVERY_PATH) {
+    assert.deepEqual(decideRoute('example.org', path, config), { kind: 'serve' }, path);
+  }
+});
+
+test('MARKETING_HOST alone: withholding on that host, all other hosts untouched', () => {
+  const config = readHostRoutingConfig({ MARKETING_HOST: 'example.org' });
+  assert.deepEqual(decideRoute('example.org', '/dashboard', config), { kind: 'withhold' });
+  assert.deepEqual(decideRoute('example.org', '/', config), { kind: 'serve' });
+  for (const path of EVERY_PATH) {
+    assert.deepEqual(decideRoute('app.example.org', path, config), { kind: 'serve' }, path);
+  }
+});
+
+// --- App-only single-host instances (contract amendment 1) --------------------
+
+test('app-only: every host gets the app role', () => {
+  for (const host of ['gated.example.net', 'preview-abc.vercel.app', 'localhost:3000']) {
+    assert.deepEqual(decideRoute(host, '/', APP_ONLY), { kind: 'redirect', destination: '/evidence' });
+    assert.deepEqual(decideRoute(host, '/dashboard', APP_ONLY), { kind: 'serve' });
+    assert.deepEqual(decideRoute(host, '/auth/device', APP_ONLY), { kind: 'serve' });
+    assert.deepEqual(decideRoute(host, '/evidence/some-slug', APP_ONLY), { kind: 'serve' });
+    for (const path of MARKETING_SAMPLES) {
+      assert.deepEqual(decideRoute(host, path, APP_ONLY), { kind: 'withhold' }, `${host} ${path}`);
+    }
+    for (const path of OTHER_SAMPLES) {
+      assert.deepEqual(decideRoute(host, path, APP_ONLY), { kind: 'serve' }, `${host} ${path}`);
+    }
+  }
+});
+
+test('app-only wins over host matching: APP_HOST/MARKETING_HOST are ignored', () => {
+  const config = readHostRoutingConfig({
+    APP_ONLY: 'true',
+    APP_HOST: 'app.example.org',
+    MARKETING_HOST: 'example.org',
+  });
+  // Even the configured marketing host gets the app role.
+  assert.deepEqual(decideRoute('example.org', '/dashboard', config), { kind: 'serve' });
+  assert.deepEqual(decideRoute('example.org', '/about', config), { kind: 'withhold' });
+});
+
+// --- Host normalization --------------------------------------------------------
+
+test('host matching is case-, port-, and www-insensitive', () => {
+  assert.deepEqual(decideRoute('App.Example.Org', '/about', SPLIT), { kind: 'withhold' });
+  assert.deepEqual(decideRoute('app.example.org:443', '/about', SPLIT), { kind: 'withhold' });
+  assert.deepEqual(decideRoute('www.example.org', '/dashboard', SPLIT), { kind: 'withhold' });
+  assert.deepEqual(decideRoute('WWW.EXAMPLE.ORG:8443', '/dashboard', SPLIT), { kind: 'withhold' });
+});
+
+test('config values accept a full origin as well as a bare host', () => {
+  const config = readHostRoutingConfig({
+    APP_HOST: 'https://app.example.org/',
+    MARKETING_HOST: 'http://localhost:3000',
+  });
+  assert.equal(resolveHostRole('app.example.org', config), 'app');
+  assert.equal(resolveHostRole('localhost:4000', config), 'marketing'); // port never participates in matching
+  assert.equal(resolveHostRole('other.example.org', config), 'passthrough');
+});
+
+test('normalizeHost edge cases', () => {
+  assert.equal(normalizeHost(undefined), null);
+  assert.equal(normalizeHost(''), null);
+  assert.equal(normalizeHost('   '), null);
+  assert.equal(normalizeHost('Example.Org.'), 'example.org');
+  assert.equal(normalizeHost('https://www.Example.org:8443/path?q=1'), 'example.org');
+  assert.equal(normalizeHost('[::1]:3000'), '[::1]');
+  assert.equal(normalizeHost('www.'), null);
+});
+
+test('identical APP_HOST and MARKETING_HOST: the app role wins (documented precedence)', () => {
+  const config = readHostRoutingConfig({ APP_HOST: 'x.example.org', MARKETING_HOST: 'x.example.org' });
+  assert.equal(resolveHostRole('x.example.org', config), 'app');
+});
+
+// --- Flag parsing ---------------------------------------------------------------
+
+test('APP_ONLY parsing: 1/true (any case) on; everything else off', () => {
+  for (const on of ['1', 'true', 'TRUE', ' True ']) assert.equal(parseBooleanFlag(on), true, on);
+  for (const off of [undefined, null, '', '0', 'false', 'yes', 'on', 'app-only']) {
+    assert.equal(parseBooleanFlag(off), false, String(off));
+  }
+});
+
+// --- Path classification ---------------------------------------------------------
+
+test('classifyPath covers every declared prefix and resists prefix collisions', () => {
+  assert.equal(classifyPath('/'), 'root');
+  for (const p of MARKETING_PATHS) assert.equal(classifyPath(p), 'marketing', p);
+  for (const p of APP_PRIVATE_PATHS) assert.equal(classifyPath(p), 'app-private', p);
+  assert.equal(classifyPath('/evidence'), 'dual-served');
+  assert.equal(classifyPath('/evidence/slug/extra'), 'dual-served');
+  assert.equal(classifyPath('/aboutus'), 'other');
+  assert.equal(classifyPath('/dashboard-widgets'), 'other');
+  assert.equal(classifyPath('/auth'), 'other'); // no page lives at /auth itself
+  assert.equal(classifyPath('/auth/device/extra'), 'app-private');
+});
+
+// --- URL helpers (AppChrome exit link, device-flow pairing origin) ---------------
+
+test('resolvePublicSiteHref: unset topology keeps the relative link', () => {
+  assert.equal(resolvePublicSiteHref({}), '/');
+});
+
+test('resolvePublicSiteHref: split-host points at the marketing origin', () => {
+  assert.equal(resolvePublicSiteHref({ MARKETING_HOST: 'example.org' }), 'https://example.org');
+  assert.equal(
+    resolvePublicSiteHref({ MARKETING_HOST: 'http://localhost:3000/' }),
+    'http://localhost:3000',
+  );
+});
+
+test('resolvePublicSiteHref: app-only hides the affordance (null)', () => {
+  assert.equal(resolvePublicSiteHref({ APP_ONLY: '1', MARKETING_HOST: 'example.org' }), null);
+});
+
+test('resolveDashboardHref: relative today and on app-only; app origin on a split host', () => {
+  assert.equal(resolveDashboardHref({}), '/dashboard');
+  assert.equal(resolveDashboardHref({ APP_ONLY: '1', APP_HOST: 'app.example.org' }), '/dashboard');
+  assert.equal(
+    resolveDashboardHref({ APP_HOST: 'app.example.org' }),
+    'https://app.example.org/dashboard',
+  );
+  assert.equal(
+    resolveDashboardHref({ APP_HOST: 'http://localhost:3000' }),
+    'http://localhost:3000/dashboard',
+  );
+});
+
+test('resolveAppOrigin: null without APP_HOST, https for bare hosts, scheme honored', () => {
+  assert.equal(resolveAppOrigin({}), null);
+  assert.equal(resolveAppOrigin({ APP_HOST: 'app.example.org' }), 'https://app.example.org');
+  assert.equal(resolveAppOrigin({ APP_HOST: 'http://localhost:3000/' }), 'http://localhost:3000');
+});
+
+test('originFromHostValue trims and never emits a trailing slash', () => {
+  assert.equal(originFromHostValue('  app.example.org  '), 'https://app.example.org');
+  assert.equal(originFromHostValue('https://app.example.org///'), 'https://app.example.org');
+  assert.equal(originFromHostValue(''), null);
+  assert.equal(originFromHostValue(undefined), null);
+});

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -14,7 +14,7 @@
  * Configuration (all optional; host names are env-driven, never literals):
  *
  * - `APP_HOST` — the host that serves the gated `(app)` surface. On it,
- *   `/` redirects to `/dashboard` (interim — see APP_ROOT_ACTION), the
+ *   `/` redirects to `/evidence` (interim — see APP_ROOT_ACTION), the
  *   marketing routes 404, and the full `(app)` group serves.
  * - `MARKETING_HOST` — the host that serves the marketing face and the
  *   public evidence registry. On it, the app-private routes

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -1,0 +1,291 @@
+/**
+ * Host-topology routing (app front-door v0.1.0, P3).
+ *
+ * Pure decision logic for which routes each HOST serves. `src/middleware.ts`
+ * is a thin adapter over `decideRoute`; everything testable lives here, with
+ * no Next.js imports so the module runs under `node --test` and in the edge
+ * runtime alike.
+ *
+ * THE SEAM CONVENTION (rule zero): with none of the three variables below
+ * set, every request passes through untouched — no withholding, no
+ * rewrites, anywhere. An instance that has never heard of host topology
+ * behaves exactly as before this module existed.
+ *
+ * Configuration (all optional; host names are env-driven, never literals):
+ *
+ * - `APP_HOST` — the host that serves the gated `(app)` surface. On it,
+ *   `/` redirects to `/dashboard` (interim — see APP_ROOT_ACTION), the
+ *   marketing routes 404, and the full `(app)` group serves.
+ * - `MARKETING_HOST` — the host that serves the marketing face and the
+ *   public evidence registry. On it, the app-private routes
+ *   (`/dashboard`, `/auth/device`, `/dev/notebook-preview`) 404;
+ *   everything else serves byte-identically to a single-host deployment.
+ * - `APP_ONLY` — `1`/`true`: a single-host instance that deploys ONLY the
+ *   gated surface (no marketing site). Every request, on every host, gets
+ *   the app role; `APP_HOST`/`MARKETING_HOST` are ignored.
+ *
+ * Roles are claimed EXPLICITLY: a request on a host that matches neither
+ * variable (a preview deployment, a health check by IP, a not-yet-flipped
+ * alias) passes through — today's behavior, on purpose. Withholding is
+ * topology, not security: the access gate is sign-in
+ * (`SIGN_IN_ALLOWLIST`), and routes keep enforcing their own sessions.
+ *
+ * Deliberately DUAL-SERVED either way: `/evidence` and `/evidence/[slug]`
+ * (public product surface — published URLs must keep resolving on the
+ * marketing host; their `(app)` group placement is structural, not an
+ * access classification), the whole `/api/*` family, `_next`, and static
+ * assets.
+ *
+ * Host matching mirrors `api-auth.ts`'s origin normalization:
+ * case-insensitive, port-insensitive, and `www.`-insensitive — the
+ * production deployment 307-redirects apex → www for GET, so browsers land
+ * on `www.` even when the configured host is the apex.
+ */
+
+/** What a request's host entitles it to. */
+export type HostRole = 'app' | 'marketing' | 'passthrough';
+
+/** Parsed host-topology configuration (see module doc). */
+export interface HostRoutingConfig {
+  /** Normalized `APP_HOST`, or null when unset. */
+  appHost: string | null;
+  /** Normalized `MARKETING_HOST`, or null when unset. */
+  marketingHost: string | null;
+  /** `APP_ONLY` flag. */
+  appOnly: boolean;
+}
+
+/**
+ * The action the middleware should take for one request.
+ * - `serve`    — pass through untouched (NextResponse.next()).
+ * - `withhold` — 404: rewrite to a path no route claims, so the standard
+ *                not-found page renders and the response status is 404 —
+ *                indistinguishable from a route that does not exist.
+ * - `redirect` — temporary (307) redirect to `destination`.
+ */
+export type RouteAction =
+  | { kind: 'serve' }
+  | { kind: 'withhold' }
+  | { kind: 'redirect'; destination: string };
+
+const SERVE: RouteAction = { kind: 'serve' };
+const WITHHOLD: RouteAction = { kind: 'withhold' };
+
+/**
+ * What the app host serves at `/`. P4 claims `/` for the signed-in query
+ * mount; until then, a temporary redirect into the `(app)` group so the
+ * root is never a marketing page on the gated surface. P4's change is this
+ * one constant (e.g. swap in a rewrite once an `(app)` route owns the
+ * mount). 307, not 308: browsers cache permanent redirects; this is not one.
+ *
+ * `/evidence`, NOT `/dashboard`, and the choice is load-bearing: the
+ * dashboard bounces signed-out visitors back to `/` (`redirect('/')` in
+ * dashboard/page.tsx), so `/` → `/dashboard` would be a redirect LOOP for
+ * anyone without a valid session — every anonymous visitor, and every
+ * returning visitor after a NEXTAUTH_SECRET rotation. The evidence index
+ * never redirects, serves publicly on the app surface by design, and a
+ * signed-in visitor gets the AppChrome strip there with Dashboard one
+ * click away.
+ */
+const APP_ROOT_ACTION: RouteAction = { kind: 'redirect', destination: '/evidence' };
+
+/**
+ * Route classes, matched by first path segment(s). Derived from the route
+ * groups under `src/app/` — verify against the filesystem when adding a
+ * page. Paths not listed anywhere (public files like `/bpmn/*`, unknown
+ * URLs) are unclassified and always pass through: unknown URLs 404
+ * naturally, and static assets serve on both hosts by design.
+ */
+export const MARKETING_PATHS = [
+  '/about',
+  '/directory',
+  '/explore',
+  '/learn',
+  '/project',
+  '/roadmap',
+] as const;
+
+/** The `(app)`-private routes the marketing host withholds. */
+export const APP_PRIVATE_PATHS = [
+  '/dashboard',
+  '/auth/device',
+  '/dev/notebook-preview',
+] as const;
+
+/** Public product surface served on BOTH hosts (owner-decided; see module doc). */
+export const DUAL_SERVED_PATHS = ['/evidence'] as const;
+
+export type PathClass = 'root' | 'marketing' | 'app-private' | 'dual-served' | 'other';
+
+/** True when `pathname` is `prefix` itself or nested under it. */
+function underPath(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+/** Classify a pathname into the route classes above. Pure. */
+export function classifyPath(pathname: string): PathClass {
+  if (pathname === '/') return 'root';
+  if (APP_PRIVATE_PATHS.some((p) => underPath(pathname, p))) return 'app-private';
+  if (MARKETING_PATHS.some((p) => underPath(pathname, p))) return 'marketing';
+  if (DUAL_SERVED_PATHS.some((p) => underPath(pathname, p))) return 'dual-served';
+  return 'other';
+}
+
+/**
+ * Normalize a host for comparison: lowercase, scheme/path/port stripped,
+ * leading `www.` and trailing dot dropped. Accepts a bare hostname
+ * (recommended), a `host:port`, or a full origin — so the same variable
+ * value works for matching and for origin construction (below). Returns
+ * null for unset/empty input.
+ */
+export function normalizeHost(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  let host = raw.trim().toLowerCase();
+  if (host.length === 0) return null;
+  // Strip a scheme if a full origin was supplied.
+  host = host.replace(/^[a-z][a-z0-9+.-]*:\/\//, '');
+  // Strip any path/query suffix.
+  host = host.split('/')[0].split('?')[0];
+  // Strip the port — bracketed IPv6 first, then host:port.
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']');
+    if (end !== -1) host = host.slice(0, end + 1);
+  } else {
+    host = host.split(':')[0];
+  }
+  // www-insensitive, matching api-auth.ts isSameOrigin.
+  host = host.replace(/^www\./, '').replace(/\.$/, '');
+  return host.length > 0 ? host : null;
+}
+
+/** `1`/`true` (any case, trimmed) is on; anything else — including unset — is off. */
+export function parseBooleanFlag(raw: string | null | undefined): boolean {
+  if (typeof raw !== 'string') return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true';
+}
+
+/**
+ * Read the host-topology configuration from an env record. Takes the record
+ * as an argument (never `process.env` directly) so tests can pass fixtures.
+ */
+export function readHostRoutingConfig(
+  env: Record<string, string | undefined>,
+): HostRoutingConfig {
+  return {
+    appHost: normalizeHost(env.APP_HOST),
+    marketingHost: normalizeHost(env.MARKETING_HOST),
+    appOnly: parseBooleanFlag(env.APP_ONLY),
+  };
+}
+
+/**
+ * Which role does this request's host get?
+ *
+ * Precedence: `APP_ONLY` beats host matching; `APP_HOST` beats
+ * `MARKETING_HOST` if both are (mis)configured to the same value; a host
+ * matching neither is `passthrough` — today's behavior, so previews and
+ * unnamed aliases are never withheld from.
+ */
+export function resolveHostRole(
+  rawHost: string | null | undefined,
+  config: HostRoutingConfig,
+): HostRole {
+  if (config.appOnly) return 'app';
+  const host = normalizeHost(rawHost);
+  if (host === null) return 'passthrough';
+  if (config.appHost !== null && host === config.appHost) return 'app';
+  if (config.marketingHost !== null && host === config.marketingHost) return 'marketing';
+  return 'passthrough';
+}
+
+/**
+ * THE decision function: (host, pathname, config) → action. Pure; the
+ * middleware adapter contributes nothing but the translation to
+ * NextResponse. See the module doc for the full behavior matrix.
+ */
+export function decideRoute(
+  rawHost: string | null | undefined,
+  pathname: string,
+  config: HostRoutingConfig,
+): RouteAction {
+  const role = resolveHostRole(rawHost, config);
+  if (role === 'passthrough') return SERVE;
+
+  const pathClass = classifyPath(pathname);
+
+  if (role === 'marketing') {
+    // The marketing host serves everything it serves today EXCEPT the
+    // app-private routes. Root, marketing pages, evidence, and everything
+    // unclassified are untouched — the apex demo stays byte-identical.
+    return pathClass === 'app-private' ? WITHHOLD : SERVE;
+  }
+
+  // role === 'app': the gated surface. No marketing face here.
+  switch (pathClass) {
+    case 'root':
+      return APP_ROOT_ACTION;
+    case 'marketing':
+      return WITHHOLD;
+    default:
+      // app-private, dual-served evidence, and unclassified (assets, API
+      // under a non-excluded matcher miss, unknown URLs → natural 404).
+      return SERVE;
+  }
+}
+
+/**
+ * Build an origin (`https://host`) from a host-shaped env value. A value
+ * already carrying a scheme is honored as given (trailing slash trimmed) —
+ * that is how a dev instance says `http://localhost:3000`; a bare host gets
+ * `https://`. Null for unset/empty.
+ */
+export function originFromHostValue(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  const value = raw.trim();
+  if (value.length === 0) return null;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value.replace(/\/+$/, '');
+  return `https://${value.replace(/\/+$/, '')}`;
+}
+
+/**
+ * Origin of the gated app surface, or null when no split-host topology is
+ * configured. Used by URL builders that must point AT the app surface —
+ * e.g. the device-flow pairing URL, whose `/auth/device` page is withheld
+ * on the marketing host once `MARKETING_HOST` is set.
+ */
+export function resolveAppOrigin(env: Record<string, string | undefined>): string | null {
+  return originFromHostValue(env.APP_HOST);
+}
+
+/**
+ * Where the site header's Dashboard links should point. The header renders
+ * on EVERY page — including the marketing host, where `/dashboard` is
+ * withheld once a split topology is configured — so on a split-host
+ * deployment the link must carry the app origin. Relative everywhere else:
+ * unset topology is today's exact href, and an app-only instance serves
+ * the dashboard on whatever host the request came in on.
+ */
+export function resolveDashboardHref(env: Record<string, string | undefined>): string {
+  if (parseBooleanFlag(env.APP_ONLY)) return '/dashboard';
+  const appOrigin = resolveAppOrigin(env);
+  return appOrigin !== null ? `${appOrigin}/dashboard` : '/dashboard';
+}
+
+/**
+ * Where the app surface's "Public site" affordances should point (the
+ * `AppChrome` exit link):
+ * - app-only instance → null: there IS no public marketing site — hide the
+ *   affordance rather than link a gated user to a 404 or back to the
+ *   dashboard.
+ * - split-host → the marketing origin.
+ * - no topology configured → `/` (today's relative link, byte-identical).
+ */
+export function resolvePublicSiteHref(
+  env: Record<string, string | undefined>,
+): string | null {
+  if (parseBooleanFlag(env.APP_ONLY)) return null;
+  const marketingOrigin = originFromHostValue(env.MARKETING_HOST);
+  if (marketingOrigin !== null) return marketingOrigin;
+  return '/';
+}

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -1,7 +1,7 @@
 /**
  * Host-topology routing (app front-door v0.1.0, P3).
  *
- * Pure decision logic for which routes each HOST serves. `src/middleware.ts`
+ * Pure decision logic for which routes each HOST serves. `src/proxy.ts`
  * is a thin adapter over `decideRoute`; everything testable lives here, with
  * no Next.js imports so the module runs under `node --test` and in the edge
  * runtime alike.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { decideRoute, readHostRoutingConfig } from '@/lib/host-routing';
+
+/**
+ * Host-topology routing proxy (app front-door v0.1.0, P3) — a thin
+ * adapter over the pure decision function in `src/lib/host-routing.ts`.
+ * All behavior (the role matrix, the withheld route list, the seam
+ * convention that unset config means untouched requests) is decided and
+ * unit-tested there; this file only translates a RouteAction into a
+ * NextResponse.
+ *
+ * `proxy.ts`, not `middleware.ts`: Next 16 renamed the request-
+ * interception file convention, and the old name emits a deprecation
+ * warning on every build. Same standard mechanism, current name.
+ *
+ * With none of APP_HOST / MARKETING_HOST / APP_ONLY set, every request
+ * resolves to `serve` and this proxy is a pass-through.
+ */
+export function proxy(request: NextRequest) {
+  const action = decideRoute(
+    // The raw Host header, not nextUrl.hostname: on hosted platforms the
+    // parsed URL can reflect the deployment's internal host rather than
+    // the one the visitor addressed.
+    request.headers.get('host'),
+    request.nextUrl.pathname,
+    readHostRoutingConfig(process.env),
+  );
+
+  switch (action.kind) {
+    case 'withhold':
+      // Rewrite to a path no route claims: Next renders the standard
+      // not-found page with a 404 status while the browser URL stays put —
+      // indistinguishable from a route that does not exist.
+      return NextResponse.rewrite(new URL('/404', request.url));
+    case 'redirect':
+      // Temporary on purpose (APP_ROOT_ACTION is an interim mount — P4
+      // claims the app root); browsers cache permanent redirects.
+      return NextResponse.redirect(new URL(action.destination, request.url), 307);
+    default:
+      return NextResponse.next();
+  }
+}
+
+export const config = {
+  /*
+   * Everything EXCEPT the surfaces that serve on every host regardless of
+   * topology and must never pay the middleware toll:
+   * - /api/*           — the full API family serves on both hosts
+   * - /_next/*         — build assets, image optimizer, RSC payloads
+   * - /.well-known/*   — the trust registry must resolve on every host
+   * - favicon.ico, robots.txt
+   *
+   * Public-folder files that still match (e.g. /bpmn/*, /talks/*, root
+   * SVGs) fall through decideRoute unclassified and are served unchanged —
+   * the matcher is an optimization, the function is the authority.
+   */
+  matcher: ['/((?!api/|_next/|\\.well-known/|favicon\\.ico|robots\\.txt).*)'],
+};


### PR DESCRIPTION
Phase 3 of the app-front-door v0.1.0 sprint (#191): host-aware routing. A pure decision core (`src/lib/host-routing.ts`) with `src/proxy.ts` as a thin adapter — host names env-driven, never literals; with none of the new variables set, the proxy is a pass-through and every request behaves exactly as before this phase.

## The matrix (contract amendments 1 + 2 applied)

- **`MARKETING_HOST`** serves the marketing face plus the public evidence registry byte-identically to today, and 404s the app-private routes (`/dashboard`, `/auth/device`, `/dev/notebook-preview`) via rewrite to the standard not-found page — indistinguishable from a nonexistent route.
- **`APP_HOST`** serves the full `(app)` group; marketing routes 404; `/` 307s to `/evidence` (interim `APP_ROOT_ACTION` seam — P4 claims the app root; `/dashboard` was rejected after discovering its signed-out `redirect('/')` makes a loop).
- **`APP_ONLY=1`** (amendment 1): a single-host instance serving only the gated surface, on any host — designed and tested, not emergent; nothing references the marketing group.
- Hosts matching neither variable pass through untouched (previews stay whole; roles are claimed, never assumed). Matching is case-, port-, and www-insensitive. `/api/*`, `_next`, `.well-known`, and public files serve on every host.

## Also in scope

- `AppChrome` "Public site" link server-resolved: `/` unset, the marketing origin on split-host, hidden on app-only.
- Device-flow pairing URLs now prefer the app origin (`/auth/device` is withheld on the marketing host); Header dashboard links threaded through `resolveDashboardHref`.
- Env single-authority rider: the trio in the preflight inventory (`optional` + `hasFallback` — unset reproduces pre-P3 behavior exactly), `docs/deploy.md` "Host topology (optional)" section, env-example entries in an owner-run follow-up commit on this branch.

`proxy.ts`, not `middleware.ts`: Next 16 renamed the interception convention and the old name emits a deprecation warning on every build.

## Evidence

- 26 new matrix tests in `host-routing.test.ts` (unset/split/app-only × every route class × multiple hosts, precedence, normalization, prefix-collision guards). Suite 483/483; preflight 30/30; lint 0 errors; build clean with `ƒ Proxy (Middleware)` registered.
- Live three-configuration dev-server smoke with `Host:` headers: apex serving `/` + `/evidence` and 404ing app-private; app host 307ing `/` → `/evidence` and 404ing marketing; unset config identical to today on every host.

Flagged follow-ons (not in scope): `api-auth.ts` same-origin check vs `NEXTAUTH_URL` on split hosts; which host owns sign-in (owner decision at the DNS gate); the marketing header's links when rendered on the app host (P4 question).

Part of #191. IMPL ran on Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
