### PR TITLE
App front-door P4: the (app) query mount at /ask in signed-in configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,9 @@ Each page has a distinct purpose. Use this framing to decide where new features 
 | **Directory** | `/directory` | MCP-server inventory | "What sources can I connect to?" |
 | **Roadmap** | `/roadmap` | Plans + commitments | "Where is this project going?" |
 | **Dashboard** | `/dashboard` | The user's own publishes | "Manage my evidence" |
+| **Ask** | `/ask` | The query form (signed-in) | "Answer a question against live data and publish it" |
+
+`/ask` is the signed-in query mount (app front-door v0.1.0): the same shared `QuerySurface` as home, in signed-in configuration — app-private in the host topology (`src/lib/host-routing.ts`), so it 404s on the marketing host and is where the app host's `/` redirects.
 
 (`/auth/device` is the device-flow pairing screen; `/dev/notebook-preview` is a dev-only preview harness, not user-facing.)
 
@@ -238,7 +241,7 @@ KV_REST_API_READ_ONLY_TOKEN=
 Deliberately a short orientation, not an exhaustive tree — the tree drifted badly once already. Verify against the filesystem when precision matters.
 
 - `src/app/(marketing)/` — the public pages: home (`page.tsx`), `/explore`, `/directory`, `/learn`, `/project`, `/about`, `/roadmap`
-- `src/app/(app)/` — dashboard, evidence, and auth surfaces: `/dashboard`, `/evidence`, `/auth/device`, plus the dev-only `/dev/notebook-preview`
+- `src/app/(app)/` — dashboard, evidence, auth, and the signed-in query surfaces: `/dashboard`, `/evidence`, `/ask`, `/auth/device`, plus the dev-only `/dev/notebook-preview`
 - `src/app/api/` — serverless routes: `compare`, `compare-stream`, `models`, `rate-limit`, `query-notebook`, plus the `evidence/*`, `blob/*`, `cron/*`, and `auth/*` route families
 - `src/lib/` — the major areas:
   - `evidence/` — evidence-system core: packaging, signing, verification, provenance, attestation, lifecycle
@@ -321,7 +324,8 @@ The `McpResponseDisplay` shared component is the canonical example — both `Res
 
 ### Prop threading for context
 Query text, progress state, and tool call data are threaded from page → wrapper → panel → shared component. Follow the existing prop chains when adding new data:
-- Home: `page.tsx → ComparisonDisplay → ResponsePanel → McpResponseDisplay`
+- Home: `page.tsx → QuerySurface → ComparisonDisplay → ResponsePanel → McpResponseDisplay`
+- Ask: `(app)/ask/page.tsx → QuerySurface → …` (same chain as home from `QuerySurface` down)
 - Explore: `McpFlowDiagram → LiveResponsePanel → McpResponseDisplay`
 
 ### styled-jsx for component-scoped CSS

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -503,8 +503,8 @@ The decision logic lives in `src/lib/host-routing.ts` (unit-tested;
 
 | Variable | Meaning |
 | --- | --- |
-| `APP_HOST` | The host that serves the gated app surface. On it, `/` temporarily redirects to `/evidence` (a later release mounts the signed-in query surface at `/`; the dashboard is not the target because it bounces signed-out visitors back to `/`, which would loop), the marketing pages return 404, and the dashboard, device pairing, and evidence routes all serve. |
-| `MARKETING_HOST` | The host that serves the public face. On it, the marketing pages and the public evidence registry serve exactly as on a single host, and the app-private routes — `/dashboard`, `/auth/device`, `/dev/notebook-preview` — return 404. |
+| `APP_HOST` | The host that serves the gated app surface. On it, `/` redirects (307) to `/ask` — the signed-in query surface — the marketing pages return 404, and `/ask`, the dashboard, device pairing, and evidence routes all serve. |
+| `MARKETING_HOST` | The host that serves the public face. On it, the marketing pages and the public evidence registry serve exactly as on a single host, and the app-private routes — `/ask`, `/dashboard`, `/auth/device`, `/dev/notebook-preview` — return 404. |
 | `APP_ONLY` | `1` or `true`: an app-only instance. Every request on every host gets the app-surface behavior above; `APP_HOST`/`MARKETING_HOST` are ignored. For operators deploying only the gated surface, with no marketing site. |
 
 Values are host names (`app.example.org`); a full origin
@@ -526,7 +526,9 @@ internalizing:
 - **Withholding is topology, not security.** The 404s shape which host
   presents which surface; access control is sign-in
   (`SIGN_IN_ALLOWLIST`) and the per-route session checks, which apply
-  identically on every host.
+  identically on every host. `/ask` is the visible case: a signed-out
+  visitor gets a sign-in prompt there rather than a redirect, on any
+  host that serves it.
 
 Two split-host interactions to plan for: `NEXTAUTH_URL` can point at
 only one host, and sessions are per-host cookies — decide which host

--- a/src/app/(app)/ask/AskSignInPanel.tsx
+++ b/src/app/(app)/ask/AskSignInPanel.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+
+/**
+ * The signed-out state of `/ask` — a prompt rendered IN PLACE, never a
+ * redirect (app front-door v0.1.0, P4).
+ *
+ * Why in place: on the app host `/` redirects here, and `/dashboard`
+ * bounces signed-out visitors to `/`. A page that redirect-bounced its own
+ * anonymous visitors would close that circle into a loop. Rendering the
+ * prompt terminates every chain in one 200.
+ *
+ * `signIn(undefined, …)` — no provider named — is deliberate. It hands the
+ * visitor to NextAuth's own sign-in page, which lists whatever providers
+ * the instance actually configured: GitHub on the reference deployment, an
+ * operator's own OIDC provider on an instance that set the OIDC triple and
+ * no GitHub credentials. Naming a provider here would be the same literal
+ * that made an OIDC-only instance render a dead button before #193, and
+ * the sprint's posture (P2's refusal to build a custom refusal page) is to
+ * lean on the built-in auth surface rather than grow a second one.
+ */
+export default function AskSignInPanel() {
+  return (
+    <div
+      style={{
+        padding: '20px',
+        border: '1px solid var(--border-color)',
+        borderRadius: '6px',
+      }}
+    >
+      <p style={{ fontSize: '14px', marginBottom: '16px', lineHeight: 1.5 }}>
+        Sign in to ask a question against live public data and publish the
+        result.
+      </p>
+      <button
+        onClick={() => signIn(undefined, { callbackUrl: '/ask' })}
+        className="nyc-button nyc-button-primary"
+        style={{ padding: '10px 18px', fontSize: '14px' }}
+      >
+        Sign in
+      </button>
+    </div>
+  );
+}

--- a/src/app/(app)/ask/page.tsx
+++ b/src/app/(app)/ask/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from 'next';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import QuerySurface from '@/components/shared/QuerySurface';
+import AskSignInPanel from './AskSignInPanel';
+
+/**
+ * `/ask` — the query surface in signed-in configuration (app front-door
+ * v0.1.0, P4). The app surface's front door: `APP_HOST`'s `/` redirects
+ * here, and `src/lib/host-routing.ts` classifies the path as app-private,
+ * so it serves on the app host, 404s on the marketing host, and — with no
+ * host topology configured — serves anywhere, like every other route.
+ *
+ * THE SAME SURFACE, NOT A SECOND ONE. The form, both streaming modes, and
+ * everything they produce come from `QuerySurface`, the component P1
+ * extracted from the apex demo. This page contributes framing and
+ * configuration only. What differs from the apex mount is what
+ * configuration means here:
+ *
+ *   - APP-TIER LIMITS, with nothing wired for them. `selectLimit()` (P2)
+ *     already applies the app tier to an authenticated request on a gated
+ *     instance, server-side, from the session — no host or surface hint
+ *     travels from this page, and none should. The quota the form's
+ *     rate-limit line shows after the first query is whatever the server
+ *     selected, so on a gated instance it reads the app tier here already.
+ *   - PUBLISH AFFORDANCES, likewise already present: publishing is offered
+ *     by `McpResponseDisplay` on a completed, tool-grounded result to a
+ *     visitor with a session. Every visitor who reaches the surface below
+ *     has one.
+ *   - NO MARKETING FRAMING. No positioning band, no "go set it up locally"
+ *     call to action, and `showLocalSetupFootnote={false}` suppresses the
+ *     one piece of that framing living inside the shared component.
+ *
+ * SIGNED OUT RENDERS A PROMPT, NOT A REDIRECT — see AskSignInPanel for why
+ * a redirect here would close a loop. This is not the access gate either:
+ * the gate is at sign-in (`SIGN_IN_ALLOWLIST`), and an off-list account
+ * never gets a session to arrive with.
+ */
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Ask - Civic AI Tools',
+  description:
+    'Ask a question about public data and publish the answer as a signed evidence package.',
+};
+
+export default async function AskPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    return (
+      <div style={{ maxWidth: '520px', margin: '0 auto', padding: '48px 24px 64px' }}>
+        <h1 style={{ fontSize: '24px', fontWeight: 700, marginBottom: '8px' }}>
+          Ask a question
+        </h1>
+        <p
+          style={{
+            fontSize: '14px',
+            color: 'var(--text-muted)',
+            marginBottom: '24px',
+            lineHeight: 1.5,
+          }}
+        >
+          This is the signed-in workspace: ask a question in plain language,
+          get an answer built from live public data, and publish it as a
+          signed evidence package anyone can verify independently.
+        </p>
+        <AskSignInPanel />
+      </div>
+    );
+  }
+
+  return (
+    <QuerySurface showLocalSetupFootnote={false}>
+      <div style={{ marginBottom: '24px' }}>
+        <h1 style={{ fontSize: '28px', fontWeight: 700, marginBottom: '8px' }}>
+          Ask a question
+        </h1>
+        <p
+          style={{
+            fontSize: '15px',
+            lineHeight: '160%',
+            color: 'var(--text-secondary)',
+            maxWidth: '650px',
+          }}
+        >
+          Ask in plain language. The answer is built from live public data, and
+          you can publish it as a signed evidence package anyone can verify
+          independently.
+        </p>
+      </div>
+    </QuerySurface>
+  );
+}

--- a/src/components/shared/QuerySurface.tsx
+++ b/src/components/shared/QuerySurface.tsx
@@ -25,9 +25,25 @@ import { useNotebookStream } from '@/hooks/useNotebookStream';
 interface QuerySurfaceProps {
   /** Framing content rendered above the form, inside its container. */
   children?: React.ReactNode;
+  /**
+   * Whether to close a completed comparison with the footnote suggesting the
+   * reader run the tools locally for complex multi-step analysis.
+   *
+   * Default `true` — the apex demo's existing behavior, unchanged and
+   * unconfigured (the marketing page passes nothing). The signed-in `(app)`
+   * mount passes `false`: there, the footnote would send a user who just
+   * signed in to the surface built for exactly this work somewhere else to
+   * do it, and the limit it implicitly apologizes for is the app tier, not
+   * the demo's. On the apex the footnote is honest — that surface IS the
+   * rate-limited demo, and pointing past it is the point.
+   */
+  showLocalSetupFootnote?: boolean;
 }
 
-export default function QuerySurface({ children }: QuerySurfaceProps) {
+export default function QuerySurface({
+  children,
+  showLocalSetupFootnote = true,
+}: QuerySurfaceProps) {
   const [queryCount, setQueryCount] = useState(0);
   const [usedModel, setUsedModel] = useState<string>('');
   const [lastQuery, setLastQuery] = useState<string>('');
@@ -132,7 +148,7 @@ export default function QuerySurface({ children }: QuerySurfaceProps) {
             onPublishDialogChange={setPublishDialogOpen}
             onContinue={handleContinue}
           />
-          {(streaming.withoutMcp.isComplete && streaming.withMcp.isComplete) && (
+          {showLocalSetupFootnote && (streaming.withoutMcp.isComplete && streaming.withMcp.isComplete) && (
             <p
               style={{
                 marginTop: '16px',

--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -22,6 +22,7 @@ import {
   resolveHostRole,
   resolvePublicSiteHref,
   APP_PRIVATE_PATHS,
+  APP_ROOT_ACTION,
   MARKETING_PATHS,
 } from './host-routing.ts';
 
@@ -37,7 +38,7 @@ const UNSET = readHostRoutingConfig({});
 // One representative per route class, plus depth and edge variants.
 const ROOT = '/';
 const MARKETING_SAMPLES = ['/about', '/explore', '/learn', '/project', '/roadmap', '/directory', '/explore/deep/link'];
-const APP_PRIVATE_SAMPLES = ['/dashboard', '/dashboard/settings', '/auth/device', '/dev/notebook-preview'];
+const APP_PRIVATE_SAMPLES = ['/ask', '/dashboard', '/dashboard/settings', '/auth/device', '/dev/notebook-preview'];
 const DUAL_SAMPLES = ['/evidence', '/evidence/some-published-slug'];
 const OTHER_SAMPLES = [
   '/api/rate-limit', // matcher-excluded in prod, but the function must serve it regardless
@@ -49,6 +50,7 @@ const OTHER_SAMPLES = [
   '/no-such-page',
   '/authors', // prefix-collision guard: not /auth/device
   '/dashboard-widgets', // prefix-collision guard: not /dashboard
+  '/asked', // prefix-collision guard: not /ask
 ];
 const EVERY_PATH = [ROOT, ...MARKETING_SAMPLES, ...APP_PRIVATE_SAMPLES, ...DUAL_SAMPLES, ...OTHER_SAMPLES];
 
@@ -90,13 +92,51 @@ test('split: every declared app-private prefix is withheld on the marketing host
 
 // --- Split-host: the app host -------------------------------------------------
 
-test('split: the app host redirects / into the app group (interim P4 seam)', () => {
-  // /evidence, not /dashboard: the dashboard bounces signed-out visitors
-  // back to /, so /dashboard here would loop for anyone without a session.
+test('split: the app host redirects / to the signed-in query mount', () => {
   assert.deepEqual(decideRoute('app.example.org', ROOT, SPLIT), {
     kind: 'redirect',
-    destination: '/evidence',
+    destination: '/ask',
   });
+});
+
+test('the app root redirect terminates: its destination is served on the app host', () => {
+  // Read the destination off the exported constant rather than repeating the
+  // literal, so this stays a PROPERTY of whatever the app root points at:
+  // wherever it points must be a path this same function serves there. The
+  // companion half of the no-loop argument — that the destination page does
+  // not itself redirect signed-out visitors — is the (app)/ask page's
+  // sign-in-prompt-in-place rendering, documented at both ends.
+  assert.equal(APP_ROOT_ACTION.kind, 'redirect');
+  const destination = APP_ROOT_ACTION.kind === 'redirect' ? APP_ROOT_ACTION.destination : '';
+  assert.deepEqual(decideRoute('app.example.org', destination, SPLIT), { kind: 'serve' });
+  assert.deepEqual(decideRoute('gated.example.net', destination, APP_ONLY), { kind: 'serve' });
+});
+
+test('signed-out chain on the app host terminates: /dashboard → / → /ask, no cycle', () => {
+  // The dashboard's own redirect('/') is the first hop (page-level, not this
+  // module's); the proxy contributes the second. Walking the routing half
+  // pins that it converges rather than cycling back to a redirect.
+  const hops: string[] = [];
+  let path = '/'; // where dashboard/page.tsx sends a session-less visitor
+  for (let i = 0; i < 5; i++) {
+    const action = decideRoute('app.example.org', path, SPLIT);
+    if (action.kind !== 'redirect') break;
+    path = action.destination;
+    hops.push(path);
+  }
+  assert.deepEqual(hops, ['/ask']); // exactly one proxy hop, then a served page
+  assert.deepEqual(decideRoute('app.example.org', path, SPLIT), { kind: 'serve' });
+});
+
+test('the query mount is app-private: served on the app host, withheld on the marketing host', () => {
+  assert.equal(classifyPath('/ask'), 'app-private');
+  assert.deepEqual(decideRoute('app.example.org', '/ask', SPLIT), { kind: 'serve' });
+  assert.deepEqual(decideRoute('example.org', '/ask', SPLIT), { kind: 'withhold' });
+  // ...and with no topology configured it serves everywhere, like every
+  // other route on a single-host instance.
+  for (const host of ['example.org', 'app.example.org', 'localhost:3000']) {
+    assert.deepEqual(decideRoute(host, '/ask', UNSET), { kind: 'serve' }, host);
+  }
 });
 
 test('split: the app host withholds every marketing route', () => {
@@ -141,7 +181,7 @@ test('APP_HOST alone: app role on that host, NO withholding anywhere else', () =
   const config = readHostRoutingConfig({ APP_HOST: 'app.example.org' });
   // The app host takes its role...
   assert.deepEqual(decideRoute('app.example.org', '/about', config), { kind: 'withhold' });
-  assert.deepEqual(decideRoute('app.example.org', '/', config), { kind: 'redirect', destination: '/evidence' });
+  assert.deepEqual(decideRoute('app.example.org', '/', config), { kind: 'redirect', destination: '/ask' });
   // ...and every other host keeps today's behavior — withholding on the
   // marketing face starts only when MARKETING_HOST is set (incremental
   // rollout: stand up the app host first, flip the apex second).
@@ -163,7 +203,8 @@ test('MARKETING_HOST alone: withholding on that host, all other hosts untouched'
 
 test('app-only: every host gets the app role', () => {
   for (const host of ['gated.example.net', 'preview-abc.vercel.app', 'localhost:3000']) {
-    assert.deepEqual(decideRoute(host, '/', APP_ONLY), { kind: 'redirect', destination: '/evidence' });
+    assert.deepEqual(decideRoute(host, '/', APP_ONLY), { kind: 'redirect', destination: '/ask' });
+    assert.deepEqual(decideRoute(host, '/ask', APP_ONLY), { kind: 'serve' });
     assert.deepEqual(decideRoute(host, '/dashboard', APP_ONLY), { kind: 'serve' });
     assert.deepEqual(decideRoute(host, '/auth/device', APP_ONLY), { kind: 'serve' });
     assert.deepEqual(decideRoute(host, '/evidence/some-slug', APP_ONLY), { kind: 'serve' });
@@ -240,6 +281,7 @@ test('classifyPath covers every declared prefix and resists prefix collisions', 
   assert.equal(classifyPath('/evidence/slug/extra'), 'dual-served');
   assert.equal(classifyPath('/aboutus'), 'other');
   assert.equal(classifyPath('/dashboard-widgets'), 'other');
+  assert.equal(classifyPath('/asked'), 'other');
   assert.equal(classifyPath('/auth'), 'other'); // no page lives at /auth itself
   assert.equal(classifyPath('/auth/device/extra'), 'app-private');
 });

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -14,11 +14,11 @@
  * Configuration (all optional; host names are env-driven, never literals):
  *
  * - `APP_HOST` — the host that serves the gated `(app)` surface. On it,
- *   `/` redirects to `/evidence` (interim — see APP_ROOT_ACTION), the
- *   marketing routes 404, and the full `(app)` group serves.
+ *   `/` redirects to the query surface at `/ask` (see APP_ROOT_ACTION),
+ *   the marketing routes 404, and the full `(app)` group serves.
  * - `MARKETING_HOST` — the host that serves the marketing face and the
  *   public evidence registry. On it, the app-private routes
- *   (`/dashboard`, `/auth/device`, `/dev/notebook-preview`) 404;
+ *   (`/ask`, `/dashboard`, `/auth/device`, `/dev/notebook-preview`) 404;
  *   everything else serves byte-identically to a single-host deployment.
  * - `APP_ONLY` — `1`/`true`: a single-host instance that deploys ONLY the
  *   gated surface (no marketing site). Every request, on every host, gets
@@ -72,22 +72,34 @@ const SERVE: RouteAction = { kind: 'serve' };
 const WITHHOLD: RouteAction = { kind: 'withhold' };
 
 /**
- * What the app host serves at `/`. P4 claims `/` for the signed-in query
- * mount; until then, a temporary redirect into the `(app)` group so the
- * root is never a marketing page on the gated surface. P4's change is this
- * one constant (e.g. swap in a rewrite once an `(app)` route owns the
- * mount). 307, not 308: browsers cache permanent redirects; this is not one.
+ * What the app host serves at `/` — the app surface's front door. P4
+ * claimed the seam P3 left here: the destination is now `/ask`, the
+ * signed-in query mount (`src/app/(app)/ask/page.tsx`), rather than P3's
+ * interim `/evidence`.
  *
- * `/evidence`, NOT `/dashboard`, and the choice is load-bearing: the
- * dashboard bounces signed-out visitors back to `/` (`redirect('/')` in
- * dashboard/page.tsx), so `/` → `/dashboard` would be a redirect LOOP for
- * anyone without a valid session — every anonymous visitor, and every
- * returning visitor after a NEXTAUTH_SECRET rotation. The evidence index
- * never redirects, serves publicly on the app surface by design, and a
- * signed-in visitor gets the AppChrome strip there with Dashboard one
- * click away.
+ * REDIRECT, NOT REWRITE, and the reasoning is recorded because both were
+ * available. A rewrite would make `/` itself BE the query surface, which
+ * reads well in a URL bar; it would also give the same content two
+ * addresses on the same host (`/` and `/ask`), invisibly — nothing in the
+ * response says the proxy substituted a route, so "why does the root
+ * render the query page?" becomes unanswerable without reading this file.
+ * A redirect is one visible hop (`curl -I` shows it), leaves exactly one
+ * canonical URL for the surface, needs no new RouteAction kind, and keeps
+ * the proxy adapter untouched. 307, not 308: browsers cache permanent
+ * redirects; this is not one.
+ *
+ * NO LOOP, and the property is load-bearing rather than incidental. The
+ * destination must be a path this same function SERVES on the app host,
+ * and whose page does not itself redirect a signed-out visitor. `/ask`
+ * satisfies both: it is app-private (served here, withheld on the
+ * marketing host), and it renders a sign-in prompt in place for anonymous
+ * visitors instead of bouncing them. That is why the target is not
+ * `/dashboard` — the dashboard does `redirect('/')` without a session, so
+ * `/` → `/dashboard` → `/` would loop for every anonymous visitor. The
+ * signed-out chain on the app host now terminates in one render:
+ * `/dashboard` → `/` → `/ask` → sign-in prompt (200).
  */
-const APP_ROOT_ACTION: RouteAction = { kind: 'redirect', destination: '/evidence' };
+export const APP_ROOT_ACTION: RouteAction = { kind: 'redirect', destination: '/ask' };
 
 /**
  * Route classes, matched by first path segment(s). Derived from the route
@@ -105,8 +117,16 @@ export const MARKETING_PATHS = [
   '/roadmap',
 ] as const;
 
-/** The `(app)`-private routes the marketing host withholds. */
+/**
+ * The `(app)`-private routes the marketing host withholds.
+ *
+ * `/ask` is the signed-in query mount (P4). It is app-private rather than
+ * dual-served because the apex already has its own query surface at `/` in
+ * anonymous demo configuration — a second, signed-in copy of it on the
+ * public face would be two front doors to the same thing.
+ */
 export const APP_PRIVATE_PATHS = [
+  '/ask',
   '/dashboard',
   '/auth/device',
   '/dev/notebook-preview',

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -33,8 +33,9 @@ export function proxy(request: NextRequest) {
       // indistinguishable from a route that does not exist.
       return NextResponse.rewrite(new URL('/404', request.url));
     case 'redirect':
-      // Temporary on purpose (APP_ROOT_ACTION is an interim mount — P4
-      // claims the app root); browsers cache permanent redirects.
+      // Temporary on purpose: where the app root points is a product
+      // decision (APP_ROOT_ACTION), and browsers cache permanent redirects
+      // past the point where changing it would take effect.
       return NextResponse.redirect(new URL(action.destination, request.url), 307);
     default:
       return NextResponse.next();


### PR DESCRIPTION
Phase 4 — the final phase — of the app-front-door v0.1.0 sprint (#191): the shared `QuerySurface` mounted inside `(app)` at `/ask`, in signed-in configuration. The apex is zero-diff: `(marketing)/` untouched, and the one `QuerySurface` change is inert by construction for the existing mount. No new env variables.

## Decisions (recorded in the code)

- **`/ask`** — user language (the verb the visitor is there to do), classified app-private in `host-routing.ts`: serves on the app host, 404s on the marketing host (byte-identical to a nonexistent route), serves everywhere when topology is unset.
- **`APP_ROOT_ACTION` repointed:** app-host `/` now 307s to `/ask`. Redirect over rewrite — one visible hop, one canonical URL, no new action kind.
- **Signed-out renders a sign-in prompt in place — no redirect.** `/dashboard` bounces session-less visitors to `/`, and app-host `/` points here; a bouncing page would close that loop. The chain `/dashboard → / → /ask → 200` is enumerated in the smoke and pinned by a bounded-loop test.
- **`signIn(undefined, …)`** — no provider literal; NextAuth lists whatever the instance configured (the #193 principle).
- **One prop grown: `showLocalSetupFootnote`** (default `true`, marketing page passes nothing — literally identical expression). The signed-in mount passes `false`: the "run it locally" footnote apologizes for the demo's limits, not the app tier's.
- **App-tier limits and publish affordances: nothing wired, deliberately.** `selectLimit()` (P2) already applies the app tier server-side from the session; `McpResponseDisplay` already offers publish to a session-holder; the rate-limit line already shows the server-selected quota.

Also carries the deferred P1 CLAUDE.md doc pass, unblocked now that the component's shape is final (IA row, prop-threading chains, orientation line).

## Evidence

- 486/486 tests (3 new: app-root destination is served, signed-out chain terminates with exactly one proxy hop, `/ask` is app-private; plus `/asked` prefix-collision guard), preflight 30/30, lint 0 errors, build clean with `ƒ /ask` registered.
- Four-configuration dev-server smoke with `Host:` headers: unset (everything serves, `/ask` included), split (marketing host 404s `/ask`; app host `/` 307 → `/ask` 200; P3 matrix rows hold), signed-out chain hop-by-hop, `APP_ONLY=1` (amendment 1's leg holds).
- Apex zero-diff: normalized DOM md5-identical to `main`; the raw HTML's only difference is the per-render router id.

Flagged follow-ons (filed at G1): an "Ask" link in `AppChrome` (needs the env-driven-origin treatment — it renders on the dual-served evidence pages), marketing-bound links inside shared components on the app host, `RateLimitBanner`/`DeviceSignInPanel`/`Header` provider-and-copy literals.

Part of #191. IMPL ran on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
