### PR TITLE
App front-door P4b: name the provider — fix the /ask sign-in loop

### DIFF
--- a/src/app/(app)/ask/AskSignInPanel.tsx
+++ b/src/app/(app)/ask/AskSignInPanel.tsx
@@ -1,26 +1,41 @@
 'use client';
 
 import { signIn } from 'next-auth/react';
+import type { SignInOption } from '@/lib/auth-provider-options';
 
 /**
  * The signed-out state of `/ask` — a prompt rendered IN PLACE, never a
- * redirect (app front-door v0.1.0, P4).
+ * redirect (app front-door v0.1.0, P4; provider derivation added in P4b).
  *
- * Why in place: on the app host `/` redirects here, and `/dashboard`
+ * WHY IN PLACE: on the app host `/` redirects here, and `/dashboard`
  * bounces signed-out visitors to `/`. A page that redirect-bounced its own
  * anonymous visitors would close that circle into a loop. Rendering the
  * prompt terminates every chain in one 200.
  *
- * `signIn(undefined, …)` — no provider named — is deliberate. It hands the
- * visitor to NextAuth's own sign-in page, which lists whatever providers
- * the instance actually configured: GitHub on the reference deployment, an
- * operator's own OIDC provider on an instance that set the OIDC triple and
- * no GitHub credentials. Naming a provider here would be the same literal
- * that made an OIDC-only instance render a dead button before #193, and
- * the sprint's posture (P2's refusal to build a custom refusal page) is to
- * lean on the built-in auth surface rather than grow a second one.
+ * WHY EVERY BUTTON NAMES ITS PROVIDER. `signIn(id)` goes straight to that
+ * provider's authorize flow. `signIn()` with no id goes to the instance's
+ * configured sign-in page — and on this instance `authOptions.pages.signIn`
+ * is `/`, which the proxy redirects back to `/ask` on the app host. The
+ * un-named call therefore looped silently: click, land back on the same
+ * page, still signed out. P4 shipped that call believing it reached
+ * NextAuth's default provider-list page; the `pages` override makes that
+ * page unreachable. Naming the provider is not a workaround for the
+ * override, it is the fix that makes the loop structurally impossible —
+ * the authorize redirect leaves the site entirely.
+ *
+ * WHY THE LIST IS A PROP, not a fetch. `options` is derived on the server
+ * (the page calls `buildProviders()` → `toSignInOptions()`), so there is no
+ * loading state, no flash of a wrong or empty prompt, and no failure path
+ * where a request for `/api/auth/providers` fails and the visitor is left
+ * with no way in. It is also still not a hardcoded provider: an OIDC-only
+ * instance renders its own provider's label, which is the #193 principle
+ * carried into this surface.
+ *
+ * ZERO OPTIONS ⇒ NO BUTTON. An instance with no complete provider
+ * credentials says so plainly rather than rendering a control that cannot
+ * work — the same #193 principle at its limit.
  */
-export default function AskSignInPanel() {
+export default function AskSignInPanel({ options }: { options: SignInOption[] }) {
   return (
     <div
       style={{
@@ -29,17 +44,31 @@ export default function AskSignInPanel() {
         borderRadius: '6px',
       }}
     >
-      <p style={{ fontSize: '14px', marginBottom: '16px', lineHeight: 1.5 }}>
-        Sign in to ask a question against live public data and publish the
-        result.
-      </p>
-      <button
-        onClick={() => signIn(undefined, { callbackUrl: '/ask' })}
-        className="nyc-button nyc-button-primary"
-        style={{ padding: '10px 18px', fontSize: '14px' }}
-      >
-        Sign in
-      </button>
+      {options.length === 0 ? (
+        <p style={{ fontSize: '14px', lineHeight: 1.5, margin: 0 }}>
+          This instance has no sign-in provider configured, so there is no way
+          to sign in here yet.
+        </p>
+      ) : (
+        <>
+          <p style={{ fontSize: '14px', marginBottom: '16px', lineHeight: 1.5 }}>
+            Sign in to ask a question against live public data and publish the
+            result.
+          </p>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '12px' }}>
+            {options.map((option) => (
+              <button
+                key={option.id}
+                onClick={() => signIn(option.id, { callbackUrl: '/ask' })}
+                className="nyc-button nyc-button-primary"
+                style={{ padding: '10px 18px', fontSize: '14px' }}
+              >
+                Sign in with {option.name}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(app)/ask/page.tsx
+++ b/src/app/(app)/ask/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { buildProviders } from '@/lib/auth-providers';
+import { toSignInOptions } from '@/lib/auth-provider-options';
 import QuerySurface from '@/components/shared/QuerySurface';
 import AskSignInPanel from './AskSignInPanel';
 
@@ -35,6 +37,20 @@ import AskSignInPanel from './AskSignInPanel';
  * a redirect here would close a loop. This is not the access gate either:
  * the gate is at sign-in (`SIGN_IN_ALLOWLIST`), and an off-list account
  * never gets a session to arrive with.
+ *
+ * THE PROMPT'S BUTTONS ARE DERIVED HERE, ON THE SERVER (P4b). This page
+ * asks `buildProviders()` what the instance actually configured and narrows
+ * the configs — which carry client secrets and callbacks, and can never
+ * cross to the client — to serializable `{id, name}` options. Two reasons
+ * it is a server derivation and not a client fetch of
+ * `/api/auth/providers`: there is no loading flash and no failure path in
+ * which the visitor is left with no way to sign in. And two reasons the
+ * options carry the provider ID at all: `signIn(id)` goes straight to that
+ * provider's authorize flow, where `signIn()` unnamed would land on
+ * `authOptions.pages.signIn` (`/`) and be redirected back here by the proxy
+ * — a silent sign-in loop, which is exactly what Gate C found; and naming
+ * no provider in this file keeps an OIDC-only instance rendering its own
+ * provider's label rather than a hardcoded one (#193).
  */
 
 export const dynamic = 'force-dynamic';
@@ -66,7 +82,7 @@ export default async function AskPage() {
           get an answer built from live public data, and publish it as a
           signed evidence package anyone can verify independently.
         </p>
-        <AskSignInPanel />
+        <AskSignInPanel options={toSignInOptions(buildProviders())} />
       </div>
     );
   }

--- a/src/lib/auth-provider-options.test.ts
+++ b/src/lib/auth-provider-options.test.ts
@@ -1,0 +1,93 @@
+// Tests for the provider → sign-in-option narrowing (app front-door v0.1.0,
+// P4b). The property that matters: what `/ask` renders as sign-in buttons is
+// exactly what the instance actually configured — no hardcoded provider, no
+// button for a provider that cannot complete an authorization.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Provider } from 'next-auth/providers/index';
+import { toSignInOptions } from './auth-provider-options.ts';
+import { buildProviders } from './auth-providers.ts';
+
+/** A provider config with only the fields this module reads. */
+function fakeProvider(id: string, name: string): Provider {
+  return { id, name, type: 'oauth' } as Provider;
+}
+
+test('toSignInOptions: narrows to {id, name}, preserving order', () => {
+  assert.deepEqual(
+    toSignInOptions([fakeProvider('github', 'GitHub'), fakeProvider('oidc', 'Acme SSO')]),
+    [
+      { id: 'github', name: 'GitHub' },
+      { id: 'oidc', name: 'Acme SSO' },
+    ],
+  );
+});
+
+test('toSignInOptions: no providers ⇒ no options (no dead button)', () => {
+  assert.deepEqual(toSignInOptions([]), []);
+});
+
+test('toSignInOptions: a provider with no usable id is dropped, not rendered', () => {
+  const malformed = [
+    { name: 'Nameless', type: 'oauth' } as unknown as Provider,
+    { id: '', name: 'Empty id', type: 'oauth' } as unknown as Provider,
+    fakeProvider('github', 'GitHub'),
+  ];
+  assert.deepEqual(toSignInOptions(malformed), [{ id: 'github', name: 'GitHub' }]);
+});
+
+test('toSignInOptions: a missing label falls back to the id', () => {
+  const unlabeled = [{ id: 'oidc', type: 'oauth' } as unknown as Provider];
+  assert.deepEqual(toSignInOptions(unlabeled), [{ id: 'oidc', name: 'oidc' }]);
+});
+
+// --- Composed with the real provider construction --------------------------
+
+test('the reference deployment shape (GitHub pair only) ⇒ one GitHub button', () => {
+  const options = toSignInOptions(
+    buildProviders({ GITHUB_CLIENT_ID: 'id', GITHUB_CLIENT_SECRET: 'secret' }),
+  );
+  assert.deepEqual(options, [{ id: 'github', name: 'GitHub' }]);
+});
+
+test('an OIDC-only instance ⇒ one button labeled with its own provider name', () => {
+  const options = toSignInOptions(
+    buildProviders({
+      OIDC_ISSUER: 'https://sso.example.org',
+      OIDC_CLIENT_ID: 'id',
+      OIDC_CLIENT_SECRET: 'secret',
+      OIDC_PROVIDER_NAME: 'Acme SSO',
+    }),
+  );
+  assert.deepEqual(options, [{ id: 'oidc', name: 'Acme SSO' }]);
+});
+
+test('both configured ⇒ one button each; a half-configured pair contributes none', () => {
+  const options = toSignInOptions(
+    buildProviders({
+      GITHUB_CLIENT_ID: 'id',
+      GITHUB_CLIENT_SECRET: 'secret',
+      OIDC_ISSUER: 'https://sso.example.org',
+      OIDC_CLIENT_ID: 'id',
+      OIDC_CLIENT_SECRET: 'secret',
+    }),
+  );
+  assert.deepEqual(options, [
+    { id: 'github', name: 'GitHub' },
+    { id: 'oidc', name: 'SSO' },
+  ]);
+
+  // Half a pair is not a provider — the #193 property, restated at this layer.
+  assert.deepEqual(toSignInOptions(buildProviders({ GITHUB_CLIENT_ID: 'id' })), []);
+  assert.deepEqual(
+    toSignInOptions(buildProviders({ OIDC_ISSUER: 'https://sso.example.org', OIDC_CLIENT_ID: 'id' })),
+    [],
+  );
+});
+
+test('an unconfigured instance ⇒ zero options', () => {
+  assert.deepEqual(toSignInOptions(buildProviders({})), []);
+});

--- a/src/lib/auth-provider-options.ts
+++ b/src/lib/auth-provider-options.ts
@@ -1,0 +1,47 @@
+// The sign-in choices an instance offers, in the shape a client component
+// can receive (app front-door v0.1.0, P4b).
+//
+// `buildProviders()` returns NextAuth provider CONFIGS — they carry client
+// secrets and non-serializable callbacks, so they can never cross the
+// server/client boundary. A server component derives the list, narrows it
+// to `{id, name}` here, and passes that down as a plain prop.
+//
+// The `id` is the load-bearing half: `signIn(id)` goes straight to that
+// provider's authorize flow, whereas `signIn()` with no id goes to the
+// instance's configured sign-in page. On this instance those are not
+// equivalent — `authOptions.pages.signIn` is `/`, and on the app host `/`
+// redirects to `/ask`, so the un-named call loops. Naming the provider
+// makes that structurally impossible.
+//
+// Deriving names from the configs (rather than hardcoding "GitHub") is the
+// same principle as #193: an instance that configured only its own OIDC
+// provider must render that provider's label, and an instance that
+// configured nothing must render no button at all.
+
+import type { Provider } from 'next-auth/providers/index';
+
+/** One sign-in choice: what to label the button, and what to call `signIn` with. */
+export interface SignInOption {
+  /** Provider id — the argument `signIn(id)` needs. */
+  id: string;
+  /** Human label: "GitHub", or the operator's `OIDC_PROVIDER_NAME`. */
+  name: string;
+}
+
+/**
+ * Narrow NextAuth provider configs to serializable sign-in options, in the
+ * order `buildProviders()` produced them.
+ *
+ * Anything without a usable id is dropped rather than rendered: a button
+ * that cannot name its provider is the dead button #193 removed. A provider
+ * with an id but no label falls back to the id, which is ugly but honest and
+ * still works.
+ */
+export function toSignInOptions(providers: Provider[]): SignInOption[] {
+  return providers
+    .filter((provider) => typeof provider?.id === 'string' && provider.id.length > 0)
+    .map((provider) => ({
+      id: provider.id,
+      name: typeof provider.name === 'string' && provider.name.length > 0 ? provider.name : provider.id,
+    }));
+}


### PR DESCRIPTION
Gate C fix for the app-front-door sprint (#191): the `/ask` sign-in panel's `signIn(undefined, …)` silently looped — NextAuth's un-named `signIn()` goes to the configured sign-in page, `pages.signIn: '/'` sends that to the apex root, and on the app host the proxy 307s `/` straight back to `/ask`. Click, land on the same page, session stays empty. Reproduced hop-by-hop before fixing.

**The fix names the provider.** `pages.signIn` stands untouched (the AccessDenied back-link and the apex flow depend on it). Instead:

- New `src/lib/auth-provider-options.ts`: `toSignInOptions(providers)` narrows NextAuth provider configs (which carry secrets and callbacks and can never cross to the client) to serializable `{id, name}` pairs.
- The `/ask` page derives options server-side from the pure `buildProviders()` — no client fetch, no loading flash, no failure path — and passes them down.
- The panel renders one `signIn(option.id, { callbackUrl: '/ask' })` button per option. A named provider goes straight to its authorize flow and leaves the site, so the loop is structurally impossible. Zero configured providers ⇒ an honest inline note, no dead button (the #193 principle at its limit).

**Evidence:** 494/494 tests (+8: narrowing properties, plus composition with the real `buildProviders()` over env fixtures — GitHub-only, OIDC-only with the operator's label, both, and half-configured pairs yielding none). Lint 0 errors; build clean. Dev-server smoke on the split config: GitHub pair ⇒ "Sign in with GitHub" with `options:[{id:"github",name:"GitHub"}]` in the RSC payload; OIDC-only ⇒ "Sign in with Acme SSO", no GitHub button; nothing configured ⇒ zero buttons and the note. P3/P4 host matrix re-verified unchanged. The live OAuth round-trip is the owner's re-smoke.

Flagged, not fixed (pre-existing, same class): `Header.tsx` and `DeviceSignInPanel.tsx` hardcode `signIn('github')` — `toSignInOptions` is now the ready-made fix when those are picked up.

Part of #191. IMPL ran on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
