### PR TITLE
App front-door P4c: cross-host affordances — sign-in targets and nav/footer origins

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,9 @@ import './globals.css';
 import Link from 'next/link';
 import Providers from '@/components/Providers';
 import Header from '@/components/Header';
+import { HostLinksProvider } from '@/components/HostLinksProvider';
 import { resolveDashboardHref } from '@/lib/host-routing';
+import { resolveHostLinks } from '@/lib/host-links';
 import RunningUnsignedBanner from '@/components/RunningUnsignedBanner';
 import SponsorLine from '@/components/SponsorLine';
 
@@ -50,6 +52,15 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  /**
+   * Cross-host link targets (P4c), derived once per render from the
+   * environment — never from the request's host, which would force every
+   * static marketing page to render dynamically. Unset topology resolves to
+   * an empty marketing prefix and a null sign-in href: today's exact links
+   * and today's in-place sign-in.
+   */
+  const hostLinks = resolveHostLinks(process.env);
+
   return (
     <html lang="en">
       {GA_MEASUREMENT_ID && (
@@ -70,11 +81,20 @@ export default function RootLayout({
       )}
       <body className={`${spaceGrotesk.variable} ${notoSans.variable}`}>
         <Providers>
+          <HostLinksProvider value={hostLinks}>
           <div className="flex flex-col">
             {/* Env-driven (P3): on a split-host topology the marketing host
                 withholds /dashboard, so the signed-in menu must carry the
-                app origin. Unset topology resolves to '/dashboard'. */}
-            <Header dashboardHref={resolveDashboardHref(process.env)} />
+                app origin. Unset topology resolves to '/dashboard'.
+                `marketingOrigin`/`signInHref` are P4c's equivalents for the
+                nav links and the sign-in button — props here because the
+                layout renders Header directly; the components deeper inside
+                the page read the same values from HostLinksProvider. */}
+            <Header
+              dashboardHref={resolveDashboardHref(process.env)}
+              marketingOrigin={hostLinks.marketingOrigin}
+              signInHref={hostLinks.signInHref}
+            />
             {/* ADR-0020: running-unsigned indicator — renders only when this
                 instance has no signing key AND is outside a dev environment. */}
             <RunningUnsignedBanner />
@@ -86,12 +106,21 @@ export default function RootLayout({
                 </p>
                 <p style={{ fontSize: '13px', color: 'var(--text-muted)', margin: '8px 0 0 0' }}>
                   <a href="https://github.com/npstorey/civic-ai-tools" target="_blank" rel="noopener noreferrer">GitHub</a>
-                  {' \u00b7 '}
-                  <Link href="/learn">Learn</Link>
-                  {' \u00b7 '}
-                  <Link href="/about">About</Link>
-                  {' \u00b7 '}
-                  <Link href="/roadmap">Roadmap</Link>
+                  {/* Marketing routes (P4c): prefixed with the marketing
+                      origin on a split host so they resolve from the app
+                      host too, exactly relative when nothing is configured,
+                      and omitted entirely on an app-only instance \u2014 which
+                      has no marketing site for them to point at. */}
+                  {hostLinks.marketingOrigin !== null && (
+                    <>
+                      {' \u00b7 '}
+                      <Link href={`${hostLinks.marketingOrigin}/learn`}>Learn</Link>
+                      {' \u00b7 '}
+                      <Link href={`${hostLinks.marketingOrigin}/about`}>About</Link>
+                      {' \u00b7 '}
+                      <Link href={`${hostLinks.marketingOrigin}/roadmap`}>Roadmap</Link>
+                    </>
+                  )}
                   {' \u00b7 '}
                   <a href="https://github.com/npstorey/civic-ai-tools/issues/new?template=suggest-server.yml&labels=directory-submission" target="_blank" rel="noopener noreferrer">Suggest a Server</a>
                 </p>
@@ -103,6 +132,7 @@ export default function RootLayout({
               </div>
             </footer>
           </div>
+          </HostLinksProvider>
         </Providers>
       </body>
     </html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,16 +22,32 @@ const DROPDOWN_ITEM_STYLE: React.CSSProperties = {
 };
 
 /**
- * `dashboardHref` is env-driven (app front-door P3): the root layout passes
- * `resolveDashboardHref()` so that on a split-host deployment — where the
- * marketing host withholds `/dashboard` — the signed-in menu points at the
- * app host instead of a 404. Default (and unset topology) is today's
- * relative href, byte-identical.
+ * Every cross-host target this header needs is env-derived and passed in by
+ * the root layout; none of it is computed from the request's host, so the
+ * markup is identical on every host and every render.
+ *
+ * - `dashboardHref` (P3) — the marketing host withholds `/dashboard`, so on a
+ *   split-host deployment the signed-in menu points at the app host.
+ * - `marketingOrigin` (P4c) — prefix for the nav's marketing routes, which
+ *   the APP host withholds. `''` (the default, and unset topology) leaves
+ *   every href exactly the relative one it is today; `null` means an
+ *   app-only instance with no marketing site, and those items are hidden
+ *   rather than pointed at a 404.
+ * - `signInHref` (P4c) — where "sign in" should go. On the marketing host an
+ *   in-place `signIn()` cannot finish: the OAuth state cookie is written for
+ *   the host the click happened on, and the session belongs to the app host,
+ *   so the round-trip dies at the provider's redirect warning. Non-null
+ *   turns the button into a plain link to the app surface's sign-in panel;
+ *   `null` (the default, and unset topology) keeps today's in-place button.
  */
 export default function Header({
   dashboardHref = '/dashboard',
+  marketingOrigin = '',
+  signInHref = null,
 }: {
   dashboardHref?: string;
+  marketingOrigin?: string | null;
+  signInHref?: string | null;
 }) {
   const { data: session, status } = useSession();
   const headerRef = useRef<HTMLElement>(null);
@@ -42,6 +58,12 @@ export default function Header({
   const exploreRef = useRef<HTMLDivElement>(null);
   const aboutRef = useRef<HTMLDivElement>(null);
   const userMenuRef = useRef<HTMLDivElement>(null);
+
+  // Marketing-route href, prefixed with the marketing origin when one is
+  // configured. With the default empty prefix this is the identity function
+  // on the path — the byte-identity guarantee, in one expression.
+  const showMarketingNav = marketingOrigin !== null;
+  const mkt = (path: string) => `${marketingOrigin ?? ''}${path}`;
 
   // Publish header height as a CSS variable so other components can offset below it
   useEffect(() => {
@@ -137,8 +159,10 @@ export default function Header({
                     padding: '4px 0',
                   }}
                 >
+                  {showMarketingNav && (
+                    <>
                   <Link
-                    href="/explore"
+                    href={mkt('/explore')}
                     onClick={() => setExploreOpen(false)}
                     style={DROPDOWN_ITEM_STYLE}
                     onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'var(--card-background)'; }}
@@ -147,7 +171,7 @@ export default function Header({
                     Data Flow
                   </Link>
                   <Link
-                    href="/directory"
+                    href={mkt('/directory')}
                     onClick={() => setExploreOpen(false)}
                     style={DROPDOWN_ITEM_STYLE}
                     onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'var(--card-background)'; }}
@@ -155,6 +179,9 @@ export default function Header({
                   >
                     Directory
                   </Link>
+                    </>
+                  )}
+                  {/* Dual-served by design (P3): stays relative on both hosts. */}
                   <Link
                     href="/evidence"
                     onClick={() => setExploreOpen(false)}
@@ -167,15 +194,17 @@ export default function Header({
                 </div>
               )}
             </div>
+            {showMarketingNav && (
+              <>
             <Link
-              href="/learn"
+              href={mkt('/learn')}
               className="no-link-style"
               style={NAV_LINK_STYLE}
             >
               Learn
             </Link>
             <Link
-              href="/project"
+              href={mkt('/project')}
               className="no-link-style"
               style={NAV_LINK_STYLE}
             >
@@ -217,7 +246,7 @@ export default function Header({
                   }}
                 >
                   <Link
-                    href="/about"
+                    href={mkt('/about')}
                     onClick={() => setAboutOpen(false)}
                     style={DROPDOWN_ITEM_STYLE}
                     onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'var(--card-background)'; }}
@@ -226,7 +255,7 @@ export default function Header({
                     About
                   </Link>
                   <Link
-                    href="/roadmap"
+                    href={mkt('/roadmap')}
                     onClick={() => setAboutOpen(false)}
                     style={DROPDOWN_ITEM_STYLE}
                     onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'var(--card-background)'; }}
@@ -237,6 +266,8 @@ export default function Header({
                 </div>
               )}
             </div>
+              </>
+            )}
             <a
               href={TYPED_STANDARDS_URL}
               target="_blank"
@@ -351,6 +382,18 @@ export default function Header({
                 </div>
               )}
             </div>
+          ) : signInHref !== null ? (
+            /* Split topology: sign-in happens on the app surface, so this is
+               a plain link — it works before hydration, and the label drops
+               the provider name because the panel it lands on lists whatever
+               providers the instance actually configured. */
+            <a
+              href={signInHref}
+              className="nyc-button nyc-button-primary"
+              style={{ padding: '8px 16px', fontSize: '14px', textDecoration: 'none' }}
+            >
+              Sign in
+            </a>
           ) : (
             <button
               onClick={() => signIn('github')}
@@ -387,8 +430,10 @@ export default function Header({
           >
             Explore
           </span>
+          {showMarketingNav && (
+            <>
           <Link
-            href="/explore"
+            href={mkt('/explore')}
             onClick={() => setMobileMenuOpen(false)}
             style={{
               color: 'var(--text-secondary)',
@@ -401,7 +446,7 @@ export default function Header({
             Data Flow
           </Link>
           <Link
-            href="/directory"
+            href={mkt('/directory')}
             onClick={() => setMobileMenuOpen(false)}
             style={{
               color: 'var(--text-secondary)',
@@ -413,6 +458,8 @@ export default function Header({
           >
             Directory
           </Link>
+            </>
+          )}
           <Link
             href="/evidence"
             onClick={() => setMobileMenuOpen(false)}
@@ -426,10 +473,12 @@ export default function Header({
           >
             Evidence
           </Link>
+          {showMarketingNav && (
+            <>
           {/* Divider */}
           <div style={{ borderTop: '1px solid var(--border-color)', margin: '4px 0' }} />
           <Link
-            href="/learn"
+            href={mkt('/learn')}
             onClick={() => setMobileMenuOpen(false)}
             style={{
               color: 'var(--text-secondary)',
@@ -443,7 +492,7 @@ export default function Header({
           {/* Divider */}
           <div style={{ borderTop: '1px solid var(--border-color)', margin: '4px 0' }} />
           <Link
-            href="/project"
+            href={mkt('/project')}
             onClick={() => setMobileMenuOpen(false)}
             style={{
               color: 'var(--text-secondary)',
@@ -469,7 +518,7 @@ export default function Header({
             About
           </span>
           <Link
-            href="/about"
+            href={mkt('/about')}
             onClick={() => setMobileMenuOpen(false)}
             style={{
               color: 'var(--text-secondary)',
@@ -482,7 +531,7 @@ export default function Header({
             About
           </Link>
           <Link
-            href="/roadmap"
+            href={mkt('/roadmap')}
             onClick={() => setMobileMenuOpen(false)}
             style={{
               color: 'var(--text-secondary)',
@@ -494,6 +543,8 @@ export default function Header({
           >
             Roadmap
           </Link>
+            </>
+          )}
           {/* Divider */}
           <div style={{ borderTop: '1px solid var(--border-color)', margin: '4px 0' }} />
           <a

--- a/src/components/HostLinksProvider.tsx
+++ b/src/components/HostLinksProvider.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { DEFAULT_HOST_LINKS, type HostLinks } from '@/lib/host-links';
+
+/**
+ * Carries the server-derived cross-host link targets to client components
+ * that props cannot reach (app front-door v0.1.0, P4c).
+ *
+ * WHY A CONTEXT AND NOT PROP THREADING. Three of the four sign-in
+ * affordances live inside `QuerySurface` — in `QueryForm`,
+ * `RateLimitBanner`, and `McpResponseDisplay` — and the surface is mounted
+ * by `(marketing)/page.tsx`, which is itself a client component. A client
+ * component cannot read `process.env`, so no prop chain from a server
+ * ancestor exists to extend; threading would mean converting the apex page
+ * to a server component, which is precisely the acceptance-protected file
+ * this sprint may not disturb. One provider mounted once in the root layout
+ * reaches all three without touching a single intermediate component.
+ *
+ * Components the root layout renders DIRECTLY — `Header`, and the footer
+ * inside the layout itself — take their values as props instead, extending
+ * P3's `dashboardHref` precedent. The rule: props where the server can
+ * reach, context only where the client boundary blocks it.
+ *
+ * The default value is today's behavior (relative marketing hrefs, sign in
+ * place), so a component rendered outside the provider — a test, a future
+ * surface that forgets to mount it — degrades to the pre-topology shape
+ * rather than to broken links.
+ */
+const HostLinksContext = createContext<HostLinks>(DEFAULT_HOST_LINKS);
+
+export function HostLinksProvider({
+  value,
+  children,
+}: {
+  value: HostLinks;
+  children: ReactNode;
+}) {
+  return <HostLinksContext.Provider value={value}>{children}</HostLinksContext.Provider>;
+}
+
+/** Read the cross-host link targets. Safe outside the provider (see above). */
+export function useHostLinks(): HostLinks {
+  return useContext(HostLinksContext);
+}

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { signIn, useSession } from 'next-auth/react';
+import { useHostLinks } from '@/components/HostLinksProvider';
 import RateLimitBanner from './RateLimitBanner';
 
 interface Model {
@@ -88,6 +89,10 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
   // 'standard' when the user is not authenticated.
   const { status: authStatus } = useSession();
   const isAuthenticated = authStatus === 'authenticated';
+  // Where sign-in should go (P4c). Null on an instance with no host
+  // topology configured — then the affordance below stays in place, exactly
+  // as it is today. See src/lib/host-links.ts.
+  const { signInHref } = useHostLinks();
   const [mode, updateMode] = useStoredMode(isAuthenticated);
   const [models, setModels] = useState<Model[]>([]);
   const [modelOpen, setModelOpen] = useState(false);
@@ -367,11 +372,27 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
                 <div style={{ marginBottom: '6px', fontWeight: 500, color: 'var(--text-primary)' }}>
                   Sign in to execute in a signed sandbox
                 </div>
+                {/* One expression, not a sentence split around a ternary:
+                    two adjacent text children would make React emit comment
+                    separators, and the unset case must stay byte-identical. */}
                 <p style={{ margin: '0 0 10px' }}>
-                  Executed-sandbox mode generates and runs a Jupyter notebook
-                  against live data, then signs the execution record. Sign in
-                  with GitHub to enable.
+                  {signInHref !== null
+                    ? 'Executed-sandbox mode generates and runs a Jupyter notebook against live data, then signs the execution record. Sign in to enable.'
+                    : 'Executed-sandbox mode generates and runs a Jupyter notebook against live data, then signs the execution record. Sign in with GitHub to enable.'}
                 </p>
+                {signInHref !== null ? (
+                  /* Split topology (P4c): sign-in lives on the app surface,
+                     so this is a link rather than an in-place OAuth start —
+                     which could not complete from this host anyway. No
+                     loading state: the destination decides server-side. */
+                  <a
+                    href={signInHref}
+                    className="nyc-button nyc-button-primary"
+                    style={{ fontSize: '13px', padding: '6px 14px', textDecoration: 'none' }}
+                  >
+                    Sign in
+                  </a>
+                ) : (
                 <button
                   type="button"
                   onClick={() => signIn('github')}
@@ -385,6 +406,7 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
                 >
                   {authStatus === 'loading' ? 'Loading…' : 'Sign in with GitHub'}
                 </button>
+                )}
               </div>
             )}
           </div>

--- a/src/components/RateLimitBanner.tsx
+++ b/src/components/RateLimitBanner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { signIn, useSession } from 'next-auth/react';
+import { useHostLinks } from '@/components/HostLinksProvider';
 
 interface RateLimitInfo {
   remaining: number;
@@ -16,6 +17,9 @@ interface RateLimitBannerProps {
 
 export default function RateLimitBanner({ refreshTrigger = 0 }: RateLimitBannerProps) {
   const { data: session } = useSession();
+  // P4c: null when no host topology is configured — the button below stays
+  // an in-place sign-in, exactly as today. See src/lib/host-links.ts.
+  const { signInHref } = useHostLinks();
   const [rateLimit, setRateLimit] = useState<RateLimitInfo | null>(null);
 
   useEffect(() => {
@@ -68,6 +72,21 @@ export default function RateLimitBanner({ refreshTrigger = 0 }: RateLimitBannerP
         {!rateLimit.authenticated && !session && (
           <span style={{ marginLeft: '4px' }}>
             ·{' '}
+            {signInHref !== null ? (
+              /* Split topology (P4c): a link to the app surface's sign-in
+                 panel. An in-place OAuth start cannot complete from the
+                 marketing host — the session lives on the app host. */
+              <a
+                href={signInHref}
+                style={{
+                  color: 'var(--nyc-blue-40)',
+                  textDecoration: 'underline',
+                  fontSize: 'inherit',
+                }}
+              >
+                Sign in for a higher daily limit
+              </a>
+            ) : (
             <button
               onClick={() => signIn('github')}
               style={{
@@ -82,6 +101,7 @@ export default function RateLimitBanner({ refreshTrigger = 0 }: RateLimitBannerP
             >
               Sign in for 25/day
             </button>
+            )}
           </span>
         )}
       </span>

--- a/src/components/shared/McpResponseDisplay.tsx
+++ b/src/components/shared/McpResponseDisplay.tsx
@@ -9,7 +9,29 @@ import { buildProvenanceLine, buildNarrativeSummary, buildStatsSummary, getPorta
 import { generateNotebook, downloadNotebook } from '@/lib/notebook';
 import type { ProgressLogEntry, ProgressGroup, ToolCall, EvidenceTrace } from '@/hooks/useStreamingComparison';
 import { useSession, signIn } from 'next-auth/react';
+import { useHostLinks } from '@/components/HostLinksProvider';
 import PublishEvidenceDialog from '@/components/PublishEvidenceDialog';
+
+/**
+ * Shared by the publish affordance's two shapes — the button that opens the
+ * publish dialog, and (on a split-host topology) the link that sends a
+ * signed-out visitor to the app surface's sign-in panel. Extracted so the
+ * two render identically rather than by copied style objects.
+ */
+const PUBLISH_BUTTON_STYLE: React.CSSProperties = {
+  background: 'none',
+  border: '1px solid var(--nyc-blue)',
+  borderRadius: '4px',
+  padding: '4px 10px',
+  fontSize: '12px',
+  color: 'var(--nyc-blue)',
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  fontWeight: 500,
+  transition: 'background-color 0.15s',
+};
 
 interface McpResponseDisplayProps {
   content: string;
@@ -375,6 +397,9 @@ export default function McpResponseDisplay({
   const [copied, setCopied] = useState(false);
   const [publishDialogOpenLocal, setPublishDialogOpenLocal] = useState(false);
   const { data: session } = useSession();
+  // P4c: null when no host topology is configured — the publish button's
+  // signed-out branch then signs in place, exactly as today.
+  const { signInHref } = useHostLinks();
 
   // Use parent-controlled state if provided, otherwise local
   const publishDialogOpen = publishDialogOpenProp ?? publishDialogOpenLocal;
@@ -772,6 +797,26 @@ export default function McpResponseDisplay({
             {/* Publish as Evidence button */}
             {canPublish && (
               <>
+                {!session?.user && signInHref !== null ? (
+                  /* Split topology (P4c): publishing needs a session, and a
+                     session cannot be started from this host — the OAuth
+                     state cookie would be written here while the session
+                     belongs to the app host. So the signed-out affordance
+                     becomes a link to the app surface's sign-in panel. The
+                     "re-run your query" note below already described this
+                     shape; it is now literally true. */
+                  <a
+                    href={signInHref}
+                    style={{ ...PUBLISH_BUTTON_STYLE, textDecoration: 'none' }}
+                    onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'rgba(16, 63, 239, 0.06)'; }}
+                    onMouseOut={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
+                    </svg>
+                    Sign in to publish
+                  </a>
+                ) : (
                 <button
                   onClick={() => {
                     if (!session?.user) {
@@ -782,20 +827,7 @@ export default function McpResponseDisplay({
                       setPublishDialogOpen(true);
                     }
                   }}
-                  style={{
-                    background: 'none',
-                    border: '1px solid var(--nyc-blue)',
-                    borderRadius: '4px',
-                    padding: '4px 10px',
-                    fontSize: '12px',
-                    color: 'var(--nyc-blue)',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '4px',
-                    fontWeight: 500,
-                    transition: 'background-color 0.15s',
-                  }}
+                  style={PUBLISH_BUTTON_STYLE}
                   onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'rgba(16, 63, 239, 0.06)'; }}
                   onMouseOut={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                 >
@@ -804,6 +836,7 @@ export default function McpResponseDisplay({
                   </svg>
                   {session?.user ? 'Publish as Evidence' : 'Sign in to publish'}
                 </button>
+                )}
                 {!session?.user && (
                   <span style={{ fontSize: '11px', color: '#666' }}>
                     Sign in first, then re-run your query

--- a/src/lib/host-links.test.ts
+++ b/src/lib/host-links.test.ts
@@ -1,0 +1,78 @@
+// Tests for the cross-host link derivation (app front-door v0.1.0, P4c).
+//
+// Rule zero, the same one every other seam in this sprint obeys: with none of
+// the three host-topology variables set, the derivation reproduces today's
+// behavior exactly — relative marketing hrefs (empty prefix) and in-place
+// sign-in (null href).
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_HOST_LINKS, resolveHostLinks } from './host-links.ts';
+
+test('unset topology: relative marketing links, sign in place', () => {
+  assert.deepEqual(resolveHostLinks({}), { marketingOrigin: '', signInHref: null });
+  // ...which is exactly what a consumer rendered outside the provider sees.
+  assert.deepEqual(resolveHostLinks({}), DEFAULT_HOST_LINKS);
+});
+
+test('split host: marketing links carry the marketing origin, sign-in goes to the app surface', () => {
+  assert.deepEqual(
+    resolveHostLinks({ APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }),
+    { marketingOrigin: 'https://example.org', signInHref: 'https://app.example.org/ask' },
+  );
+});
+
+test('app-only: no marketing site to link to, sign-in is a relative path', () => {
+  // marketingOrigin null is the instruction to HIDE the affordance, matching
+  // resolvePublicSiteHref's null for the AppChrome exit link.
+  assert.deepEqual(resolveHostLinks({ APP_ONLY: '1' }), {
+    marketingOrigin: null,
+    signInHref: '/ask',
+  });
+  // APP_ONLY wins over host matching, as it does in decideRoute.
+  assert.deepEqual(
+    resolveHostLinks({ APP_ONLY: 'true', APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }),
+    { marketingOrigin: null, signInHref: '/ask' },
+  );
+});
+
+test('the two halves are independent — an incremental rollout is coherent at every step', () => {
+  // Stage 1: APP_HOST only. Sign-in already redirects to the app surface;
+  // marketing links stay relative because no marketing origin is named yet.
+  assert.deepEqual(resolveHostLinks({ APP_HOST: 'app.example.org' }), {
+    marketingOrigin: '',
+    signInHref: 'https://app.example.org/ask',
+  });
+  // Stage 2: MARKETING_HOST only. The mirror image.
+  assert.deepEqual(resolveHostLinks({ MARKETING_HOST: 'example.org' }), {
+    marketingOrigin: 'https://example.org',
+    signInHref: null,
+  });
+});
+
+test('host values accept a full origin, and a dev instance keeps its scheme and port', () => {
+  assert.deepEqual(
+    resolveHostLinks({ APP_HOST: 'http://app.localhost:3000/', MARKETING_HOST: 'http://localhost:3000' }),
+    { marketingOrigin: 'http://localhost:3000', signInHref: 'http://app.localhost:3000/ask' },
+  );
+});
+
+test('empty and whitespace values are unset, not configuration', () => {
+  assert.deepEqual(resolveHostLinks({ APP_HOST: '', MARKETING_HOST: '   ', APP_ONLY: '' }), {
+    marketingOrigin: '',
+    signInHref: null,
+  });
+  assert.deepEqual(resolveHostLinks({ APP_ONLY: '0' }).marketingOrigin, '');
+  assert.deepEqual(resolveHostLinks({ APP_ONLY: 'false' }).signInHref, null);
+});
+
+test('concatenation property: an empty prefix yields exactly the relative href', () => {
+  // This is the byte-identity argument, expressed as an assertion: every
+  // consumer builds `${marketingOrigin}${path}`.
+  const { marketingOrigin } = resolveHostLinks({});
+  for (const path of ['/about', '/directory', '/explore', '/learn', '/project', '/roadmap']) {
+    assert.equal(`${marketingOrigin}${path}`, path);
+  }
+});

--- a/src/lib/host-links.ts
+++ b/src/lib/host-links.ts
@@ -1,0 +1,99 @@
+// Cross-host link targets (app front-door v0.1.0, P4c).
+//
+// THE PROBLEM THIS SOLVES. Once host topology is configured, two families of
+// in-place affordance break, each in the mirror-image way:
+//
+//   - SIGN-IN affordances on the MARKETING host. `signIn('github')` starts an
+//     OAuth flow whose state cookie is written for the host the click
+//     happened on; sessions live on the app host, so the round-trip reaches
+//     the provider's redirect warning and never completes. The fix is not to
+//     sign in there at all, but to send the visitor to the app surface's
+//     sign-in panel.
+//   - MARKETING links on the APP host. `/learn`, `/about`, and friends are
+//     withheld there, so every relative marketing href is a 404. The fix is
+//     to carry the marketing origin.
+//
+// THE DERIVATION IS A CONSTANT, NOT A RUNTIME HOST CHECK. Every value here
+// comes from the environment, so it is identical on every host and every
+// render: hydration-safe, cacheable, and — critically — byte-identical to
+// today when nothing is configured. An absolute link to the host you are
+// already on is a harmless self-link; that is the price of not reading
+// request headers in a layout, which would force the static marketing pages
+// to render dynamically.
+//
+// This module only READS the P3 host-topology derivations; it does not
+// duplicate their parsing, and it introduces no environment variables of its
+// own.
+
+import {
+  originFromHostValue,
+  parseBooleanFlag,
+  resolveAppOrigin,
+} from './host-routing.ts';
+
+/**
+ * Where the app surface takes someone who needs to sign in. `/ask` renders
+ * the provider panel (P4b) for a signed-out visitor, and it is the app
+ * host's root destination, so this is the one door that works for every
+ * instance shape.
+ */
+const SIGN_IN_PATH = '/ask';
+
+export interface HostLinks {
+  /**
+   * Prefix to put in front of a marketing route's path.
+   *
+   * - `''` — no topology configured: hrefs stay exactly the relative ones
+   *   they are today. This is the seam convention, and it is what makes the
+   *   unset case byte-identical rather than merely equivalent.
+   * - an origin — a split-host instance: marketing routes resolve on the
+   *   marketing host from wherever they are rendered.
+   * - `null` — an app-only instance: there IS no marketing site, so the
+   *   affordances are hidden rather than pointed somewhere. Same treatment
+   *   `resolvePublicSiteHref` gives the `AppChrome` exit link (P3).
+   */
+  marketingOrigin: string | null;
+
+  /**
+   * Where a sign-in affordance should send the visitor, or `null` to sign in
+   * IN PLACE — today's exact behavior, and still the right one on an
+   * instance with no separate app host to send anyone to.
+   */
+  signInHref: string | null;
+}
+
+/** What every consumer sees when nothing is configured: today's behavior. */
+export const DEFAULT_HOST_LINKS: HostLinks = {
+  marketingOrigin: '',
+  signInHref: null,
+};
+
+/**
+ * Read the cross-host link targets from an env record. Takes the record as an
+ * argument (never `process.env` directly) so tests pass fixtures, matching
+ * `readHostRoutingConfig`.
+ *
+ * The two fields are independent on purpose, because the rollout is
+ * incremental (P3: "set `APP_HOST` first and verify the app host, then set
+ * `MARKETING_HOST` to switch on the withholding"). With only `APP_HOST` set,
+ * sign-in already redirects to the app surface while marketing links stay
+ * relative — there is no marketing origin to name yet. With only
+ * `MARKETING_HOST` set, the reverse. Neither half waits for the other.
+ */
+export function resolveHostLinks(
+  env: Record<string, string | undefined>,
+): HostLinks {
+  // An app-only instance is its own app host: sign-in is a relative path on
+  // whatever host the request arrived on, and there is no marketing site.
+  if (parseBooleanFlag(env.APP_ONLY)) {
+    return { marketingOrigin: null, signInHref: SIGN_IN_PATH };
+  }
+
+  const appOrigin = resolveAppOrigin(env);
+  const marketingOrigin = originFromHostValue(env.MARKETING_HOST);
+
+  return {
+    marketingOrigin: marketingOrigin ?? '',
+    signInHref: appOrigin !== null ? `${appOrigin}${SIGN_IN_PATH}` : null,
+  };
+}


### PR DESCRIPTION
Gate C fixes, second and final set (#191): the two remaining smoke failures, both cross-host affordance classes.

**Leg 1 — marketing-host sign-in affordances.** The four in-place `signIn('github')` sites (`Header`, `QueryForm`'s notebook prompt, `RateLimitBanner`, `McpResponseDisplay`'s publish button) reached the GitHub redirect warning on the apex post-topology-flip — sessions live on the app host and the OAuth state cookie can't cross. With topology configured they are now anchors to `{appOrigin}/ask` (the P4b provider panel); unset keeps the in-place behavior exactly. Copy that named GitHub or "25/day" is generalized in the configured branch only ("Sign in", "Sign in for a higher daily limit") — the destination lists whatever providers the instance configured.

**Leg 2 — app-host nav/footer links.** The header's marketing links and the footer's links now carry the marketing origin when topology is configured, relative when unset. `/evidence` and the brand `/` deliberately stay relative (dual-served; the app front door). App-only instances hide the marketing links entirely — there is no marketing site to point at (the `AppChrome` exit-link treatment from P3).

**Mechanism:** one pure `resolveHostLinks(env)` (new `src/lib/host-links.ts`) reading the P3 derivations — env-constant values, identical on every host and render: hydration-safe, and byte-identical when unset (`marketingOrigin: ''` makes the prefix concatenation the identity function). Threaded as props where the server can reach (`Header`, the footer — which turned out to be inline JSX in the root layout) and via one root-mounted `HostLinksProvider` context for the three components inside `QuerySurface`'s client-only chain, whose default reproduces today's behavior. No new env variables, no `NEXT_PUBLIC_*`, no proxy/auth changes.

**Recorded consequence:** with topology configured, marketing links on the marketing host become absolute self-links, so `next/link` renders them as full page navigations rather than client-side ones — the cost of constant-not-detection; invisible when unset.

## Evidence

- 501/501 tests (+7 on `resolveHostLinks`: rule-zero unset identity, split/app-only shapes, both single-variable rollout stages, concatenation property over the six marketing paths). Lint 0 errors; build clean, 27/27 static pages preserved.
- Unset-topology byte-identity vs `main` for `/` AND `/evidence`: normalized DOM md5-identical, zero non-script lines in the raw diffs.
- Split-config smoke: all four sign-in affordances render `href="https://app.localhost/ask"` on the marketing host (client-only branches temporarily forced, captured, reverted — tree verified clean); on the app host no relative marketing link remains and every emitted absolute target resolves 200 on the marketing host; P3/P4 matrix unchanged; app-only payload shows `marketingOrigin: null` with zero marketing hrefs in the chrome.

Flagged for the close-out filing: `McpResponseDisplay`'s truncation CTA to `/learn#try-it` (page-content link, renders on both hosts, wants the same `marketingOrigin` treatment — outside this phase's owner-directed nav/footer scope); `DeviceSignInPanel`'s last `signIn('github')` literal (app-host-only, no cross-host failure); the `AppChrome` "Ask" link.

Part of #191. IMPL ran on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
