### PR TITLE
App front-door P4d: cross-host truncation CTA + sign-in intent handoff

### DIFF
--- a/src/app/(app)/ask/AskSignInPanel.tsx
+++ b/src/app/(app)/ask/AskSignInPanel.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { signIn } from 'next-auth/react';
 import type { SignInOption } from '@/lib/auth-provider-options';
+import { SIGN_IN_INTENT_PARAM } from '@/lib/sign-in-intent';
 
 /**
  * The signed-out state of `/ask` — a prompt rendered IN PLACE, never a
@@ -34,8 +36,71 @@ import type { SignInOption } from '@/lib/auth-provider-options';
  * ZERO OPTIONS ⇒ NO BUTTON. An instance with no complete provider
  * credentials says so plainly rather than rendering a control that cannot
  * work — the same #193 principle at its limit.
+ *
+ * AUTO-INVOKE ON INTENT (P4d). `autoSignIn` is decided by the server page:
+ * the visitor arrived with `?signin=1` (they clicked "sign in" on another
+ * host) AND this instance offers exactly one provider. Then the second
+ * click is pure friction and this component starts the flow itself.
+ *
+ * ONE SHOT, and both halves of that matter:
+ *   1. The parameter is stripped from the URL with `history.replaceState`
+ *      BEFORE `signIn` is called. If the provider returns an error to
+ *      `/ask`, or the visitor presses Back, the URL no longer says "sign
+ *      in" — so the auto-invoke cannot re-fire and trap them in a loop
+ *      between this page and a failing provider.
+ *   2. A ref guards the effect within a mount. The prop is a server value
+ *      and does not change when the URL is replaced client-side, and React
+ *      runs effects twice in development; without the ref either would fire
+ *      the redirect twice.
+ *
+ * While invoking, the panel renders a plain progress line rather than the
+ * buttons: a control that is about to be navigated away from is a control
+ * someone will click. If `signIn` rejects (network failure — a successful
+ * call navigates away and never resolves here), the buttons come back, so
+ * the interstitial is never a dead end.
  */
-export default function AskSignInPanel({ options }: { options: SignInOption[] }) {
+export default function AskSignInPanel({
+  options,
+  autoSignIn = false,
+}: {
+  options: SignInOption[];
+  autoSignIn?: boolean;
+}) {
+  const [autoSigningIn, setAutoSigningIn] = useState(autoSignIn);
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (!autoSignIn || firedRef.current) return;
+    const option = options[0];
+    if (!option) return;
+    firedRef.current = true;
+
+    // Strip first, invoke second — see ONE SHOT above.
+    const url = new URL(window.location.href);
+    if (url.searchParams.has(SIGN_IN_INTENT_PARAM)) {
+      url.searchParams.delete(SIGN_IN_INTENT_PARAM);
+      window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+    }
+
+    signIn(option.id, { callbackUrl: '/ask' }).catch(() => setAutoSigningIn(false));
+  }, [autoSignIn, options]);
+
+  if (autoSigningIn && options.length > 0) {
+    return (
+      <div
+        style={{
+          padding: '20px',
+          border: '1px solid var(--border-color)',
+          borderRadius: '6px',
+        }}
+      >
+        <p style={{ fontSize: '14px', lineHeight: 1.5, margin: 0 }}>
+          Taking you to sign in with {options[0].name}…
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div
       style={{

--- a/src/app/(app)/ask/page.tsx
+++ b/src/app/(app)/ask/page.tsx
@@ -3,6 +3,11 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { buildProviders } from '@/lib/auth-providers';
 import { toSignInOptions } from '@/lib/auth-provider-options';
+import {
+  SIGN_IN_INTENT_PARAM,
+  readSignInIntent,
+  shouldAutoSignIn,
+} from '@/lib/sign-in-intent';
 import QuerySurface from '@/components/shared/QuerySurface';
 import AskSignInPanel from './AskSignInPanel';
 
@@ -51,6 +56,16 @@ import AskSignInPanel from './AskSignInPanel';
  * — a silent sign-in loop, which is exactly what Gate C found; and naming
  * no provider in this file keeps an OIDC-only instance rendering its own
  * provider's label rather than a hardcoded one (#193).
+ *
+ * SIGN-IN INTENT IS READ HERE, NOT IN THE CLIENT (P4d). A visitor who
+ * clicked "sign in" on another host arrives with `?signin=1`; when the
+ * instance offers exactly one provider, the panel starts that provider's
+ * flow rather than asking for a second, identical click. The parameter is
+ * read from `searchParams` in this server component and handed down as a
+ * decided boolean — `useSearchParams()` in the panel would need a Suspense
+ * boundary and would put a routing concern inside a presentational
+ * component. The gate itself (`shouldAutoSignIn`) is pure and tested; every
+ * case it refuses falls back to rendering the ordinary panel.
  */
 
 export const dynamic = 'force-dynamic';
@@ -61,10 +76,22 @@ export const metadata: Metadata = {
     'Ask a question about public data and publish the answer as a signed evidence package.',
 };
 
-export default async function AskPage() {
+interface AskPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function AskPage({ searchParams }: AskPageProps) {
   const session = await getServerSession(authOptions);
 
   if (!session?.user) {
+    const options = toSignInOptions(buildProviders());
+    const params = await searchParams;
+    const autoSignIn = shouldAutoSignIn({
+      hasIntent: readSignInIntent(params[SIGN_IN_INTENT_PARAM]),
+      signedOut: true,
+      optionCount: options.length,
+    });
+
     return (
       <div style={{ maxWidth: '520px', margin: '0 auto', padding: '48px 24px 64px' }}>
         <h1 style={{ fontSize: '24px', fontWeight: 700, marginBottom: '8px' }}>
@@ -82,7 +109,7 @@ export default async function AskPage() {
           get an answer built from live public data, and publish it as a
           signed evidence package anyone can verify independently.
         </p>
-        <AskSignInPanel options={toSignInOptions(buildProviders())} />
+        <AskSignInPanel options={options} autoSignIn={autoSignIn} />
       </div>
     );
   }

--- a/src/components/shared/McpResponseDisplay.tsx
+++ b/src/components/shared/McpResponseDisplay.tsx
@@ -874,12 +874,18 @@ export default function McpResponseDisplay({
         >
           AI-generated analysis may contain errors. Verify findings against the{' '}
           original dataset before citing.{' '}
-          <a
-            href="/learn#ai-limitations"
-            style={{ color: 'var(--text-muted)', textDecoration: 'underline' }}
-          >
-            Learn more &rarr;
-          </a>
+          {/* Same marketing-route treatment as the truncation CTA above, and
+              found beside it: this link renders on EVERY completed result, so
+              on the app host it was the more frequently broken of the two.
+              The sentence stands on its own when the link is omitted. */}
+          {marketingOrigin !== null && (
+            <a
+              href={`${marketingOrigin}/learn#ai-limitations`}
+              style={{ color: 'var(--text-muted)', textDecoration: 'underline' }}
+            >
+              Learn more &rarr;
+            </a>
+          )}
         </div>
       )}
 

--- a/src/components/shared/McpResponseDisplay.tsx
+++ b/src/components/shared/McpResponseDisplay.tsx
@@ -399,7 +399,7 @@ export default function McpResponseDisplay({
   const { data: session } = useSession();
   // P4c: null when no host topology is configured — the publish button's
   // signed-out branch then signs in place, exactly as today.
-  const { signInHref } = useHostLinks();
+  const { signInHref, marketingOrigin } = useHostLinks();
 
   // Use parent-controlled state if provided, otherwise local
   const publishDialogOpen = publishDialogOpenProp ?? publishDialogOpenLocal;
@@ -637,17 +637,25 @@ export default function McpResponseDisplay({
                 Continue this analysis
               </button>
             )}
-            <a
-              href="/learn#try-it"
-              style={{
-                fontSize: '12px',
-                color: '#8a6d00',
-                textDecoration: 'underline',
-                textUnderlineOffset: '2px',
-              }}
-            >
-              Try this locally (no limits)
-            </a>
+            {/* Marketing route (P4d): the app host withholds /learn, so the
+                CTA carries the marketing origin when one is configured,
+                stays exactly relative when nothing is, and is omitted on an
+                app-only instance — which has no marketing site, and where
+                a link to /learn could only 404. Same treatment the header
+                and footer marketing links got in P4c. */}
+            {marketingOrigin !== null && (
+              <a
+                href={`${marketingOrigin}/learn#try-it`}
+                style={{
+                  fontSize: '12px',
+                  color: '#8a6d00',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: '2px',
+                }}
+              >
+                Try this locally (no limits)
+              </a>
+            )}
           </div>
         </div>
       )}

--- a/src/lib/host-links.test.ts
+++ b/src/lib/host-links.test.ts
@@ -10,6 +10,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { DEFAULT_HOST_LINKS, resolveHostLinks } from './host-links.ts';
+import { SIGN_IN_INTENT_PARAM } from './sign-in-intent.ts';
 
 test('unset topology: relative marketing links, sign in place', () => {
   assert.deepEqual(resolveHostLinks({}), { marketingOrigin: '', signInHref: null });
@@ -20,7 +21,7 @@ test('unset topology: relative marketing links, sign in place', () => {
 test('split host: marketing links carry the marketing origin, sign-in goes to the app surface', () => {
   assert.deepEqual(
     resolveHostLinks({ APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }),
-    { marketingOrigin: 'https://example.org', signInHref: 'https://app.example.org/ask' },
+    { marketingOrigin: 'https://example.org', signInHref: 'https://app.example.org/ask?signin=1' },
   );
 });
 
@@ -29,12 +30,12 @@ test('app-only: no marketing site to link to, sign-in is a relative path', () =>
   // resolvePublicSiteHref's null for the AppChrome exit link.
   assert.deepEqual(resolveHostLinks({ APP_ONLY: '1' }), {
     marketingOrigin: null,
-    signInHref: '/ask',
+    signInHref: '/ask?signin=1',
   });
   // APP_ONLY wins over host matching, as it does in decideRoute.
   assert.deepEqual(
     resolveHostLinks({ APP_ONLY: 'true', APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }),
-    { marketingOrigin: null, signInHref: '/ask' },
+    { marketingOrigin: null, signInHref: '/ask?signin=1' },
   );
 });
 
@@ -43,7 +44,7 @@ test('the two halves are independent — an incremental rollout is coherent at e
   // marketing links stay relative because no marketing origin is named yet.
   assert.deepEqual(resolveHostLinks({ APP_HOST: 'app.example.org' }), {
     marketingOrigin: '',
-    signInHref: 'https://app.example.org/ask',
+    signInHref: 'https://app.example.org/ask?signin=1',
   });
   // Stage 2: MARKETING_HOST only. The mirror image.
   assert.deepEqual(resolveHostLinks({ MARKETING_HOST: 'example.org' }), {
@@ -55,7 +56,7 @@ test('the two halves are independent — an incremental rollout is coherent at e
 test('host values accept a full origin, and a dev instance keeps its scheme and port', () => {
   assert.deepEqual(
     resolveHostLinks({ APP_HOST: 'http://app.localhost:3000/', MARKETING_HOST: 'http://localhost:3000' }),
-    { marketingOrigin: 'http://localhost:3000', signInHref: 'http://app.localhost:3000/ask' },
+    { marketingOrigin: 'http://localhost:3000', signInHref: 'http://app.localhost:3000/ask?signin=1' },
   );
 });
 
@@ -66,6 +67,24 @@ test('empty and whitespace values are unset, not configuration', () => {
   });
   assert.deepEqual(resolveHostLinks({ APP_ONLY: '0' }).marketingOrigin, '');
   assert.deepEqual(resolveHostLinks({ APP_ONLY: 'false' }).signInHref, null);
+});
+
+test('every non-null sign-in href carries the intent parameter, relative one included', () => {
+  // The parameter encodes intent, not topology — an app-only visitor who
+  // clicks "sign in" wants what a split-host visitor who clicks it wants.
+  const configured = [
+    resolveHostLinks({ APP_HOST: 'app.example.org' }).signInHref,
+    resolveHostLinks({ APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }).signInHref,
+    resolveHostLinks({ APP_ONLY: '1' }).signInHref,
+  ];
+  for (const href of configured) {
+    assert.ok(href !== null);
+    assert.ok(href.includes(`${SIGN_IN_INTENT_PARAM}=1`), href);
+    assert.ok(href.split('?')[0].endsWith('/ask'), href);
+  }
+  // ...and an unset instance still has no href at all, so no parameter
+  // reaches anything: the affordances stay in-place buttons.
+  assert.equal(resolveHostLinks({}).signInHref, null);
 });
 
 test('concatenation property: an empty prefix yields exactly the relative href', () => {

--- a/src/lib/host-links.ts
+++ b/src/lib/host-links.ts
@@ -30,14 +30,25 @@ import {
   parseBooleanFlag,
   resolveAppOrigin,
 } from './host-routing.ts';
+import { SIGN_IN_INTENT_PARAM } from './sign-in-intent.ts';
 
 /**
  * Where the app surface takes someone who needs to sign in. `/ask` renders
  * the provider panel (P4b) for a signed-out visitor, and it is the app
  * host's root destination, so this is the one door that works for every
  * instance shape.
+ *
+ * The intent parameter (P4d) says the visitor ARRIVED BY CLICKING "sign in"
+ * rather than by browsing to the page, which lets the panel start the flow
+ * for them when the instance offers exactly one provider. It rides on every
+ * non-null `signInHref`, including the relative app-only one: the parameter
+ * encodes intent, not topology. An app-only visitor who clicks "sign in"
+ * wants precisely what a split-host visitor who clicks "sign in" wants, and
+ * making the two configurations behave differently would be a distinction
+ * with no user-visible justification — plus a second code path to keep true.
  */
 const SIGN_IN_PATH = '/ask';
+const SIGN_IN_HREF = `${SIGN_IN_PATH}?${SIGN_IN_INTENT_PARAM}=1`;
 
 export interface HostLinks {
   /**
@@ -86,7 +97,7 @@ export function resolveHostLinks(
   // An app-only instance is its own app host: sign-in is a relative path on
   // whatever host the request arrived on, and there is no marketing site.
   if (parseBooleanFlag(env.APP_ONLY)) {
-    return { marketingOrigin: null, signInHref: SIGN_IN_PATH };
+    return { marketingOrigin: null, signInHref: SIGN_IN_HREF };
   }
 
   const appOrigin = resolveAppOrigin(env);
@@ -94,6 +105,6 @@ export function resolveHostLinks(
 
   return {
     marketingOrigin: marketingOrigin ?? '',
-    signInHref: appOrigin !== null ? `${appOrigin}${SIGN_IN_PATH}` : null,
+    signInHref: appOrigin !== null ? `${appOrigin}${SIGN_IN_HREF}` : null,
   };
 }

--- a/src/lib/sign-in-intent.test.ts
+++ b/src/lib/sign-in-intent.test.ts
@@ -1,0 +1,73 @@
+// Tests for the sign-in intent handoff gate (app front-door v0.1.0, P4d).
+//
+// The property worth pinning: auto-invoking an off-site redirect happens only
+// when all three conditions hold, and every other combination degrades to
+// rendering the ordinary panel — never to a wrong provider, never to a
+// redirect the visitor did not ask for.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SIGN_IN_INTENT_PARAM,
+  readSignInIntent,
+  shouldAutoSignIn,
+} from './sign-in-intent.ts';
+
+test('the parameter name is the one the hrefs carry', () => {
+  assert.equal(SIGN_IN_INTENT_PARAM, 'signin');
+});
+
+test('readSignInIntent: only the literal 1 counts', () => {
+  assert.equal(readSignInIntent('1'), true);
+  for (const value of [undefined, '', '0', 'true', 'yes', 'signin', ' 1']) {
+    assert.equal(readSignInIntent(value), false, JSON.stringify(value));
+  }
+});
+
+test('readSignInIntent: a repeated parameter arrives as an array', () => {
+  assert.equal(readSignInIntent(['1']), true);
+  assert.equal(readSignInIntent(['0', '1']), true);
+  assert.equal(readSignInIntent(['0']), false);
+  assert.equal(readSignInIntent([]), false);
+});
+
+// --- The gate -----------------------------------------------------------
+
+const ONE_PROVIDER = { hasIntent: true, signedOut: true, optionCount: 1 };
+
+test('all three conditions ⇒ auto-invoke', () => {
+  assert.equal(shouldAutoSignIn(ONE_PROVIDER), true);
+});
+
+test('no intent ⇒ never: a direct visit to /ask renders the panel', () => {
+  assert.equal(shouldAutoSignIn({ ...ONE_PROVIDER, hasIntent: false }), false);
+});
+
+test('signed in ⇒ never', () => {
+  assert.equal(shouldAutoSignIn({ ...ONE_PROVIDER, signedOut: false }), false);
+});
+
+test('the intent is IGNORED when the provider is ambiguous or absent', () => {
+  // Two providers: "sign in" does not name one, so the visitor chooses.
+  assert.equal(shouldAutoSignIn({ ...ONE_PROVIDER, optionCount: 2 }), false);
+  assert.equal(shouldAutoSignIn({ ...ONE_PROVIDER, optionCount: 5 }), false);
+  // None configured: there is nothing to invoke, and the panel says so.
+  assert.equal(shouldAutoSignIn({ ...ONE_PROVIDER, optionCount: 0 }), false);
+});
+
+test('every combination that is not exactly-one-and-intended falls back to the panel', () => {
+  for (const hasIntent of [true, false]) {
+    for (const signedOut of [true, false]) {
+      for (const optionCount of [0, 1, 2, 3]) {
+        const expected = hasIntent && signedOut && optionCount === 1;
+        assert.equal(
+          shouldAutoSignIn({ hasIntent, signedOut, optionCount }),
+          expected,
+          `intent=${hasIntent} signedOut=${signedOut} options=${optionCount}`,
+        );
+      }
+    }
+  }
+});

--- a/src/lib/sign-in-intent.ts
+++ b/src/lib/sign-in-intent.ts
@@ -1,0 +1,63 @@
+// Sign-in intent handoff (app front-door v0.1.0, P4d).
+//
+// A visitor who clicks "Sign in" on the marketing host is sent to the app
+// surface's `/ask` panel (P4c), where — before this module — they had to
+// click a second, near-identical button to actually start the flow. The
+// second click carries no information; the first one already said what the
+// visitor wants. This module carries that INTENT across the host boundary as
+// a query parameter, and decides when honoring it is safe.
+//
+// WHY A PARAMETER AND NOT A REDIRECT STRAIGHT TO THE PROVIDER. The marketing
+// host cannot start the flow itself — that is the whole Gate C finding: the
+// OAuth state cookie would be written for the wrong host. It also does not
+// know which providers this instance configured; only the server rendering
+// `/ask` does. So the marketing host says "this visitor wants to sign in"
+// and the app surface decides what that means.
+//
+// WHY THE GATE IS NARROW. Auto-invoking a redirect off-site is only
+// defensible when there is exactly one thing it could mean. With two
+// providers configured, "sign in" does not name a provider and the visitor
+// must choose; with none, there is nothing to invoke; with a session
+// already, there is nothing to do. Each of those falls back to rendering the
+// panel, which is never wrong — only slower by one click.
+
+/**
+ * The query parameter carrying sign-in intent. Declared here rather than at
+ * either end so the producer (`host-links.ts`, which builds the href) and
+ * the consumer (`/ask`, which reads it) cannot drift apart.
+ */
+export const SIGN_IN_INTENT_PARAM = 'signin';
+
+/**
+ * Read the intent flag out of a Next `searchParams` value, which is
+ * `string | string[] | undefined` — a repeated parameter arrives as an
+ * array. Only the literal `1` counts: a bare `?signin` or any other value is
+ * not the handoff this codebase emits, and guessing at intent is how an
+ * auto-redirect becomes a surprise.
+ */
+export function readSignInIntent(value: string | string[] | undefined): boolean {
+  if (Array.isArray(value)) return value.includes('1');
+  return value === '1';
+}
+
+/**
+ * Should the sign-in panel start the flow on its own?
+ *
+ * All three conditions are required, and each failure mode is a render of
+ * the ordinary panel:
+ * - `hasIntent` — the visitor clicked a sign-in affordance somewhere. A
+ *   direct visit to `/ask` never auto-redirects.
+ * - `signedOut` — belt and braces. The page returns the query surface
+ *   before the panel for a visitor with a session, so this cannot be false
+ *   in practice; encoding it here keeps the gate honest if that ever
+ *   changes.
+ * - exactly one option — "sign in" is unambiguous only when the instance
+ *   offers a single provider.
+ */
+export function shouldAutoSignIn(opts: {
+  hasIntent: boolean;
+  signedOut: boolean;
+  optionCount: number;
+}): boolean {
+  return opts.hasIntent && opts.signedOut && opts.optionCount === 1;
+}


### PR DESCRIPTION
The final Gate C code phase (#191), two owner-directed items plus one same-file finding.

**Item 1 — the truncation CTA carries the marketing origin.** `McpResponseDisplay`'s "Try this locally (no limits)" link (`/learn#try-it`) 404'd on the app host; it now reads `marketingOrigin` from the `useHostLinks()` context the component already consumes — identity when unset, absolute on split-host, omitted on app-only (the P4c precedent: hide rather than point at a withheld route). **Scope addition, recorded:** smoking this surfaced the AI-accuracy disclaimer's "Learn more →" (`/learn#ai-limitations`) in the same file — the same defect and strictly more visible, since it renders on every completed result. Identical treatment, separate commit.

**Item 2 — sign-in intent handoff.** The cross-host sign-in affordances now link to `{appOrigin}/ask?signin=1`, and the `/ask` panel auto-invokes the named `signIn(id, {callbackUrl:'/ask'})` when the param is present ∧ signed out ∧ exactly one provider is configured:

- **One-shot, both halves:** the param is stripped via `history.replaceState` *before* `signIn` is called (an OAuth error return or Back finds no intent to re-fire), and a ref guards the effect within the mount (the server-passed prop doesn't change on a client-side URL replace; dev-mode double effects).
- Multiple providers or signed in: the param is provably ignored — the ordinary panel renders. Unset topology: `signInHref` stays null, nothing changes; a manually-typed `?signin=1` on a single-provider instance auto-invokes, accepted as correct (the visitor typed the intent).
- The param name lives in new `src/lib/sign-in-intent.ts`, imported by both the producer (`host-links.ts`) and the consumer (`/ask`), so they cannot drift; the gate is the pure, tested `shouldAutoSignIn()`. Intent is read from the server page's `searchParams` and handed down as a decided boolean — no `useSearchParams`/Suspense in the presentational component.
- While invoking, the panel renders "Taking you to sign in with {name}…" instead of buttons; a rejected `signIn` restores them, so the interstitial is never a dead end.
- The app-only relative href carries the param too — it encodes intent, not topology; pinned by a test asserting every non-null `signInHref` carries it.

## Evidence

510/510 tests (+9: the gate's truth table, intent parsing including the repeated-param `string[]` shape, the every-href-carries-the-param pin). Lint 0 errors; build clean, 27/27 static pages. Byte-identity vs `main` for apex `/` and param-less `/ask` (normalized DOM md5-identical, zero non-script raw-diff lines). Split-config smoke: `signInHref":"https://app.localhost/ask?signin=1"` threaded to all four affordances; single-provider + param renders the interstitial with the URL stripped; two-provider + param renders both buttons; zero relative `/learn` links remain on the app host and the absolute targets resolve. App-only: `signin=1` works on the relative href; both `/learn` links absent; the disclaimer sentence reads correctly without its link.

The live OAuth hop through the handoff is the owner's re-smoke.

Part of #191. IMPL ran on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
