### PR TITLE
feat: instance branding/theming seam — SITE_BRAND_* knobs + neutral accent tokens (#217)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,3 +123,13 @@ MARKETING_HOST=
 # App-only instance (no marketing site): 1/true serves the gated surface on
 # every host; APP_HOST/MARKETING_HOST are ignored.
 APP_ONLY=
+
+# --- Instance branding (chrome only; all optional - unset renders the demo chrome byte-identically) ---
+# Chrome knobs: header wordmark, page titles, footer identity lines, accent color.
+# Never signed or emitted into evidence (that is the EVIDENCE_* identity set above).
+# Set in the BUILD environment as well as at run time: statically prerendered
+# pages bake their chrome at next build. See docs/deploy.md "Branding and theming".
+# SITE_BRAND_NAME=                   # header wordmark + page titles + citation labels
+# SITE_BRAND_ACCENT=                 # #rgb or #rrggbb; hover/light companions are derived
+# SITE_BRAND_TAGLINE=                # footer first identity line
+# SITE_BRAND_ATTRIBUTION=            # footer attribution line (plain text)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -396,7 +396,11 @@ doesn't):
 (`EVIDENCE_SITE_ORIGIN`, `EVIDENCE_SIGNER_*`, `EVIDENCE_PLATFORM_AGENT_*`,
 `EVIDENCE_PUBLICATION_HOST`, the registry-URL overrides — with none set,
 the demo deployment's values are emitted; see
-[`docs/instance-setup.md`](instance-setup.md)), `OIDC_PROVIDER_NAME`
+[`docs/instance-setup.md`](instance-setup.md)), the chrome-branding set
+(`SITE_BRAND_NAME`, `SITE_BRAND_ACCENT`, `SITE_BRAND_TAGLINE`,
+`SITE_BRAND_ATTRIBUTION` — with none set, the demo chrome renders
+byte-identically; see [Branding and
+theming](#branding-and-theming-chrome-only) below), `OIDC_PROVIDER_NAME`
 (button label), `SIGN_IN_ALLOWLIST` (unset or empty = open sign-in,
 exactly the pre-allowlist behavior; see the sign-in section),
 the host-topology set (`APP_HOST`, `MARKETING_HOST`, `APP_ONLY` — with
@@ -413,6 +417,36 @@ defaults described in the storage section), and analytics
 One build-time caveat: `NEXT_PUBLIC_*` values are inlined into client
 bundles at build time. They belong to the image build, not to `docker
 compose up` — a pass-through at run time cannot change them.
+
+### Branding and theming (chrome only)
+
+Four variables rebrand the site chrome — and only the chrome. Nothing
+here touches emitted evidence: the values that name your instance
+*inside signed packages* are the `EVIDENCE_*` set
+([`docs/instance-setup.md`](instance-setup.md)), and the two sets are
+read independently so a chrome change can never invalidate a package or
+a registry cross-check. All four resolve in
+[`src/lib/brand-config.ts`](../src/lib/brand-config.ts); with none set,
+the demo chrome renders byte-identically.
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `SITE_BRAND_NAME` | Display name in chrome: the header wordmark, the page `<title>`s, and the "… Evidence Package" citation labels. Prose *about* the reference project (the About/Project pages) is content, not chrome, and does not follow this variable. | `Civic AI Tools` |
+| `SITE_BRAND_ACCENT` | Accent color as `#rgb`/`#rrggbb`. Overrides the accent tokens (`--accent` and companions in `src/app/globals.css`) via one inline style on `<html>`; every accent-colored surface follows, including the aliased NYC-palette names. The darker hover and lighter fill companions are derived from this one value. Invalid values are ignored — the stylesheet default renders. Semantic status colors (success green, caution amber, error red) are governed by `docs/design-principles.md` and are deliberately NOT themable. | the NYC blue `#103FEF` |
+| `SITE_BRAND_TAGLINE` | The footer's first identity line. | the demo tagline |
+| `SITE_BRAND_ATTRIBUTION` | The footer's attribution line, as plain text (replaces the demo deployment's authored line, which carries a hyperlink). The footer's repo links and the sponsor line are not part of this seam. | the demo attribution |
+
+Set these **in the build environment as well as at run time**.
+Statically prerendered pages bake their chrome at `next build` (the
+same server-side seam behavior as the host-topology variables), while
+dynamic pages read the runtime environment — with the variables present
+in both, every page agrees. None of these are `NEXT_PUBLIC_*`, and none
+may become so: client inlining is exactly what would break runtime
+container configuration for the dynamic pages.
+
+The favicon is a file, not a variable: replace
+[`src/app/favicon.ico`](../src/app/favicon.ico) in your checkout (the
+App Router serves it at `/favicon.ico`) and rebuild.
 
 ## Sign-in configuration
 

--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -124,6 +124,18 @@ set, the demo deployment's values are emitted):
 Check the wiring with the presence-only preflight (no values are read or
 printed): `node scripts/preflight-env.mjs`.
 
+**Chrome branding is a separate, lighter set.** The table above covers
+everything that names your instance *inside emitted evidence* — values
+that are signed and cross-checked against your registry. What names it
+in the *site chrome* — the header wordmark, page titles, the footer
+identity lines, and the accent color — is presentation, configured by
+the `SITE_BRAND_*` set in
+[deploy.md's Branding and theming section](deploy.md#branding-and-theming-chrome-only).
+Nothing in that set is ever signed or verified. A fully renamed instance
+typically sets both `SITE_BRAND_NAME` (chrome) and
+`EVIDENCE_PLATFORM_AGENT_TITLE` (evidence attribution); the two are read
+independently on purpose, so neither can surprise the other.
+
 ## 5. Smoke test
 
 Publish a fresh package and verify it on your instance's detail page: the

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -216,6 +216,16 @@ export const ENV_SPEC = [
   { name: 'EVIDENCE_PLATFORM_AGENT_TITLE', tier: 'optional', purpose: 'PROV platform-agent title + notebook attribution display name', hasFallback: true },
   { name: 'EVIDENCE_PLATFORM_AGENT_URL', tier: 'optional', purpose: 'PROV platform-agent URL (defaults to EVIDENCE_SITE_ORIGIN when set)', hasFallback: true },
 
+  // --- Instance branding (#217: chrome-only theming seam; src/lib/brand-config.ts).
+  //     All optional with coded defaults: unset, the demo chrome renders
+  //     byte-identically. Chrome only — nothing here is emitted inside signed
+  //     evidence (that is the EVIDENCE_* identity set above), so these can
+  //     never invalidate a package or a registry cross-check. ---
+  { name: 'SITE_BRAND_NAME', tier: 'optional', purpose: 'Instance display name — header wordmark, page titles, citation labels (default "Civic AI Tools")', hasFallback: true },
+  { name: 'SITE_BRAND_ACCENT', tier: 'optional', purpose: 'Accent color (#rgb/#rrggbb) — overrides the accent tokens site-wide; unset or invalid = stylesheet default', hasFallback: true },
+  { name: 'SITE_BRAND_TAGLINE', tier: 'optional', purpose: 'Footer tagline line (default: the demo tagline)', hasFallback: true },
+  { name: 'SITE_BRAND_ATTRIBUTION', tier: 'optional', purpose: 'Footer attribution line, plain text (unset: the demo authored attribution markup)', hasFallback: true },
+
   // --- Optional / feature / ops ---
   { name: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },
   { name: 'CIVICAITOOLS_SESSION_TOKEN', tier: 'optional', purpose: 'publish-evidence skill (Claude Code) auth' },

--- a/src/app/(app)/ask/page.tsx
+++ b/src/app/(app)/ask/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/sign-in-intent';
 import QuerySurface from '@/components/shared/QuerySurface';
 import AskSignInPanel from './AskSignInPanel';
+import { getBrandName } from '@/lib/brand-config';
 
 /**
  * `/ask` — the query surface in signed-in configuration (app front-door
@@ -71,7 +72,7 @@ import AskSignInPanel from './AskSignInPanel';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Ask - Civic AI Tools',
+  title: `Ask - ${getBrandName()}`,
   description:
     'Ask a question about public data and publish the answer as a signed evidence package.',
 };

--- a/src/app/(app)/auth/device/page.tsx
+++ b/src/app/(app)/auth/device/page.tsx
@@ -4,11 +4,12 @@ import { authOptions } from '@/lib/auth';
 import { normalizeUserCode } from '@/lib/device-flow';
 import DeviceApprovalPanel from './DeviceApprovalPanel';
 import DeviceSignInPanel from './DeviceSignInPanel';
+import { getBrandName } from '@/lib/brand-config';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Authorize device - Civic AI Tools',
+  title: `Authorize device - ${getBrandName()}`,
   description: 'Authorize a CLI or external client to publish evidence on your behalf.',
 };
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -7,11 +7,12 @@ import { apiTokens, evidenceRecords, attestationPackages, users } from '@/lib/db
 import { eq, desc, and, ne, isNull, sql } from 'drizzle-orm';
 import DashboardTabs from '@/components/dashboard/DashboardTabs';
 import { isSigningConfigured } from '@/lib/evidence/unsigned-tier';
+import { getBrandName } from '@/lib/brand-config';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Dashboard - Civic AI Tools',
+  title: `Dashboard - ${getBrandName()}`,
   description: 'Manage your evidence records and evaluations.',
 };
 

--- a/src/app/(app)/evidence/[slug]/page.tsx
+++ b/src/app/(app)/evidence/[slug]/page.tsx
@@ -9,6 +9,9 @@ import { evidenceRecords, users } from '@/lib/db/schema';
 // request-host fallback resolve per-instance (server component — env is
 // available at request time; demo defaults when unset).
 import { getEvidenceSiteOrigin, getPublicationHost } from '@/lib/site-config';
+// Chrome branding (#217): the citation label's display name — chrome-only,
+// never part of the signed package (that is the EVIDENCE_* set above).
+import { getBrandName } from '@/lib/brand-config';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import type { EvidencePackage } from '@/lib/evidence/packager';
@@ -154,7 +157,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, { bg: string; text: string }> = {
     unverified: { bg: 'rgba(0,0,0,0.06)', text: 'var(--text-muted)' },
-    consistency_tested: { bg: 'rgba(16, 63, 239, 0.1)', text: 'var(--nyc-blue)' },
+    consistency_tested: { bg: 'rgba(var(--accent-rgb), 0.1)', text: 'var(--nyc-blue)' },
     evaluated: { bg: 'rgba(0, 183, 3, 0.1)', text: 'var(--nyc-success)' },
     fully_attested: { bg: 'rgba(0, 183, 3, 0.15)', text: 'var(--nyc-success)' },
   };
@@ -304,8 +307,8 @@ export default async function EvidencePage({ params }: PageProps) {
         {isSealed && (
           <div style={{
             padding: '16px 20px', marginBottom: '24px',
-            backgroundColor: 'rgba(16, 63, 239, 0.05)',
-            border: '1px solid rgba(16, 63, 239, 0.25)',
+            backgroundColor: 'rgba(var(--accent-rgb), 0.05)',
+            border: '1px solid rgba(var(--accent-rgb), 0.25)',
             borderRadius: '6px',
           }}>
             <div style={{ fontSize: '15px', fontWeight: 600, color: 'var(--nyc-blue)', marginBottom: '6px' }}>
@@ -394,7 +397,7 @@ export default async function EvidencePage({ params }: PageProps) {
         {!isDatHere && (
           <Section title="Summary">
             <div style={{
-              padding: '16px 20px', backgroundColor: 'rgba(16, 63, 239, 0.04)',
+              padding: '16px 20px', backgroundColor: 'rgba(var(--accent-rgb), 0.04)',
               borderLeft: '3px solid var(--nyc-blue)', borderRadius: '0 4px 4px 0',
               fontSize: '15px', lineHeight: 1.6, color: 'var(--text-secondary)',
             }}>
@@ -445,7 +448,7 @@ export default async function EvidencePage({ params }: PageProps) {
             <Section title="A · Initial prompt">
               {renderPkg.prompt.text ? (
                 <div style={{
-                  padding: '16px 20px', backgroundColor: 'rgba(16, 63, 239, 0.04)',
+                  padding: '16px 20px', backgroundColor: 'rgba(var(--accent-rgb), 0.04)',
                   borderLeft: '3px solid var(--nyc-blue)', borderRadius: '0 4px 4px 0',
                   fontSize: '15px', lineHeight: 1.6, color: 'var(--text-primary)',
                   whiteSpace: 'pre-wrap',
@@ -598,7 +601,7 @@ export default async function EvidencePage({ params }: PageProps) {
             {/* G · Summary */}
             <Section title="G · Summary">
               <div style={{
-                padding: '12px 16px', backgroundColor: 'rgba(16, 63, 239, 0.04)',
+                padding: '12px 16px', backgroundColor: 'rgba(var(--accent-rgb), 0.04)',
                 borderLeft: '3px solid var(--nyc-blue)', borderRadius: '0 4px 4px 0',
                 fontSize: '14px', lineHeight: 1.6, color: 'var(--text-secondary)',
               }}>
@@ -895,6 +898,7 @@ export default async function EvidencePage({ params }: PageProps) {
             captureMethod={record.captureMethod}
             visibility={record.visibility}
             commitmentUrl={commitmentUrl}
+            brandName={getBrandName()}
           />
         </Section>
 

--- a/src/app/(app)/evidence/page.tsx
+++ b/src/app/(app)/evidence/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import EvidenceIndex from '@/components/evidence/EvidenceIndex';
+import { getBrandName } from '@/lib/brand-config';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Evidence - Civic AI Tools',
+  title: `Evidence - ${getBrandName()}`,
   description: 'Published evidence packages from AI-assisted civic data analyses.',
 };
 

--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -2,9 +2,10 @@ import Link from 'next/link';
 import { prose, sectionHeading, sectionSpacing } from '@/styles/page-styles';
 import { EXPRESS_INTEREST_URL } from '@/lib/site-config';
 import SponsorLine from '@/components/SponsorLine';
+import { getBrandName } from '@/lib/brand-config';
 
 export const metadata = {
-  title: 'About - Civic AI Tools',
+  title: `About - ${getBrandName()}`,
   description: 'Civic AI Tools is an open-source project that connects AI assistants to government open data using the Model Context Protocol.',
 };
 

--- a/src/app/(marketing)/directory/page.tsx
+++ b/src/app/(marketing)/directory/page.tsx
@@ -2,9 +2,10 @@ import { Suspense } from 'react';
 import { getDirectoryData } from '@/lib/mcp/directory-data';
 import { getPortalData, getPortalCounts } from '@/lib/mcp/portal-data';
 import DirectoryWrapper from '@/components/DirectoryWrapper';
+import { getBrandName } from '@/lib/brand-config';
 
 export const metadata = {
-  title: 'Directory - Civic AI Tools',
+  title: `Directory - ${getBrandName()}`,
   description:
     'Browse 65+ MCP servers for civic data and 2,000+ open data portals across Socrata and CKAN platforms.',
 };

--- a/src/app/(marketing)/explore/page.tsx
+++ b/src/app/(marketing)/explore/page.tsx
@@ -1,7 +1,8 @@
 import McpFlowDiagramWrapper from '@/components/explore/McpFlowDiagramWrapper';
+import { getBrandName } from '@/lib/brand-config';
 
 export const metadata = {
-  title: 'Data Flow | Civic AI Tools',
+  title: `Data Flow | ${getBrandName()}`,
   description: 'Watch how AI connects to live civic data. Replay example traces or run your own query to see the process in real time.',
 };
 

--- a/src/app/(marketing)/learn/page.tsx
+++ b/src/app/(marketing)/learn/page.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link';
 import { prose, sectionHeading, sectionSpacing, calloutBox, excerptBlock, card } from '@/styles/page-styles';
+import { getBrandName } from '@/lib/brand-config';
 
 export const metadata = {
-  title: 'Learn - Civic AI Tools',
+  title: `Learn - ${getBrandName()}`,
   description: 'Learn how this demo works, how AI connects to live civic data through MCP, and what shapes the quality of AI responses.',
 };
 

--- a/src/app/(marketing)/project/page.tsx
+++ b/src/app/(marketing)/project/page.tsx
@@ -3,9 +3,10 @@ import Link from 'next/link';
 import { prose, sectionHeading, sectionSpacing, card } from '@/styles/page-styles';
 import { EXPRESS_INTEREST_URL, TYPED_STANDARDS_URL } from '@/lib/site-config';
 import { CONSORTIUM_MEMBERS } from '@/lib/consortium';
+import { getBrandName } from '@/lib/brand-config';
 
 export const metadata: Metadata = {
-  title: 'Project - Civic AI Tools',
+  title: `Project - ${getBrandName()}`,
   description:
     'What the Civic AI Tools project is: verifiable AI-assisted analysis of open civic data, the pillars it works across, and real published evidence records.',
 };

--- a/src/app/(marketing)/roadmap/page.tsx
+++ b/src/app/(marketing)/roadmap/page.tsx
@@ -2,9 +2,10 @@ import type { Metadata } from 'next';
 import { getRoadmapMarkdown, ROADMAP_GITHUB_URL } from '@/lib/roadmap/data';
 import AudienceRoutingStrip from '@/components/roadmap/AudienceRoutingStrip';
 import RoadmapBody from '@/components/roadmap/RoadmapBody';
+import { getBrandName } from '@/lib/brand-config';
 
 export const metadata: Metadata = {
-  title: 'Roadmap - Civic AI Tools',
+  title: `Roadmap - ${getBrandName()}`,
   description:
     'The civic-ai-tools public roadmap — vision pillars, trust commitments, near-term plans, and how the evidence-system fork resolved (toward a domain-neutral, spec-first protocol). Mirrored from the hub repo.',
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,15 +2,37 @@
 
 /* NYC Design System Color Palette */
 :root {
+  /* Accent tokens — the operator-facing theming seam (#217).
+     These four are the ONLY color tokens an instance is ever told to change,
+     and they are set through configuration (SITE_BRAND_ACCENT → an inline
+     style on <html> in the root layout), not by editing this file. The
+     values here are the reference deployment's NYC-palette defaults; with no
+     brand configuration the rendered output is byte-identical to before the
+     seam existed.
+     --accent-rgb is --accent's channel triplet. The pair MUST stay in
+     lockstep: rgba(var(--accent-rgb), α) is the sanctioned form for every
+     translucent accent (no hardcoded rgba(16, 63, 239, …) call sites), and
+     the runtime override always writes all four properties from one
+     configured value (src/lib/brand-config.ts derives the companions), so a
+     configured instance cannot drift either. */
+  --accent: #103FEF;
+  --accent-rgb: 16, 63, 239;
+  --accent-hover: #050560;
+  --accent-light: #B5DBFF;
+
   /* Primary Brand Colors */
   --nyc-black: #000000;
   --nyc-white: #FFFFFF;
-  --nyc-blue-40: #103FEF;
-  --nyc-blue: #103FEF;
+  /* Accent-family NYC names — aliased to the neutral tokens above (#217) so
+     every existing --nyc-* reference keeps resolving to the same computed
+     value. New code and operators use the neutral names; the wholesale
+     reference migration is #220's, not this seam's. */
+  --nyc-blue-40: var(--accent);
+  --nyc-blue: var(--accent);
 
   /* Interactive State Colors */
-  --nyc-blue-80: #B5DBFF;
-  --nyc-blue-10: #050560;
+  --nyc-blue-80: var(--accent-light);
+  --nyc-blue-10: var(--accent-hover);
 
   /* Foreground Colors (Text & Elements) */
   --nyc-gray-20: #333333;
@@ -44,9 +66,8 @@
   --text-secondary: var(--nyc-gray-20);
   --text-muted: #757575;
   --border-color: var(--nyc-gray-80);
-  --accent: var(--nyc-blue-40);
-  --accent-hover: var(--nyc-blue-10);
-  --accent-light: var(--nyc-blue-80);
+  /* --accent / --accent-hover / --accent-light are defined at the top of
+     this block (#217) — they are the settable seam now, not applied aliases. */
   --card-background: var(--nyc-gray-90);
   --skeleton-color: var(--nyc-gray-80);
 }
@@ -508,7 +529,7 @@ footer a:visited {
 /* About page query suggestion cards */
 .query-suggestion-card:hover {
   border-color: var(--nyc-blue-40);
-  background-color: rgba(16, 63, 239, 0.03);
+  background-color: rgba(var(--accent-rgb), 0.03);
 }
 
 .query-suggestion-card:visited {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,13 @@ import { resolveDashboardHref } from '@/lib/host-routing';
 import { resolveHostLinks } from '@/lib/host-links';
 import RunningUnsignedBanner from '@/components/RunningUnsignedBanner';
 import SponsorLine from '@/components/SponsorLine';
+import { BrandProvider } from '@/components/BrandProvider';
+import {
+  getBrandAccent,
+  getBrandAttribution,
+  getBrandName,
+  getBrandTagline,
+} from '@/lib/brand-config';
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
@@ -26,7 +33,7 @@ const notoSans = Noto_Sans({
 });
 
 export const metadata: Metadata = {
-  title: 'Civic AI Tools - MCP Demo',
+  title: `${getBrandName()} - MCP Demo`,
   description:
     'See the difference MCP (Model Context Protocol) makes when querying civic data. Compare AI responses with and without live data access.',
   robots: {
@@ -34,14 +41,14 @@ export const metadata: Metadata = {
     follow: false,
   },
   openGraph: {
-    title: 'Civic AI Tools - MCP Demo',
+    title: `${getBrandName()} - MCP Demo`,
     description:
       'See the difference MCP makes when querying civic data. Compare AI responses with and without live data access.',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Civic AI Tools - MCP Demo',
+    title: `${getBrandName()} - MCP Demo`,
     description:
       'See the difference MCP makes when querying civic data. Compare AI responses with and without live data access.',
   },
@@ -61,8 +68,39 @@ export default function RootLayout({
    */
   const hostLinks = resolveHostLinks(process.env);
 
+  /**
+   * Instance branding (#217), resolved server-side like the host links
+   * above. All four knobs default to the demo chrome, so with nothing
+   * configured every branch below renders today's exact bytes.
+   *
+   * The accent override writes the four accent-family custom properties as
+   * an inline style on <html> — inline beats the stylesheet's `:root` block,
+   * so every `var(--accent…)` reference (including the aliased `--nyc-*`
+   * names) follows the configured color. `null` (unset or invalid) writes NO
+   * style attribute at all: the stylesheet defaults render, a zero-byte
+   * delta.
+   */
+  const brandName = getBrandName();
+  const brandTagline = getBrandTagline();
+  const brandAttribution = getBrandAttribution();
+  const brandAccent = getBrandAccent();
+  // Conditional SPREAD, not `style={maybeUndefined}`: an explicit
+  // `style={undefined}` would still serialize a `"style":"$undefined"` entry
+  // into the RSC flight payload, a needless unset-case byte delta. With the
+  // spread, the unset case carries no style prop at all.
+  const accentProps = brandAccent
+    ? {
+        style: {
+          '--accent': brandAccent.accent,
+          '--accent-rgb': brandAccent.accentRgb,
+          '--accent-hover': brandAccent.accentHover,
+          '--accent-light': brandAccent.accentLight,
+        } as React.CSSProperties,
+      }
+    : {};
+
   return (
-    <html lang="en">
+    <html lang="en" {...accentProps}>
       {GA_MEASUREMENT_ID && (
         <>
           <Script
@@ -82,6 +120,10 @@ export default function RootLayout({
       <body className={`${spaceGrotesk.variable} ${notoSans.variable}`}>
         <Providers>
           <HostLinksProvider value={hostLinks}>
+          {/* Brand name for client components props cannot reach (#217) —
+              currently the chat citation preview. Same pattern and mount
+              point as HostLinksProvider above. */}
+          <BrandProvider value={brandName}>
           <div className="flex flex-col">
             {/* Env-driven (P3): on a split-host topology the marketing host
                 withholds /dashboard, so the signed-in menu must carry the
@@ -94,6 +136,7 @@ export default function RootLayout({
               dashboardHref={resolveDashboardHref(process.env)}
               marketingOrigin={hostLinks.marketingOrigin}
               signInHref={hostLinks.signInHref}
+              brandName={brandName}
             />
             {/* ADR-0020: running-unsigned indicator — renders only when this
                 instance has no signing key AND is outside a dev environment. */}
@@ -101,8 +144,11 @@ export default function RootLayout({
             <main>{children}</main>
             <footer className="border-t py-8 text-center" style={{ borderColor: 'var(--border-color)' }}>
               <div style={{ maxWidth: '600px', margin: '0 auto' }}>
+                {/* Footer identity lines (#217): the tagline and attribution
+                    are instance-config knobs. Repo links and the sponsor line
+                    below are NOT part of the seam and stay as they are. */}
                 <p style={{ fontSize: '15px', color: 'var(--text-secondary)', margin: 0 }}>
-                  Open-source tools for AI-powered civic data access
+                  {brandTagline}
                 </p>
                 <p style={{ fontSize: '13px', color: 'var(--text-muted)', margin: '8px 0 0 0' }}>
                   <a href="https://github.com/npstorey/civic-ai-tools" target="_blank" rel="noopener noreferrer">GitHub</a>
@@ -124,14 +170,25 @@ export default function RootLayout({
                   {' \u00b7 '}
                   <a href="https://github.com/npstorey/civic-ai-tools/issues/new?template=suggest-server.yml&labels=directory-submission" target="_blank" rel="noopener noreferrer">Suggest a Server</a>
                 </p>
-                <p style={{ fontSize: '12px', color: 'var(--text-muted)', margin: '8px 0 0 0', opacity: 0.8 }}>
-                  By <a href="https://nathanstorey.com" target="_blank" rel="noopener noreferrer">Nathan Storey</a>
-                  {' \u00b7 '}Personal project{' \u00b7 '}Not affiliated with any employer.
-                </p>
+                {/* Attribution: a configured instance supplies its own
+                    plain-text line; unset renders the demo deployment's
+                    authored markup verbatim (it carries a hyperlink, so it
+                    cannot live in the config module as a string default). */}
+                {brandAttribution !== null ? (
+                  <p style={{ fontSize: '12px', color: 'var(--text-muted)', margin: '8px 0 0 0', opacity: 0.8 }}>
+                    {brandAttribution}
+                  </p>
+                ) : (
+                  <p style={{ fontSize: '12px', color: 'var(--text-muted)', margin: '8px 0 0 0', opacity: 0.8 }}>
+                    By <a href="https://nathanstorey.com" target="_blank" rel="noopener noreferrer">Nathan Storey</a>
+                    {' \u00b7 '}Personal project{' \u00b7 '}Not affiliated with any employer.
+                  </p>
+                )}
                 <SponsorLine style={{ fontSize: '12px', color: 'var(--text-muted)', margin: '8px 0 0 0', opacity: 0.8 }} />
               </div>
             </footer>
           </div>
+          </BrandProvider>
           </HostLinksProvider>
         </Providers>
       </body>

--- a/src/components/BrandProvider.tsx
+++ b/src/components/BrandProvider.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { DEMO_BRAND_NAME } from '@/lib/brand-config';
+
+/**
+ * Carries the server-resolved brand name to client components that props
+ * cannot reach (instance branding seam, #217) — the exact shape of
+ * `HostLinksProvider`, and mounted beside it in the root layout.
+ *
+ * WHY A CONTEXT AND NOT PROP THREADING. `ChatCitationPreview` renders deep
+ * inside `ChatNotebookOutput`, which is a `'use client'` tree with no server
+ * ancestor to extend a prop chain from. Components a server component
+ * renders directly — `Header` (via the root layout), `EvidenceActions` (via
+ * the evidence detail page) — take the name as a prop instead: props where
+ * the server can reach, context only where the client boundary blocks it.
+ *
+ * The default value is the demo brand name, so a component rendered outside
+ * the provider — a test, a future surface that forgets to mount it —
+ * degrades to today's chrome rather than to a blank label.
+ */
+const BrandNameContext = createContext<string>(DEMO_BRAND_NAME);
+
+export function BrandProvider({
+  value,
+  children,
+}: {
+  value: string;
+  children: ReactNode;
+}) {
+  return <BrandNameContext.Provider value={value}>{children}</BrandNameContext.Provider>;
+}
+
+/** Read the instance brand name. Safe outside the provider (see above). */
+export function useBrandName(): string {
+  return useContext(BrandNameContext);
+}

--- a/src/components/DirectoryClient.tsx
+++ b/src/components/DirectoryClient.tsx
@@ -664,7 +664,7 @@ function ServerCard({ server }: { server: McpServerEntry }) {
         border: `1px solid ${server.included ? 'var(--nyc-blue)' : 'var(--border-color)'}`,
         borderRadius: '4px',
         padding: '20px',
-        backgroundColor: server.included ? 'rgba(16, 63, 239, 0.03)' : 'var(--background)',
+        backgroundColor: server.included ? 'rgba(var(--accent-rgb), 0.03)' : 'var(--background)',
         display: 'flex',
         flexDirection: 'column',
         gap: '10px',
@@ -681,7 +681,7 @@ function ServerCard({ server }: { server: McpServerEntry }) {
           >
             {server.name}
           </a>
-          {server.included && <Badge color="#103FEF" bg="rgba(16, 63, 239, 0.1)">Included</Badge>}
+          {server.included && <Badge color="var(--accent)" bg="rgba(var(--accent-rgb), 0.1)">Included</Badge>}
           {server.verificationStatus === 'official' && (
             <Badge color="var(--nyc-success)" bg="rgba(0, 138, 2, 0.1)">Official</Badge>
           )}
@@ -699,8 +699,8 @@ function ServerCard({ server }: { server: McpServerEntry }) {
         {server.transport.map((t) => (
           <Badge
             key={t}
-            color={t === 'http' ? '#103FEF' : t === 'sse' ? '#B8860B' : 'var(--text-muted)'}
-            bg={t === 'http' ? 'rgba(16, 63, 239, 0.08)' : t === 'sse' ? 'rgba(184, 134, 11, 0.08)' : 'var(--card-background)'}
+            color={t === 'http' ? 'var(--accent)' : t === 'sse' ? '#B8860B' : 'var(--text-muted)'}
+            bg={t === 'http' ? 'rgba(var(--accent-rgb), 0.08)' : t === 'sse' ? 'rgba(184, 134, 11, 0.08)' : 'var(--card-background)'}
           >
             {t}
           </Badge>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,15 +39,20 @@ const DROPDOWN_ITEM_STYLE: React.CSSProperties = {
  *   so the round-trip dies at the provider's redirect warning. Non-null
  *   turns the button into a plain link to the app surface's sign-in panel;
  *   `null` (the default, and unset topology) keeps today's in-place button.
+ * - `brandName` (#217) — the wordmark text, resolved by the layout from
+ *   `SITE_BRAND_NAME` (src/lib/brand-config.ts). The default is the demo
+ *   name, so a mount that omits the prop renders today's chrome.
  */
 export default function Header({
   dashboardHref = '/dashboard',
   marketingOrigin = '',
   signInHref = null,
+  brandName = 'Civic AI Tools',
 }: {
   dashboardHref?: string;
   marketingOrigin?: string | null;
   signInHref?: string | null;
+  brandName?: string;
 }) {
   const { data: session, status } = useSession();
   const headerRef = useRef<HTMLElement>(null);
@@ -121,7 +126,7 @@ export default function Header({
               color: 'var(--text-primary)',
             }}
           >
-            Civic AI Tools
+            {brandName}
           </Link>
           <nav className="hidden sm:flex items-center gap-6">
             {/* Explore dropdown */}

--- a/src/components/dashboard/DashboardTabs.tsx
+++ b/src/components/dashboard/DashboardTabs.tsx
@@ -85,11 +85,11 @@ const tabStyle = (isActive: boolean): CSSProperties => ({
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, { bg: string; text: string }> = {
     unverified: { bg: 'rgba(0,0,0,0.06)', text: 'var(--text-muted)' },
-    consistency_tested: { bg: 'rgba(16, 63, 239, 0.1)', text: 'var(--nyc-blue)' },
+    consistency_tested: { bg: 'rgba(var(--accent-rgb), 0.1)', text: 'var(--nyc-blue)' },
     evaluated: { bg: 'rgba(0, 183, 3, 0.1)', text: 'var(--nyc-success)' },
     fully_attested: { bg: 'rgba(0, 183, 3, 0.15)', text: 'var(--nyc-success)' },
     withdrawn: { bg: 'rgba(236, 19, 30, 0.08)', text: 'var(--nyc-error)' },
-    sealed: { bg: 'rgba(16, 63, 239, 0.08)', text: 'var(--nyc-blue)' },
+    sealed: { bg: 'rgba(var(--accent-rgb), 0.08)', text: 'var(--nyc-blue)' },
   };
   const c = colors[status] || colors.unverified;
   return (
@@ -109,7 +109,7 @@ function TypeBadge({ type }: { type: string }) {
     <span style={{
       display: 'inline-block', padding: '2px 8px', borderRadius: '10px',
       fontSize: '11px', fontWeight: 600,
-      backgroundColor: isConsistency ? 'rgba(16, 63, 239, 0.1)' : 'rgba(0, 183, 3, 0.1)',
+      backgroundColor: isConsistency ? 'rgba(var(--accent-rgb), 0.1)' : 'rgba(0, 183, 3, 0.1)',
       color: isConsistency ? 'var(--nyc-blue)' : 'var(--nyc-success)',
       textTransform: 'capitalize',
     }}>
@@ -713,7 +713,7 @@ function TokensTab({ rows }: { rows: TokenRow[] }) {
                   <span style={{
                     display: 'inline-block', padding: '2px 8px', borderRadius: '10px',
                     fontSize: '11px', fontWeight: 600,
-                    backgroundColor: 'rgba(16, 63, 239, 0.1)', color: 'var(--nyc-blue)',
+                    backgroundColor: 'rgba(var(--accent-rgb), 0.1)', color: 'var(--nyc-blue)',
                   }}>
                     {t.scope}
                   </span>

--- a/src/components/evidence/AttestationDialog.tsx
+++ b/src/components/evidence/AttestationDialog.tsx
@@ -376,7 +376,7 @@ export default function AttestationDialog({
         {requiresApiKey && (
           <>
             <div style={{
-              padding: '10px 14px', backgroundColor: 'rgba(16, 63, 239, 0.04)',
+              padding: '10px 14px', backgroundColor: 'rgba(var(--accent-rgb), 0.04)',
               borderRadius: '4px', fontSize: '12px', color: 'var(--text-secondary)',
               marginBottom: '16px', lineHeight: 1.5,
             }}>

--- a/src/components/evidence/AttestationSection.tsx
+++ b/src/components/evidence/AttestationSection.tsx
@@ -202,7 +202,7 @@ function AttestationCard({ attestation, expanded, isExpanded, onToggle }: {
   });
 
   const typeBadge = attestation.type === 'consistency'
-    ? { label: 'Consistency Test', bg: 'rgba(16, 63, 239, 0.1)', color: 'var(--nyc-blue)' }
+    ? { label: 'Consistency Test', bg: 'rgba(var(--accent-rgb), 0.1)', color: 'var(--nyc-blue)' }
     : { label: 'Evaluation', bg: 'rgba(0, 183, 3, 0.1)', color: 'var(--nyc-success)' };
 
   return (

--- a/src/components/evidence/EvidenceActions.tsx
+++ b/src/components/evidence/EvidenceActions.tsx
@@ -39,10 +39,17 @@ interface EvidenceActionsProps {
    *  (resolved server-side from the request host). The verify badge (#114)
    *  deep-links the neutral verifier to it. */
   commitmentUrl: string;
+  /** Instance display name for the citation label (#217), resolved
+   *  server-side by the detail page from `SITE_BRAND_NAME`
+   *  (src/lib/brand-config.ts) — a prop, not context, because the server
+   *  page renders this component directly. Defaults to the demo name. */
+  brandName?: string;
 }
 
-function CitePopover({ title, creatorName, createdAt, slug, onClose }: {
-  title: string; creatorName: string; createdAt: string; slug: string; onClose: () => void;
+/** Exported for render-harness/tests only — the popover mounts on the Cite
+ *  button's click, which a DOM-free server render cannot simulate. */
+export function CitePopover({ title, creatorName, createdAt, slug, brandName, onClose }: {
+  title: string; creatorName: string; createdAt: string; slug: string; brandName: string; onClose: () => void;
 }) {
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
   const date = new Date(createdAt);
@@ -53,7 +60,7 @@ function CitePopover({ title, creatorName, createdAt, slug, onClose }: {
   const citations = [
     {
       label: 'Plain text',
-      text: `${creatorName} (${year}). "${title}." Civic AI Tools Evidence Package. ${url}. Published: ${dateStr}.`,
+      text: `${creatorName} (${year}). "${title}." ${brandName} Evidence Package. ${url}. Published: ${dateStr}.`,
     },
     {
       label: 'For deliberative process reference',
@@ -146,6 +153,7 @@ interface VerifyResult {
 
 export default function EvidenceActions({
   slug, title, creatorName, createdAt, packageUrl, captureMethod, visibility, commitmentUrl,
+  brandName = 'Civic AI Tools',
 }: EvidenceActionsProps) {
   const [linkCopied, setLinkCopied] = useState(false);
   const [showCite, setShowCite] = useState(false);
@@ -306,6 +314,7 @@ export default function EvidenceActions({
           creatorName={creatorName}
           createdAt={createdAt}
           slug={slug}
+          brandName={brandName}
           onClose={() => setShowCite(false)}
         />
       )}

--- a/src/components/evidence/EvidenceIndex.tsx
+++ b/src/components/evidence/EvidenceIndex.tsx
@@ -47,7 +47,7 @@ const SORT_OPTIONS = [
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, { bg: string; text: string }> = {
     unverified: { bg: 'rgba(0,0,0,0.06)', text: 'var(--text-muted)' },
-    consistency_tested: { bg: 'rgba(16, 63, 239, 0.1)', text: 'var(--nyc-blue)' },
+    consistency_tested: { bg: 'rgba(var(--accent-rgb), 0.1)', text: 'var(--nyc-blue)' },
     evaluated: { bg: 'rgba(0, 183, 3, 0.1)', text: 'var(--nyc-success)' },
     fully_attested: { bg: 'rgba(0, 183, 3, 0.15)', text: 'var(--nyc-success)' },
     withdrawn: { bg: 'rgba(236, 19, 30, 0.08)', text: 'var(--nyc-error)' },
@@ -219,7 +219,7 @@ export default function EvidenceIndex() {
                   }}
                   onMouseOver={(e) => {
                     e.currentTarget.style.borderColor = 'var(--nyc-blue)';
-                    e.currentTarget.style.boxShadow = '0 2px 8px rgba(16, 63, 239, 0.1)';
+                    e.currentTarget.style.boxShadow = '0 2px 8px rgba(var(--accent-rgb), 0.1)';
                   }}
                   onMouseOut={(e) => {
                     e.currentTarget.style.borderColor = 'var(--border-color)';

--- a/src/components/explore/BpmnViewer.tsx
+++ b/src/components/explore/BpmnViewer.tsx
@@ -20,7 +20,7 @@ interface BpmnViewerProps {
 }
 
 const LANE_COLORS: Record<string, string> = {
-  Participant_Browser: 'rgba(16, 63, 239, 0.06)',      // nyc-blue-40
+  Participant_Browser: 'rgba(var(--accent-rgb), 0.06)',      // accent (nyc-blue-40 alias)
   Participant_AI: 'rgba(147, 51, 234, 0.06)',           // light purple (no NYC equivalent)
   Participant_MCP: 'rgba(0, 138, 2, 0.06)',             // nyc-success
   Participant_Socrata: 'rgba(255, 179, 32, 0.06)',      // nyc-caution

--- a/src/components/explore/TraceControls.tsx
+++ b/src/components/explore/TraceControls.tsx
@@ -51,7 +51,7 @@ function SpeedSelector({ speed, onSetSpeed }: { speed: PlaybackSpeed; onSetSpeed
               ? '1px solid var(--nyc-blue-40)'
               : '1px solid var(--border-color)',
             background: s === speed
-              ? 'rgba(16, 63, 239, 0.1)'
+              ? 'rgba(var(--accent-rgb), 0.1)'
               : 'var(--background)',
             color: s === speed
               ? 'var(--nyc-blue-40)'
@@ -378,8 +378,8 @@ export default function TraceControls({
                     ? {
                         color: 'var(--nyc-blue-40)',
                         padding: '8px 12px',
-                        background: 'rgba(16, 63, 239, 0.06)',
-                        border: '1px solid rgba(16, 63, 239, 0.15)',
+                        background: 'rgba(var(--accent-rgb), 0.06)',
+                        border: '1px solid rgba(var(--accent-rgb), 0.15)',
                         borderRadius: '4px',
                       }
                     : {

--- a/src/components/explore/bpmn-diagram.css
+++ b/src/components/explore/bpmn-diagram.css
@@ -24,7 +24,7 @@
 
 /* Active flow */
 .bpmn-active-flow .djs-visual > path {
-  stroke: var(--nyc-blue-40, #103FEF) !important;
+  stroke: var(--nyc-blue-40) !important;
   stroke-width: 3px !important;
   transition: all 0.3s ease;
 }
@@ -98,7 +98,7 @@
 
 .bpmn-overlay .iteration-badge {
   display: inline-block;
-  background: var(--nyc-blue-40, #103FEF);
+  background: var(--nyc-blue-40);
   color: white;
   font-size: 20px;
   font-weight: 700;
@@ -170,8 +170,8 @@
 
 .bpmn-zoom-controls button:hover {
   background: var(--card-background, #eee);
-  border-color: var(--nyc-blue-40, #103FEF);
-  color: var(--nyc-blue-40, #103FEF);
+  border-color: var(--nyc-blue-40);
+  color: var(--nyc-blue-40);
 }
 
 .bpmn-zoom-level {

--- a/src/components/notebook/ChatCitationPreview.tsx
+++ b/src/components/notebook/ChatCitationPreview.tsx
@@ -19,6 +19,7 @@
  */
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
+import { useBrandName } from '@/components/BrandProvider';
 
 interface ChatCitationPreviewProps {
   prompt: string;
@@ -44,9 +45,9 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-function deriveTitle(prompt: string): string {
+function deriveTitle(prompt: string, brandName: string): string {
   const trimmed = prompt.trim();
-  if (trimmed.length === 0) return 'Civic AI Tools Evidence Package';
+  if (trimmed.length === 0) return `${brandName} Evidence Package`;
   // Use the first sentence-ish chunk, capped.
   const firstChunk = trimmed.split(/[?.!\n]/)[0]?.trim() || trimmed;
   if (firstChunk.length <= 100) return firstChunk;
@@ -56,6 +57,9 @@ function deriveTitle(prompt: string): string {
 export default function ChatCitationPreview({ prompt, executedAt, structuredSummary }: ChatCitationPreviewProps) {
   const { data: session } = useSession();
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+  // Instance display name (#217) via BrandProvider (root layout) — this
+  // component sits deep in a 'use client' tree, so context, not props.
+  const brandName = useBrandName();
 
   const creatorName = session?.user?.name || 'Anonymous';
   const date = executedAt ? new Date(executedAt) : new Date();
@@ -67,7 +71,7 @@ export default function ChatCitationPreview({ prompt, executedAt, structuredSumm
   // title heuristic.
   const title = structuredSummary?.analysisDescription
     ? structuredSummary.analysisDescription.replace(/[.!?]+$/, '')
-    : deriveTitle(prompt);
+    : deriveTitle(prompt, brandName);
   const placeholderUrl = 'https://civicaitools.org/evidence/(URL assigned at publish)';
 
   const headlineSuffix = structuredSummary?.headlineFinding
@@ -76,7 +80,7 @@ export default function ChatCitationPreview({ prompt, executedAt, structuredSumm
   const citations = [
     {
       label: 'Plain text',
-      text: `${creatorName} (${year}). "${title}." Civic AI Tools Evidence Package. ${placeholderUrl}. Published: (date assigned at publish).${headlineSuffix}`,
+      text: `${creatorName} (${year}). "${title}." ${brandName} Evidence Package. ${placeholderUrl}. Published: (date assigned at publish).${headlineSuffix}`,
     },
     {
       label: 'For deliberative process reference',

--- a/src/components/notebook/ChatNotebookOutput.tsx
+++ b/src/components/notebook/ChatNotebookOutput.tsx
@@ -151,7 +151,7 @@ export default function ChatNotebookOutput({
       {/* A · Initial prompt */}
       <Section title="A · Initial prompt">
         <div style={{
-          padding: '16px 20px', backgroundColor: 'rgba(16, 63, 239, 0.04)',
+          padding: '16px 20px', backgroundColor: 'rgba(var(--accent-rgb), 0.04)',
           borderLeft: '3px solid var(--nyc-blue)', borderRadius: '0 4px 4px 0',
           fontSize: '15px', lineHeight: 1.6, color: 'var(--text-primary)',
           whiteSpace: 'pre-wrap',
@@ -351,7 +351,7 @@ export default function ChatNotebookOutput({
       {/* G · Summary (Phase 2a2 item 3: structured two-clause blurb) */}
       <Section title="G · Summary">
         <div style={{
-          padding: '12px 16px', backgroundColor: 'rgba(16, 63, 239, 0.04)',
+          padding: '12px 16px', backgroundColor: 'rgba(var(--accent-rgb), 0.04)',
           borderLeft: '3px solid var(--nyc-blue)', borderRadius: '0 4px 4px 0',
           fontSize: '14px', lineHeight: 1.6, color: 'var(--text-secondary)',
         }}>

--- a/src/components/notebook/ChatSignersSection.tsx
+++ b/src/components/notebook/ChatSignersSection.tsx
@@ -67,7 +67,7 @@ function PlatformPendingSignerRow({
         display: 'flex',
         alignItems: 'flex-start',
         gap: '12px',
-        background: 'rgba(16, 63, 239, 0.02)',
+        background: 'rgba(var(--accent-rgb), 0.02)',
       }}
     >
       <span aria-hidden style={{
@@ -86,7 +86,7 @@ function PlatformPendingSignerRow({
               fontSize: '10px', fontWeight: 600, letterSpacing: '0.04em',
               textTransform: 'uppercase',
               padding: '1px 6px', borderRadius: '999px',
-              background: 'rgba(16, 63, 239, 0.1)', color: 'var(--nyc-blue, #0039a6)',
+              background: 'rgba(var(--accent-rgb), 0.1)', color: 'var(--nyc-blue)',
             }}
           >
             Pre-publish preview
@@ -174,7 +174,7 @@ export default function ChatSignersSection({ executedAt, signingKeyId }: ChatSig
           <span style={{
             display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
             width: '22px', height: '22px', borderRadius: '50%',
-            background: 'rgba(16, 63, 239, 0.1)', color: 'var(--nyc-blue, #0039a6)',
+            background: 'rgba(var(--accent-rgb), 0.1)', color: 'var(--nyc-blue)',
             fontSize: '11px', fontWeight: 700,
           }}>↻</span>
           <div>

--- a/src/components/notebook/NotebookProgress.tsx
+++ b/src/components/notebook/NotebookProgress.tsx
@@ -75,7 +75,7 @@ function StatusGlyph({ status }: { status: 'pending' | 'active' | 'done' }) {
         aria-hidden
         style={{
           width: '16px', height: '16px', display: 'inline-block',
-          border: '2px solid var(--nyc-blue, #0039a6)',
+          border: '2px solid var(--nyc-blue)',
           borderTopColor: 'transparent', borderRadius: '50%',
           animation: 'spin 1s linear infinite',
         }}

--- a/src/components/roadmap/AudienceRoutingStrip.tsx
+++ b/src/components/roadmap/AudienceRoutingStrip.tsx
@@ -96,7 +96,7 @@ function AudienceCardTile({ card }: { card: AudienceCard }) {
   const linkStyle: React.CSSProperties = {
     fontSize: '14px',
     fontWeight: 500,
-    color: 'var(--nyc-blue, #103FEF)',
+    color: 'var(--nyc-blue)',
     textDecoration: 'none',
   };
   const arrow = ' →';

--- a/src/components/roadmap/RoadmapBody.tsx
+++ b/src/components/roadmap/RoadmapBody.tsx
@@ -215,7 +215,7 @@ function TocRail({ headings }: { headings: SectionHeading[] }) {
         }
         .toc-rail-desktop a:hover,
         .toc-rail-mobile a:hover {
-          color: var(--nyc-blue, #103fef);
+          color: var(--nyc-blue);
           text-decoration: underline;
         }
         .toc-rail-mobile {

--- a/src/components/shared/McpResponseDisplay.tsx
+++ b/src/components/shared/McpResponseDisplay.tsx
@@ -449,7 +449,7 @@ export default function McpResponseDisplay({
           <div
             style={{
               borderLeft: '3px solid var(--nyc-blue)',
-              backgroundColor: 'rgba(16, 63, 239, 0.04)',
+              backgroundColor: 'rgba(var(--accent-rgb), 0.04)',
               padding: '8px 12px',
               marginBottom: '16px',
               fontSize: '15px',
@@ -816,7 +816,7 @@ export default function McpResponseDisplay({
                   <a
                     href={signInHref}
                     style={{ ...PUBLISH_BUTTON_STYLE, textDecoration: 'none' }}
-                    onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'rgba(16, 63, 239, 0.06)'; }}
+                    onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'rgba(var(--accent-rgb), 0.06)'; }}
                     onMouseOut={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                   >
                     <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
@@ -836,7 +836,7 @@ export default function McpResponseDisplay({
                     }
                   }}
                   style={PUBLISH_BUTTON_STYLE}
-                  onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'rgba(16, 63, 239, 0.06)'; }}
+                  onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'rgba(var(--accent-rgb), 0.06)'; }}
                   onMouseOut={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                 >
                   <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">

--- a/src/lib/brand-config.test.ts
+++ b/src/lib/brand-config.test.ts
@@ -1,0 +1,97 @@
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  DEMO_BRAND_NAME,
+  DEMO_BRAND_TAGLINE,
+  getBrandName,
+  getBrandTagline,
+  getBrandAttribution,
+  getBrandAccent,
+  parseBrandAccent,
+} from './brand-config.ts';
+
+const BRAND_VARS = [
+  'SITE_BRAND_NAME',
+  'SITE_BRAND_ACCENT',
+  'SITE_BRAND_TAGLINE',
+  'SITE_BRAND_ATTRIBUTION',
+];
+
+afterEach(() => {
+  for (const v of BRAND_VARS) delete process.env[v];
+});
+
+describe('brand-config getters (call-time env, demo defaults)', () => {
+  test('unset environment yields the demo chrome values (byte-parity bar)', () => {
+    assert.equal(getBrandName(), DEMO_BRAND_NAME);
+    assert.equal(getBrandName(), 'Civic AI Tools');
+    assert.equal(getBrandTagline(), DEMO_BRAND_TAGLINE);
+    assert.equal(getBrandAttribution(), null);
+    assert.equal(getBrandAccent(), null);
+  });
+
+  test('set variables override at call time, not module load', () => {
+    process.env.SITE_BRAND_NAME = 'Alt City Data';
+    process.env.SITE_BRAND_TAGLINE = 'Open data for Alt City';
+    process.env.SITE_BRAND_ATTRIBUTION = 'Run by the Alt City data office.';
+    assert.equal(getBrandName(), 'Alt City Data');
+    assert.equal(getBrandTagline(), 'Open data for Alt City');
+    assert.equal(getBrandAttribution(), 'Run by the Alt City data office.');
+  });
+
+  test('empty strings fall back to the defaults, matching site-config.ts', () => {
+    process.env.SITE_BRAND_NAME = '';
+    process.env.SITE_BRAND_ATTRIBUTION = '';
+    assert.equal(getBrandName(), DEMO_BRAND_NAME);
+    assert.equal(getBrandAttribution(), null);
+  });
+});
+
+describe('parseBrandAccent', () => {
+  test('six-digit hex: normalizes and derives the family', () => {
+    const a = parseBrandAccent('#0A7A3D');
+    assert.ok(a);
+    assert.equal(a.accent, '#0a7a3d');
+    assert.equal(a.accentRgb, '10, 122, 61');
+    // Derivations: hover = channel × 0.6; light = channel × 0.25 + 255 × 0.75.
+    assert.equal(a.accentHover, '#064925'); // 6, 73, 37
+    assert.equal(a.accentLight, '#c2decf'); // 194, 222, 207
+  });
+
+  test('three-digit hex expands', () => {
+    const a = parseBrandAccent('#f80');
+    assert.ok(a);
+    assert.equal(a.accent, '#ff8800');
+    assert.equal(a.accentRgb, '255, 136, 0');
+  });
+
+  test('whitespace is tolerated; case is normalized', () => {
+    const a = parseBrandAccent('  #103FEF  ');
+    assert.ok(a);
+    assert.equal(a.accent, '#103fef');
+    assert.equal(a.accentRgb, '16, 63, 239');
+  });
+
+  test('invalid values return null — degrade to stylesheet defaults, never emit garbage', () => {
+    for (const bad of [
+      undefined,
+      '',
+      'blue',
+      '103FEF',
+      '#103FE',
+      '#103FEF0',
+      '#gggggg',
+      'rgb(16, 63, 239)',
+      'url(javascript:alert(1))',
+    ]) {
+      assert.equal(parseBrandAccent(bad), null, `expected null for ${JSON.stringify(bad)}`);
+    }
+  });
+
+  test('getBrandAccent reads SITE_BRAND_ACCENT and rejects invalid values', () => {
+    process.env.SITE_BRAND_ACCENT = '#0a7a3d';
+    assert.deepEqual(getBrandAccent(), parseBrandAccent('#0a7a3d'));
+    process.env.SITE_BRAND_ACCENT = 'not-a-color';
+    assert.equal(getBrandAccent(), null);
+  });
+});

--- a/src/lib/brand-config.ts
+++ b/src/lib/brand-config.ts
@@ -1,0 +1,123 @@
+// --- Instance branding (chrome-only theming seam; #217) -------------------
+//
+// Every value that names or colors THIS deployment in the SITE CHROME — the
+// header wordmark, page titles, the footer identity lines, the citation
+// labels, and the accent-token override — resolves through the getters
+// below. The demo defaults are the civicaitools.org reference deployment's
+// historical hardcoded values, so with NO environment set the rendered
+// chrome is byte-identical to before (the same byte-parity bar as
+// site-config.ts).
+//
+// CHROME, NOT EVIDENCE. This module is deliberately separate from the
+// `EVIDENCE_*` instance-identity set in src/lib/site-config.ts: those values
+// are emitted INSIDE signed evidence artifacts and are cross-checked against
+// the instance's trust registry (verify check #14). Nothing here is ever
+// signed, verified, or emitted into a package — changing a `SITE_BRAND_*`
+// variable can never invalidate an evidence surface. A fully renamed
+// instance typically sets BOTH `SITE_BRAND_NAME` (chrome) and
+// `EVIDENCE_PLATFORM_AGENT_TITLE` (evidence attribution); the two do not
+// read each other on purpose, so neither can surprise the other.
+//
+// Values are read at CALL time (not module load) so tests can vary them
+// per-process. On statically prerendered pages a call-time read still
+// resolves during the build — the same seam behavior as
+// `resolveHostLinks(process.env)` in the root layout. None of these may ever
+// become `NEXT_PUBLIC_*`: build-time client inlining is exactly what breaks
+// runtime container configuration (docs/deploy.md's build-time caveat).
+//
+// Client components cannot read these getters. The root layout threads the
+// values instead: props where the layout renders the consumer directly
+// (Header, the footer), context where the client boundary blocks a prop
+// chain (components/BrandProvider.tsx) — the host-links precedent.
+
+/** Demo default site/brand display name — the header wordmark and title base. */
+export const DEMO_BRAND_NAME = 'Civic AI Tools';
+
+/** Demo default footer tagline. */
+export const DEMO_BRAND_TAGLINE = 'Open-source tools for AI-powered civic data access';
+
+/**
+ * Display name of this instance in site chrome — the header wordmark, the
+ * page `<title>`s, and the "… Evidence Package" citation labels.
+ * Env: `SITE_BRAND_NAME`.
+ */
+export function getBrandName(): string {
+  return process.env.SITE_BRAND_NAME || DEMO_BRAND_NAME;
+}
+
+/**
+ * Footer tagline line (the first line of the footer identity block).
+ * Env: `SITE_BRAND_TAGLINE`.
+ */
+export function getBrandTagline(): string {
+  return process.env.SITE_BRAND_TAGLINE || DEMO_BRAND_TAGLINE;
+}
+
+/**
+ * Footer attribution line, as plain text. Env: `SITE_BRAND_ATTRIBUTION`.
+ *
+ * `null` (unset) means "render the demo deployment's authored attribution
+ * markup" — that line carries a hyperlink, so it lives as JSX in the root
+ * layout rather than as a string default here. A configured instance
+ * replaces the whole line with its own plain-text attribution.
+ */
+export function getBrandAttribution(): string | null {
+  return process.env.SITE_BRAND_ATTRIBUTION || null;
+}
+
+/**
+ * The resolved accent override: the four accent-family custom properties the
+ * root layout writes onto `<html style=…>` when `SITE_BRAND_ACCENT` is set.
+ * Property names match the neutral tokens in src/app/globals.css.
+ */
+export interface BrandAccent {
+  /** The accent color itself (normalized `#rrggbb`) → `--accent`. */
+  accent: string;
+  /** Comma-separated channel triplet (`"r, g, b"`) → `--accent-rgb`,
+   *  consumed as `rgba(var(--accent-rgb), α)` at the alpha call sites. */
+  accentRgb: string;
+  /** Derived darker companion for hover/active states → `--accent-hover`. */
+  accentHover: string;
+  /** Derived lighter companion for soft fills → `--accent-light`. */
+  accentLight: string;
+}
+
+/**
+ * Parse and derive the accent family from a raw `SITE_BRAND_ACCENT` value.
+ * Pure — exported for tests.
+ *
+ * Accepts `#rgb` or `#rrggbb` (case-insensitive). Anything else returns
+ * `null` — an invalid value must degrade to the stylesheet defaults, never
+ * leak garbage into an inline style attribute.
+ *
+ * The hover/light companions are DERIVED (channel-scale toward black /
+ * mix toward white) rather than independently configurable: one variable is
+ * the whole theming story, and the pair can never drift out of step with the
+ * accent. The derivation runs only for a CONFIGURED accent — the unset case
+ * never reaches this code and keeps the stylesheet's authored values, so the
+ * demo palette is not an output of these formulas.
+ */
+export function parseBrandAccent(raw: string | undefined): BrandAccent | null {
+  if (!raw) return null;
+  const m = /^#(?:([0-9a-f]{3})|([0-9a-f]{6}))$/i.exec(raw.trim());
+  if (!m) return null;
+  const hex6 = m[2] ?? m[1]!.split('').map((c) => c + c).join('');
+  const channels = [0, 2, 4].map((i) => parseInt(hex6.slice(i, i + 2), 16));
+  const toHex = (values: number[]) =>
+    '#' + values.map((v) => Math.round(v).toString(16).padStart(2, '0')).join('');
+  return {
+    accent: toHex(channels),
+    accentRgb: channels.join(', '),
+    accentHover: toHex(channels.map((c) => c * 0.6)),
+    accentLight: toHex(channels.map((c) => c * 0.25 + 255 * 0.75)),
+  };
+}
+
+/**
+ * Accent override for this instance, or `null` when `SITE_BRAND_ACCENT` is
+ * unset or invalid — `null` means the root layout writes NO style attribute
+ * and the stylesheet defaults render, a zero-byte delta.
+ */
+export function getBrandAccent(): BrandAccent | null {
+  return parseBrandAccent(process.env.SITE_BRAND_ACCENT);
+}


### PR DESCRIPTION
Adds the instance branding seam (#217): four chrome-only configuration knobs and a neutral accent-token layer, with the no-config case rendering byte-identically to today. Closes #217.

**Token layer.** `globals.css` defines the accent family as neutral operator-facing tokens (`--accent`, `--accent-rgb`, `--accent-hover`, `--accent-light`); the NYC accent names alias to them so every existing `--nyc-*` reference keeps resolving unchanged. This round is aliases only — the wholesale `--nyc-*` reference migration remains #220. Semantic status colors are untouched (design-principles.md governs those).

**Alpha treatment: `--accent-rgb` companion token** (not `color-mix()`). It keeps the `rgba(…, α)` form at all ~30 formerly hardcoded call sites, making the unset-case computed value arithmetically identical to before; and the pair cannot drift — the stylesheet defines both adjacently under a lockstep contract, and a configured instance sets only `SITE_BRAND_ACCENT`, from which the server derives the triplet plus hover/light companions and writes all four custom properties in one inline style on `<html>` (conditional spread: unset ⇒ no attribute at all). Invalid values are ignored in favor of the stylesheet defaults. Two `#103FEF` prop hardcodes and nine dead hex-blue `var()` fallbacks were also routed/dropped.

**Naming: `SITE_BRAND_*`, not `EVIDENCE_*`.** The `EVIDENCE_*` set names the instance inside signed evidence and is registry-cross-checked (verify check #14); the brand set is chrome-only — never signed, never inside a package — so a chrome change can never invalidate evidence. `SITE_BRAND_NAME` and `EVIDENCE_PLATFORM_AGENT_TITLE` stay independent on purpose; a fully renamed instance sets both. No `NEXT_PUBLIC_*` (build-time inlining breaks runtime container config).

**Reach.** Header wordmark (prop from layout), the 10 page titles + root-layout metadata, the footer tagline/attribution lines (repo links and sponsor line untouched), and both client citation components — `EvidenceActions` by prop from the server detail page, `ChatCitationPreview` via the new `BrandProvider` context, per the host-links rule (props where the server can reach, context only where the client boundary blocks). Preflight registers all four vars (optional, `hasFallback`); deploy.md gains the brand set in the "merely overrides a default" list plus a Branding and theming section (favicon = file swap of `src/app/favicon.ico`); instance-setup.md gains the chrome-vs-evidence rider.

**Parity evidence.** With no brand vars set, production builds of this branch and its branch point serve a byte-identical visible document on `/`, `/explore`, `/directory`, `/evidence`, and `/about` (raw diff, hash-normalized). The RSC flight payload differs only by the serialization of the seam itself — the `BrandProvider` module row, its demo-string value, and the Header `brandName` demo prop (the same class as the existing host-links serialized props) — plus the row renumbering that one added row causes; nothing content-bearing. A themed build (`SITE_BRAND_ACCENT='#0a7a3d'` etc.) shows zero `#103FEF`/`rgba(16, 63, 239, …)` remnants in the rendered HTML of all five pages and the configured name in titles, wordmark, footer, and both citation components.

**Suites** (verified independently by the orchestrating session on the final tree): lint 0 errors (4 known-tech-debt warnings), typecheck clean, 548/548 tests pass, keyless build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
