### PR TITLE
Light housekeeping pass: status labels + directory indexes (civic-ai-tools#134)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,4 +348,4 @@ CSS keyframes (`blink`, `spin`, `pulse`) and component-specific styles use style
 
 ## Retrospectives
 
-Session retrospectives are kept in [`RETROSPECTIVE.md`](RETROSPECTIVE.md) (reverse-chronological). Review before starting work to understand recent decisions and lessons learned.
+Session retrospectives are kept in [`docs/RETROSPECTIVE.md`](docs/RETROSPECTIVE.md) (reverse-chronological). Review before starting work to understand recent decisions and lessons learned.

--- a/docs/RETROSPECTIVE.md
+++ b/docs/RETROSPECTIVE.md
@@ -1,5 +1,7 @@
 # Retrospectives
 
+> **Dormant log.** Entries stop at 2026-03-05, the Sprint 004 retro (the 2026-03-07 commit only moved this file into `docs/`, without changing content). The practice lapsed rather than moving elsewhere — the one per-sprint retro under [`../sprints/completed/`](../sprints/completed/) predates that last entry. This file is retained as the early-project record.
+
 Reverse-chronological session retros for the civic-ai-tools-website project.
 
 ---

--- a/docs/model-audit.md
+++ b/docs/model-audit.md
@@ -1,5 +1,7 @@
 # Model Audit - OpenRouter Models for Civic AI Tools
 
+> **Historical — audit run 2026-01-15, not repeated.** (The date line below says 2025-01-15; the year is a typo — this repo's first commit is 2026-01-14, and this file entered git on 2026-03-05.) Model availability, pricing, and tool-calling reliability have turned over completely since. Retained for the evaluation criteria, not the verdicts. The live model list is defined in code (`availableModels` in [`../src/lib/mcp/tools.ts`](../src/lib/mcp/tools.ts), served via `/api/models`); the model endpoint and API key are environment-driven (`MODEL_API_BASE_URL`, `OPENROUTER_API_KEY`) — see [`deploy.md`](deploy.md#the-model-seam).
+
 **Date:** 2025-01-15
 **Purpose:** Evaluate available models for the MCP demo, considering cost, performance, and tool calling reliability.
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,5 +1,7 @@
 # civic-ai-tools-website Project Plan
 
+> **Historical — superseded.** This plan dates from the pre-launch phase (last revised 2026-03-08) and is retained for context, not as current direction. Current scope lives in GitHub issues and sprint docs; the current architecture is described in [`../README.md`](../README.md) and [`deploy.md`](deploy.md).
+
 A demo website that showcases the value of MCP (Model Context Protocol) servers for civic data queries by showing side-by-side comparisons of LLM responses with and without MCP.
 
 ---

--- a/docs/proposed-issues/README.md
+++ b/docs/proposed-issues/README.md
@@ -1,0 +1,16 @@
+# Proposed issues
+
+Proposed-issue drafts per the project's [working method](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/working-method.md) — decision-surface drafts that get promoted to GitHub issues when taken up. Numbering starts at 002.
+
+- `002-extend-agent-receipts-response-capture.md` — Contribute response-capture extension to Agent Receipts (upstream)
+- `003-civic-claim-vocabulary-domain-extensions-portfolio.md` — Explore and define Civic Claim Vocabulary domain extensions portfolio
+- `004-croissant-outbound-metadata.md` — Publish outbound Croissant metadata on every evidence page
+- `005-promote-civic-claim-vocabulary-to-ontology.md` — Promote Civic Claim Vocabulary from controlled vocabulary to full OWL ontology
+- `006-typed-claims-as-attestation-reframe.md` — Reframe typed claims as a kind of attestation
+- `007-attestation-as-upstream-evidence.md` — Use attestations as the implementation path for upstream-evidence references
+- `008-host-self-attestation-pattern.md` — Host self-attestation pattern + first reference implementation
+- `009-subject-of-claim-natural-person-ontology.md` — Subject-of-claim ontology for natural persons + default host-side filtering
+- `010-platform-independence-documentation.md` — Platform-independence documentation for closed dependencies
+- `011-skill-guidance-methodology-uplift.md` — Skill-guidance methodology uplift (promoted to [civic-ai-tools#78](https://github.com/npstorey/civic-ai-tools/issues/78))
+
+Dispositions are tracked in GitHub issues.

--- a/docs/rate-limit-headroom.md
+++ b/docs/rate-limit-headroom.md
@@ -3,6 +3,9 @@
 # Rate-limit headroom for a high-traffic event
 
 **Status:** Decision recorded — **A + B**. The Option B mechanism (env-overridable limits) is now **applied in code** (`src/lib/rate-limit.ts`) but **not activated**: no override env var is set, so the live limits are still the defaults (10 anonymous / 25 authenticated). Activation is a maintainer step on demo day — set `ANONYMOUS_RATE_LIMIT` (and optionally `AUTHENTICATED_RATE_LIMIT`) in Vercel **production** for the demo window only, then delete it. Option A stands as the primary path (the driver signs in).
+
+> **Post-event note.** The demo window this memo was written for has passed. The mechanism it describes remains in [`../src/lib/rate-limit.ts`](../src/lib/rate-limit.ts) and remains opt-in — the limits resolve to their defaults (10 anonymous / 25 authenticated) unless the `ANONYMOUS_RATE_LIMIT` / `AUTHENTICATED_RATE_LIMIT` override variables are set (a third override, `APP_TIER_RATE_LIMIT`, has since been added alongside them). The memo stays as the runbook for the next high-traffic event.
+
 **Why this exists:** An upcoming public demo will put a burst of traffic on `civicaitools.org` from one venue. The current anonymous limit is low and keys on IP, which interacts badly with a shared venue network. This memo lays out the options and the exact code that each one touches, so the choice is yours and reversible.
 
 ---

--- a/sprints/README.md
+++ b/sprints/README.md
@@ -1,0 +1,17 @@
+# Sprints
+
+The convention: `sprints/` holds sprint plans (active or backlog); `sprints/completed/` holds finished sprints with their outcomes.
+
+## `sprints/`
+
+- `SPRINT-community-trace-gallery.md` — Community Trace Gallery (unblocked but unscheduled; treat as a backlog proposal)
+
+## `sprints/completed/`
+
+- `sprint-001-mcp-messaging-ux.md` — Sprint 001: MCP Messaging UX
+- `sprint-002-reasoning-ux-data-literacy.md` — Sprint 002: Streaming Reasoning UX & Ambient Data Literacy
+- `sprint-003-polish-audit.md` — Sprint 003: Full Polish Audit (closed at 28 of 44 issues fixed)
+- `sprint-004-explore-page-migration.md` — Sprint 004: Migrate BPMN to /explore, Restructure About (done)
+- `SPRINT-live-query-bpmn.md` — Live Query Mode for BPMN Diagram (complete; ticket 8 manual step remaining)
+- `SPRINT-side-by-side-layout.md` — Side-by-Side Live Query Layout (shipped; its in-file status line still reads "Ready to start")
+- `RETRO-side-by-side-layout.md` — Retrospective: Side-by-Side Live Query Layout (2026-02-27)

--- a/sprints/SPRINT-community-trace-gallery.md
+++ b/sprints/SPRINT-community-trace-gallery.md
@@ -1,5 +1,7 @@
 # Sprint Plan: Community Trace Gallery
 
+> **Status note.** The stated prerequisite (sprint 004, explore-page migration) is complete — see [`completed/sprint-004-explore-page-migration.md`](completed/sprint-004-explore-page-migration.md). This plan is unblocked but unscheduled; treat it as a backlog proposal, not an active sprint.
+
 **Status:** Not started — blocked on sprint 004
 **Prerequisite:** Sprint 004 (explore page migration) must be complete first
 **Estimated effort:** 2–3 days


### PR DESCRIPTION
Final leg of the owner-approved LIGHT housekeeping pass from npstorey/civic-ai-tools#134 — rows 24–28 of the approved edit list, plus the two approved directory index files. Docs-only; additions only on the five edited files (11 inserted lines, 0 deletions).

## Status headers added (rows 24–28)

| File | Note added |
|------|-----------|
| `docs/project-plan.md` | Historical — superseded (last revised 2026-03-08) |
| `docs/model-audit.md` | Historical — audit run 2026-01-15, not repeated |
| `sprints/SPRINT-community-trace-gallery.md` | Status note: sprint-004 prerequisite complete; unblocked but unscheduled |
| `docs/RETROSPECTIVE.md` | Dormant log — entries stop at 2026-03-05 |
| `docs/rate-limit-headroom.md` | Post-event note — demo window passed; mechanism remains, opt-in |

## New index files

- `docs/proposed-issues/README.md` — one-line index of drafts 002–011 (titles from each file's own heading); notes numbering starts at 002; dispositions tracked in GitHub issues
- `sprints/README.md` — the `sprints/` vs `sprints/completed/` convention plus a one-line-per-file index from each file's own title/status

## Date/claim corrections made during verification

Every factual claim in the added notes was checked against git history and the code before shipping:

- **`docs/model-audit.md` date corrected.** The in-file header says `2025-01-15`; the repo's first commit is 2026-01-14 (`0503ded`) and the file entered git 2026-03-05 (`12c9b10`), so the in-file year is a typo — the note ships **2026-01-15** with a parenthetical flagging the typo. Supporting evidence: the initial commit's `availableModels` list matches the audit's "Final Selection" (gpt-4o-mini default), consistent with a January-2026 audit.
- **`docs/model-audit.md` model-config claim corrected.** The approved draft said "the live model configuration is environment-driven." Verified reality: the live model **list** is hardcoded (`availableModels` in `src/lib/mcp/tools.ts`, served via `/api/models`); only the model **endpoint and API key** are environment-driven (`MODEL_API_BASE_URL`, `OPENROUTER_API_KEY`). The note asserts exactly that, linking `deploy.md#the-model-seam` (slug verified — the doc links to that anchor itself).
- **`docs/RETROSPECTIVE.md` last-entry date settled at 2026-03-05.** The survey had recorded both 03-05 and 03-07: the last entry in the file is dated 2026-03-05 (Sprint 004 retro); the 2026-03-07 commit (`a5cbafc`) was a pure rename (`RETROSPECTIVE.md` → `docs/RETROSPECTIVE.md`, R100, no content change). The note says so explicitly.
- **`docs/RETROSPECTIVE.md` "moved to per-sprint retros" claim replaced with "practice lapsed."** The only per-sprint retro in `sprints/completed/` (`RETRO-side-by-side-layout.md`, 2026-02-27) predates the log's last entry, and nothing later exists anywhere under `sprints/` — so the approved draft's "practice moved" framing was not supportable.
- **`docs/project-plan.md` revision date verified.** Last substantive revision 2026-03-08 (`806b632`, 24+/24−), matching the drafted date.
- **`docs/rate-limit-headroom.md` mechanism verified against code.** `src/lib/rate-limit.ts` still resolves both limits through `resolveLimit()` with defaults 10 anonymous / 25 authenticated unless `ANONYMOUS_RATE_LIMIT` / `AUTHENTICATED_RATE_LIMIT` are set; a third override (`APP_TIER_RATE_LIMIT`) has been added since the memo, and the note mentions it.
- **`sprints/SPRINT-community-trace-gallery.md` prerequisite link verified.** `sprints/completed/sprint-004-explore-page-migration.md` exists with `**Status:** Done`.

## Drift observed (rider)

- Root `CLAUDE.md` still linked `RETROSPECTIVE.md` at the repo root ("Retrospectives" section); the file has lived at `docs/RETROSPECTIVE.md` since 2026-03-07.
- **Owner approved the rider:** the CLAUDE.md link fix is included in this PR (commit `0b1568b`, one-line path correction — nothing else in CLAUDE.md touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
