### PR TITLE
fix: route ChatCitationPreview placeholder origin through instance config (#227)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,12 +11,14 @@ import { resolveHostLinks } from '@/lib/host-links';
 import RunningUnsignedBanner from '@/components/RunningUnsignedBanner';
 import SponsorLine from '@/components/SponsorLine';
 import { BrandProvider } from '@/components/BrandProvider';
+import { EvidenceOriginProvider } from '@/components/EvidenceOriginProvider';
 import {
   getBrandAccent,
   getBrandAttribution,
   getBrandName,
   getBrandTagline,
 } from '@/lib/brand-config';
+import { getEvidenceSiteOrigin } from '@/lib/site-config';
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
@@ -124,6 +126,10 @@ export default function RootLayout({
               currently the chat citation preview. Same pattern and mount
               point as HostLinksProvider above. */}
           <BrandProvider value={brandName}>
+          {/* Evidence site origin for the same unreachable client surface
+              (#227) — instance identity (EVIDENCE_SITE_ORIGIN), so its own
+              provider rather than a rider on the chrome-brand one. */}
+          <EvidenceOriginProvider value={getEvidenceSiteOrigin()}>
           <div className="flex flex-col">
             {/* Env-driven (P3): on a split-host topology the marketing host
                 withholds /dashboard, so the signed-in menu must carry the
@@ -188,6 +194,7 @@ export default function RootLayout({
               </div>
             </footer>
           </div>
+          </EvidenceOriginProvider>
           </BrandProvider>
           </HostLinksProvider>
         </Providers>

--- a/src/components/EvidenceOriginProvider.tsx
+++ b/src/components/EvidenceOriginProvider.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { DEMO_SITE_ORIGIN } from '@/lib/site-config';
+
+/**
+ * Carries the server-resolved evidence site origin (`EVIDENCE_SITE_ORIGIN`,
+ * ADR-0020 instance identity — src/lib/site-config.ts) to client components
+ * that props cannot reach (#227) — the exact shape of `BrandProvider` and
+ * `HostLinksProvider`, and mounted beside them in the root layout.
+ *
+ * WHY A CONTEXT AND NOT PROP THREADING. The consumer,
+ * `ChatCitationPreview`, renders deep inside `ChatNotebookOutput`, a
+ * `'use client'` tree with no server ancestor to extend a prop chain from —
+ * the same reasoning documented in `BrandProvider`. The rule: props where
+ * the server can reach, context only where the client boundary blocks it.
+ *
+ * WHY NOT `BrandProvider`. The origin is evidence instance identity
+ * (`EVIDENCE_*` set), deliberately separate from the `SITE_BRAND_*` chrome
+ * seam — brand-config.ts's "CHROME, NOT EVIDENCE" contract says the two
+ * families never read each other, so they don't share a context either.
+ *
+ * The default value is the demo origin, so a component rendered outside the
+ * provider — a test, a future surface that forgets to mount it — degrades
+ * to today's reference-deployment URL rather than to a broken one.
+ */
+const EvidenceOriginContext = createContext<string>(DEMO_SITE_ORIGIN);
+
+export function EvidenceOriginProvider({
+  value,
+  children,
+}: {
+  value: string;
+  children: ReactNode;
+}) {
+  return (
+    <EvidenceOriginContext.Provider value={value}>{children}</EvidenceOriginContext.Provider>
+  );
+}
+
+/** Read the instance's evidence site origin. Safe outside the provider (see above). */
+export function useEvidenceSiteOrigin(): string {
+  return useContext(EvidenceOriginContext);
+}

--- a/src/components/notebook/ChatCitationPreview.tsx
+++ b/src/components/notebook/ChatCitationPreview.tsx
@@ -20,6 +20,8 @@
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
 import { useBrandName } from '@/components/BrandProvider';
+import { useEvidenceSiteOrigin } from '@/components/EvidenceOriginProvider';
+import { buildCitationPlaceholderUrl } from './citation-placeholder';
 
 interface ChatCitationPreviewProps {
   prompt: string;
@@ -60,6 +62,9 @@ export default function ChatCitationPreview({ prompt, executedAt, structuredSumm
   // Instance display name (#217) via BrandProvider (root layout) — this
   // component sits deep in a 'use client' tree, so context, not props.
   const brandName = useBrandName();
+  // Instance evidence origin (#227) via EvidenceOriginProvider, same mount
+  // and same reasoning — evidence identity, so its own seam, not the brand one.
+  const siteOrigin = useEvidenceSiteOrigin();
 
   const creatorName = session?.user?.name || 'Anonymous';
   const date = executedAt ? new Date(executedAt) : new Date();
@@ -72,7 +77,7 @@ export default function ChatCitationPreview({ prompt, executedAt, structuredSumm
   const title = structuredSummary?.analysisDescription
     ? structuredSummary.analysisDescription.replace(/[.!?]+$/, '')
     : deriveTitle(prompt, brandName);
-  const placeholderUrl = 'https://civicaitools.org/evidence/(URL assigned at publish)';
+  const placeholderUrl = buildCitationPlaceholderUrl(siteOrigin);
 
   const headlineSuffix = structuredSummary?.headlineFinding
     ? ` Headline finding: ${structuredSummary.headlineFinding}`

--- a/src/components/notebook/citation-placeholder.test.ts
+++ b/src/components/notebook/citation-placeholder.test.ts
@@ -1,0 +1,47 @@
+// #227 — citation placeholder-URL tests. Run with: npm test
+//
+// Same shape as the brand-config / instance-config tests: the unset
+// environment is the byte-compat oracle (the demo default must reproduce the
+// historical hardcoded string exactly), overrides are exercised per-process
+// through the real site-config getter and cleaned up after each test.
+
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCitationPlaceholderUrl } from './citation-placeholder.ts';
+import { DEMO_SITE_ORIGIN, getEvidenceSiteOrigin } from '../../lib/site-config.ts';
+
+afterEach(() => {
+  delete process.env.EVIDENCE_SITE_ORIGIN;
+});
+
+describe('buildCitationPlaceholderUrl', () => {
+  test('demo origin reproduces the historical hardcoded string (byte-parity bar)', () => {
+    assert.equal(
+      buildCitationPlaceholderUrl(DEMO_SITE_ORIGIN),
+      'https://civicaitools.org/evidence/(URL assigned at publish)',
+    );
+  });
+
+  test('unset environment resolves to the same bytes through the getter', () => {
+    assert.equal(
+      buildCitationPlaceholderUrl(getEvidenceSiteOrigin()),
+      'https://civicaitools.org/evidence/(URL assigned at publish)',
+    );
+  });
+
+  test('EVIDENCE_SITE_ORIGIN re-points the placeholder to the instance origin', () => {
+    process.env.EVIDENCE_SITE_ORIGIN = 'https://evidence.example.org';
+    assert.equal(
+      buildCitationPlaceholderUrl(getEvidenceSiteOrigin()),
+      'https://evidence.example.org/evidence/(URL assigned at publish)',
+    );
+  });
+
+  test('trailing slash on the configured origin never doubles the separator', () => {
+    process.env.EVIDENCE_SITE_ORIGIN = 'https://evidence.example.org/';
+    assert.equal(
+      buildCitationPlaceholderUrl(getEvidenceSiteOrigin()),
+      'https://evidence.example.org/evidence/(URL assigned at publish)',
+    );
+  });
+});

--- a/src/components/notebook/citation-placeholder.ts
+++ b/src/components/notebook/citation-placeholder.ts
@@ -1,0 +1,17 @@
+// Pre-publish citation placeholder URL (#227).
+//
+// Pure module (no 'use client', no JSX) so the URL shape is testable under
+// `node --test` — the `buildChatEvidenceView.ts` precedent for keeping
+// client-component logic in a checkable form.
+
+/**
+ * The placeholder citation URL `ChatCitationPreview` shows before publish:
+ * the instance's own `/evidence/` namespace with `(URL assigned at publish)`
+ * where the slug would go. The origin arrives from
+ * `getEvidenceSiteOrigin()` (server) via `EvidenceOriginProvider`; with no
+ * environment set that is `DEMO_SITE_ORIGIN` and the result is
+ * byte-identical to the historical hardcoded string.
+ */
+export function buildCitationPlaceholderUrl(siteOrigin: string): string {
+  return `${siteOrigin}/evidence/(URL assigned at publish)`;
+}


### PR DESCRIPTION
Closes #227

## What

`ChatCitationPreview` hardcoded the reference deployment's origin in its pre-publish placeholder citation URL (`https://civicaitools.org/evidence/(URL assigned at publish)`). The placeholder origin now resolves through the instance's evidence identity config (`EVIDENCE_SITE_ORIGIN`, `src/lib/site-config.ts` / ADR-0020), so a self-hosted instance previews citations on its own domain.

## Pattern

Context threading, per the rule documented in `BrandProvider` / `HostLinksProvider`: props where the server can reach, context where the client boundary blocks. `ChatCitationPreview` renders deep inside the `'use client'` `ChatNotebookOutput` tree with no server ancestor to extend a prop chain from, so a new `EvidenceOriginProvider` (exact shape of `BrandProvider`, mounted beside it in the root layout) carries the server-resolved `getEvidenceSiteOrigin()` value down.

A separate provider rather than a rider on `BrandProvider` because the origin is evidence instance identity (`EVIDENCE_*`), deliberately distinct from the `SITE_BRAND_*` chrome seam per brand-config.ts's "CHROME, NOT EVIDENCE" contract. No `NEXT_PUBLIC_*` introduced.

The URL template itself lives in a pure module (`src/components/notebook/citation-placeholder.ts`, the `buildChatEvidenceView.ts` precedent) so it is testable under `node --test`.

## Byte parity

With no environment set, `getEvidenceSiteOrigin()` returns `DEMO_SITE_ORIGIN` (`https://civicaitools.org`) and the rendered placeholder is byte-identical to the previous hardcoded string — asserted directly by the new test's byte-compat oracle. The provider's default value is the demo origin, so a surface rendered outside the provider degrades to today's URL.

## Tests

`src/components/notebook/citation-placeholder.test.ts`, following the brand-config/instance-config pattern: unset env reproduces the historical string exactly (oracle), `EVIDENCE_SITE_ORIGIN` override exercised per-process through the real getter, trailing-slash trim covered. Suite: 550/552 pass; the 2 failures are pre-existing sandbox artifacts (`openrouter-streaming.test.ts` binds a local mock server; `listen EPERM` in the sandboxed environment — untouched by this change). Typecheck clean; lint 0 errors (4 pre-existing warnings, all in the Known Tech Debt list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
