### PR TITLE
Operator-experience batch: preflight partial-group warnings, env-template slim-to-pointer, font-egress build prerequisite (#195, #198, #225)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,135 +1,54 @@
-# OpenRouter
+# Local-development starter environment. Copy to .env.local and fill in —
+# this is the minimal set to boot `npm run dev` and exercise the app's core
+# paths on your own machine.
+#
+# This file is deliberately NOT the full environment reference. The
+# authorities on the environment are:
+#
+#   - scripts/preflight-env.mjs — the executable authority. It enumerates
+#     every variable the app reads, resolves the three driver selectors, and
+#     tiers each variable for your instance profile (presence only; it never
+#     reads values). Run:  node scripts/preflight-env.mjs
+#   - docs/deploy.md, "Environment reference, tier by tier" — the narrative
+#     authority: what each variable does, what its absence means, and the
+#     whole instance-configuration surface (driver selectors, the S3_* set,
+#     the notebook executor, OIDC sign-in, KV rate limiting, instance
+#     identity, branding, host topology, tuning knobs).
+#
+# Instance configuration lives there, not here — keeping this file a small
+# local-dev quick start is what stops it drifting into a third authority.
+
+# --- Model access (required — every query fails fast without it) ---
 OPENROUTER_API_KEY=
-# Chat-completions endpoint override — any OpenAI-compatible endpoint
-# (unset = OpenRouter: https://openrouter.ai/api/v1)
+# Any OpenAI-compatible chat-completions endpoint; unset = OpenRouter.
+# The key above is the credential either way.
 # MODEL_API_BASE_URL=
 
-# socrata-mcp-server
+# --- Data sources ---
 SOCRATA_MCP_URL=https://socrata-mcp.civicaitools.org
-# Client-side mirror for notebook output links (defaults to SOCRATA_MCP_URL)
-# NEXT_PUBLIC_SOCRATA_MCP_URL=
-
-# Data Commons MCP (Google-hosted; US demographic + federal statistical data)
-# The hosted endpoint requires an X-API-Key header. Free key from
-# https://apikeys.datacommons.org — anonymous access is not permitted.
+# Data Commons (second data source). The hosted endpoint mandates an API
+# key — free from https://apikeys.datacommons.org.
 DATA_COMMONS_MCP_URL=https://api.datacommons.org/mcp
 DATA_COMMONS_API_KEY=
 
-# GitHub OAuth (create at github.com/settings/developers)
+# --- Evidence store (publish + dashboard + detail pages) ---
+DATABASE_URL=              # postgres://user:pass@host/dbname?sslmode=require
+BLOB_READ_WRITE_TOKEN=     # Vercel Blob token (the default blob driver; S3: see docs/deploy.md)
+
+# --- Evidence signing (unset = the unsigned tier: banner shows, seal/publish gated off) ---
+# Generate with: npx tsx scripts/generate-signing-key.ts
+EVIDENCE_SIGNING_KEY=      # Base64-encoded Ed25519 private key (PKCS8 DER)
+# EVIDENCE_KEY_ID=         # kid of the active key — must match the trust registry (unset = demo kid)
+
+# --- Sign-in (unlocks notebook execution, the dashboard, the higher rate limit) ---
+NEXTAUTH_SECRET=           # Generate with: openssl rand -base64 32
+NEXTAUTH_URL=http://localhost:3000
+# GitHub OAuth app (github.com/settings/developers) — or any standard OIDC
+# provider instead via the OIDC_* set: docs/deploy.md "Sign-in configuration".
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
-# NextAuth
-NEXTAUTH_SECRET=       # Generate with: openssl rand -base64 32
-NEXTAUTH_URL=http://localhost:3000   # Update for production
-
-# Generic OIDC sign-in (optional) — any OIDC provider with standard discovery
-# (/.well-known/openid-configuration). Active only when ISSUER + CLIENT_ID +
-# CLIENT_SECRET are all set; unset, sign-in is GitHub only.
-# OIDC_ISSUER=https://your-idp.example.org
-# OIDC_CLIENT_ID=
-# OIDC_CLIENT_SECRET=
-# OIDC_PROVIDER_NAME=      # sign-in button label (default "SSO")
-
-# Neon PostgreSQL (evidence system)
-DATABASE_URL=              # postgres://user:pass@host/dbname?sslmode=require
-# DB driver: neon-http (default) or node-postgres (any Postgres over TCP)
-# DB_DRIVER=
-
-# Vercel Blob (evidence package storage)
-BLOB_READ_WRITE_TOKEN=     # From Vercel Blob store settings
-
-# Blob storage driver: vercel-blob (default) or s3 — any S3-compatible
-# endpoint (MinIO, R2, AWS S3) via the S3_* set below
-# BLOB_DRIVER=
-# S3-compatible object storage (read only when BLOB_DRIVER=s3)
-# S3_ENDPOINT=         # e.g. http://127.0.0.1:9000 for MinIO; omit for AWS S3
-# S3_REGION=           # default us-east-1
-# S3_BUCKET=
-# S3_ACCESS_KEY_ID=
-# S3_SECRET_ACCESS_KEY=
-# S3_FORCE_PATH_STYLE= # default: true when S3_ENDPOINT is set (MinIO), false otherwise
-# S3_PUBLIC_BASE_URL=  # public object URL base (default: <endpoint>/<bucket> path-style)
-
-# Notebook executor (executed-notebook pipeline)
-# Driver: vercel-sandbox (default) or container — the host container runtime
-# via the docker CLI, using the prebuilt image from docker/executor/Dockerfile
-# (build: docker build -t civic-notebook-executor:0.1.0 docker/executor)
-# EXECUTOR_DRIVER=
-# EXECUTOR_CONTAINER_IMAGE=  # default civic-notebook-executor:0.1.0 (container driver only)
-# Prebuilt Vercel Sandbox snapshot (npm run sandbox:build-snapshot); unset,
-# the vercel-sandbox driver falls back to a slow fresh boot + pip install
-# SANDBOX_SNAPSHOT_ID=
-# Vercel Sandbox auth for off-platform runs (on Vercel deploys auth is
-# OIDC-automatic; off-platform, set this token/team/project triple)
-# VERCEL_TOKEN=
-# VERCEL_TEAM_ID=
-# VERCEL_PROJECT_ID=
-
-# Evidence package signing (generate with: npx tsx scripts/generate-signing-key.ts)
-EVIDENCE_SIGNING_KEY=      # Base64-encoded Ed25519 private key (PKCS8 DER)
-EVIDENCE_KEY_ID=           # kid of the active signing key — must match the trust registry (unset = demo kid)
-EVIDENCE_PUBLIC_KEY=       # Public half (SPKI DER). NOT read by the app — operator reference for trust-registry updates
-
-# Instance identity (ADR-0020) — all optional; unset, the app runs as the demo
-# instance (civicaitools.org). A self-hosted instance sets EVIDENCE_SITE_ORIGIN
-# plus the signer set, and every derived surface follows. Full walkthrough:
-# docs/instance-setup.md. Keep unused lines commented rather than empty — for
-# EVIDENCE_TRUST_REGISTRY_LEGACY_URL an explicit empty string is meaningful
-# (it omits the legacy field from sidecars).
-# EVIDENCE_SITE_ORIGIN=https://your-instance.example.org
-# EVIDENCE_SIGNER_BINDING_TIER=platform
-# EVIDENCE_SIGNER_IDENTIFIER=        # must match the trust-registry entry
-# EVIDENCE_SIGNER_DISPLAY_NAME=      # must match the trust-registry entry
-# EVIDENCE_PUBLICATION_HOST=         # host label on publishes-attestations + notebook "Generated via" lines
-# EVIDENCE_TRUST_REGISTRY_CANONICAL_URL=   # only if the registry is hosted off-origin
-# EVIDENCE_TRUST_REGISTRY_LEGACY_URL=      # empty string omits the sidecar legacy field
-# EVIDENCE_PLATFORM_AGENT_ID=
-# EVIDENCE_PLATFORM_AGENT_TITLE=
-# EVIDENCE_PLATFORM_AGENT_URL=       # defaults to EVIDENCE_SITE_ORIGIN when set
-# EVIDENCE_TRUST_REGISTRY_URL=       # verify-side external trust-registry override
-
-# Cron endpoint auth (blob-gc, portal refresh)
-# CRON_SECRET=
-
-# Google Analytics (set in production only — omit locally)
-# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
-
-# Vercel KV (auto-populated if using Vercel KV; the REST URL/token pair powers the durable rate-limit counter)
-KV_URL=
-KV_REST_API_URL=
-KV_REST_API_TOKEN=
-KV_REST_API_READ_ONLY_TOKEN=
-
-# Sign-in gate (app front door): provider-account keys permitted to sign in.
-# GitHub = the numeric account id; OIDC = oidc:{issuer}:{sub}.
-# Comma/whitespace separated. Unset or empty = open sign-in (the default).
-SIGN_IN_ALLOWLIST=
-
-# Per-day query limit for signed-in users of a gated instance.
-# Default: AUTHENTICATED_RATE_LIMIT - unset changes nothing.
-APP_TIER_RATE_LIMIT=
-
-# --- Host topology (app front-door P3; all optional - unset = single host, no withholding) ---
-# Split-host deployment: set both. Requests on APP_HOST serve the gated app
-# surface (/ temporarily 307s to /evidence; marketing pages 404); requests on
-# MARKETING_HOST serve the public face and 404 the app-private routes
-# (/dashboard, /auth/device, /dev/notebook-preview). /evidence and /api/* serve
-# on both. Hosts that match neither variable are untouched (previews stay
-# whole). Values are hostnames (app.example.org); a full origin also works;
-# matching is case-, port-, and www-insensitive.
-APP_HOST=
-MARKETING_HOST=
-# App-only instance (no marketing site): 1/true serves the gated surface on
-# every host; APP_HOST/MARKETING_HOST are ignored.
-APP_ONLY=
-
-# --- Instance branding (chrome only; all optional - unset renders the demo chrome byte-identically) ---
-# Chrome knobs: header wordmark, page titles, footer identity lines, accent color.
-# Never signed or emitted into evidence (that is the EVIDENCE_* identity set above).
-# Set in the BUILD environment as well as at run time: statically prerendered
-# pages bake their chrome at next build. See docs/deploy.md "Branding and theming".
-# SITE_BRAND_NAME=                   # header wordmark + page titles + citation labels
-# SITE_BRAND_ACCENT=                 # #rgb or #rrggbb; hover/light companions are derived
-# SITE_BRAND_TAGLINE=                # footer first identity line
-# SITE_BRAND_ATTRIBUTION=            # footer attribution line (plain text)
+# Everything else the app reads — DB_DRIVER / BLOB_DRIVER / EXECUTOR_DRIVER,
+# the S3_* set, the executor variables, OIDC_*, KV_*, EVIDENCE_* instance
+# identity, SITE_BRAND_*, host topology, rate-limit and token-budget knobs —
+# is enumerated by the preflight and explained tier by tier in docs/deploy.md.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -51,6 +51,18 @@ You need:
 - **Node.js ≥ 22** on the host if you want to run the preflight and
   rehearsal scripts from the checkout (recommended; the containers
   themselves don't need it).
+- **Network egress to `fonts.googleapis.com` from the build
+  environment.** The app loads its two typefaces through
+  `next/font/google`, which fetches them at `next build` time — and
+  since Next.js 16.2.11 an unreachable `fonts.googleapis.com`
+  **hard-fails the build** (16.2.7 and earlier warned and fell back to
+  system fonts). Every path that builds the app is affected: the compose
+  bring-up's image build below, a bare `next build`, and the standalone
+  build. A restricted-egress build environment — common in government
+  and enterprise CI — must allow that host, or the build stops there.
+  This is a build-time requirement only; the running app makes no
+  request to it. Removing the dependency by self-hosting the fonts is
+  tracked in [#225] / [#221].
 
 > **Sign-in prerequisite — read before bring-up.** The notebook/query
 > execution feature (executed-sandbox mode: generate a Jupyter notebook,
@@ -311,7 +323,12 @@ the **presence** (never the value) of every variable the app reads,
 resolves the three driver selectors first, and tiers every other
 variable against the resolved profile — so a self-hosted instance is
 neither passed while unrunnable nor nagged about variables its profile
-never reads. Preflight reads only the shell environment it runs in. **Run off-stack,
+never reads. It also warns when an **all-or-nothing variable group** is
+only partially set — the Vercel Sandbox auth trio, either sign-in
+provider's credential set, the KV pair. The code consumes each of those
+sets only complete, so a partial set is indistinguishable from an empty
+one at run time and the feature silently stays off; the warning names
+the missing members. Preflight reads only the shell environment it runs in. **Run off-stack,
 it cannot see what compose wires in** — the three driver selectors,
 `DATABASE_URL`, and the `S3_*` set live inside `docker-compose.yml` — so
 a bare `node scripts/preflight-env.mjs` reports the *default managed
@@ -490,6 +507,14 @@ the client with redirect URI:
 ```
 
 The flow requests `openid profile email` scopes and uses PKCE + state.
+
+Treat `OIDC_ISSUER` as **identity-bearing, not just configuration**: the
+issuer URL is embedded in every OIDC user's stored account key
+(`oidc:{issuer}:{sub}` — the same string the allowlist matches), so
+changing or unsetting it later silently re-keys every OIDC user into a
+fresh database row on their next sign-in. Existing allowlist entries
+stop matching, and each user's earlier activity stays bound to the old
+row. Pick the issuer value once, before real users sign in.
 
 **Restricting who may sign in (optional allowlist).** By default any
 account the active provider authenticates may sign in. To gate an
@@ -950,3 +975,5 @@ values to your deployment and go.
 [ADR-0016]: https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0016-vcs-native-lifecycle-mapping.md
 [ADR-0020]: https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0020-instance-key-custody.md
 [ADR-0023]: https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0023-notebook-executor-driver.md
+[#221]: https://github.com/npstorey/civic-ai-tools-website/issues/221
+[#225]: https://github.com/npstorey/civic-ai-tools-website/issues/225

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -38,6 +38,13 @@
  * the script can gate a deploy check or a CI step. Missing RECOMMENDED or
  * OPTIONAL variables are reported but never fail the run.
  *
+ * GROUPS (#195): beyond per-variable tiers, some variable sets are
+ * all-or-nothing in the code — a partial set is indistinguishable from an
+ * empty one at run time, so the feature silently stays off. ENV_GROUPS
+ * declares those sets and a partially set group emits a WARN naming the
+ * missing members. Warn-only, never a failure: each member keeps its own
+ * tier above, and the group check adds the set semantics on top.
+ *
  * The pure check logic (`evaluateEnv`, `resolveSpec`, `ENV_SPEC`) is exported
  * and covered by scripts/preflight-env.test.mjs (run:
  * `node --test scripts/preflight-env.test.mjs`).
@@ -250,6 +257,63 @@ export const ENV_SPEC = [
   { name: 'EVAL_QUERIES', tier: 'optional', purpose: 'Model-eval harness query set (scripts/eval-models.mjs only)', hasFallback: true },
 ];
 
+/**
+ * All-or-nothing variable groups (#195). Each names a set the code consumes
+ * only as a complete set: with any member absent the whole set is ignored —
+ * no error, no log — so a partially set group means the operator configured
+ * something that is silently not in effect, and preflight is the only place
+ * that can be surfaced. Detection is presence-only, same test as everywhere
+ * else; no value is ever read or echoed.
+ *
+ * Fields:
+ *   - members: the variable names (each must also be declared in ENV_SPEC —
+ *     the test suite pins that).
+ *   - feature: what stays off while the group is partial (rendered in the
+ *     warning).
+ *   - onlyWhen: same semantics as the ENV_SPEC field — the group is checked
+ *     only when the resolved drivers match, so a profile that never reads the
+ *     members is never warned about them.
+ *   - note: extra caution rendered under the warning.
+ */
+export const ENV_GROUPS = [
+  {
+    name: 'Vercel Sandbox off-platform auth',
+    members: ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID'],
+    // resolveSandboxAuthParams (src/lib/sandbox/vercel-sandbox.ts:88-96)
+    // returns null unless all three are present, so a two-of-three set
+    // silently downgrades to no sandbox auth — off-platform, that means
+    // notebook execution cannot start.
+    feature: 'off-platform sandbox auth — notebook execution fails off-deploy',
+    onlyWhen: { executor: 'vercel-sandbox' },
+  },
+  {
+    name: 'Generic OIDC sign-in',
+    members: OIDC_PROVIDER_SET,
+    // src/lib/auth-providers.ts activates the provider only on the full
+    // triple; with any member absent the provider never appears — no error,
+    // no log.
+    feature: 'the OIDC provider is not offered on the sign-in screen',
+    note: 'OIDC_ISSUER is identity-bearing, not just configuration: it is embedded in every OIDC user\'s stored account key, so changing or unsetting it later re-keys those users into fresh accounts.',
+  },
+  {
+    name: 'GitHub sign-in',
+    members: ['GITHUB_CLIENT_ID', 'GITHUB_CLIENT_SECRET'],
+    // src/lib/auth-providers.ts renders the provider only when both halves
+    // are present. When the OIDC triple is complete the pair is individually
+    // optional (requiredUnlessAllPresent above), so a half-set pair is
+    // otherwise fully silent.
+    feature: 'the GitHub provider is not offered on the sign-in screen',
+  },
+  {
+    name: 'Durable rate limiting',
+    members: ['KV_REST_API_URL', 'KV_REST_API_TOKEN'],
+    // src/lib/rate-limit.ts requires both; with either absent the counter
+    // silently falls back to per-process memory (resets on restart, not
+    // shared across instances).
+    feature: 'the rate-limit counter falls back to per-process memory',
+  },
+];
+
 const TIER_ORDER = ['required', 'recommended', 'optional'];
 
 /**
@@ -288,15 +352,47 @@ function conditionMet(condition, drivers) {
 }
 
 /**
- * True when every named variable is present in `env`. Presence only — the
- * same non-empty-after-trim test `evaluateEnv` uses, and no value is read
- * beyond that boolean.
+ * THE presence test — non-empty after trim. Every check in this script
+ * (tiers, alternatives, groups) uses this one boolean; no value is read
+ * beyond it.
  */
+function isPresent(raw) {
+  return typeof raw === 'string' && raw.trim().length > 0;
+}
+
+/** True when every named variable is present in `env`. Presence only. */
 function allPresent(names, env) {
-  return names.every((name) => {
-    const raw = env[name];
-    return typeof raw === 'string' && raw.trim().length > 0;
-  });
+  return names.every((name) => isPresent(env[name]));
+}
+
+/**
+ * Detect partially set all-or-nothing groups (#195). A group whose
+ * `onlyWhen` condition the resolved drivers do not meet is skipped entirely
+ * (its members are not read by that profile). A group with zero members
+ * present is deliberately not configured; a complete group is in effect;
+ * anything in between is the silent-failure case this check exists for.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @param {Record<string, string>} drivers
+ * @param {typeof ENV_GROUPS} [groups]
+ * @returns {{ name: string, feature: string, note?: string, total: number, present: string[], missing: string[] }[]}
+ */
+export function evaluateGroups(env, drivers, groups = ENV_GROUPS) {
+  const partial = [];
+  for (const g of groups) {
+    if (g.onlyWhen && !conditionMet(g.onlyWhen, drivers)) continue;
+    const present = g.members.filter((name) => isPresent(env[name]));
+    if (present.length === 0 || present.length === g.members.length) continue;
+    partial.push({
+      name: g.name,
+      feature: g.feature,
+      note: g.note,
+      total: g.members.length,
+      present,
+      missing: g.members.filter((name) => !isPresent(env[name])),
+    });
+  }
+  return partial;
 }
 
 /**
@@ -350,8 +446,7 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
   const { applicable, notApplicable } = resolveSpec(drivers, spec, env);
 
   const rows = applicable.map((s) => {
-    const raw = env[s.name];
-    const present = typeof raw === 'string' && raw.trim().length > 0;
+    const present = isPresent(env[s.name]);
     return {
       name: s.name,
       tier: s.tier,
@@ -369,12 +464,17 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
   const missingRequired = rows.filter((r) => r.tier === 'required' && !r.present && !r.hasFallback);
   const requiredOnFallback = rows.filter((r) => r.tier === 'required' && !r.present && r.hasFallback);
   const missingRecommended = rows.filter((r) => r.tier === 'recommended' && !r.present);
+  const partialGroups = evaluateGroups(env, drivers);
 
   return {
     rows,
     missingRequired,
     requiredOnFallback,
     missingRecommended,
+    // All-or-nothing groups only partially set (#195). Warn-only by design:
+    // a partial group never flips `ok` — each member's own tier already
+    // governs pass/fail, and the group adds the set semantics on top.
+    partialGroups,
     // Profile context. `notApplicable` is deliberately NOT rendered as rows:
     // an instance must not be told about variables its profile never reads.
     profile: { drivers, isDefault },
@@ -441,6 +541,18 @@ export function renderReport(result) {
     for (const name of result.driverErrors) {
       const seam = Object.values(DRIVER_SEAMS).find((d) => d.env === name);
       lines.push(`            - ${name} (expected one of: ${seam.values.join(', ')})`);
+    }
+  }
+  // Partially set all-or-nothing groups (#195): louder than a NOTE because
+  // the operator configured something that is silently not in effect, but
+  // never a failure — the members' own tiers govern pass/fail. Only names
+  // are printed, never values.
+  if (result.partialGroups && result.partialGroups.length > 0) {
+    lines.push(`  WARN: ${result.partialGroups.length} all-or-nothing variable group(s) partially set — a partial group leaves its feature silently off:`);
+    for (const g of result.partialGroups) {
+      lines.push(`            - ${g.name}: ${g.present.length} of ${g.total} present; off until all ${g.total} are set. Missing: ${g.missing.join(', ')}`);
+      lines.push(`              (while partial: ${g.feature})`);
+      if (g.note) lines.push(`              Note: ${g.note}`);
     }
   }
   if (result.requiredOnFallback && result.requiredOnFallback.length > 0) {

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -9,10 +9,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   evaluateEnv,
+  evaluateGroups,
   renderReport,
   resolveDrivers,
   resolveSpec,
   ENV_SPEC,
+  ENV_GROUPS,
   DRIVER_SEAMS,
   OIDC_PROVIDER_SET,
 } from './preflight-env.mjs';
@@ -417,4 +419,134 @@ test('the durable rate-limit counter is soft: absent, the run still passes', () 
     result.requiredOnFallback.map((r) => r.name).filter((n) => n.startsWith('KV_')),
     ['KV_REST_API_URL', 'KV_REST_API_TOKEN'],
   );
+});
+
+// --- All-or-nothing groups (#195) -------------------------------------------
+
+test('every group member is declared in ENV_SPEC and every group condition names a known seam/driver', () => {
+  const declared = new Set(ENV_SPEC.map((s) => s.name));
+  for (const g of ENV_GROUPS) {
+    assert.ok(typeof g.name === 'string' && g.name.length > 0, 'group has a name');
+    assert.ok(typeof g.feature === 'string' && g.feature.length > 0, `${g.name} names its feature`);
+    assert.ok(Array.isArray(g.members) && g.members.length >= 2, `${g.name} has at least two members`);
+    for (const name of g.members) {
+      assert.ok(declared.has(name), `${g.name} member ${name} is declared in ENV_SPEC`);
+    }
+    if (!g.onlyWhen) continue;
+    for (const [seam, driver] of Object.entries(g.onlyWhen)) {
+      assert.ok(DRIVER_SEAMS[seam], `${g.name}.onlyWhen names a known seam (${seam})`);
+      assert.ok(
+        DRIVER_SEAMS[seam].values.includes(driver),
+        `${g.name}.onlyWhen.${seam} names a known driver (${driver})`,
+      );
+    }
+  }
+});
+
+test('a partially set group warns, naming exactly the missing members, and never fails the run', () => {
+  const env = envWithAllRequired();
+  env.VERCEL_TOKEN = 'present';
+  env.VERCEL_TEAM_ID = 'present'; // VERCEL_PROJECT_ID deliberately absent
+  const result = evaluateEnv(env);
+
+  assert.equal(result.ok, true, 'a partial group warns; it must not fail the run');
+  const partial = result.partialGroups.find((g) => g.name === 'Vercel Sandbox off-platform auth');
+  assert.ok(partial, 'the sandbox trio is reported as partial');
+  assert.equal(partial.total, 3);
+  assert.deepEqual(partial.present.sort(), ['VERCEL_TEAM_ID', 'VERCEL_TOKEN']);
+  assert.deepEqual(partial.missing, ['VERCEL_PROJECT_ID']);
+
+  const report = renderReport(result);
+  assert.match(report, /WARN: 1 all-or-nothing variable group\(s\) partially set/);
+  assert.match(report, /Vercel Sandbox off-platform auth: 2 of 3 present; off until all 3 are set\. Missing: VERCEL_PROJECT_ID/);
+});
+
+test('complete groups and untouched groups do not warn (the default full-required env is warning-free)', () => {
+  // envWithAllRequired sets the GitHub pair and the KV pair completely and
+  // leaves the OIDC triple and the sandbox trio empty — no group is partial.
+  const result = evaluateEnv(envWithAllRequired());
+  assert.deepEqual(result.partialGroups, []);
+  assert.ok(!renderReport(result).includes('WARN'), 'no WARN block when no group is partial');
+});
+
+test('a group is not checked when its profile never reads its members (container executor)', () => {
+  const env = { ...envWithAllRequired(), EXECUTOR_DRIVER: 'container' };
+  env.VERCEL_TOKEN = 'present'; // would be a partial trio under vercel-sandbox
+  const result = evaluateEnv(env);
+  assert.ok(
+    !result.partialGroups.some((g) => g.name === 'Vercel Sandbox off-platform auth'),
+    'the sandbox-auth group is skipped for a container-executor instance',
+  );
+  assert.ok(!renderReport(result).includes('VERCEL_TOKEN'), 'suppressed members stay unmentioned');
+});
+
+test('a partial OIDC triple warns and carries the identity-bearing issuer note', () => {
+  const env = envWithAllRequired();
+  env.OIDC_ISSUER = 'present';
+  env.OIDC_CLIENT_ID = 'present'; // OIDC_CLIENT_SECRET deliberately absent
+  const result = evaluateEnv(env);
+
+  const partial = result.partialGroups.find((g) => g.name === 'Generic OIDC sign-in');
+  assert.ok(partial);
+  assert.deepEqual(partial.missing, ['OIDC_CLIENT_SECRET']);
+
+  const report = renderReport(result);
+  assert.match(report, /Generic OIDC sign-in: 2 of 3 present/);
+  assert.match(report, /not offered on the sign-in screen/);
+  // The rider from #195: the issuer is part of every OIDC user's account key.
+  assert.match(report, /OIDC_ISSUER is identity-bearing/);
+});
+
+test('a half-set GitHub pair on an OIDC-complete instance warns (the genuinely silent case)', () => {
+  // With the OIDC triple complete the pair is demoted to optional, so this
+  // partial configuration passes every tier check — the group warning is the
+  // only surface that catches it.
+  const env = withOidcProvider(envWithAllRequired());
+  delete env.GITHUB_CLIENT_SECRET;
+  const result = evaluateEnv(env);
+
+  assert.equal(result.ok, true);
+  const partial = result.partialGroups.find((g) => g.name === 'GitHub sign-in');
+  assert.ok(partial, 'the half pair is reported even though its tier is optional');
+  assert.deepEqual(partial.missing, ['GITHUB_CLIENT_SECRET']);
+  assert.match(renderReport(result), /GitHub sign-in: 1 of 2 present; off until all 2 are set\. Missing: GITHUB_CLIENT_SECRET/);
+});
+
+test('a partial KV pair warns that durable rate limiting is off, while the run still passes', () => {
+  const env = envWithAllRequired();
+  delete env.KV_REST_API_TOKEN; // URL stays set — silently in-memory at run time
+  const result = evaluateEnv(env);
+
+  assert.equal(result.ok, true);
+  const partial = result.partialGroups.find((g) => g.name === 'Durable rate limiting');
+  assert.ok(partial);
+  assert.deepEqual(partial.missing, ['KV_REST_API_TOKEN']);
+  assert.match(renderReport(result), /falls back to per-process memory/);
+});
+
+test('group detection uses the same presence test as everything else: whitespace-only is absent', () => {
+  const env = envWithAllRequired();
+  env.OIDC_ISSUER = 'present';
+  env.OIDC_CLIENT_ID = '   '; // whitespace-only must count as absent
+  const result = evaluateEnv(env);
+  const partial = result.partialGroups.find((g) => g.name === 'Generic OIDC sign-in');
+  assert.ok(partial);
+  assert.deepEqual(partial.missing.sort(), ['OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET']);
+});
+
+test('group warnings never echo values — only variable names reach the report', () => {
+  const env = envWithAllRequired();
+  env.VERCEL_TOKEN = 'vercel-tok-SENTINEL-DO-NOT-LEAK';
+  const report = renderReport(evaluateEnv(env));
+  assert.ok(!report.includes('SENTINEL'), 'a group member value is never printed');
+  assert.ok(report.includes('VERCEL_TEAM_ID'), 'the missing members are named');
+});
+
+test('evaluateGroups is pure and driver-aware when called directly', () => {
+  const { drivers } = resolveDrivers({ EXECUTOR_DRIVER: 'container' });
+  const partial = evaluateGroups({ VERCEL_TOKEN: 'present' }, drivers);
+  assert.ok(!partial.some((g) => g.name === 'Vercel Sandbox off-platform auth'));
+  const { drivers: defaults } = resolveDrivers({});
+  const partialDefault = evaluateGroups({ VERCEL_TOKEN: 'present' }, defaults);
+  assert.ok(partialDefault.some((g) => g.name === 'Vercel Sandbox off-platform auth'));
 });


### PR DESCRIPTION
Pre-deploy operator-experience batch: three small env/docs items, one PR.

Closes #195
Closes #198

Also partially addresses #225 — **documentation leg only**; the code-level fix (self-hosted fonts) stays open there and in #221, so #225 must NOT be closed by this PR.

## #195 — preflight warns on partially set all-or-nothing groups

`scripts/preflight-env.mjs` now declares `ENV_GROUPS`: variable sets the code consumes only as a complete set, where a partial set is indistinguishable from an empty one at run time (the feature silently stays off). A partially set group emits a `WARN` block naming the count, the missing members, and what stays off — warn-only by design, never a failure, since every member keeps its own tier.

Groups declared, each with a code citation in the spec:

- **Vercel Sandbox off-platform auth** — `VERCEL_TOKEN` / `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` (`resolveSandboxAuthParams` returns null unless all three); checked only under the `vercel-sandbox` executor, so a container-executor profile is never warned about it.
- **Generic OIDC sign-in** — the `OIDC_*` triple (`auth-providers.ts` activates the provider only on the full triple). The warning carries the issue's rider: `OIDC_ISSUER` is identity-bearing (part of every OIDC user's stored account key), and the same caution now appears in deploy.md's sign-in section.
- **GitHub sign-in** — the pair both-or-neither gates the provider; on an OIDC-complete instance the pair is individually optional, making a half-set pair otherwise fully silent — the case only the group check catches.
- **Durable rate limiting** — `KV_REST_API_URL` / `KV_REST_API_TOKEN` (`rate-limit.ts` requires both; either absent silently falls back to per-process memory).

The signing pair and host-topology set were considered and deliberately excluded: neither is all-or-nothing in the code (`EVIDENCE_KEY_ID` has a coded fallback the existing NOTE already surfaces; each host-topology variable has independent effect).

12 new tests in `scripts/preflight-env.test.mjs` (40 total, all passing; CI's `npm test` glob covers them): partial-warn with exact missing members, complete/empty groups silent, profile suppression, the OIDC identity-bearing note, the silent GitHub-pair case, whitespace-presence parity, no-value-echo, and byte-stability of the warning-free report. Deploy.md's environment-reference intro documents the new behavior in one paragraph.

## #198 — disposition: slim `.env.example` to a pointer (option 2)

Rationale: the docs-tail sprint established the canonical pair — the driver-aware preflight (executable authority) and deploy.md's tier-by-tier reference (narrative authority) — and `CONTRIBUTING.md` already routes readers to both. A full `ENV_SPEC` mirror in `.env.example` is a third authority that had **already drifted** (it lacked `BOSTON_OPENCONTEXT_MCP_URL`, the rate/token tuning knobs, and `CIVICAITOOLS_SESSION_TOKEN`, and each new seam — most recently `SITE_BRAND_*` — needs a manual parallel edit) and will drift again.

The slim file keeps the conventional first touchpoint working: a fresh developer still copies it to `.env.local` and boots `npm run dev` — it retains the minimal local-dev set (model key, data sources, evidence store, signing, sign-in) with the same placeholder conventions, under a header that names the two authorities and states the drift-resistant line: local-dev quick start lives here; instance configuration (drivers, `S3_*`, executor, OIDC, identity, branding, topology, knobs) lives with the preflight + deploy.md.

## #225 (docs leg) — font-egress build prerequisite

deploy.md's "Before you start" list (the section a cold reader hits before the compose bring-up's first image build) now names the requirement: `next/font/google` fetches the two typefaces at `next build` time, and since Next.js 16.2.11 an unreachable `fonts.googleapis.com` hard-fails the build where 16.2.7 warned and fell back. Restricted-egress build environments must allow that host; build-time only — the running app makes no request to it. The removal path (self-hosted fonts) is cross-referenced to #225/#221.

## Verification

- `node --test scripts/preflight-env.test.mjs` — 40/40 pass.
- CLI, inline env only: clean all-required run → PASS, exit 0, no WARN block (byte-stable report); run with three deliberately partial groups (2/3 sandbox trio, 1/3 OIDC, 1/2 KV) → all three warned with exact missing members, exit still 0; partial sandbox trio under `EXECUTOR_DRIVER=container` → suppressed, unmentioned.
- `git diff --stat` touches only `scripts/preflight-env.mjs`, `scripts/preflight-env.test.mjs`, `.env.example`, `docs/deploy.md` — no overlap with the #229 sprint's surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
