### PR TITLE
P1 (s6 · #229): provider-derived sign-in affordances + absorbed literals

### DIFF
--- a/src/app/(app)/auth/device/DeviceSignInPanel.tsx
+++ b/src/app/(app)/auth/device/DeviceSignInPanel.tsx
@@ -1,16 +1,41 @@
 'use client';
 
 import { signIn } from 'next-auth/react';
+import type { SignInOption } from '@/lib/auth-provider-options';
 
-interface DeviceSignInPanelProps {
-  callbackUrl: string;
-  prefilledUserCode: string;
-}
-
+/**
+ * The signed-out state of `/auth/device` (#211, closed in #229 P1).
+ *
+ * WHY THIS IS A PANEL, NOT A ONE-CONTROL AFFORDANCE. It is the same shape as
+ * `AskSignInPanel` and takes the same treatment: it maps over every option the
+ * instance offers rather than collapsing a multi-provider instance to a link.
+ * Two reasons it must, where the header and publish buttons may not:
+ *
+ *   1. `callbackUrl` is load-bearing. It carries the device code back to this
+ *      page after the round-trip, so the pairing continues where it left off.
+ *      Deferring to the `/ask` panel would drop the code and strand the CLI.
+ *   2. There is room. This is a whole page's primary content, not a strip.
+ *
+ * WHY THE LIST IS A PROP. `buildProviders()` returns configs carrying client
+ * secrets, so only a server component may call it; the page is already a
+ * server component, so the narrowed `{id, name}` list threads down with no
+ * client fetch — no loading flash, no failure path that leaves the visitor
+ * with no way in. Same reasoning, same shape as `/ask` (P4b).
+ *
+ * ZERO OPTIONS ⇒ NO BUTTON, and the copy says why. A button for a provider
+ * this instance never configured cannot complete an authorization; before
+ * this change an OIDC-only instance rendered exactly that (#193's defect
+ * class, surviving here after P4b fixed `/ask`).
+ */
 export default function DeviceSignInPanel({
   callbackUrl,
   prefilledUserCode,
-}: DeviceSignInPanelProps) {
+  options,
+}: {
+  callbackUrl: string;
+  prefilledUserCode: string;
+  options: SignInOption[];
+}) {
   return (
     <div
       style={{
@@ -19,22 +44,36 @@ export default function DeviceSignInPanel({
         borderRadius: '6px',
       }}
     >
-      <p style={{ fontSize: '14px', marginBottom: '16px', lineHeight: 1.5 }}>
-        Sign in with GitHub to review the authorization request
-        {prefilledUserCode ? (
-          <>
-            {' '}for code <code style={{ fontWeight: 600 }}>{prefilledUserCode}</code>
-          </>
-        ) : null}
-        .
-      </p>
-      <button
-        onClick={() => signIn('github', { callbackUrl })}
-        className="nyc-button nyc-button-primary"
-        style={{ padding: '10px 18px', fontSize: '14px' }}
-      >
-        Sign in with GitHub
-      </button>
+      {options.length === 0 ? (
+        <p style={{ fontSize: '14px', lineHeight: 1.5, margin: 0 }}>
+          This instance has no sign-in provider configured, so there is no way
+          to authorize a device here yet.
+        </p>
+      ) : (
+        <>
+          <p style={{ fontSize: '14px', marginBottom: '16px', lineHeight: 1.5 }}>
+            Sign in to review the authorization request
+            {prefilledUserCode ? (
+              <>
+                {' '}for code <code style={{ fontWeight: 600 }}>{prefilledUserCode}</code>
+              </>
+            ) : null}
+            .
+          </p>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '12px' }}>
+            {options.map((option) => (
+              <button
+                key={option.id}
+                onClick={() => signIn(option.id, { callbackUrl })}
+                className="nyc-button nyc-button-primary"
+                style={{ padding: '10px 18px', fontSize: '14px' }}
+              >
+                Sign in with {option.name}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(app)/auth/device/page.tsx
+++ b/src/app/(app)/auth/device/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { normalizeUserCode } from '@/lib/device-flow';
+import { buildProviders } from '@/lib/auth-providers';
+import { toSignInOptions } from '@/lib/auth-provider-options';
 import DeviceApprovalPanel from './DeviceApprovalPanel';
 import DeviceSignInPanel from './DeviceSignInPanel';
 import { getBrandName } from '@/lib/brand-config';
@@ -47,7 +49,15 @@ export default async function DeviceAuthPage({ searchParams }: PageProps) {
       {session?.user?.id ? (
         <DeviceApprovalPanel initialUserCode={normalized} />
       ) : (
-        <DeviceSignInPanel callbackUrl={callbackUrl} prefilledUserCode={normalized} />
+        /* #211: the panel's buttons are what this instance actually
+           configured, derived here on the server (the configs carry client
+           secrets and cannot cross to the client) — the same derivation
+           `/ask` has used since P4b. */
+        <DeviceSignInPanel
+          callbackUrl={callbackUrl}
+          prefilledUserCode={normalized}
+          options={toSignInOptions(buildProviders())}
+        />
       )}
     </div>
   );

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,5 @@
 import AppChrome from '@/components/AppChrome';
-import { resolvePublicSiteHref } from '@/lib/host-routing';
+import { resolveAskHref, resolvePublicSiteHref } from '@/lib/host-routing';
 
 /**
  * Layout for the `(app)` route group — the gated app surface's shell
@@ -27,6 +27,10 @@ import { resolvePublicSiteHref } from '@/lib/host-routing';
  * bundle. Unset topology resolves to `/`, today's exact link. For routes
  * prerendered at build time the value freezes at build, the same semantics
  * an inlined NEXT_PUBLIC var would have.
+ *
+ * The "Ask" link (#210) is resolved the same way and for the same reason:
+ * this group's `/evidence` pages are dual-served, so the strip can render on
+ * the marketing host, where `/ask` is withheld.
  */
 export default function AppLayout({
   children,
@@ -35,7 +39,10 @@ export default function AppLayout({
 }>) {
   return (
     <>
-      <AppChrome publicSiteHref={resolvePublicSiteHref(process.env)} />
+      <AppChrome
+        publicSiteHref={resolvePublicSiteHref(process.env)}
+        askHref={resolveAskHref(process.env)}
+      />
       {children}
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,9 @@ import RunningUnsignedBanner from '@/components/RunningUnsignedBanner';
 import SponsorLine from '@/components/SponsorLine';
 import { BrandProvider } from '@/components/BrandProvider';
 import { EvidenceOriginProvider } from '@/components/EvidenceOriginProvider';
+import { SignInOptionsProvider } from '@/components/SignInOptionsProvider';
+import { buildProviders } from '@/lib/auth-providers';
+import { toSignInOptions } from '@/lib/auth-provider-options';
 import {
   getBrandAccent,
   getBrandAttribution,
@@ -86,6 +89,16 @@ export default function RootLayout({
   const brandTagline = getBrandTagline();
   const brandAttribution = getBrandAttribution();
   const brandAccent = getBrandAccent();
+
+  /**
+   * The instance's sign-in choices (#229 P1 / Q63), derived here for the same
+   * reason the host links are: `buildProviders()` returns provider configs
+   * carrying client secrets, so the derivation is server-only and only the
+   * narrowed `{id, name}` list crosses to the client. `/ask` has done this
+   * since P4b; this hoists it to the layout so the five affordances outside
+   * `/ask` stop hardcoding one provider.
+   */
+  const signInOptions = toSignInOptions(buildProviders());
   // Conditional SPREAD, not `style={maybeUndefined}`: an explicit
   // `style={undefined}` would still serialize a `"style":"$undefined"` entry
   // into the RSC flight payload, a needless unset-case byte delta. With the
@@ -130,6 +143,11 @@ export default function RootLayout({
               (#227) — instance identity (EVIDENCE_SITE_ORIGIN), so its own
               provider rather than a rider on the chrome-brand one. */}
           <EvidenceOriginProvider value={getEvidenceSiteOrigin()}>
+          {/* Sign-in choices for the affordances inside client trees (#229
+              P1) — QueryForm, RateLimitBanner, McpResponseDisplay and
+              NotebookOutput all render under the apex page, a client
+              component with no server ancestor to thread a prop from. */}
+          <SignInOptionsProvider value={signInOptions}>
           <div className="flex flex-col">
             {/* Env-driven (P3): on a split-host topology the marketing host
                 withholds /dashboard, so the signed-in menu must carry the
@@ -143,6 +161,7 @@ export default function RootLayout({
               marketingOrigin={hostLinks.marketingOrigin}
               signInHref={hostLinks.signInHref}
               brandName={brandName}
+              signInOptions={signInOptions}
             />
             {/* ADR-0020: running-unsigned indicator — renders only when this
                 instance has no signing key AND is outside a dev environment. */}
@@ -194,6 +213,7 @@ export default function RootLayout({
               </div>
             </footer>
           </div>
+          </SignInOptionsProvider>
           </EvidenceOriginProvider>
           </BrandProvider>
           </HostLinksProvider>

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -20,8 +20,11 @@ import { useSession } from 'next-auth/react';
  *      avatar menu, because on the app surface "which account is this?" is a
  *      question you must be able to answer at a glance before publishing
  *      anything under it.
- *   2. WHERE IS MY WORK — a direct Dashboard link, current-page aware.
- *   3. HOW DO I GET OUT — an explicit exit to the public site.
+ *   2. WHAT DO I DO HERE — a direct Ask link (#210). Before it, a signed-in
+ *      user who landed on `/dashboard` had no in-app path back to the query
+ *      surface at all; the URL bar was the only way.
+ *   3. WHERE IS MY WORK — a direct Dashboard link, current-page aware.
+ *   4. HOW DO I GET OUT — an explicit exit to the public site.
  *
  * CLIENT COMPONENT ON PURPOSE. It reads the session through `useSession()`
  * (the provider is already mounted in the root layout) rather than
@@ -45,11 +48,21 @@ import { useSession } from 'next-auth/react';
  * host, the marketing origin on a split-host deployment, and null on an
  * app-only instance — null hides the link entirely, because an app-only
  * instance HAS no public marketing site to exit to.
+ *
+ * `askHref` is resolved the same way, by `resolveAskHref()`, and it is NOT a
+ * plain `/ask` for the reason #210 records: this strip also renders on the
+ * dual-served `/evidence` pages, which serve on the MARKETING host, where
+ * `/ask` is app-private and withheld. A relative href would 404 there, so a
+ * split-host instance carries the app origin — the treatment
+ * `resolveDashboardHref` established for the header's Dashboard link.
+ * Defaults to `/ask`: today's relative path, for any mount that omits it.
  */
 export default function AppChrome({
   publicSiteHref = '/',
+  askHref = '/ask',
 }: {
   publicSiteHref?: string | null;
+  askHref?: string;
 }) {
   const { data: session, status } = useSession();
   const pathname = usePathname();
@@ -60,6 +73,7 @@ export default function AppChrome({
 
   const displayName = session.user.name || session.user.email || 'your account';
   const onDashboard = pathname === '/dashboard';
+  const onAsk = pathname === '/ask';
 
   return (
     <div
@@ -87,6 +101,18 @@ export default function AppChrome({
           <strong style={{ color: 'var(--text-primary)', fontWeight: 600 }}>{displayName}</strong>
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          {/* The app surface's primary action, first (#210). Same
+              current-page treatment as Dashboard: on `/ask` itself the item
+              states where you are rather than linking to it. */}
+          {onAsk ? (
+            <span aria-current="page" style={{ color: 'var(--text-muted)' }}>
+              Ask
+            </span>
+          ) : (
+            <Link href={askHref} style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
+              Ask
+            </Link>
+          )}
           {onDashboard ? (
             <span aria-current="page" style={{ color: 'var(--text-muted)' }}>
               Dashboard

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,11 @@ import { signIn, signOut, useSession } from 'next-auth/react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { TYPED_STANDARDS_URL } from '@/lib/site-config';
+import {
+  DEFAULT_SIGN_IN_OPTIONS,
+  resolveSignInAffordance,
+  type SignInOption,
+} from '@/lib/auth-provider-options';
 
 const NAV_LINK_STYLE: React.CSSProperties = {
   color: 'var(--text-secondary)',
@@ -42,17 +47,24 @@ const DROPDOWN_ITEM_STYLE: React.CSSProperties = {
  * - `brandName` (#217) — the wordmark text, resolved by the layout from
  *   `SITE_BRAND_NAME` (src/lib/brand-config.ts). The default is the demo
  *   name, so a mount that omits the prop renders today's chrome.
+ * - `signInOptions` (#229 P1) — the providers this instance actually
+ *   configured, derived by the layout from `buildProviders()`. Only the
+ *   in-place branch below reads it (the split-host branch links to the `/ask`
+ *   panel, which lists the providers itself). The default is today's single
+ *   GitHub button.
  */
 export default function Header({
   dashboardHref = '/dashboard',
   marketingOrigin = '',
   signInHref = null,
   brandName = 'Civic AI Tools',
+  signInOptions = DEFAULT_SIGN_IN_OPTIONS,
 }: {
   dashboardHref?: string;
   marketingOrigin?: string | null;
   signInHref?: string | null;
   brandName?: string;
+  signInOptions?: SignInOption[];
 }) {
   const { data: session, status } = useSession();
   const headerRef = useRef<HTMLElement>(null);
@@ -69,6 +81,13 @@ export default function Header({
   // on the path — the byte-identity guarantee, in one expression.
   const showMarketingNav = marketingOrigin !== null;
   const mkt = (path: string) => `${marketingOrigin ?? ''}${path}`;
+
+  // The in-place sign-in control, for instances with no app host to send
+  // anyone to. One configured provider ⇒ that provider's button (GitHub's, on
+  // the reference deployment — today's exact markup); none ⇒ no button; more
+  // than one ⇒ a link to the panel that can list them. See
+  // resolveSignInAffordance.
+  const signInAffordance = resolveSignInAffordance(signInOptions);
 
   // Publish header height as a CSS variable so other components can offset below it
   useEffect(() => {
@@ -399,15 +418,23 @@ export default function Header({
             >
               Sign in
             </a>
-          ) : (
+          ) : signInAffordance.kind === 'provider' ? (
             <button
-              onClick={() => signIn('github')}
+              onClick={() => signIn(signInAffordance.option.id)}
               className="nyc-button nyc-button-primary"
               style={{ padding: '8px 16px', fontSize: '14px' }}
             >
-              Sign in with GitHub
+              Sign in with {signInAffordance.option.name}
             </button>
-          )}
+          ) : signInAffordance.kind === 'panel' ? (
+            <a
+              href={signInAffordance.href}
+              className="nyc-button nyc-button-primary"
+              style={{ padding: '8px 16px', fontSize: '14px', textDecoration: 'none' }}
+            >
+              Sign in
+            </a>
+          ) : null}
         </div>
       </div>
 

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useRef, useCallback, useSyncExternalStore } from '
 import Link from 'next/link';
 import { signIn, useSession } from 'next-auth/react';
 import { useHostLinks } from '@/components/HostLinksProvider';
+import { useSignInOptions } from '@/components/SignInOptionsProvider';
+import { resolveSignInAffordance } from '@/lib/auth-provider-options';
 import RateLimitBanner from './RateLimitBanner';
 
 interface Model {
@@ -93,6 +95,9 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
   // topology configured — then the affordance below stays in place, exactly
   // as it is today. See src/lib/host-links.ts.
   const { signInHref } = useHostLinks();
+  // #229 P1: which provider the in-place branch below starts, and whether it
+  // can name one at all — derived from the instance's configuration (Q63).
+  const signInAffordance = resolveSignInAffordance(useSignInOptions());
   const [mode, updateMode] = useStoredMode(isAuthenticated);
   const [models, setModels] = useState<Model[]>([]);
   const [modelOpen, setModelOpen] = useState(false);
@@ -374,11 +379,14 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
                 </div>
                 {/* One expression, not a sentence split around a ternary:
                     two adjacent text children would make React emit comment
-                    separators, and the unset case must stay byte-identical. */}
+                    separators, and the unset case must stay byte-identical.
+                    The provider name is interpolated (#229 P1) only where the
+                    in-place branch can name one — every other shape keeps the
+                    provider-neutral sentence P4c already ships. */}
                 <p style={{ margin: '0 0 10px' }}>
-                  {signInHref !== null
-                    ? 'Executed-sandbox mode generates and runs a Jupyter notebook against live data, then signs the execution record. Sign in to enable.'
-                    : 'Executed-sandbox mode generates and runs a Jupyter notebook against live data, then signs the execution record. Sign in with GitHub to enable.'}
+                  {signInHref === null && signInAffordance.kind === 'provider'
+                    ? `Executed-sandbox mode generates and runs a Jupyter notebook against live data, then signs the execution record. Sign in with ${signInAffordance.option.name} to enable.`
+                    : 'Executed-sandbox mode generates and runs a Jupyter notebook against live data, then signs the execution record. Sign in to enable.'}
                 </p>
                 {signInHref !== null ? (
                   /* Split topology (P4c): sign-in lives on the app surface,
@@ -392,10 +400,10 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
                   >
                     Sign in
                   </a>
-                ) : (
+                ) : signInAffordance.kind === 'provider' ? (
                 <button
                   type="button"
-                  onClick={() => signIn('github')}
+                  onClick={() => signIn(signInAffordance.option.id)}
                   disabled={authStatus === 'loading'}
                   className="nyc-button nyc-button-primary"
                   style={{
@@ -404,9 +412,18 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
                     cursor: authStatus === 'loading' ? 'wait' : 'pointer',
                   }}
                 >
-                  {authStatus === 'loading' ? 'Loading…' : 'Sign in with GitHub'}
+                  {authStatus === 'loading' ? 'Loading…' : `Sign in with ${signInAffordance.option.name}`}
                 </button>
-                )}
+                ) : signInAffordance.kind === 'panel' ? (
+                  /* More than one provider: the panel that can list them. */
+                  <a
+                    href={signInAffordance.href}
+                    className="nyc-button nyc-button-primary"
+                    style={{ fontSize: '13px', padding: '6px 14px', textDecoration: 'none' }}
+                  >
+                    Sign in
+                  </a>
+                ) : null}
               </div>
             )}
           </div>

--- a/src/components/RateLimitBanner.tsx
+++ b/src/components/RateLimitBanner.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { signIn, useSession } from 'next-auth/react';
 import { useHostLinks } from '@/components/HostLinksProvider';
+import { useSignInOptions } from '@/components/SignInOptionsProvider';
+import { resolveSignInAffordance } from '@/lib/auth-provider-options';
 
 interface RateLimitInfo {
   remaining: number;
@@ -15,11 +17,39 @@ interface RateLimitBannerProps {
   refreshTrigger?: number;
 }
 
+/**
+ * The signed-out prompt, tier-neutral (#212).
+ *
+ * It used to read "Sign in for 25/day" — a literal that is simply wrong on
+ * any instance overriding `AUTHENTICATED_RATE_LIMIT` or `APP_TIER_RATE_LIMIT`,
+ * and the defect predates host topology. P4c already rephrased the
+ * split-topology branch this way; naming the string once makes both branches
+ * carry the same promise and leaves no number to drift.
+ *
+ * NOT rendered from the API's `limit` field, deliberately: `/api/rate-limit`
+ * answers for the CALLER, so a signed-out visitor is served the ANONYMOUS
+ * quota. Printing that number after "Sign in for" would state the limit they
+ * already have as the one sign-in would buy — a quieter version of the same
+ * bug. The line above this one does consume the served value, which is the
+ * number that is actually true for this visitor.
+ */
+const SIGN_IN_PROMPT = 'Sign in for a higher daily limit';
+
+/** Shared by all three shapes of the prompt so they render identically. */
+const PROMPT_LINK_STYLE: React.CSSProperties = {
+  color: 'var(--nyc-blue-40)',
+  textDecoration: 'underline',
+  fontSize: 'inherit',
+};
+
 export default function RateLimitBanner({ refreshTrigger = 0 }: RateLimitBannerProps) {
   const { data: session } = useSession();
   // P4c: null when no host topology is configured — the button below stays
   // an in-place sign-in, exactly as today. See src/lib/host-links.ts.
   const { signInHref } = useHostLinks();
+  // #229 P1: the in-place branch's provider, derived from what the instance
+  // configured rather than hardcoded (Q63). See resolveSignInAffordance.
+  const signInAffordance = resolveSignInAffordance(useSignInOptions());
   const [rateLimit, setRateLimit] = useState<RateLimitInfo | null>(null);
 
   useEffect(() => {
@@ -69,26 +99,20 @@ export default function RateLimitBanner({ refreshTrigger = 0 }: RateLimitBannerP
     >
       <span>
         <strong>{rateLimit.remaining}</strong>/{rateLimit.limit} requests remaining today
-        {!rateLimit.authenticated && !session && (
+        {!rateLimit.authenticated && !session &&
+          (signInHref !== null || signInAffordance.kind !== 'none') && (
           <span style={{ marginLeft: '4px' }}>
             ·{' '}
             {signInHref !== null ? (
               /* Split topology (P4c): a link to the app surface's sign-in
                  panel. An in-place OAuth start cannot complete from the
                  marketing host — the session lives on the app host. */
-              <a
-                href={signInHref}
-                style={{
-                  color: 'var(--nyc-blue-40)',
-                  textDecoration: 'underline',
-                  fontSize: 'inherit',
-                }}
-              >
-                Sign in for a higher daily limit
+              <a href={signInHref} style={PROMPT_LINK_STYLE}>
+                {SIGN_IN_PROMPT}
               </a>
-            ) : (
+            ) : signInAffordance.kind === 'provider' ? (
             <button
-              onClick={() => signIn('github')}
+              onClick={() => signIn(signInAffordance.option.id)}
               style={{
                 background: 'none',
                 border: 'none',
@@ -99,9 +123,15 @@ export default function RateLimitBanner({ refreshTrigger = 0 }: RateLimitBannerP
                 fontSize: 'inherit',
               }}
             >
-              Sign in for 25/day
+              {SIGN_IN_PROMPT}
             </button>
-            )}
+            ) : signInAffordance.kind === 'panel' ? (
+              /* More than one provider: the same panel the split branch uses,
+                 relatively — a one-line prompt cannot offer a choice. */
+              <a href={signInAffordance.href} style={PROMPT_LINK_STYLE}>
+                {SIGN_IN_PROMPT}
+              </a>
+            ) : null}
           </span>
         )}
       </span>

--- a/src/components/SignInOptionsProvider.tsx
+++ b/src/components/SignInOptionsProvider.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import { DEFAULT_SIGN_IN_OPTIONS, type SignInOption } from '@/lib/auth-provider-options';
+
+/**
+ * Carries the server-derived sign-in options to client components that props
+ * cannot reach (#229 P1 / Q63) — the exact shape of `HostLinksProvider` and
+ * `BrandProvider`, and mounted beside them in the root layout.
+ *
+ * WHY A CONTEXT AND NOT PROP THREADING. `buildProviders()` returns NextAuth
+ * provider CONFIGS carrying client secrets and callbacks; only a server
+ * component may call it, and only the narrowed `{id, name}` list may cross to
+ * the client. But three of the affordances that need that list —
+ * `RateLimitBanner`, `QueryForm`, and `McpResponseDisplay` — render inside
+ * `QuerySurface`, mounted by the apex page, which is itself a client
+ * component; `NotebookOutput` is the fourth, in the same tree. There is no
+ * server ancestor to extend a prop chain from without converting the apex
+ * page. One provider mounted once in the root layout reaches all four.
+ *
+ * Components a server component renders DIRECTLY take the list as a prop
+ * instead: `Header` from the root layout, `DeviceSignInPanel` from the device
+ * page. Props where the server can reach, context only where the client
+ * boundary blocks it — the rule `HostLinksProvider` set and `BrandProvider`
+ * followed.
+ *
+ * The default is `DEFAULT_SIGN_IN_OPTIONS` — today's single GitHub button —
+ * so a component rendered outside the provider degrades to the pre-seam
+ * affordance rather than to no way to sign in.
+ *
+ * BUILD-TIME RESOLUTION, same caveat as the brand and host-link seams: the
+ * root layout resolves this from `process.env`, so for statically prerendered
+ * routes (the apex `/` among them) the value freezes at build. An instance
+ * whose auth variables are absent at BUILD time but present at runtime
+ * prerenders no sign-in control. That is the documented behavior of every
+ * non-`NEXT_PUBLIC_` chrome knob in this app (docs/deploy.md), not a new
+ * property of this one.
+ */
+const SignInOptionsContext = createContext<SignInOption[]>(DEFAULT_SIGN_IN_OPTIONS);
+
+export function SignInOptionsProvider({
+  value,
+  children,
+}: {
+  value: SignInOption[];
+  children: ReactNode;
+}) {
+  return <SignInOptionsContext.Provider value={value}>{children}</SignInOptionsContext.Provider>;
+}
+
+/** Read the instance's sign-in options. Safe outside the provider (see above). */
+export function useSignInOptions(): SignInOption[] {
+  return useContext(SignInOptionsContext);
+}

--- a/src/components/dashboard/DashboardTabs.tsx
+++ b/src/components/dashboard/DashboardTabs.tsx
@@ -262,9 +262,17 @@ function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signi
 
   if (rows.length === 0) {
     return (
+      /* Topology-stale copy fixed in #229 P1. "The home page" is a
+         marketing-surface noun: the dashboard is app-private, so on a
+         split-host instance it renders on the app host, which HAS no home
+         page — `/` there 307s to `/ask`. `/ask` is the signed-in query
+         surface on every topology (it serves everywhere when none is
+         configured), and everyone reading this empty state is signed in by
+         definition, so the relative href is correct on all three shapes with
+         no origin treatment needed. */
       <EmptyState
-        message="You haven't published any evidence yet. Run an analysis on the home page and click 'Publish as Evidence' to get started."
-        cta={{ text: 'Go to home page', href: '/' }}
+        message="You haven't published any evidence yet. Ask a question, then click 'Publish as Evidence' to get started."
+        cta={{ text: 'Ask a question', href: '/ask' }}
       />
     );
   }

--- a/src/components/evidence/EvidenceIndex.tsx
+++ b/src/components/evidence/EvidenceIndex.tsx
@@ -188,7 +188,14 @@ export default function EvidenceIndex() {
           </p>
           {!debouncedQuery && !status && range === 'all' && (
             <p style={{ fontSize: '14px', margin: 0 }}>
-              Run a query on the <Link href="/" style={{ color: 'var(--nyc-blue)' }}>home page</Link> and
+              {/* Topology-stale copy fixed in #229 P1 — the second instance
+                  of the "home page" noun the dashboard carried. `/evidence`
+                  is DUAL-SERVED, so this line renders on both hosts, and the
+                  href must stay relative: `/` is the query surface on the
+                  marketing host and 307s to `/ask` on the app host, while a
+                  direct `/ask` would 404 on the marketing host. Only the
+                  wording was wrong — the app host has no "home page". */}
+              <Link href="/" style={{ color: 'var(--nyc-blue)' }}>Run a query</Link> and
               click &ldquo;Publish as Evidence&rdquo; to create the first one.
             </p>
           )}

--- a/src/components/notebook/NotebookOutput.tsx
+++ b/src/components/notebook/NotebookOutput.tsx
@@ -24,6 +24,8 @@ import { useSession, signIn } from 'next-auth/react';
 import ChatNotebookOutput from './ChatNotebookOutput';
 import NotebookProgress from './NotebookProgress';
 import PublishEvidenceDialog from '@/components/PublishEvidenceDialog';
+import { useSignInOptions } from '@/components/SignInOptionsProvider';
+import { resolveSignInAffordance } from '@/lib/auth-provider-options';
 import { SUMMARY_EXTENSION_KEY } from '@/lib/notebook-author/prompt';
 import type { NotebookStreamState } from '@/hooks/useNotebookStream';
 import type { Notebook } from '@/lib/notebook-author/cells';
@@ -54,6 +56,11 @@ function structuredSummaryText(notebook: Notebook): string | undefined {
 
 export default function NotebookOutput({ state, prompt, model, portal, onRetry }: NotebookOutputProps) {
   const { data: session } = useSession();
+  // #229 P1: same treatment as the chat flow's publish button — the
+  // signed-out branch starts whatever provider this instance configured.
+  // (This surface has no split-topology branch of its own; it only renders
+  // under `/ask` and the dev preview, both app-private.)
+  const signInAffordance = resolveSignInAffordance(useSignInOptions());
   const [publishDialogOpen, setPublishDialogOpen] = useState(false);
 
   // Publishable iff the pipeline completed AND the publish inputs arrived
@@ -137,13 +144,32 @@ export default function NotebookOutput({ state, prompt, model, portal, onRetry }
                 borderTop: '1px solid var(--border-color)',
               }}
             >
+              {!session?.user && signInAffordance.kind === 'panel' ? (
+                /* More than one provider: defer to the panel that lists them. */
+                <a
+                  href={signInAffordance.href}
+                  style={{
+                    background: 'none',
+                    border: '1px solid var(--nyc-blue)',
+                    borderRadius: '4px',
+                    padding: '6px 14px',
+                    fontSize: '13px',
+                    color: 'var(--nyc-blue)',
+                    cursor: 'pointer',
+                    fontWeight: 500,
+                    textDecoration: 'none',
+                  }}
+                >
+                  Sign in to publish
+                </a>
+              ) : !session?.user && signInAffordance.kind === 'none' ? null : (
               <button
                 onClick={() => {
-                  if (!session?.user) {
+                  if (!session?.user && signInAffordance.kind === 'provider') {
                     // NextAuth v4 OAuth providers need a full redirect; the
                     // user signs in, then re-runs the query (same caveat as
                     // the chat flow's publish button).
-                    signIn('github');
+                    signIn(signInAffordance.option.id);
                   } else {
                     setPublishDialogOpen(true);
                   }
@@ -161,11 +187,14 @@ export default function NotebookOutput({ state, prompt, model, portal, onRetry }
               >
                 {session?.user ? 'Publish as Evidence' : 'Sign in to publish'}
               </button>
+              )}
+              {(session?.user || signInAffordance.kind !== 'none') && (
               <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
                 {session?.user
                   ? 'Publishes the executed notebook and its execution record — not a regenerated skeleton.'
                   : 'Sign in first, then re-run your query.'}
               </span>
+              )}
             </div>
           )}
 

--- a/src/components/shared/McpResponseDisplay.tsx
+++ b/src/components/shared/McpResponseDisplay.tsx
@@ -10,6 +10,8 @@ import { generateNotebook, downloadNotebook } from '@/lib/notebook';
 import type { ProgressLogEntry, ProgressGroup, ToolCall, EvidenceTrace } from '@/hooks/useStreamingComparison';
 import { useSession, signIn } from 'next-auth/react';
 import { useHostLinks } from '@/components/HostLinksProvider';
+import { useSignInOptions } from '@/components/SignInOptionsProvider';
+import { resolveSignInAffordance } from '@/lib/auth-provider-options';
 import PublishEvidenceDialog from '@/components/PublishEvidenceDialog';
 
 /**
@@ -400,6 +402,9 @@ export default function McpResponseDisplay({
   // P4c: null when no host topology is configured — the publish button's
   // signed-out branch then signs in place, exactly as today.
   const { signInHref, marketingOrigin } = useHostLinks();
+  // #229 P1: the publish button's signed-out, in-place branch starts the
+  // provider this instance actually configured — not a hardcoded one (Q63).
+  const signInAffordance = resolveSignInAffordance(useSignInOptions());
 
   // Use parent-controlled state if provided, otherwise local
   const publishDialogOpen = publishDialogOpenProp ?? publishDialogOpenLocal;
@@ -824,13 +829,30 @@ export default function McpResponseDisplay({
                     </svg>
                     Sign in to publish
                   </a>
+                ) : !session?.user && signInAffordance.kind === 'panel' ? (
+                  /* No topology, but more than one provider: a single button
+                     cannot offer a choice, so link to the panel that can. */
+                  <a
+                    href={signInAffordance.href}
+                    style={{ ...PUBLISH_BUTTON_STYLE, textDecoration: 'none' }}
+                    onMouseOver={(e) => { e.currentTarget.style.backgroundColor = 'rgba(var(--accent-rgb), 0.06)'; }}
+                    onMouseOut={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M8 2a.75.75 0 0 1 .75.75v4.5h4.5a.75.75 0 0 1 0 1.5h-4.5v4.5a.75.75 0 0 1-1.5 0v-4.5h-4.5a.75.75 0 0 1 0-1.5h4.5v-4.5A.75.75 0 0 1 8 2Z" />
+                    </svg>
+                    Sign in to publish
+                  </a>
+                ) : !session?.user && signInAffordance.kind === 'none' ? (
+                  /* Nothing configured: no way in, so no control (#193). */
+                  null
                 ) : (
                 <button
                   onClick={() => {
-                    if (!session?.user) {
+                    if (!session?.user && signInAffordance.kind === 'provider') {
                       // NextAuth v4 doesn't support redirect:false for OAuth providers,
                       // so we do a normal redirect. User signs in, then re-runs their query.
-                      signIn('github');
+                      signIn(signInAffordance.option.id);
                     } else {
                       setPublishDialogOpen(true);
                     }
@@ -845,7 +867,9 @@ export default function McpResponseDisplay({
                   {session?.user ? 'Publish as Evidence' : 'Sign in to publish'}
                 </button>
                 )}
-                {!session?.user && (
+                {/* Suppressed only when there is no way to sign in at all —
+                    an instruction with no control to follow it is noise. */}
+                {!session?.user && (signInHref !== null || signInAffordance.kind !== 'none') && (
                   <span style={{ fontSize: '11px', color: '#666' }}>
                     Sign in first, then re-run your query
                   </span>

--- a/src/lib/auth-provider-options.test.ts
+++ b/src/lib/auth-provider-options.test.ts
@@ -8,8 +8,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { Provider } from 'next-auth/providers/index';
-import { toSignInOptions } from './auth-provider-options.ts';
+import {
+  DEFAULT_SIGN_IN_OPTIONS,
+  resolveSignInAffordance,
+  toSignInOptions,
+} from './auth-provider-options.ts';
 import { buildProviders } from './auth-providers.ts';
+import { SIGN_IN_PANEL_HREF } from './host-links.ts';
 
 /** A provider config with only the fields this module reads. */
 function fakeProvider(id: string, name: string): Provider {
@@ -90,4 +95,66 @@ test('both configured ⇒ one button each; a half-configured pair contributes no
 
 test('an unconfigured instance ⇒ zero options', () => {
   assert.deepEqual(toSignInOptions(buildProviders({})), []);
+});
+
+// --- One-control affordances (#229 P1 / Q63) -------------------------------
+//
+// The header button, the rate-limit line, the sandbox-mode prompt and the two
+// publish buttons each have room for exactly one control, so they cannot map
+// over the options the way the /ask and /auth/device panels do.
+
+test('resolveSignInAffordance: one provider ⇒ start it in place, named', () => {
+  const affordance = resolveSignInAffordance([{ id: 'oidc', name: 'Acme SSO' }]);
+  assert.deepEqual(affordance, {
+    kind: 'provider',
+    option: { id: 'oidc', name: 'Acme SSO' },
+  });
+});
+
+test('resolveSignInAffordance: nothing configured ⇒ no control at all (#193)', () => {
+  assert.deepEqual(resolveSignInAffordance([]), { kind: 'none' });
+});
+
+test('resolveSignInAffordance: more than one ⇒ defer to the panel that can list them', () => {
+  assert.deepEqual(
+    resolveSignInAffordance([
+      { id: 'github', name: 'GitHub' },
+      { id: 'oidc', name: 'Acme SSO' },
+    ]),
+    { kind: 'panel', href: SIGN_IN_PANEL_HREF },
+  );
+});
+
+test('the seam default is today’s exact affordance: one GitHub button', () => {
+  // The value a mount OUTSIDE SignInOptionsProvider falls back to. It must
+  // reproduce the pre-seam rendering, not an empty list.
+  assert.deepEqual(DEFAULT_SIGN_IN_OPTIONS, [{ id: 'github', name: 'GitHub' }]);
+  assert.deepEqual(resolveSignInAffordance(DEFAULT_SIGN_IN_OPTIONS), {
+    kind: 'provider',
+    option: { id: 'github', name: 'GitHub' },
+  });
+});
+
+test('the reference deployment resolves to exactly the pre-seam button', () => {
+  // GitHub pair configured, nothing else: derivation → affordance → the same
+  // in-place `signIn('github')` button the five surfaces hardcoded before.
+  const affordance = resolveSignInAffordance(
+    toSignInOptions(buildProviders({ GITHUB_CLIENT_ID: 'id', GITHUB_CLIENT_SECRET: 'secret' })),
+  );
+  assert.deepEqual(affordance, { kind: 'provider', option: { id: 'github', name: 'GitHub' } });
+});
+
+test('an OIDC-only instance renders its own provider, never GitHub', () => {
+  const affordance = resolveSignInAffordance(
+    toSignInOptions(
+      buildProviders({
+        OIDC_ISSUER: 'https://sso.example.org',
+        OIDC_CLIENT_ID: 'id',
+        OIDC_CLIENT_SECRET: 'secret',
+        OIDC_PROVIDER_NAME: 'Acme SSO',
+      }),
+    ),
+  );
+  assert.deepEqual(affordance, { kind: 'provider', option: { id: 'oidc', name: 'Acme SSO' } });
+  assert.equal(JSON.stringify(affordance).includes('GitHub'), false);
 });

--- a/src/lib/auth-provider-options.ts
+++ b/src/lib/auth-provider-options.ts
@@ -19,6 +19,7 @@
 // configured nothing must render no button at all.
 
 import type { Provider } from 'next-auth/providers/index';
+import { SIGN_IN_PANEL_HREF } from './host-links.ts';
 
 /** One sign-in choice: what to label the button, and what to call `signIn` with. */
 export interface SignInOption {
@@ -44,4 +45,50 @@ export function toSignInOptions(providers: Provider[]): SignInOption[] {
       id: provider.id,
       name: typeof provider.name === 'string' && provider.name.length > 0 ? provider.name : provider.id,
     }));
+}
+
+/**
+ * The seam default: the single GitHub button every generalized affordance
+ * rendered before this seam existed.
+ *
+ * It is the same kind of default as `DEFAULT_HOST_LINKS` and `BrandProvider`'s
+ * demo name — what a mount OUTSIDE the provider (a test, a future surface that
+ * forgets to pass the value) falls back to. It is deliberately today's exact
+ * rendering rather than `[]`, so forgetting to wire the seam degrades to the
+ * pre-seam bytes instead of silently deleting every sign-in control. Instances
+ * never see it: the root layout and the device page both pass the derived list.
+ */
+export const DEFAULT_SIGN_IN_OPTIONS: SignInOption[] = [{ id: 'github', name: 'GitHub' }];
+
+/**
+ * What a ONE-CONTROL sign-in affordance should do — the header button, the
+ * rate-limit line, the query form's sandbox-mode prompt, and the two publish
+ * buttons. Each of those has room for exactly one control and (unlike the
+ * `/ask` and `/auth/device` panels) cannot lay out a row of provider buttons
+ * without becoming a different component.
+ *
+ * Three cases, and each is the honest render for its instance shape:
+ *
+ * - `provider` — exactly one configured provider: start its flow in place,
+ *   naming it. On the reference deployment that one provider is GitHub, so
+ *   this is byte-for-byte today's affordance; on an OIDC-only instance it is
+ *   that instance's own provider, which is the #193 principle these five
+ *   surfaces were still missing.
+ * - `none` — nothing configured: render no control at all. A button that
+ *   cannot complete an authorization is the dead button #193 removed.
+ * - `panel` — more than one: a single control cannot express a choice, so
+ *   defer to the surface that can. This mirrors what the topology-configured
+ *   branch of these same affordances already does — it links to the `/ask`
+ *   panel rather than starting a flow — and the panel lists every provider
+ *   the instance actually offers.
+ */
+export type SignInAffordance =
+  | { kind: 'none' }
+  | { kind: 'provider'; option: SignInOption }
+  | { kind: 'panel'; href: string };
+
+export function resolveSignInAffordance(options: SignInOption[]): SignInAffordance {
+  if (options.length === 0) return { kind: 'none' };
+  if (options.length === 1) return { kind: 'provider', option: options[0] };
+  return { kind: 'panel', href: SIGN_IN_PANEL_HREF };
 }

--- a/src/lib/host-links.ts
+++ b/src/lib/host-links.ts
@@ -50,6 +50,16 @@ import { SIGN_IN_INTENT_PARAM } from './sign-in-intent.ts';
 const SIGN_IN_PATH = '/ask';
 const SIGN_IN_HREF = `${SIGN_IN_PATH}?${SIGN_IN_INTENT_PARAM}=1`;
 
+/**
+ * The same door, as a RELATIVE href — for affordances that need the panel
+ * without any cross-host question. `resolveSignInAffordance` uses it for the
+ * multi-provider case of a one-control affordance (see auth-provider-options),
+ * which only arises on the null-topology branch: an instance with no app
+ * origin to prefix, where `/ask` serves on whatever host the request arrived
+ * on. Exported so that case names one constant rather than a second literal.
+ */
+export const SIGN_IN_PANEL_HREF = SIGN_IN_HREF;
+
 export interface HostLinks {
   /**
    * Prefix to put in front of a marketing route's path.

--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -18,6 +18,7 @@ import {
   parseBooleanFlag,
   readHostRoutingConfig,
   resolveAppOrigin,
+  resolveAskHref,
   resolveDashboardHref,
   resolveHostRole,
   resolvePublicSiteHref,
@@ -314,6 +315,18 @@ test('resolveDashboardHref: relative today and on app-only; app origin on a spli
   assert.equal(
     resolveDashboardHref({ APP_HOST: 'http://localhost:3000' }),
     'http://localhost:3000/dashboard',
+  );
+});
+
+test('resolveAskHref: relative today and on app-only; app origin on a split host (#210)', () => {
+  // The dual-served /evidence pages render the AppChrome strip on the
+  // MARKETING host, where /ask is withheld — hence the origin.
+  assert.equal(resolveAskHref({}), '/ask');
+  assert.equal(resolveAskHref({ APP_ONLY: '1', APP_HOST: 'app.example.org' }), '/ask');
+  assert.equal(resolveAskHref({ APP_HOST: 'app.example.org' }), 'https://app.example.org/ask');
+  assert.equal(
+    resolveAskHref({ APP_HOST: 'http://localhost:3000' }),
+    'http://localhost:3000/ask',
   );
 });
 

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -293,6 +293,22 @@ export function resolveDashboardHref(env: Record<string, string | undefined>): s
 }
 
 /**
+ * Where an "Ask" affordance should point (#210 — the `AppChrome` strip).
+ *
+ * Exactly `resolveDashboardHref`'s shape, and for exactly its reason: the
+ * strip renders on the DUAL-SERVED `/evidence` pages, which serve on the
+ * marketing host too — where `/ask` is app-private and withheld. A relative
+ * href there is a 404, so a split-host instance must carry the app origin.
+ * Relative everywhere else: unset topology serves `/ask` on whatever host the
+ * request arrived on, and an app-only instance is its own app host.
+ */
+export function resolveAskHref(env: Record<string, string | undefined>): string {
+  if (parseBooleanFlag(env.APP_ONLY)) return '/ask';
+  const appOrigin = resolveAppOrigin(env);
+  return appOrigin !== null ? `${appOrigin}/ask` : '/ask';
+}
+
+/**
  * Where the app surface's "Public site" affordances should point (the
  * `AppChrome` exit link):
  * - app-only instance → null: there IS no public marketing site — hide the


### PR DESCRIPTION
Phase P1 of the sprint anchored at #229 (front door v0.2, round 1). Delivers #210, #211, #212 and the dashboard empty-state copy fix — the sign-in defect class plus the absorbed literals. Owner merges per the sprint contract; issues are closed with shipped comments after merge.

## What changed

**1. Sign-in affordances derive from the configured providers (#211, Q63).** Six surfaces hardcoded `signIn('github')`: `Header`, `RateLimitBanner`, `McpResponseDisplay`, `QueryForm`, `DeviceSignInPanel`, and `NotebookOutput` (a sixth instance of the class found at implementation time). All six now use the proven `toSignInOptions(buildProviders())` derivation, applied to the null-topology branch:

- New `resolveSignInAffordance(options)` for one-control surfaces: exactly one provider ⇒ start its flow in place, named; none ⇒ no control (the #193 principle); more than one ⇒ link to the `/ask` panel via the now-exported `SIGN_IN_PANEL_HREF` — mirroring what the topology-configured branch of these affordances already does.
- Delivery follows the #217 seam rule — props where a server component can reach (`Header` from the root layout, `DeviceSignInPanel` from the device page, no client fetch), a new `SignInOptionsProvider` context beside `HostLinksProvider`/`BrandProvider` for the four affordances inside the apex client tree.
- `DEFAULT_SIGN_IN_OPTIONS` is today's single GitHub button, so every new prop/context defaults to today's rendering.
- `DeviceSignInPanel` maps the full option list (the device `callbackUrl` carries the pairing code, so it cannot defer to `/ask`) and carries a zero-provider message.

**2. Rate-limit copy (#212).** The signed-out "Sign in for 25/day" literal is gone; both topology branches share the tier-neutral prompt the configured branch already shipped. The endpoint-supplied `{remaining}/{limit}` line continues to consume the server-selected value. (Printing the endpoint's limit after "Sign in for" was rejected: `/api/rate-limit` answers for the caller, so a signed-out visitor would be shown the anonymous quota as the sign-in benefit.)

**3. Topology-stale empty states.** `DashboardTabs` (app-private) no longer sends users to "the home page" — on a split host the app host has no home page — it now points to `/ask`. `EvidenceIndex`'s empty state keeps its `/` href (correct on both hosts for a dual-served route) and fixes only the wording.

**4. AppChrome Ask link (#210).** `resolveAskHref` added to `host-routing.ts` (shape of `resolveDashboardHref`), threaded through the `(app)` layout; the strip renders Ask · Dashboard · Public site, current-page-aware. On the dual-served `/evidence` pages the link carries the app origin.

## Evidence

- Keyless build (CI's invariant), 559 tests (+7 new), lint (0 errors, 4 pre-existing warnings), typecheck — all green.
- OIDC-only, null-topology run: provider list serves only the configured provider; hydrated DOM shows "Sign in with Acme SSO" on header, `/ask`, `/auth/device`, and the QueryForm prompt; zero GitHub-labeled sign-in copy; `Sign in with GitHub` and `25/day` absent from emitted chunks.
- Configured-branch byte-identity (split-host env, 10 routes, both hosts): visible rendered document byte-identical on all 10; the RSC flight payload grows by exactly the new seam's rows (+512/+557 bytes) — the same accounting recorded for the #217 brand seam. The #210 Ask link is additive by design and isolated in its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)