### PR TITLE
P2 (s6 · #229): answer-first /ask — notebook default, one-call demoted path, restorable comparison

### DIFF
--- a/src/app/(app)/ask/page.tsx
+++ b/src/app/(app)/ask/page.tsx
@@ -38,6 +38,17 @@ import { getBrandName } from '@/lib/brand-config';
  *   - NO MARKETING FRAMING. No positioning band, no "go set it up locally"
  *     call to action, and `showLocalSetupFootnote={false}` suppresses the
  *     one piece of that framing living inside the shared component.
+ *   - ANSWER-FIRST, ONE MODEL CALL (s6 P2, #229; Q62 G0).
+ *     `presentation="answer-first"` makes the with-data answer primary and
+ *     demotes the side-by-side comparison to an expand option; demoted
+ *     standard runs pass `mcpOnly` so only the with-data arm executes. The
+ *     visitor restores the comparison per session — via the demoted element
+ *     or the Advanced-options toggle — and restored runs execute both arms
+ *     exactly as the apex always has.
+ *   - NOTEBOOK BY DEFAULT (same decision set). `defaultMode="notebook"`
+ *     starts the form in executed-sandbox mode; an explicit mode choice is
+ *     session-sticky and wins over the default. The apex default mode is
+ *     untouched.
  *
  * SIGNED OUT RENDERS A PROMPT, NOT A REDIRECT — see AskSignInPanel for why
  * a redirect here would close a loop. This is not the access gate either:
@@ -116,7 +127,11 @@ export default async function AskPage({ searchParams }: AskPageProps) {
   }
 
   return (
-    <QuerySurface showLocalSetupFootnote={false}>
+    <QuerySurface
+      showLocalSetupFootnote={false}
+      presentation="answer-first"
+      defaultMode="notebook"
+    >
       <div style={{ marginBottom: '24px' }}>
         <h1 style={{ fontSize: '28px', fontWeight: 700, marginBottom: '8px' }}>
           Ask a question

--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -7,7 +7,7 @@ import { callMcpTool, routeTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
 import { headers } from 'next/headers';
-import { encodeSSE, type ModelErrorCode, type PanelType, type StreamEvent } from '@/lib/streaming';
+import { encodeSSE, panelsForRun, type ModelErrorCode, type PanelType, type StreamEvent } from '@/lib/streaming';
 import { getMissingModelCredentialError } from '@/lib/model-client';
 import { TraceBuilder, hash } from '@/lib/evidence/trace';
 
@@ -46,8 +46,7 @@ export async function POST(request: NextRequest) {
     if (credentialError) {
       console.error('[compare-stream]', credentialError.message);
       const encoder = new TextEncoder();
-      const panels: PanelType[] = mcpOnly ? ['withMcp'] : ['withoutMcp', 'withMcp'];
-      const body = panels
+      const body = panelsForRun(mcpOnly)
         .map((panel) =>
           encodeSSE({
             type: 'error',

--- a/src/components/ComparisonDisplay.tsx
+++ b/src/components/ComparisonDisplay.tsx
@@ -48,6 +48,21 @@ interface ComparisonDisplayProps {
   publishDialogOpen?: boolean;
   onPublishDialogChange?: (open: boolean) => void;
   onContinue?: (continuationPrompt: string) => void;
+  /**
+   * Answer-first presentation (s6 P2, #229): the with-data answer is the
+   * page and the side-by-side comparison is demoted to an expand option —
+   * the same demotion the mobile layout has always applied, promoted to
+   * every width. Set for runs that skipped the without-data arm, so the
+   * demoted element offers to run the comparison rather than previewing a
+   * panel that never streamed. Default false: today's layout, unchanged.
+   */
+  answerFirst?: boolean;
+  /**
+   * Called when the reader expands the demoted comparison. The surface
+   * restores the side-by-side presentation for the session and re-runs the
+   * question with both arms.
+   */
+  onRunComparison?: () => void;
 }
 
 function useMediaQuery(query: string) {
@@ -81,6 +96,8 @@ export default function ComparisonDisplay({
   publishDialogOpen,
   onPublishDialogChange,
   onContinue,
+  answerFirst = false,
+  onRunComparison,
 }: ComparisonDisplayProps) {
   const isMobile = useMediaQuery('(max-width: 640px)');
   const [nonMcpExpanded, setNonMcpExpanded] = useState(false);
@@ -259,6 +276,90 @@ export default function ComparisonDisplay({
       </button>
     </div>
   );
+
+  // Answer-first (s6 P2): the demoted element keeps the page's dominant
+  // split — AI alone vs AI with civic data — discoverable without running
+  // both arms up front. Visually it is the mobile collapsed panel; because
+  // the without-data arm was skipped, activating it runs the comparison
+  // (restoring the side-by-side presentation for the session) instead of
+  // expanding content that does not exist.
+  const runComparisonAffordance = (
+    <button
+      type="button"
+      onClick={onRunComparison}
+      disabled={isLoading || !onRunComparison}
+      style={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        border: '2px solid var(--border-color)',
+        borderRadius: '4px',
+        cursor: isLoading || !onRunComparison ? 'not-allowed' : 'pointer',
+        overflow: 'hidden',
+        padding: 0,
+        background: 'none',
+        font: 'inherit',
+      }}
+    >
+      <div
+        style={{
+          padding: '16px 24px',
+          backgroundColor: 'var(--card-background)',
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '12px',
+        }}
+      >
+        <span
+          style={{
+            color: 'var(--text-muted)',
+            fontSize: '14px',
+            lineHeight: '24px',
+            flexShrink: 0,
+          }}
+        >
+          &#9654;
+        </span>
+        <div>
+          <h3
+            style={{
+              fontSize: '20px',
+              fontWeight: 600,
+              margin: 0,
+              color: 'var(--text-primary)',
+            }}
+          >
+            Without Data Tools
+          </h3>
+          <p
+            style={{
+              fontSize: '14px',
+              color: 'var(--text-muted)',
+              margin: '4px 0 0 0',
+            }}
+          >
+            Run the side-by-side comparison — ask this question again with and
+            without data tools to see the difference.
+          </p>
+        </div>
+      </div>
+    </button>
+  );
+
+  if (answerFirst) {
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr',
+          gap: '24px',
+        }}
+      >
+        {withMcpPanel}
+        {runComparisonAffordance}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -1,11 +1,18 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, useSyncExternalStore } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import Link from 'next/link';
 import { signIn, useSession } from 'next-auth/react';
 import { useHostLinks } from '@/components/HostLinksProvider';
 import { useSignInOptions } from '@/components/SignInOptionsProvider';
 import { resolveSignInAffordance } from '@/lib/auth-provider-options';
+import { useSessionChoice } from '@/hooks/useSessionChoice';
+import {
+  MODE_STORAGE_KEY,
+  parseStoredMode,
+  resolveEffectiveMode,
+  type QueryMode,
+} from '@/lib/query-presentation';
 import RateLimitBanner from './RateLimitBanner';
 
 interface Model {
@@ -16,47 +23,25 @@ interface Model {
   description?: string;
 }
 
-export type QueryMode = 'standard' | 'notebook';
-
-const MODE_STORAGE_KEY = 'civicaitools.notebookMode';
+// Re-exported for existing importers; the type itself lives in
+// src/lib/query-presentation.ts alongside the derivations that use it.
+export type { QueryMode };
 
 /**
- * Sticky-per-session mode persistence. Subscribes to the `storage` event so
- * multiple tabs reflecting each other in the same session stay in sync, and
- * survives Strict Mode double-invocation. SSR returns 'standard'.
+ * Sticky-per-session mode persistence (§10 Q7), on the shared
+ * `useSessionChoice` mechanism. The user's explicit, stored choice wins over
+ * the mount's `defaultMode`; with no choice stored the mount default applies
+ * (s6 P2, #229 — 'standard' everywhere except mounts that say otherwise).
+ * When the toggle is disabled (anonymous user, loading auth state, etc.)
+ * the effective mode is forced to 'standard'; the stored preference is
+ * preserved so signing back in restores the previous choice.
  */
-function subscribeToStorage(notify: () => void): () => void {
-  if (typeof window === 'undefined') return () => {};
-  window.addEventListener('storage', notify);
-  return () => window.removeEventListener('storage', notify);
-}
-
-function readStoredMode(): QueryMode {
-  if (typeof window === 'undefined') return 'standard';
-  const raw = window.sessionStorage.getItem(MODE_STORAGE_KEY);
-  return raw === 'notebook' || raw === 'standard' ? raw : 'standard';
-}
-
-function useStoredMode(enabled: boolean): [QueryMode, (next: QueryMode) => void] {
-  const stored = useSyncExternalStore(
-    subscribeToStorage,
-    readStoredMode,
-    () => 'standard' as QueryMode,
-  );
-  // Local override lets the component update synchronously on click without
-  // round-tripping through a `storage` event (which never fires in the same
-  // tab).
-  const [override, setOverride] = useState<QueryMode | null>(null);
-  const set = useCallback((next: QueryMode) => {
-    setOverride(next);
-    if (typeof window !== 'undefined') {
-      window.sessionStorage.setItem(MODE_STORAGE_KEY, next);
-    }
-  }, []);
-  // When the toggle is disabled (anonymous user, loading auth state, etc.)
-  // force-return 'standard'. Stored preference is preserved so signing back
-  // in restores the previous choice.
-  const effective = enabled ? (override ?? stored) : 'standard';
+function useStoredMode(
+  enabled: boolean,
+  defaultMode: QueryMode,
+): [QueryMode, (next: QueryMode) => void] {
+  const [chosen, set] = useSessionChoice<QueryMode>(MODE_STORAGE_KEY, parseStoredMode);
+  const effective = resolveEffectiveMode({ enabled, chosen, defaultMode });
   return [effective, set];
 }
 
@@ -64,6 +49,22 @@ interface QueryFormProps {
   onSubmit: (query: string, model: string, portal: string, mode: QueryMode) => void;
   isLoading: boolean;
   queryCount?: number;
+  /**
+   * The response mode the form starts in when the visitor has not made an
+   * explicit (session-persisted) choice. Default 'standard' — today's
+   * behavior on every existing mount; `/ask` passes 'notebook' (s6 P2).
+   */
+  defaultMode?: QueryMode;
+  /**
+   * When present, Advanced options renders the side-by-side-comparison
+   * restore toggle bound to this state (s6 P2, #229 — answer-first mounts
+   * only). Absent (the default, and every pre-existing mount), nothing
+   * renders and the form is unchanged.
+   */
+  comparisonControl?: {
+    restored: boolean;
+    onChange: (restored: boolean) => void;
+  };
 }
 
 const EXAMPLE_QUERIES = [
@@ -81,7 +82,13 @@ const PORTALS = [
   { id: 'data.seattle.gov', name: 'Seattle' },
 ];
 
-export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: QueryFormProps) {
+export default function QueryForm({
+  onSubmit,
+  isLoading,
+  queryCount = 0,
+  defaultMode = 'standard',
+  comparisonControl,
+}: QueryFormProps) {
   const [query, setQuery] = useState('');
   const [model, setModel] = useState('openai/gpt-4o');
   const [portal, setPortal] = useState('');
@@ -98,7 +105,7 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
   // #229 P1: which provider the in-place branch below starts, and whether it
   // can name one at all — derived from the instance's configuration (Q63).
   const signInAffordance = resolveSignInAffordance(useSignInOptions());
-  const [mode, updateMode] = useStoredMode(isAuthenticated);
+  const [mode, updateMode] = useStoredMode(isAuthenticated, defaultMode);
   const [models, setModels] = useState<Model[]>([]);
   const [modelOpen, setModelOpen] = useState(false);
   const [portalOpen, setPortalOpen] = useState(false);
@@ -427,6 +434,49 @@ export default function QueryForm({ onSubmit, isLoading, queryCount = 0 }: Query
               </div>
             )}
           </div>
+
+          {/* Side-by-side comparison restore (s6 P2, #229) — rendered only
+              when the mount runs answer-first and hands down the control.
+              Persisted per-session by the mount, exactly like the response
+              mode above. */}
+          {comparisonControl && (
+            <div style={{ marginBottom: '16px' }}>
+              <label style={{ fontSize: '13px', color: 'var(--text-muted)', fontWeight: 400, display: 'block', marginBottom: '6px' }}>
+                Side-by-side comparison
+              </label>
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '8px',
+                  fontSize: '13px',
+                  color: 'var(--text-secondary)',
+                  lineHeight: 1.5,
+                  cursor: isLoading ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={comparisonControl.restored}
+                  disabled={isLoading}
+                  onChange={(e) => comparisonControl.onChange(e.target.checked)}
+                  style={{ marginTop: '2px', cursor: 'inherit' }}
+                />
+                <span>Compare with and without data tools</span>
+              </label>
+              <p
+                style={{
+                  margin: '6px 0 0 22px',
+                  fontSize: '12px',
+                  color: 'var(--text-muted)',
+                  lineHeight: 1.5,
+                }}
+              >
+                Adds a second answer from training data alone, side by side.
+                Runs one extra model call per question.
+              </p>
+            </div>
+          )}
 
           <div className="form-controls-row">
               {/* Model dropdown */}

--- a/src/components/shared/QuerySurface.tsx
+++ b/src/components/shared/QuerySurface.tsx
@@ -16,11 +16,20 @@
  */
 
 import { useState, useRef } from 'react';
-import QueryForm, { type QueryMode } from '@/components/QueryForm';
+import QueryForm from '@/components/QueryForm';
 import ComparisonDisplay from '@/components/ComparisonDisplay';
 import NotebookOutput from '@/components/notebook/NotebookOutput';
 import { useStreamingComparison } from '@/hooks/useStreamingComparison';
 import { useNotebookStream } from '@/hooks/useNotebookStream';
+import { useSessionChoice } from '@/hooks/useSessionChoice';
+import {
+  COMPARISON_STORAGE_KEY,
+  isComparisonRunComplete,
+  parseStoredComparison,
+  shouldRunMcpOnly,
+  type QueryMode,
+  type QuerySurfacePresentation,
+} from '@/lib/query-presentation';
 
 interface QuerySurfaceProps {
   /** Framing content rendered above the form, inside its container. */
@@ -38,11 +47,34 @@ interface QuerySurfaceProps {
    * rate-limited demo, and pointing past it is the point.
    */
   showLocalSetupFootnote?: boolean;
+  /**
+   * How this mount presents the standard-mode result (s6 P2, #229; Q62 G0).
+   *
+   * Default `'comparison'` — the apex demo's side-by-side, unchanged and
+   * unconfigured (the marketing page passes nothing; the default is applied
+   * here, inside the client component, so nothing about it serializes into
+   * that mount's payload). `/ask` passes `'answer-first'`: the with-data
+   * answer is primary, the comparison is demoted to an expand option, and
+   * demoted runs make one model call instead of two. The visitor can
+   * restore the comparison per session — via the demoted element under the
+   * answer or the Advanced-options toggle — after which both arms run and
+   * render exactly as on the apex.
+   */
+  presentation?: QuerySurfacePresentation;
+  /**
+   * The response mode the form starts in when the visitor has made no
+   * explicit choice. Default `'standard'` — every existing mount's
+   * behavior; `/ask` passes `'notebook'` (Q62 G0). An explicit mode choice
+   * is session-sticky and wins over this default.
+   */
+  defaultMode?: QueryMode;
 }
 
 export default function QuerySurface({
   children,
   showLocalSetupFootnote = true,
+  presentation = 'comparison',
+  defaultMode = 'standard',
 }: QuerySurfaceProps) {
   const [queryCount, setQueryCount] = useState(0);
   const [usedModel, setUsedModel] = useState<string>('');
@@ -54,6 +86,23 @@ export default function QuerySurface({
 
   const streaming = useStreamingComparison();
   const notebook = useNotebookStream();
+
+  // Answer-first configuration (s6 P2, #229). The restore choice is
+  // session-sticky through the same mechanism as the response mode; it only
+  // means anything on an answer-first mount — the apex neither reads it into
+  // behavior (shouldRunMcpOnly is constant-false for 'comparison') nor
+  // renders the toggle that writes it.
+  const answerFirstConfigured = presentation === 'answer-first';
+  const [comparisonChoice, setComparisonChoice] = useSessionChoice(
+    COMPARISON_STORAGE_KEY,
+    parseStoredComparison,
+  );
+  const comparisonRestored = comparisonChoice === 'on';
+  // Presentation follows the run, not the toggle: flipping the toggle
+  // mid-result must not reshape an already-rendered answer (a restored
+  // comparison has nothing to show for a run whose without-data arm never
+  // executed). The next submit picks the toggle up.
+  const answerFirstActive = answerFirstConfigured && streaming.mcpOnly;
 
   // Extract display name from model ID (e.g., "anthropic/claude-sonnet-4" -> "Claude Sonnet 4")
   const getModelDisplayName = (modelId: string) => {
@@ -81,7 +130,9 @@ export default function QuerySurface({
       notebook.start(query, model, effectivePortal);
     } else {
       notebook.reset();
-      streaming.startComparison(query, model, effectivePortal);
+      streaming.startComparison(query, model, effectivePortal, {
+        mcpOnly: shouldRunMcpOnly(presentation, comparisonRestored),
+      });
     }
     setQueryCount((c) => c + 1);
   };
@@ -90,7 +141,23 @@ export default function QuerySurface({
     setTimeout(() => {
       resultsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }, 100);
-    streaming.startComparison(continuationPrompt, usedModel, lastPortal);
+    streaming.startComparison(continuationPrompt, usedModel, lastPortal, {
+      mcpOnly: shouldRunMcpOnly(presentation, comparisonRestored),
+    });
+    setQueryCount((c) => c + 1);
+  };
+
+  // Expand option on the demoted comparison (answer-first mounts): restore
+  // the side-by-side presentation for the session and re-run the question
+  // with both arms — the without-data arm was skipped, so there is nothing
+  // to expand without running it.
+  const handleRunComparison = () => {
+    if (!lastQuery) return;
+    setComparisonChoice('on');
+    setTimeout(() => {
+      resultsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 100);
+    streaming.startComparison(lastQuery, usedModel, lastPortal, { mcpOnly: false });
     setQueryCount((c) => c + 1);
   };
 
@@ -106,7 +173,20 @@ export default function QuerySurface({
 
         {/* Query Form */}
         <div style={{ marginBottom: '48px' }}>
-          <QueryForm onSubmit={handleSubmit} isLoading={streaming.isLoading} queryCount={queryCount} />
+          <QueryForm
+            onSubmit={handleSubmit}
+            isLoading={streaming.isLoading}
+            queryCount={queryCount}
+            defaultMode={defaultMode}
+            comparisonControl={
+              answerFirstConfigured
+                ? {
+                    restored: comparisonRestored,
+                    onChange: (restored) => setComparisonChoice(restored ? 'on' : 'off'),
+                  }
+                : undefined
+            }
+          />
         </div>
       </div>
 
@@ -147,8 +227,18 @@ export default function QuerySurface({
             publishDialogOpen={publishDialogOpen}
             onPublishDialogChange={setPublishDialogOpen}
             onContinue={handleContinue}
+            answerFirst={answerFirstActive}
+            onRunComparison={answerFirstConfigured ? handleRunComparison : undefined}
           />
-          {showLocalSetupFootnote && (streaming.withoutMcp.isComplete && streaming.withMcp.isComplete) && (
+          {/* The footnote closes a finished run, however many panes the run
+              had — a demoted (one-pane) run is finished when its only pane
+              is. On the apex (mcpOnly always false) this is exactly the old
+              both-panes condition. */}
+          {showLocalSetupFootnote && isComparisonRunComplete(
+            streaming.mcpOnly,
+            streaming.withoutMcp.isComplete,
+            streaming.withMcp.isComplete,
+          ) && (
             <p
               style={{
                 marginTop: '16px',

--- a/src/hooks/useSessionChoice.ts
+++ b/src/hooks/useSessionChoice.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState, useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * Sticky-per-session persisted choice (s6 P2, #229).
+ *
+ * This is the mechanism `QueryForm`'s response-mode control has always used
+ * (§10 Q7), extracted verbatim so the comparison-restore toggle persists the
+ * same way instead of growing a parallel one:
+ *
+ * - `sessionStorage`, not `localStorage` — the stickiness is per-session.
+ * - Subscribes to the `storage` event so multiple tabs sharing the session
+ *   stay in sync, and survives Strict Mode double-invocation.
+ * - A local override updates the component synchronously on set — the
+ *   `storage` event never fires in the tab that wrote the value.
+ * - SSR (and a visitor who never chose) reads as `null`: "no explicit
+ *   choice". Callers decide what no-choice means (usually a mount default),
+ *   which is what lets an explicit choice stay sticky over that default.
+ *
+ * `parse` must be pure: it validates the raw stored string and returns the
+ * choice or `null` for anything unrecognized.
+ */
+export function useSessionChoice<T extends string>(
+  key: string,
+  parse: (raw: string | null) => T | null,
+): [T | null, (next: T) => void] {
+  const subscribe = useCallback((notify: () => void) => {
+    if (typeof window === 'undefined') return () => {};
+    window.addEventListener('storage', notify);
+    return () => window.removeEventListener('storage', notify);
+  }, []);
+
+  const stored = useSyncExternalStore(
+    subscribe,
+    () => (typeof window === 'undefined' ? null : parse(window.sessionStorage.getItem(key))),
+    () => null,
+  );
+
+  const [override, setOverride] = useState<T | null>(null);
+
+  const set = useCallback(
+    (next: T) => {
+      setOverride(next);
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.setItem(key, next);
+      }
+    },
+    [key],
+  );
+
+  return [override ?? stored, set];
+}

--- a/src/hooks/useStreamingComparison.ts
+++ b/src/hooks/useStreamingComparison.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { createTraceCapture } from '@/lib/bpmn/capture-trace';
 import { connectSSE } from '@/lib/sse-client';
+import { isComparisonRunComplete } from '@/lib/query-presentation';
 import { friendlyStreamError, type ProgressPhase } from '@/lib/streaming';
 
 export interface ToolCall {
@@ -61,6 +62,15 @@ interface StreamingState {
   isLoading: boolean;
   error: string | null;
   evidenceTrace: EvidenceTrace | null;
+  /**
+   * Whether the current run executes only the with-data arm (s6 P2, #229).
+   * Latched per run at start: completion logic must not wait for a
+   * without-data panel that will never stream, and the surface renders the
+   * demoted (answer-first) treatment for exactly the runs that skipped the
+   * comparison. Always false on mounts that never pass the option — the
+   * apex default, unchanged.
+   */
+  mcpOnly: boolean;
 }
 
 const initialPanelState: PanelState = {
@@ -77,6 +87,7 @@ const initialState: StreamingState = {
   isLoading: false,
   error: null,
   evidenceTrace: null,
+  mcpOnly: false,
 };
 
 export function useStreamingComparison() {
@@ -84,7 +95,14 @@ export function useStreamingComparison() {
   const abortControllerRef = useRef<AbortController | null>(null);
   const traceCaptureRef = useRef<ReturnType<typeof createTraceCapture> | null>(null);
 
-  const startComparison = useCallback(async (query: string, model: string, portal: string) => {
+  const startComparison = useCallback(async (
+    query: string,
+    model: string,
+    portal: string,
+    opts?: { mcpOnly?: boolean },
+  ) => {
+    const mcpOnly = opts?.mcpOnly ?? false;
+
     // Abort any existing request
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
@@ -100,6 +118,7 @@ export function useStreamingComparison() {
       isLoading: true,
       error: null,
       evidenceTrace: null,
+      mcpOnly,
     });
 
     // Initialize trace capture if enabled
@@ -112,7 +131,9 @@ export function useStreamingComparison() {
     try {
       await connectSSE({
         url: '/api/compare-stream',
-        body: { query, model, portal },
+        // The flag is only serialized when set, so a default (two-arm) run's
+        // request body is byte-identical to what the apex has always sent.
+        body: { query, model, portal, ...(mcpOnly ? { mcpOnly: true } : {}) },
         signal: abortControllerRef.current.signal,
         onEvent: (eventData) => {
           // Record MCP-panel events for trace capture
@@ -136,10 +157,16 @@ export function useStreamingComparison() {
           handleEvent(eventData as { type: string; panel: 'withMcp' | 'withoutMcp'; [key: string]: unknown }, setState);
         },
         onComplete: () => {
-          // Check if both panels are complete
+          // Check whether every panel this run actually has is complete —
+          // a demoted (mcpOnly) run must not wait for the without-data
+          // panel, which never streams.
           setState(prev => ({
             ...prev,
-            isLoading: !(prev.withoutMcp.isComplete && prev.withMcp.isComplete),
+            isLoading: !isComparisonRunComplete(
+              prev.mcpOnly,
+              prev.withoutMcp.isComplete,
+              prev.withMcp.isComplete,
+            ),
           }));
         },
       });
@@ -457,11 +484,16 @@ function handleEvent(
             progressGroups: newGroups,
           },
         };
-        // Check if both are complete
-        const bothComplete = newState.withoutMcp.isComplete && newState.withMcp.isComplete;
+        // Check if every panel this run has is complete (one for a demoted
+        // mcpOnly run, both otherwise)
+        const runComplete = isComparisonRunComplete(
+          newState.mcpOnly,
+          newState.withoutMcp.isComplete,
+          newState.withMcp.isComplete,
+        );
         return {
           ...newState,
-          isLoading: !bothComplete,
+          isLoading: !runComplete,
         };
       });
       break;

--- a/src/lib/query-presentation.test.ts
+++ b/src/lib/query-presentation.test.ts
@@ -1,0 +1,99 @@
+// Tests for the query-surface mount configuration derivations (s6 P2, #229).
+//
+// Rule zero, stated as assertions: with the defaults a mount passes today
+// (comparison presentation, standard default mode, no stored choices), every
+// derivation reproduces the apex demo's existing behavior — two model arms,
+// standard mode, footnote waits on both panes.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseStoredMode,
+  parseStoredComparison,
+  resolveEffectiveMode,
+  shouldRunMcpOnly,
+  isComparisonRunComplete,
+} from './query-presentation.ts';
+import { panelsForRun } from './streaming.ts';
+
+test('parseStoredMode: only the two real modes parse; junk is "no choice"', () => {
+  assert.equal(parseStoredMode('notebook'), 'notebook');
+  assert.equal(parseStoredMode('standard'), 'standard');
+  assert.equal(parseStoredMode(null), null);
+  assert.equal(parseStoredMode(''), null);
+  assert.equal(parseStoredMode('sandbox'), null);
+});
+
+test('parseStoredComparison: on/off parse; junk is "no choice"', () => {
+  assert.equal(parseStoredComparison('on'), 'on');
+  assert.equal(parseStoredComparison('off'), 'off');
+  assert.equal(parseStoredComparison(null), null);
+  assert.equal(parseStoredComparison('true'), null);
+});
+
+test('effective mode, rule zero: apex shape (standard default, nothing stored) is standard', () => {
+  assert.equal(
+    resolveEffectiveMode({ enabled: true, chosen: null, defaultMode: 'standard' }),
+    'standard',
+  );
+});
+
+test('effective mode: an answer-first mount may default to notebook', () => {
+  assert.equal(
+    resolveEffectiveMode({ enabled: true, chosen: null, defaultMode: 'notebook' }),
+    'notebook',
+  );
+});
+
+test("effective mode: the user's explicit choice beats the mount default, both ways", () => {
+  // /ask visitor who switched to Standard stays on Standard...
+  assert.equal(
+    resolveEffectiveMode({ enabled: true, chosen: 'standard', defaultMode: 'notebook' }),
+    'standard',
+  );
+  // ...and an apex visitor who chose notebook keeps it (today's stickiness).
+  assert.equal(
+    resolveEffectiveMode({ enabled: true, chosen: 'notebook', defaultMode: 'standard' }),
+    'notebook',
+  );
+});
+
+test('effective mode: executed-sandbox unavailable forces standard, whatever is stored or defaulted', () => {
+  assert.equal(
+    resolveEffectiveMode({ enabled: false, chosen: 'notebook', defaultMode: 'notebook' }),
+    'standard',
+  );
+  assert.equal(
+    resolveEffectiveMode({ enabled: false, chosen: null, defaultMode: 'notebook' }),
+    'standard',
+  );
+});
+
+test('mcpOnly, rule zero: a comparison mount always runs both arms', () => {
+  assert.equal(shouldRunMcpOnly('comparison', false), false);
+  // A stray stored "restore" flag changes nothing on a comparison mount.
+  assert.equal(shouldRunMcpOnly('comparison', true), false);
+});
+
+test('mcpOnly: answer-first runs one arm until the visitor restores the comparison', () => {
+  assert.equal(shouldRunMcpOnly('answer-first', false), true);
+  assert.equal(shouldRunMcpOnly('answer-first', true), false);
+});
+
+test('run completion, rule zero: a two-arm run waits for both panels', () => {
+  assert.equal(isComparisonRunComplete(false, false, true), false);
+  assert.equal(isComparisonRunComplete(false, true, false), false);
+  assert.equal(isComparisonRunComplete(false, true, true), true);
+});
+
+test('run completion: a demoted run is complete when the with-data arm is', () => {
+  assert.equal(isComparisonRunComplete(true, false, true), true);
+  assert.equal(isComparisonRunComplete(true, false, false), false);
+});
+
+test('panelsForRun: one arm demoted, two arms by default — with-data arm always present', () => {
+  assert.deepEqual(panelsForRun(true), ['withMcp']);
+  assert.deepEqual(panelsForRun(false), ['withoutMcp', 'withMcp']);
+});

--- a/src/lib/query-presentation.ts
+++ b/src/lib/query-presentation.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure derivations for the query surface's mount-level configuration
+ * (s6 P2, anchor #229): which presentation a mount runs, which response
+ * mode it defaults to, and what those choices mean for a single run.
+ *
+ * Everything here is deliberately free of React and the DOM so the rules
+ * can be unit-tested under `node --test` like the rest of `src/lib`. The
+ * components (`QuerySurface`, `QueryForm`) and the SSE route consume these
+ * instead of re-deriving the logic inline.
+ *
+ * Rule zero applies throughout: every default reproduces the apex demo's
+ * behavior exactly. A mount that passes nothing gets the side-by-side
+ * comparison, the standard response mode, and two model arms per run.
+ */
+
+/** The two response modes the query form offers. */
+export type QueryMode = 'standard' | 'notebook';
+
+/**
+ * How a mount presents the standard-mode result.
+ *
+ * - `'comparison'` — today's apex behavior: both arms run, side-by-side
+ *   panels (stacked with the without-data panel demoted on mobile).
+ * - `'answer-first'` — the `/ask` configuration (Q62 G0): the with-data
+ *   answer is the page; the comparison is demoted to an expand option and
+ *   the demoted runs make one model call, not two.
+ */
+export type QuerySurfacePresentation = 'comparison' | 'answer-first';
+
+/**
+ * Session-storage keys for the two sticky per-session choices. Both use
+ * `sessionStorage` (not `localStorage`) on purpose: the stickiness is
+ * per-session, mirroring the pre-existing response-mode control.
+ */
+export const MODE_STORAGE_KEY = 'civicaitools.notebookMode';
+export const COMPARISON_STORAGE_KEY = 'civicaitools.showComparison';
+
+/** Parse a stored response-mode choice; anything unrecognized is "no choice". */
+export function parseStoredMode(raw: string | null): QueryMode | null {
+  return raw === 'notebook' || raw === 'standard' ? raw : null;
+}
+
+/**
+ * Parse the stored comparison-restore choice; anything unrecognized is
+ * "no choice" (the mount's presentation decides).
+ */
+export function parseStoredComparison(raw: string | null): 'on' | 'off' | null {
+  return raw === 'on' || raw === 'off' ? raw : null;
+}
+
+/**
+ * The response mode the form is effectively in.
+ *
+ * The user's explicit, session-persisted choice (`chosen`) always wins over
+ * the mount's default — a `/ask` visitor who switched to Standard stays on
+ * Standard for the session even though that mount defaults to notebook.
+ * When the executed-sandbox path is unavailable (`enabled: false`, i.e. the
+ * visitor is not authenticated), the only runnable mode is `'standard'`,
+ * whatever the mount or the stored choice says; the stored choice is
+ * preserved for when it becomes available again.
+ */
+export function resolveEffectiveMode(opts: {
+  enabled: boolean;
+  chosen: QueryMode | null;
+  defaultMode: QueryMode;
+}): QueryMode {
+  if (!opts.enabled) return 'standard';
+  return opts.chosen ?? opts.defaultMode;
+}
+
+/**
+ * Whether a standard-mode submit should run only the with-data arm.
+ *
+ * True only for an answer-first mount whose visitor has not restored the
+ * comparison. On a comparison mount (the apex default) this is always
+ * false — both arms run, exactly as today.
+ */
+export function shouldRunMcpOnly(
+  presentation: QuerySurfacePresentation,
+  comparisonRestored: boolean,
+): boolean {
+  return presentation === 'answer-first' && !comparisonRestored;
+}
+
+/**
+ * Whether a streaming comparison run has produced everything it is going
+ * to produce. A demoted (single-arm) run never receives a without-data
+ * completion, so waiting on it would spin forever — the with-data arm is
+ * the whole run. A two-arm run completes when both panels do, unchanged.
+ *
+ * Used by `useStreamingComparison` to settle `isLoading` and by
+ * `QuerySurface` to gate the local-setup footnote (which used to assume
+ * two panes).
+ */
+export function isComparisonRunComplete(
+  mcpOnly: boolean,
+  withoutMcpComplete: boolean,
+  withMcpComplete: boolean,
+): boolean {
+  return withMcpComplete && (mcpOnly || withoutMcpComplete);
+}

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -990,3 +990,14 @@ export function buildProvenanceLine(
 export function encodeSSE(event: StreamEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
 }
+
+/**
+ * The panels (model arms) a comparison run executes. An `mcpOnly` run is
+ * the with-data arm alone — one model call; the default is both arms.
+ * `/api/compare-stream` uses this both to dispatch work and to address
+ * fail-fast error events, so the two can never disagree about which
+ * panels a run has.
+ */
+export function panelsForRun(mcpOnly: boolean): PanelType[] {
+  return mcpOnly ? ['withMcp'] : ['withoutMcp', 'withMcp'];
+}


### PR DESCRIPTION
Phase P2 of the sprint anchored at #229 — Q62's decisions: answer-first `/ask`, notebook as its default mode, and the comparison demoted to a per-user restorable option. Owner merges per the sprint contract.

## What changed

**Answer-first presentation.** `QuerySurface` gains a `presentation` prop (`'comparison'` default — today's behavior) and `ComparisonDisplay` an `answerFirst` mode: the with-MCP panel renders full-width, and the without-MCP side is demoted to the collapsed-panel treatment that already shipped on mobile, promoted to all widths as a real button. Clicking it restores the comparison and re-runs the question with both arms (explicit copy; precedent is the truncation-continuation CTA's auto-submit).

**One model call on the demoted path.** `useStreamingComparison` threads `mcpOnly` into the POST body; `/api/compare-stream` already supported it (the `/explore` live mode's parameter — promoted, not reimplemented; the only server delta is routing its fail-fast error branch through the tested `panelsForRun` helper so dispatch and error addressing cannot disagree). Completion logic uses `isComparisonRunComplete`, so a demoted run no longer waits on the absent pane.

**Notebook default + sticky choice.** `QueryForm` takes a `defaultMode` prop; the user's explicit mode selection persists per-session via `useSessionChoice`, an extraction of the form's existing sessionStorage mechanism. `resolveEffectiveMode` arbitrates stored choice over mount default (unit-tested, rule zero asserted).

**Comparison-restore toggle.** A new Advanced-options checkbox ("Compare with and without data tools", with an honest one-extra-model-call hint), persisted per-session; presentation follows the run, not the toggle — flipping it mid-result doesn't reshape a rendered answer, the next submit honors it.

**Mounts.** Only `/ask` sets `presentation="answer-first" defaultMode="notebook"`. The apex mount is untouched; new props default internally, so nothing new serializes into the apex payload.

## Evidence

- Lint (0 errors, 4 pre-existing warnings), typecheck, 580 tests (+11 new), keyless builds green at both the base and head commits.
- Rendered `/ask` (built + headless Chrome): notebook mode selected by default; explicit Standard choice survives reload over the mount default.
- Arm dispatch verified at four levels: unit tests on the derivations; SSE responses show both-panel events on the default request vs `withMcp`-only events under `mcpOnly`; CDP-captured demoted submit posts `{"mcpOnly":true}`; code trace of `runQueries`.
- Restore toggle: 7/7 DOM checks — storage write, both-arm re-run, side-by-side return, persistence across reload.
- Apex byte-identity at a stricter bar than P1: base-vs-head keyless builds under null-topology and split-host env, `/` and `/explore` byte-identical after normalizing only content-hashed chunk names + build id, and **zero flight-payload delta** — none of the new prop/flag names appear in the apex document (positive control: each appears exactly once in `/ask`'s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)