### PR TITLE
P3 (s6 · #229): topology-aware origin gate (#213) + boolean session probe + "Open app" affordance (Q64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ Deliberately a short orientation, not an exhaustive tree — the tree drifted ba
 
 - `src/app/(marketing)/` — the public pages: home (`page.tsx`), `/explore`, `/directory`, `/learn`, `/project`, `/about`, `/roadmap`
 - `src/app/(app)/` — dashboard, evidence, auth, and the signed-in query surfaces: `/dashboard`, `/evidence`, `/ask`, `/auth/device`, plus the dev-only `/dev/notebook-preview`
-- `src/app/api/` — serverless routes: `compare`, `compare-stream`, `models`, `rate-limit`, `query-notebook`, plus the `evidence/*`, `blob/*`, `cron/*`, and `auth/*` route families
+- `src/app/api/` — serverless routes: `compare`, `compare-stream`, `models`, `rate-limit`, `query-notebook`, `session-status` (boolean-only has-a-session probe with marketing-origin CORS), plus the `evidence/*`, `blob/*`, `cron/*`, and `auth/*` route families
 - `src/lib/` — the major areas:
   - `evidence/` — evidence-system core: packaging, signing, verification, provenance, attestation, lifecycle
   - `storage/` — blob-storage driver seam (Vercel Blob / S3-compatible)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -597,6 +597,25 @@ device-pairing URL the API hands to CLI clients already follows
 `APP_HOST` when it is set, since `/auth/device` is withheld on the
 marketing host.
 
+Two split-host behaviors follow automatically from the same variables
+(no additional configuration):
+
+- **Same-origin writes work from both hosts.** Browser POSTs that guard
+  with an Origin check (device approval, token revocation) accept any of
+  the instance's own origins — `NEXTAUTH_URL`, `APP_HOST`,
+  `MARKETING_HOST` — not just `NEXTAUTH_URL`, so approving a device from
+  the app host works even when `NEXTAUTH_URL` names the marketing host.
+  With no topology set the accepted origin is `NEXTAUTH_URL` alone,
+  exactly as before.
+- **The marketing header is session-aware.** `GET /api/session-status`
+  returns `{"signedIn":…}` — a boolean, never user data — and grants
+  CORS to exactly one origin: the configured marketing origin. After
+  hydration the marketing host's header probes it (silently; any
+  failure keeps the signed-out control) and shows "Open app →" instead
+  of "Sign in" for a visitor who already has a session on the app host.
+  With no marketing origin configured the endpoint emits no CORS
+  headers at all and no probe ever fires.
+
 ## Database and migrations
 
 Schema migrations are ordinary [Drizzle](https://orm.drizzle.team)

--- a/src/app/api/session-status/route.ts
+++ b/src/app/api/session-status/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import {
+  isConfiguredMarketingOrigin,
+  resolveMarketingCorsOrigin,
+} from '@/lib/allowed-origins';
+
+/**
+ * GET /api/session-status — does this browser hold a session? (s6 P3, Q64)
+ *
+ * A BOOLEAN, NOTHING ELSE. The body is `{"signedIn":true|false}` — never
+ * user data, never session details (charter rule, #229 G0). The session
+ * cookie exists only on the app host, so this route answers there; the
+ * marketing host's header probes it cross-origin to swap "Sign in" for
+ * "Open app →" when the visitor already has a session.
+ *
+ * Reads the session with `getToken` (next-auth/jwt), not
+ * `getServerSession`: a pure cookie decode — no session callbacks run, no
+ * user object is materialized, no database is touched, and nothing can
+ * emit a Set-Cookie. Any decode failure (no cookie, bad cookie, missing
+ * NEXTAUTH_SECRET) is simply `false`, never a 5xx.
+ *
+ * CORS — exact-origin echo, one origin, or nothing:
+ * - The request Origin is echoed ONLY when the shared predicate accepts it
+ *   as the instance's configured marketing origin
+ *   (`isConfiguredMarketingOrigin`, www-insensitive), together with
+ *   `Access-Control-Allow-Credentials: true`. Never a wildcard — a
+ *   wildcard cannot carry cookies, and the allow-list is one origin by
+ *   design.
+ * - `Vary: Origin` whenever a marketing origin is configured (response
+ *   headers then depend on the Origin header — on matches AND misses).
+ * - The boolean is never cacheable: `Cache-Control: no-store`.
+ * - RULE ZERO: when topology names no marketing origin (unset topology, a
+ *   single-host instance, app-only), the route is INERT — no CORS header,
+ *   no Vary, on any request. A direct same-origin hit still gets an honest
+ *   `200 {"signedIn":…}`: same-origin callers can already read the full
+ *   session from NextAuth's own `/api/auth/session`, so the boolean is a
+ *   strict subset of existing surface, and cross-origin readers are
+ *   blocked by the browser precisely because no CORS grant exists.
+ */
+
+// The boolean depends on the request's cookie — never prerender or cache.
+export const dynamic = 'force-dynamic';
+
+/**
+ * CORS headers for one request: empty when the route is inert; `Vary`
+ * when a marketing origin is configured; the exact-origin echo pair only
+ * when the request Origin IS that marketing origin. The literal header
+ * value is echoed (under `Vary: Origin`) so the www and apex forms both
+ * satisfy the browser's exact-match check.
+ */
+function corsHeaders(request: NextRequest): Headers {
+  const headers = new Headers();
+  if (resolveMarketingCorsOrigin(process.env) === null) return headers;
+  headers.set('Vary', 'Origin');
+  const origin = request.headers.get('origin');
+  if (origin !== null && isConfiguredMarketingOrigin(origin, process.env)) {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Credentials', 'true');
+  }
+  return headers;
+}
+
+export async function GET(request: NextRequest) {
+  const headers = corsHeaders(request);
+  headers.set('Cache-Control', 'no-store');
+
+  let signedIn = false;
+  try {
+    signedIn = (await getToken({ req: request })) !== null;
+  } catch {
+    // Undecodable cookie or missing secret — an instance without working
+    // sessions has no signed-in browsers to report.
+    signedIn = false;
+  }
+
+  return NextResponse.json({ signedIn }, { headers });
+}
+
+/**
+ * Preflight. A credentialed GET with no custom headers is a simple
+ * request, so browsers normally skip this — but the contract is complete
+ * anyway: allowed origin gets the echo plus methods; anything else gets a
+ * bare 204 with no CORS grant. The preflight result (unlike the boolean)
+ * may be cached briefly.
+ */
+export async function OPTIONS(request: NextRequest) {
+  const headers = corsHeaders(request);
+  if (headers.has('Access-Control-Allow-Origin')) {
+    headers.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    headers.set('Access-Control-Max-Age', '600');
+  }
+  return new NextResponse(null, { status: 204, headers });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import Header from '@/components/Header';
 import { HostLinksProvider } from '@/components/HostLinksProvider';
 import { resolveDashboardHref } from '@/lib/host-routing';
 import { resolveHostLinks } from '@/lib/host-links';
+import { resolveSessionAffordance } from '@/lib/allowed-origins';
 import RunningUnsignedBanner from '@/components/RunningUnsignedBanner';
 import SponsorLine from '@/components/SponsorLine';
 import { BrandProvider } from '@/components/BrandProvider';
@@ -72,6 +73,15 @@ export default function RootLayout({
    * and today's in-place sign-in.
    */
   const hostLinks = resolveHostLinks(process.env);
+
+  /**
+   * The header's cross-host session affordance (s6 P3, Q64) — non-null only
+   * on a full split topology (both hosts named, not app-only). Spread
+   * conditionally below, like `accentProps`: an explicit null prop would
+   * serialize into the RSC flight payload, a needless byte delta on every
+   * configuration that has no affordance.
+   */
+  const sessionProbe = resolveSessionAffordance(process.env);
 
   /**
    * Instance branding (#217), resolved server-side like the host links
@@ -162,6 +172,7 @@ export default function RootLayout({
               signInHref={hostLinks.signInHref}
               brandName={brandName}
               signInOptions={signInOptions}
+              {...(sessionProbe !== null ? { sessionProbe } : {})}
             />
             {/* ADR-0020: running-unsigned indicator — renders only when this
                 instance has no signing key AND is outside a dev environment. */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,8 @@ import {
   resolveSignInAffordance,
   type SignInOption,
 } from '@/lib/auth-provider-options';
+import { useCrossHostSession } from '@/hooks/useCrossHostSession';
+import type { SessionAffordanceTarget } from '@/lib/allowed-origins';
 
 const NAV_LINK_STYLE: React.CSSProperties = {
   color: 'var(--text-secondary)',
@@ -52,6 +54,11 @@ const DROPDOWN_ITEM_STYLE: React.CSSProperties = {
  *   in-place branch below reads it (the split-host branch links to the `/ask`
  *   panel, which lists the providers itself). The default is today's single
  *   GitHub button.
+ * - `sessionProbe` (#229 P3 / Q64) — the app host's session-status URL and
+ *   the "Open app →" target, derived by the layout from
+ *   `resolveSessionAffordance`. Non-null only on a full split topology;
+ *   `null` (the default, and every other configuration) fires no fetch and
+ *   renders every affordance unchanged.
  */
 export default function Header({
   dashboardHref = '/dashboard',
@@ -59,14 +66,25 @@ export default function Header({
   signInHref = null,
   brandName = 'Civic AI Tools',
   signInOptions = DEFAULT_SIGN_IN_OPTIONS,
+  sessionProbe = null,
 }: {
   dashboardHref?: string;
   marketingOrigin?: string | null;
   signInHref?: string | null;
   brandName?: string;
   signInOptions?: SignInOption[];
+  sessionProbe?: SessionAffordanceTarget | null;
 }) {
   const { data: session, status } = useSession();
+
+  // Cross-host session probe (Q64): only on a split topology
+  // (sessionProbe non-null) and only while this browser has no local
+  // session. `false` — the mount value, and the value after any probe
+  // failure — keeps the sign-in control exactly as it is today.
+  const crossHostSignedIn = useCrossHostSession(
+    sessionProbe?.statusUrl ?? null,
+    !session,
+  );
   const headerRef = useRef<HTMLElement>(null);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [exploreOpen, setExploreOpen] = useState(false);
@@ -406,6 +424,45 @@ export default function Header({
                 </div>
               )}
             </div>
+          ) : signInHref !== null && sessionProbe !== null ? (
+            /* Full split topology (Q64): the same link as the plain branch
+               below, but session-aware — when the cross-host probe finds a
+               session on the app host, "Sign in" becomes "Open app →"
+               pointing there. CLS-safe by reservation: both labels occupy
+               the same grid cell from first paint, so the control's box is
+               sized to the wider label and cannot shift at swap time; the
+               inactive label is hidden but keeps contributing its width. */
+            <a
+              href={crossHostSignedIn ? sessionProbe.openAppHref : signInHref}
+              className="nyc-button nyc-button-primary"
+              style={{
+                padding: '8px 16px',
+                fontSize: '14px',
+                textDecoration: 'none',
+                display: 'inline-grid',
+              }}
+            >
+              <span
+                aria-hidden={crossHostSignedIn}
+                style={{
+                  gridArea: '1 / 1',
+                  textAlign: 'center',
+                  visibility: crossHostSignedIn ? 'hidden' : 'visible',
+                }}
+              >
+                Sign in
+              </span>
+              <span
+                aria-hidden={!crossHostSignedIn}
+                style={{
+                  gridArea: '1 / 1',
+                  textAlign: 'center',
+                  visibility: crossHostSignedIn ? 'visible' : 'hidden',
+                }}
+              >
+                Open app &rarr;
+              </span>
+            </a>
           ) : signInHref !== null ? (
             /* Split topology: sign-in happens on the app surface, so this is
                a plain link — it works before hydration, and the label drops

--- a/src/hooks/useCrossHostSession.ts
+++ b/src/hooks/useCrossHostSession.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Cross-host has-a-session probe (s6 P3, Q64).
+ *
+ * On a split-host topology the session cookie lives on the app host, so
+ * the marketing host's header cannot know from its own cookies that the
+ * visitor is already signed in. This hook asks the app host's
+ * `/api/session-status` (a boolean — nothing else crosses the origin) and
+ * returns whether a session exists there.
+ *
+ * FAILURE IS SILENT AND SIGNED-OUT, by contract: the return value starts
+ * `false` and can only ever become `true` on a well-formed
+ * `{"signedIn":true}`. A network error, a CORS refusal, a timeout, a
+ * non-200, or a malformed body all leave it `false` — the caller keeps
+ * rendering its signed-out affordance and the visitor never sees a
+ * degraded control.
+ *
+ * NO PROBE FIRES unless the caller passes a URL (`statusUrl !== null` —
+ * the layout only derives one on a full split topology; see
+ * `resolveSessionAffordance`) and `enabled` is true (the caller has no
+ * local session — a locally signed-in browser needs no probe). A probe to
+ * the page's own origin is also skipped: same-origin session state is
+ * `useSession`'s job, and the answer would be redundant.
+ *
+ * Post-hydration only — the fetch runs in an effect, so the server-
+ * rendered document is byte-identical with or without the probe.
+ */
+export function useCrossHostSession(
+  statusUrl: string | null,
+  enabled: boolean,
+): boolean {
+  const [signedIn, setSignedIn] = useState(false);
+
+  useEffect(() => {
+    if (statusUrl === null || !enabled) return;
+    try {
+      if (new URL(statusUrl).origin === window.location.origin) return;
+    } catch {
+      return; // Unparseable URL: no probe.
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => controller.abort(), 4000);
+
+    fetch(statusUrl, {
+      method: 'GET',
+      mode: 'cors',
+      credentials: 'include',
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body: unknown) => {
+        if (cancelled || body === null || typeof body !== 'object') return;
+        if ((body as { signedIn?: unknown }).signedIn === true) {
+          setSignedIn(true);
+        }
+      })
+      .catch(() => {
+        // Silent: keep the signed-out affordance.
+      })
+      .finally(() => window.clearTimeout(timer));
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [statusUrl, enabled]);
+
+  return signedIn;
+}

--- a/src/lib/allowed-origins.test.ts
+++ b/src/lib/allowed-origins.test.ts
@@ -1,0 +1,241 @@
+// Tests for the topology-aware allowed-origin predicate (s6 P3, #229).
+//
+// Security-sensitive module: the cases below are the origin-matching
+// contract — exact equality after normalization, scheme- and
+// port-sensitive, www-insensitive, no suffix matching anywhere. The evil
+// lookalikes (`evil-app.example.test`, `app.example.test.evil.com`,
+// registrable-domain suffixes) are the regression net.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isConfiguredMarketingOrigin,
+  isTrustedRequestOrigin,
+  normalizeOriginForComparison,
+  resolveMarketingCorsOrigin,
+  resolveSessionAffordance,
+  resolveTrustedOrigins,
+} from './allowed-origins.ts';
+
+// A split-host fixture used throughout: NEXTAUTH_URL stays on the
+// marketing host — the exact #213 configuration in which device-approve
+// POSTs from the app host used to 403.
+const SPLIT = {
+  NEXTAUTH_URL: 'https://example.test',
+  APP_HOST: 'app.example.test',
+  MARKETING_HOST: 'example.test',
+};
+
+test('normalization: canonical form, www- and trailing-dot-insensitive, default ports elided', () => {
+  assert.equal(normalizeOriginForComparison('https://example.test'), 'https://example.test');
+  assert.equal(normalizeOriginForComparison('https://WWW.Example.Test'), 'https://example.test');
+  assert.equal(normalizeOriginForComparison('https://example.test.'), 'https://example.test');
+  assert.equal(normalizeOriginForComparison('https://example.test:443'), 'https://example.test');
+  assert.equal(normalizeOriginForComparison('http://example.test:80'), 'http://example.test');
+  assert.equal(normalizeOriginForComparison('http://localhost:3000'), 'http://localhost:3000');
+  // A full URL normalizes to its origin — NEXTAUTH_URL may carry a path.
+  assert.equal(
+    normalizeOriginForComparison('https://example.test/api/auth'),
+    'https://example.test',
+  );
+});
+
+test('normalization: garbage, opaque, and non-web origins are null, never a match', () => {
+  assert.equal(normalizeOriginForComparison(null), null);
+  assert.equal(normalizeOriginForComparison(undefined), null);
+  assert.equal(normalizeOriginForComparison(''), null);
+  assert.equal(normalizeOriginForComparison('   '), null);
+  // `Origin: null` — sandboxed iframes, some redirects. Must never match.
+  assert.equal(normalizeOriginForComparison('null'), null);
+  assert.equal(normalizeOriginForComparison('example.test'), null); // no scheme
+  assert.equal(normalizeOriginForComparison('file:///etc/hosts'), null);
+  assert.equal(normalizeOriginForComparison('chrome-extension://abcdef'), null);
+});
+
+test('rule zero: nothing configured — empty trusted set, no marketing CORS origin, no affordance', () => {
+  assert.deepEqual(resolveTrustedOrigins({}), []);
+  assert.equal(resolveMarketingCorsOrigin({}), null);
+  assert.equal(resolveSessionAffordance({}), null);
+  assert.equal(isConfiguredMarketingOrigin('https://example.test', {}), false);
+});
+
+test('unset topology: the trusted set is exactly NEXTAUTH_URL — pre-#213 behavior, unchanged', () => {
+  const env = { NEXTAUTH_URL: 'https://example.test' };
+  assert.deepEqual(resolveTrustedOrigins(env), ['https://example.test']);
+  assert.equal(isTrustedRequestOrigin('https://example.test', null, env), true);
+  // www-insensitive in both directions (the production apex→www redirect).
+  assert.equal(isTrustedRequestOrigin('https://www.example.test', null, env), true);
+  assert.equal(
+    isTrustedRequestOrigin('https://example.test', null, { NEXTAUTH_URL: 'https://www.example.test' }),
+    true,
+  );
+  // What used to 403 still 403s: a different subdomain is a different origin.
+  assert.equal(isTrustedRequestOrigin('https://app.example.test', null, env), false);
+});
+
+test('split host (#213): app-host and marketing-host origins are the instance\'s own', () => {
+  // The fix itself: a device-approve POST from the app host passes.
+  assert.equal(isTrustedRequestOrigin('https://app.example.test', null, SPLIT), true);
+  // The marketing origin and NEXTAUTH_URL keep passing.
+  assert.equal(isTrustedRequestOrigin('https://example.test', null, SPLIT), true);
+  assert.equal(isTrustedRequestOrigin('https://www.example.test', null, SPLIT), true);
+  assert.equal(isTrustedRequestOrigin('https://www.app.example.test', null, SPLIT), true);
+});
+
+test('split host: evil-origin lookalikes never match', () => {
+  for (const evil of [
+    'https://evil-app.example.test',
+    'https://app.example.test.evil.com',
+    'https://evilexample.test', // registrable-domain suffix lookalike
+    'https://example.test.evil.com',
+    'https://app-example.test',
+    'https://wwwapp.example.test', // `www.`-stripping requires the dot
+    'https://evil.test',
+  ]) {
+    assert.equal(isTrustedRequestOrigin(evil, null, SPLIT), false, evil);
+  }
+});
+
+test('split host: scheme and port are part of the origin', () => {
+  assert.equal(isTrustedRequestOrigin('http://app.example.test', null, SPLIT), false);
+  assert.equal(isTrustedRequestOrigin('https://app.example.test:8443', null, SPLIT), false);
+  assert.equal(isTrustedRequestOrigin('https://example.test:8443', null, SPLIT), false);
+  // ...but the scheme-default port is the same origin.
+  assert.equal(isTrustedRequestOrigin('https://app.example.test:443', null, SPLIT), true);
+});
+
+test('split host, dev shape: a full-origin host value keeps its scheme and port', () => {
+  const env = {
+    NEXTAUTH_URL: 'http://localhost:3000',
+    APP_HOST: 'http://app.localhost:3000',
+    MARKETING_HOST: 'http://localhost:3000',
+  };
+  assert.deepEqual(resolveTrustedOrigins(env), [
+    'http://localhost:3000',
+    'http://app.localhost:3000',
+  ]);
+  assert.equal(isTrustedRequestOrigin('http://app.localhost:3000', null, env), true);
+  assert.equal(isTrustedRequestOrigin('http://app.localhost:3001', null, env), false);
+  assert.equal(isTrustedRequestOrigin('https://app.localhost:3000', null, env), false);
+});
+
+test('app-only: the two host variables are declared ignored, so only NEXTAUTH_URL is trusted', () => {
+  const env = { ...SPLIT, APP_ONLY: '1' };
+  assert.deepEqual(resolveTrustedOrigins(env), ['https://example.test']);
+  assert.equal(isTrustedRequestOrigin('https://app.example.test', null, env), false);
+});
+
+test('trusted set is deduplicated and skips unset values', () => {
+  assert.deepEqual(
+    resolveTrustedOrigins({
+      NEXTAUTH_URL: 'https://www.example.test',
+      MARKETING_HOST: 'example.test',
+    }),
+    ['https://example.test'],
+  );
+  assert.deepEqual(resolveTrustedOrigins({ APP_HOST: 'app.example.test' }), [
+    'https://app.example.test',
+  ]);
+  assert.deepEqual(resolveTrustedOrigins({ APP_HOST: '', MARKETING_HOST: '   ' }), []);
+});
+
+test('no Origin header is never trusted, whatever the configuration', () => {
+  assert.equal(isTrustedRequestOrigin(null, 'example.test', SPLIT), false);
+  assert.equal(isTrustedRequestOrigin(undefined, 'example.test', {}), false);
+  assert.equal(isTrustedRequestOrigin('', 'example.test', {}), false);
+  assert.equal(isTrustedRequestOrigin('null', 'example.test', {}), false);
+});
+
+test('dev fallback (nothing configured): the request\'s own host, by exact equality', () => {
+  assert.equal(isTrustedRequestOrigin('http://localhost:3000', 'localhost:3000', {}), true);
+  assert.equal(isTrustedRequestOrigin('https://example.test', 'example.test', {}), true);
+  // www-insensitive, matching the configured-origin path.
+  assert.equal(isTrustedRequestOrigin('https://www.example.test', 'example.test', {}), true);
+  assert.equal(isTrustedRequestOrigin('https://example.test', 'www.example.test', {}), true);
+  // No Host header → nothing to trust.
+  assert.equal(isTrustedRequestOrigin('http://localhost:3000', null, {}), false);
+  // Port must match.
+  assert.equal(isTrustedRequestOrigin('http://localhost:3001', 'localhost:3000', {}), false);
+});
+
+test('dev fallback: suffix lookalikes no longer pass (the pre-#213 endsWith hole)', () => {
+  // `https://evil-example.org`.endsWith('example.org') was true; exact
+  // host equality is not.
+  assert.equal(isTrustedRequestOrigin('https://evil-example.test', 'example.test', {}), false);
+  assert.equal(isTrustedRequestOrigin('https://aexample.test', 'example.test', {}), false);
+  assert.equal(isTrustedRequestOrigin('https://example.test.evil.com', 'example.test', {}), false);
+});
+
+test('dev fallback is unreachable once any origin is configured — configuration narrows trust', () => {
+  const env = { NEXTAUTH_URL: 'https://example.test' };
+  // Same-host request whose origin is not the configured one: refused,
+  // even though the fallback would have accepted it.
+  assert.equal(isTrustedRequestOrigin('https://other.test', 'other.test', env), false);
+});
+
+test('marketing CORS origin: named only by a split topology, normalized like everything else', () => {
+  assert.equal(resolveMarketingCorsOrigin(SPLIT), 'https://example.test');
+  assert.equal(
+    resolveMarketingCorsOrigin({ MARKETING_HOST: 'www.example.test' }),
+    'https://example.test',
+  );
+  assert.equal(
+    resolveMarketingCorsOrigin({ MARKETING_HOST: 'http://localhost:3000' }),
+    'http://localhost:3000',
+  );
+  // Rule zero, each shape: unset topology, app-only, APP_HOST alone.
+  assert.equal(resolveMarketingCorsOrigin({}), null);
+  assert.equal(resolveMarketingCorsOrigin({ ...SPLIT, APP_ONLY: 'true' }), null);
+  assert.equal(resolveMarketingCorsOrigin({ APP_HOST: 'app.example.test' }), null);
+});
+
+test('marketing CORS predicate: only the marketing origin, www-insensitive, nothing else', () => {
+  assert.equal(isConfiguredMarketingOrigin('https://example.test', SPLIT), true);
+  assert.equal(isConfiguredMarketingOrigin('https://www.example.test', SPLIT), true);
+  // The instance's OWN app origin is not a marketing origin — the app host
+  // has the session cookie already and needs no CORS grant.
+  assert.equal(isConfiguredMarketingOrigin('https://app.example.test', SPLIT), false);
+  for (const evil of [
+    'https://evil.test',
+    'https://evilexample.test',
+    'https://example.test.evil.com',
+    'http://example.test', // scheme mismatch
+    'https://example.test:8443', // port mismatch
+    'null',
+  ]) {
+    assert.equal(isConfiguredMarketingOrigin(evil, SPLIT), false, evil);
+  }
+});
+
+test('session affordance: full split topology only', () => {
+  assert.deepEqual(resolveSessionAffordance(SPLIT), {
+    statusUrl: 'https://app.example.test/api/session-status',
+    openAppHref: 'https://app.example.test/ask',
+  });
+  // Dev shape keeps scheme and port.
+  assert.deepEqual(
+    resolveSessionAffordance({
+      APP_HOST: 'http://app.localhost:3000',
+      MARKETING_HOST: 'http://localhost:3000',
+    }),
+    {
+      statusUrl: 'http://app.localhost:3000/api/session-status',
+      openAppHref: 'http://app.localhost:3000/ask',
+    },
+  );
+});
+
+test('session affordance rule zero: null topology, app-only, and partial rollouts are null', () => {
+  assert.equal(resolveSessionAffordance({}), null);
+  assert.equal(resolveSessionAffordance({ APP_ONLY: '1' }), null);
+  assert.equal(resolveSessionAffordance({ ...SPLIT, APP_ONLY: 'true' }), null);
+  // APP_HOST alone: the endpoint would refuse the probe (no marketing
+  // origin to allow), so no probe may fire.
+  assert.equal(resolveSessionAffordance({ APP_HOST: 'app.example.test' }), null);
+  // MARKETING_HOST alone: nowhere to probe or point.
+  assert.equal(resolveSessionAffordance({ MARKETING_HOST: 'example.test' }), null);
+  // NEXTAUTH_URL alone never conjures an affordance.
+  assert.equal(resolveSessionAffordance({ NEXTAUTH_URL: 'https://example.test' }), null);
+});

--- a/src/lib/allowed-origins.ts
+++ b/src/lib/allowed-origins.ts
@@ -1,0 +1,238 @@
+// Topology-aware allowed-origin predicate (s6 P3, #229 — #213 + Q64).
+//
+// THE QUESTION THIS MODULE ANSWERS: "is this request's Origin one of this
+// instance's own origins?" — derived entirely from the same environment
+// variables the rest of the host-topology seam reads (`NEXTAUTH_URL`,
+// `APP_HOST`, `MARKETING_HOST`, `APP_ONLY`), never from request state, so
+// the answer is identical on every host and every render.
+//
+// Two consumers, two DIFFERENT origin sets, on purpose:
+//
+//   - `isTrustedRequestOrigin` — the same-origin gate for state-changing
+//     user actions (`api-auth.ts` `isSameOrigin`). Its set is EVERY origin
+//     the instance owns: `NEXTAUTH_URL` plus, on a split topology, the app
+//     and marketing origins. Before #213 the gate compared only against
+//     `NEXTAUTH_URL`, so on a split host where `NEXTAUTH_URL` stays on the
+//     marketing host, device-approve and token-revoke POSTs from the app
+//     host 403'd. With topology unset the set is exactly `{NEXTAUTH_URL}`
+//     — today's behavior, unchanged.
+//
+//   - `isConfiguredMarketingOrigin` — the CORS allow-list for the
+//     `/api/session-status` boolean (Q64). Its set is AT MOST ONE origin:
+//     the configured marketing origin, because the only legitimate
+//     cross-origin reader of the session boolean is the marketing host's
+//     header affordance. Rule zero: on a single-host, app-only, or
+//     null-topology configuration this set is EMPTY and the endpoint stays
+//     inert — no CORS header is ever emitted.
+//
+// MATCHING RULES (security-relevant; keep them boring):
+//   - Exact string equality of normalized origins — never `endsWith`,
+//     never substring, never suffix matching. `evil-app.example.test` and
+//     `app.example.test.evil.com` share no normalized form with
+//     `app.example.test`.
+//   - Scheme-sensitive (`http://` is not `https://`) and port-sensitive
+//     (an explicit non-default port must match; default ports are elided
+//     by URL parsing on both sides).
+//   - `www.`-insensitive on the host, matching `normalizeHost` in
+//     host-routing.ts (see the comment there): the production deployment
+//     307-redirects apex → www for GET, so browsers send the `www.` form
+//     of an origin the operator configured as the apex.
+//
+// Pure module: no Next.js imports, env passed as a record — runs under
+// `node --test` like host-routing.ts and host-links.ts.
+
+import {
+  originFromHostValue,
+  parseBooleanFlag,
+  resolveAppOrigin,
+} from './host-routing.ts';
+
+/**
+ * Normalize an origin (or absolute URL) to a canonical comparison form:
+ * `scheme//host[:port]` with the hostname lowercased, a leading `www.`
+ * and trailing dot dropped, and default ports elided (URL parsing does
+ * that). Returns null for anything unparseable, non-http(s), or empty —
+ * including the literal `Origin: null` an opaque-origin request sends,
+ * which `new URL('null')` rejects.
+ */
+export function normalizeOriginForComparison(
+  input: string | null | undefined,
+): string | null {
+  if (typeof input !== 'string') return null;
+  const raw = input.trim();
+  if (raw.length === 0) return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  // Only web origins participate; a scheme mismatch can never equal a
+  // configured http(s) origin anyway, but rejecting early keeps the
+  // comparison space small and the failure mode obvious.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  const hostname = url.hostname.replace(/^www\./, '').replace(/\.$/, '');
+  if (hostname.length === 0) return null;
+  // `url.port` is '' when the port is the scheme default — elision for free.
+  const host = url.port ? `${hostname}:${url.port}` : hostname;
+  return `${url.protocol}//${host}`;
+}
+
+/**
+ * Every origin this instance owns, normalized and deduplicated:
+ * `NEXTAUTH_URL`, and — unless `APP_ONLY`, which declares the two host
+ * variables ignored (mirroring `resolveHostRole`) — the app and marketing
+ * origins. Order is stable but meaningless; membership is the contract.
+ *
+ * With topology unset this is exactly the singleton `NEXTAUTH_URL` set
+ * the pre-#213 `isSameOrigin` compared against; with nothing configured
+ * at all it is empty, which sends `isTrustedRequestOrigin` to the
+ * request-host dev fallback.
+ */
+export function resolveTrustedOrigins(
+  env: Record<string, string | undefined>,
+): string[] {
+  const candidates = [normalizeOriginForComparison(env.NEXTAUTH_URL)];
+  if (!parseBooleanFlag(env.APP_ONLY)) {
+    candidates.push(
+      normalizeOriginForComparison(originFromHostValue(env.APP_HOST)),
+      normalizeOriginForComparison(originFromHostValue(env.MARKETING_HOST)),
+    );
+  }
+  const origins: string[] = [];
+  for (const candidate of candidates) {
+    if (candidate !== null && !origins.includes(candidate)) {
+      origins.push(candidate);
+    }
+  }
+  return origins;
+}
+
+/**
+ * Normalize a Host header for the dev fallback below: lowercased, leading
+ * `www.` and trailing dot dropped from the name, an explicit port kept.
+ * (No scheme — Host headers don't carry one.)
+ */
+function normalizeHostHeader(raw: string): string | null {
+  const value = raw.trim().toLowerCase();
+  if (value.length === 0) return null;
+  if (value.startsWith('[')) {
+    // Bracketed IPv6, optionally with a port — already canonical enough.
+    return value;
+  }
+  let name = value;
+  let port = '';
+  const idx = value.lastIndexOf(':');
+  if (idx !== -1 && /^\d+$/.test(value.slice(idx + 1))) {
+    name = value.slice(0, idx);
+    port = value.slice(idx);
+  }
+  name = name.replace(/^www\./, '').replace(/\.$/, '');
+  if (name.length === 0) return null;
+  return `${name}${port}`;
+}
+
+/**
+ * THE #213 PREDICATE: does this request's Origin name one of the
+ * instance's own origins? `api-auth.ts` `isSameOrigin` is a thin adapter
+ * over this (request headers in, `process.env` in, boolean out).
+ *
+ * - No Origin header, or an unparseable one → false. Callers who need to
+ *   support header-less clients use bearer tokens, which skip this gate.
+ * - Any configured origin (`resolveTrustedOrigins` non-empty) → exact
+ *   membership, nothing else. Configuration narrows trust; there is no
+ *   union with the fallback below.
+ * - Nothing configured anywhere (dev) → trust the request's own host:
+ *   the Origin's host must EQUAL the Host header (www-insensitively).
+ *   The pre-#213 fallback used `endsWith`, which a registrable-domain
+ *   lookalike (`https://evil-example.org` vs host `example.org`)
+ *   satisfied; exact equality accepts every request the old check was
+ *   for (a page POSTing to its own host) and closes that hole.
+ */
+export function isTrustedRequestOrigin(
+  originHeader: string | null | undefined,
+  hostHeader: string | null | undefined,
+  env: Record<string, string | undefined>,
+): boolean {
+  const origin = normalizeOriginForComparison(originHeader);
+  if (origin === null) return false;
+
+  const trusted = resolveTrustedOrigins(env);
+  if (trusted.length > 0) {
+    return trusted.includes(origin);
+  }
+
+  // Dev fallback: no configured origin anywhere. Accept only the
+  // request's own host, exactly.
+  if (typeof hostHeader !== 'string') return false;
+  const host = normalizeHostHeader(hostHeader);
+  if (host === null) return false;
+  const originHost = origin.slice(origin.indexOf('//') + 2);
+  return originHost === host;
+}
+
+/**
+ * The single origin `/api/session-status` may echo in CORS headers — the
+ * configured marketing origin — or null when topology names none, which
+ * keeps the endpoint inert (rule zero): unset topology, a single-host
+ * instance, and an app-only instance (where `MARKETING_HOST` is declared
+ * ignored) all resolve to null.
+ */
+export function resolveMarketingCorsOrigin(
+  env: Record<string, string | undefined>,
+): string | null {
+  if (parseBooleanFlag(env.APP_ONLY)) return null;
+  return normalizeOriginForComparison(originFromHostValue(env.MARKETING_HOST));
+}
+
+/**
+ * THE Q64 CORS PREDICATE: is this request's Origin the instance's
+ * configured marketing origin? True is the ONLY condition under which
+ * `/api/session-status` echoes an Origin. www-insensitive like everything
+ * above, so `https://www.example.org` matches a configured `example.org`
+ * — the route echoes whichever literal form the browser sent, under
+ * `Vary: Origin`.
+ */
+export function isConfiguredMarketingOrigin(
+  originHeader: string | null | undefined,
+  env: Record<string, string | undefined>,
+): boolean {
+  const allowed = resolveMarketingCorsOrigin(env);
+  if (allowed === null) return false;
+  const origin = normalizeOriginForComparison(originHeader);
+  return origin !== null && origin === allowed;
+}
+
+/**
+ * What the marketing header's session-aware affordance needs, or null when
+ * the affordance must not exist (and no client fetch may fire): the
+ * app-origin URL to probe and where "Open app →" points.
+ *
+ * Non-null ONLY on a full split topology — both `APP_HOST` (somewhere to
+ * probe and to open) and `MARKETING_HOST` (an origin the probe endpoint
+ * will actually answer CORS for) named, and not `APP_ONLY`. A partial
+ * rollout (`APP_HOST` alone) stays null rather than firing a probe the
+ * inert endpoint is guaranteed to refuse.
+ *
+ * `openAppHref` targets `/ask` — the app front door `/` 307s to
+ * (APP_ROOT_ACTION) — going there directly skips the redirect hop.
+ */
+export interface SessionAffordanceTarget {
+  /** Absolute URL of the app host's `/api/session-status`. */
+  statusUrl: string;
+  /** Where the swapped-in "Open app →" control points. */
+  openAppHref: string;
+}
+
+export function resolveSessionAffordance(
+  env: Record<string, string | undefined>,
+): SessionAffordanceTarget | null {
+  if (parseBooleanFlag(env.APP_ONLY)) return null;
+  if (resolveMarketingCorsOrigin(env) === null) return null;
+  const appOrigin = resolveAppOrigin(env);
+  if (appOrigin === null) return null;
+  return {
+    statusUrl: `${appOrigin}/api/session-status`,
+    openAppHref: `${appOrigin}/ask`,
+  };
+}

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -5,6 +5,7 @@ import { eq } from 'drizzle-orm';
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { apiTokens, users } from '@/lib/db/schema';
+import { isTrustedRequestOrigin } from '@/lib/allowed-origins';
 
 /**
  * Auth resolution for write endpoints (POST /api/evidence,
@@ -70,52 +71,30 @@ export function hasScope(auth: AuthResult, required: string): boolean {
 }
 
 /**
- * Strip protocol noise + leading `www.` from an origin or absolute URL so
- * apex and www forms of the same domain compare equal. Callers control
- * what counts as "same logical origin" for their app; this helper just
- * normalizes the host component.
- */
-function normalizeOrigin(input: string): string | null {
-  try {
-    const url = new URL(input);
-    const host = url.host.replace(/^www\./, '');
-    return `${url.protocol}//${host}`;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Same-origin check for state-changing user actions (device approve,
- * token revoke). Accepts both apex and www variants as equivalent — the
- * production civicaitools.org deployment 307-redirects apex → www for
- * GET, so browsers land on www even when `NEXTAUTH_URL` is apex. Without
- * this normalization the Origin header (`https://www.civicaitools.org`)
- * would never match NEXTAUTH_URL (`https://civicaitools.org`) and all
- * legitimate approvals would 403.
+ * token revoke). A thin adapter over the topology-aware predicate in
+ * `allowed-origins.ts` (#213): the request's Origin must name one of the
+ * INSTANCE'S OWN origins — `NEXTAUTH_URL` plus, on a split topology, the
+ * app and marketing origins. Before #213 only `NEXTAUTH_URL` matched, so
+ * with `NEXTAUTH_URL` on the marketing host every device-approve and
+ * token-revoke POST from the app host 403'd. With topology unset the set
+ * is exactly `{NEXTAUTH_URL}` — the pre-#213 behavior.
+ *
+ * Matching is www-insensitive (the production deployment 307-redirects
+ * apex → www for GET, so browsers send the www form even when the
+ * configured value is the apex), scheme- and port-sensitive, and always
+ * exact — see the predicate module for the full rules.
  *
  * Returns false for cross-origin POSTs and for requests with no Origin
  * header (e.g. plain curl without `-H Origin`) — callers who want to
  * support those paths should use bearer tokens, which skip this check.
  */
 export function isSameOrigin(request: NextRequest): boolean {
-  const origin = request.headers.get('origin');
-  if (!origin) return false;
-  const normalizedOrigin = normalizeOrigin(origin);
-  if (!normalizedOrigin) return false;
-
-  const expected = process.env.NEXTAUTH_URL;
-  if (expected) {
-    const normalizedExpected = normalizeOrigin(expected);
-    return normalizedExpected !== null && normalizedOrigin === normalizedExpected;
-  }
-
-  // Dev fallback: no NEXTAUTH_URL set. Accept the request's own host
-  // (stripped of `www.`) as the trusted origin.
-  const host = request.headers.get('host');
-  if (!host) return false;
-  const normalizedHost = host.replace(/^www\./, '');
-  return normalizedOrigin.endsWith(normalizedHost);
+  return isTrustedRequestOrigin(
+    request.headers.get('origin'),
+    request.headers.get('host'),
+    process.env,
+  );
 }
 
 async function resolveBearer(raw: string): Promise<AuthResult | null> {


### PR DESCRIPTION
Phase P3 of the sprint anchored at #229 — Q64's session-aware affordance and #213's topology-aware origin gate. Owner merges per the sprint contract; the production cross-host smoke follows the deploy.

## What changed

**Shared topology-aware origin predicate** (`src/lib/allowed-origins.ts`, new). Pure and env-record-driven, built on host-routing's existing derivations and www-insensitivity convention. The trusted set is the instance's own origins — `NEXTAUTH_URL` plus, on a split topology, the app and marketing origins; empty additions under `APP_ONLY`; with topology unset, exactly `{NEXTAUTH_URL}` (pre-#213 behavior). Matching is exact normalized-origin equality — scheme- and port-sensitive, no suffix matching. 18 new tests cover lookalike origins (`evil-app.example.test`, `app.example.test.evil.com`), scheme/port mismatches, www variants both directions, and `Origin: null`. One deliberate tightening: the dev-only no-config fallback previously used `endsWith` (satisfiable by `evil-example.org`); it now requires exact host equality.

**#213.** `api-auth.ts`'s `isSameOrigin` is now a thin adapter over the predicate. Device-approve and token-revoke POSTs from the app host pass the origin gate when `NEXTAUTH_URL` lives on the marketing host; forged origins still 403; unset-topology behavior unchanged.

**`GET /api/session-status`** (the one additive route). Returns exactly `{"signedIn":boolean}` — read via `getToken` (pure cookie decode: no session callbacks, no DB, structurally incapable of Set-Cookie; decode failure is `false`, never 5xx). Exact-origin CORS: the request Origin is echoed only when it is the configured marketing origin, with credentialed allow and `Vary: Origin`; never a wildcard; `no-store`. With no marketing origin configured (null topology, single-host, app-only) the route is fully inert — no CORS headers on any request; direct same-origin hits still answer honestly, a strict subset of NextAuth's own `/api/auth/session` surface.

**Marketing-header affordance.** `useCrossHostSession` probes the app host post-hydration (4s abort, strict body validation, every failure silently keeps "Sign in"); with a live session, the header's "Sign in" becomes "Open app →" at the app origin. The swap happens inside a fixed-size box — CLS structurally impossible. The `sessionProbe` prop defaults to `null` (today's behavior) and is passed via conditional spread, so no-affordance configs serialize nothing new. No fetch fires at all on null-topology, app-only, or probe-less configurations.

No cookie-scope changes (the parent-domain cookie was rejected at G0 and stays rejected). No existing route gains CORS headers.

## Evidence

- 598 tests (+18), lint 0 errors (4 pre-existing warnings), keyless build, typecheck — all green at both ends of the diff.
- #213 at HTTP level (split build, `NEXTAUTH_URL` on marketing): app-origin device-approve POST passes the origin gate (401 auth-required instead of the old 403; with a session cookie, 400 bad-body — past both gates); `evil.test` and `evil-app` origins still 403; unset topology unchanged.
- Endpoint matrix: exact-origin echo + credentialed allow + `Vary: Origin` + `no-store` for the configured marketing origin (www literal echoed under Vary); no echo for unknown/lookalike/scheme/port-mismatched origins; correct preflight; zero Set-Cookie; app-only stays inert even with `MARKETING_HOST` deliberately set.
- Header affordance in a real browser (two hostnames resolved to localhost, session cookie minted via next-auth/jwt): signed-in shows "Open app →" at the app origin, signed-out keeps "Sign in", the control's box is identical in both states (108.63×60.81), and a null-topology run logs zero probe requests.
- Byte-identity: null-topology and app-only documents byte-identical base-vs-head (keyless builds, hashed-name + build-id normalization). Split-host SSR delta is exactly the 138-char `sessionProbe` flight prop + one client-module reference; zero visible-markup change (the auth control has always mounted post-hydration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)