### PR TITLE
s6 follow-ons: first-run block, sign-in copy, Dashboard origin (+2 literal riders)

### DIFF
--- a/src/app/(app)/ask/page.tsx
+++ b/src/app/(app)/ask/page.tsx
@@ -11,6 +11,7 @@ import {
 import QuerySurface from '@/components/shared/QuerySurface';
 import AskSignInPanel from './AskSignInPanel';
 import { getBrandName } from '@/lib/brand-config';
+import { hasPublishedEvidence } from '@/lib/db/creator-evidence';
 
 /**
  * `/ask` — the query surface in signed-in configuration (app front-door
@@ -126,6 +127,25 @@ export default async function AskPage({ searchParams }: AskPageProps) {
     );
   }
 
+  // FIRST-RUN ORIENTATION (#239 — Q63's first-run half, decided at the #229
+  // G0). Keyed on the dashboard's evidence-records-by-creator data path
+  // (src/lib/db/creator-evidence.ts), narrowed to an existence probe: the
+  // block renders until the user's FIRST publish and then never again. The
+  // record itself is the state — no cookie, no dismissal flag, no client
+  // fetch; it is a server derivation like everything else on this page.
+  // Failure closes to today's render: a session missing its account key or a
+  // database error renders the surface exactly as it rendered before this
+  // block existed, because a read-only orientation aid is never worth
+  // failing — or slowing the recovery of — the page over.
+  let showFirstRunOrientation = false;
+  if (session.user.id) {
+    try {
+      showFirstRunOrientation = !(await hasPublishedEvidence(session.user.id));
+    } catch {
+      // Degrade to no block (today's bytes), deliberately silently.
+    }
+  }
+
   return (
     <QuerySurface
       showLocalSetupFootnote={false}
@@ -148,6 +168,31 @@ export default async function AskPage({ searchParams }: AskPageProps) {
           you can publish it as a signed evidence package anyone can verify
           independently.
         </p>
+        {showFirstRunOrientation && (
+          <div
+            style={{
+              marginTop: '16px',
+              padding: '12px 16px',
+              border: '1px solid var(--border-color)',
+              borderRadius: '6px',
+              backgroundColor: 'var(--card-background)',
+              fontSize: '14px',
+              lineHeight: 1.6,
+              color: 'var(--text-secondary)',
+              maxWidth: '650px',
+            }}
+          >
+            <strong style={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+              Getting started.
+            </strong>{' '}
+            Ask a question below and the answer is assembled from live public
+            data, with every query it ran shown alongside the result. When an
+            answer is worth keeping, publish it: publishing creates a signed
+            evidence package — a permanent, independently verifiable record of
+            the answer and how it was produced — listed on your dashboard.
+            This note disappears after your first publish.
+          </div>
+        )}
       </div>
     </QuerySurface>
   );

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { apiTokens, evidenceRecords, attestationPackages, users } from '@/lib/db/schema';
 import { eq, desc, and, ne, isNull, sql } from 'drizzle-orm';
+import { findDbUserByAccountKey } from '@/lib/db/creator-evidence';
 import DashboardTabs from '@/components/dashboard/DashboardTabs';
 import { isSigningConfigured } from '@/lib/evidence/unsigned-tier';
 import { getBrandName } from '@/lib/brand-config';
@@ -22,19 +23,15 @@ export default async function DashboardPage() {
     redirect('/');
   }
 
-  // Look up DB user ID from GitHub ID
-  const githubId = session.user.id;
-  const dbUser = await db
-    .select({ id: users.id, displayName: users.displayName })
-    .from(users)
-    .where(eq(users.githubId, githubId))
-    .limit(1);
-
-  if (dbUser.length === 0) {
+  // Account key → internal user row, via the shared by-creator data path
+  // (src/lib/db/creator-evidence.ts — extracted for #239 so the /ask
+  // first-run block keys on the same lookup instead of duplicating it).
+  const dbUser = await findDbUserByAccountKey(session.user.id);
+  if (dbUser === null) {
     redirect('/');
   }
-  const userId = dbUser[0].id;
-  const displayName = dbUser[0].displayName;
+  const userId = dbUser.id;
+  const displayName = dbUser.displayName;
 
   // --- Tab 1: My Evidence ---
   const myEvidence = await db

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,9 @@
 import AppChrome from '@/components/AppChrome';
-import { resolveAskHref, resolvePublicSiteHref } from '@/lib/host-routing';
+import {
+  resolveAskHref,
+  resolveDashboardHref,
+  resolvePublicSiteHref,
+} from '@/lib/host-routing';
 
 /**
  * Layout for the `(app)` route group — the gated app surface's shell
@@ -30,7 +34,10 @@ import { resolveAskHref, resolvePublicSiteHref } from '@/lib/host-routing';
  *
  * The "Ask" link (#210) is resolved the same way and for the same reason:
  * this group's `/evidence` pages are dual-served, so the strip can render on
- * the marketing host, where `/ask` is withheld.
+ * the marketing host, where `/ask` is withheld. The "Dashboard" link (#236)
+ * gets the identical treatment — `/dashboard` is app-private exactly as
+ * `/ask` is — threaded the same way the root layout already threads
+ * `resolveDashboardHref` to the header.
  */
 export default function AppLayout({
   children,
@@ -42,6 +49,7 @@ export default function AppLayout({
       <AppChrome
         publicSiteHref={resolvePublicSiteHref(process.env)}
         askHref={resolveAskHref(process.env)}
+        dashboardHref={resolveDashboardHref(process.env)}
       />
       {children}
     </>

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -56,13 +56,24 @@ import { useSession } from 'next-auth/react';
  * split-host instance carries the app origin — the treatment
  * `resolveDashboardHref` established for the header's Dashboard link.
  * Defaults to `/ask`: today's relative path, for any mount that omits it.
+ *
+ * `dashboardHref` (#236) carries the SAME treatment, via
+ * `resolveDashboardHref()` itself — `/dashboard` is app-private exactly as
+ * `/ask` is, so a plain relative link has the same latent 404 on the
+ * marketing-host `/evidence` pages. Latent, because the strip renders only
+ * with a session and sessions read as unauthenticated cross-host — but the
+ * #229 P3 session-visibility direction is what turns that gap real, so the
+ * link gets the origin treatment before it can. Defaults to `/dashboard`:
+ * today's relative path, for any mount that omits it.
  */
 export default function AppChrome({
   publicSiteHref = '/',
   askHref = '/ask',
+  dashboardHref = '/dashboard',
 }: {
   publicSiteHref?: string | null;
   askHref?: string;
+  dashboardHref?: string;
 }) {
   const { data: session, status } = useSession();
   const pathname = usePathname();
@@ -118,7 +129,7 @@ export default function AppChrome({
               Dashboard
             </span>
           ) : (
-            <Link href="/dashboard" style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
+            <Link href={dashboardHref} style={{ color: 'var(--text-secondary)', fontWeight: 500 }}>
               Dashboard
             </Link>
           )}

--- a/src/components/EvidenceOriginProvider.tsx
+++ b/src/components/EvidenceOriginProvider.tsx
@@ -42,3 +42,18 @@ export function EvidenceOriginProvider({
 export function useEvidenceSiteOrigin(): string {
   return useContext(EvidenceOriginContext);
 }
+
+/**
+ * The origin's host, for surfaces that render a bare host label
+ * (`https://example.org` → `example.org`) — the client-side counterpart of
+ * `getPublicationHost()`'s derivation in src/lib/site-config.ts. Falls back
+ * to the raw value when the origin is not URL-parseable, so an instance that
+ * set a bare host still renders something honest rather than nothing.
+ */
+export function toDisplayHost(origin: string): string {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return origin;
+  }
+}

--- a/src/components/evidence/AttestationSection.tsx
+++ b/src/components/evidence/AttestationSection.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useSignInOptions } from '@/components/SignInOptionsProvider';
+import { resolveSignInProse } from '@/lib/auth-provider-options';
 import AttestationDialog from './AttestationDialog';
 
 type AttestationType = 'consistency' | 'evaluation' | 'expert_attestation';
@@ -47,6 +49,13 @@ interface AttestationSectionProps {
 
 export default function AttestationSection({ slug, analysisModel, promptVisibility }: AttestationSectionProps) {
   const { data: session } = useSession();
+  // #235 — the provider-literal class (#229 P1), prose instance: the
+  // signed-out sentence below derives its wording from the providers this
+  // instance configured rather than hardcoding one. This section ships on
+  // the DUAL-SERVED evidence detail page — the marketing host included — so
+  // the hardcoded name was wrong on every non-GitHub instance's public face.
+  // Null (nothing configured) drops the sentence entirely.
+  const signInProse = resolveSignInProse(useSignInOptions());
   const [attestations, setAttestations] = useState<Attestation[]>([]);
   const [expandedPkgs, setExpandedPkgs] = useState<Record<string, AttestationPackageData | null>>({});
   // Expert attestations render their body inline rather than behind a "Show
@@ -180,11 +189,11 @@ export default function AttestationSection({ slug, analysisModel, promptVisibili
           promptVisibility={promptVisibility}
           onAttestationCreated={handleAttestationCreated}
         />
-      ) : (
+      ) : signInProse !== null ? (
         <p style={{ margin: 0, fontSize: '12px', color: 'var(--text-muted)' }}>
-          Sign in with GitHub to add an attestation.
+          {signInProse} to add an attestation.
         </p>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/components/notebook/ChatSignersSection.tsx
+++ b/src/components/notebook/ChatSignersSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { toDisplayHost, useEvidenceSiteOrigin } from '@/components/EvidenceOriginProvider';
+
 /**
  * Phase 2a1 — Signers + attestations placeholder beneath the A-G output.
  * Phase 2a2 item 4 (Option A): the platform signer row is reframed to be
@@ -54,6 +56,12 @@ function PlatformPendingSignerRow({
   signingKeyId: string | null;
   executedAt: string | null;
 }) {
+  // Instance identity (#227 class): this row names WHO will sign at publish
+  // time — the platform signer, which is evidence identity (site-config.ts's
+  // EVIDENCE_* family), never chrome, per brand-config.ts's chrome-vs-
+  // evidence line. So it reads EvidenceOriginProvider, not BrandProvider.
+  // Host only, as the row always rendered it.
+  const platformHost = toDisplayHost(useEvidenceSiteOrigin());
   const keyIdLabel = signingKeyId ?? 'platform key (will resolve at publish)';
   const executedAtLabel = executedAt
     ? `Execution captured ${new Date(executedAt).toLocaleString()}`
@@ -80,7 +88,7 @@ function PlatformPendingSignerRow({
           fontSize: '14px', fontWeight: 500, color: 'var(--text-primary)',
           display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap',
         }}>
-          <span>civicaitools.org</span>
+          <span>{platformHost}</span>
           <span
             style={{
               fontSize: '10px', fontWeight: 600, letterSpacing: '0.04em',

--- a/src/components/roadmap/AudienceRoutingStrip.tsx
+++ b/src/components/roadmap/AudienceRoutingStrip.tsx
@@ -31,7 +31,7 @@ const CARDS: AudienceCard[] = [
   },
   {
     audience: 'OSS contributors',
-    why: 'Where to file, how the three repos relate, and the template for non-trivial roadmap proposals.',
+    why: 'Where to file, how the four repos relate, and the template for non-trivial roadmap proposals.',
     linkLabel: 'CONTRIBUTING.md',
     href: `${HUB_DOC_BASE}/CONTRIBUTING.md`,
     external: true,

--- a/src/components/shared/McpResponseDisplay.tsx
+++ b/src/components/shared/McpResponseDisplay.tsx
@@ -11,6 +11,7 @@ import type { ProgressLogEntry, ProgressGroup, ToolCall, EvidenceTrace } from '@
 import { useSession, signIn } from 'next-auth/react';
 import { useHostLinks } from '@/components/HostLinksProvider';
 import { useSignInOptions } from '@/components/SignInOptionsProvider';
+import { toDisplayHost, useEvidenceSiteOrigin } from '@/components/EvidenceOriginProvider';
 import { resolveSignInAffordance } from '@/lib/auth-provider-options';
 import PublishEvidenceDialog from '@/components/PublishEvidenceDialog';
 
@@ -405,6 +406,12 @@ export default function McpResponseDisplay({
   // #229 P1: the publish button's signed-out, in-place branch starts the
   // provider this instance actually configured — not a hardcoded one (Q63).
   const signInAffordance = resolveSignInAffordance(useSignInOptions());
+  // Instance identity (#227 class): the copied output's attribution line
+  // names the instance the analysis was generated on. That travels off-site
+  // with the copied text — the same identity a published record carries — so
+  // it is evidence identity, not chrome, per brand-config.ts's chrome-vs-
+  // evidence line, and reads EvidenceOriginProvider. Host only, as before.
+  const attributionHost = toDisplayHost(useEvidenceSiteOrigin());
 
   // Use parent-controlled state if provided, otherwise local
   const publishDialogOpen = publishDialogOpenProp ?? publishDialogOpenLocal;
@@ -738,7 +745,7 @@ export default function McpResponseDisplay({
                   if (parts.length > 0) parts.push('---');
                   parts.push(content);
                   // Attribution
-                  parts.push(`\n_Generated via civicaitools.org \u00b7 ${new Date().toLocaleDateString()}_`);
+                  parts.push(`\n_Generated via ${attributionHost} \u00b7 ${new Date().toLocaleDateString()}_`);
                   await navigator.clipboard.writeText(parts.join('\n\n'));
                   setCopied(true);
                   setTimeout(() => setCopied(false), 2000);

--- a/src/lib/auth-provider-options.test.ts
+++ b/src/lib/auth-provider-options.test.ts
@@ -11,6 +11,7 @@ import type { Provider } from 'next-auth/providers/index';
 import {
   DEFAULT_SIGN_IN_OPTIONS,
   resolveSignInAffordance,
+  resolveSignInProse,
   toSignInOptions,
 } from './auth-provider-options.ts';
 import { buildProviders } from './auth-providers.ts';
@@ -142,6 +143,32 @@ test('the reference deployment resolves to exactly the pre-seam button', () => {
     toSignInOptions(buildProviders({ GITHUB_CLIENT_ID: 'id', GITHUB_CLIENT_SECRET: 'secret' })),
   );
   assert.deepEqual(affordance, { kind: 'provider', option: { id: 'github', name: 'GitHub' } });
+});
+
+// --- Prose wording (#235) ---------------------------------------------------
+//
+// The provider-literal class's seventh instance is a SENTENCE, not a control
+// ("Sign in with GitHub to add an attestation."), so it resolves to wording
+// rather than an affordance.
+
+test('resolveSignInProse: one provider ⇒ named; the seam default is today’s exact copy', () => {
+  assert.equal(resolveSignInProse([{ id: 'oidc', name: 'Acme SSO' }]), 'Sign in with Acme SSO');
+  assert.equal(resolveSignInProse(DEFAULT_SIGN_IN_OPTIONS), 'Sign in with GitHub');
+});
+
+test('resolveSignInProse: several providers ⇒ neutral "Sign in" (prose cannot enumerate)', () => {
+  assert.equal(
+    resolveSignInProse([
+      { id: 'github', name: 'GitHub' },
+      { id: 'oidc', name: 'Acme SSO' },
+    ]),
+    'Sign in',
+  );
+});
+
+test('resolveSignInProse: nothing configured ⇒ null — the caller drops the sentence', () => {
+  assert.equal(resolveSignInProse([]), null);
+  assert.equal(resolveSignInProse(toSignInOptions(buildProviders({}))), null);
 });
 
 test('an OIDC-only instance renders its own provider, never GitHub', () => {

--- a/src/lib/auth-provider-options.ts
+++ b/src/lib/auth-provider-options.ts
@@ -92,3 +92,29 @@ export function resolveSignInAffordance(options: SignInOption[]): SignInAffordan
   if (options.length === 1) return { kind: 'provider', option: options[0] };
   return { kind: 'panel', href: SIGN_IN_PANEL_HREF };
 }
+
+/**
+ * The sign-in WORDING for pure prose — copy with no control attached (#235:
+ * `AttestationSection`'s "Sign in with GitHub to add an attestation.", the
+ * seventh instance of the provider-literal class P1 generalized out of the
+ * six interactive affordances). A sentence cannot start an OAuth flow, so it
+ * carries no affordance — but its wording must still be derived from what
+ * the instance configured rather than hardcoded:
+ *
+ * - one provider  → name it ("Sign in with GitHub") — on the reference
+ *   deployment this is byte-for-byte today's copy;
+ * - more than one → "Sign in" — prose can no more enumerate a choice than a
+ *   one-control affordance can, and the surface the reader will actually
+ *   sign in through lists the real options;
+ * - none          → null: the caller drops the sentence entirely. Prose
+ *   inviting a sign-in that cannot complete is the dead button #193 removed,
+ *   in copy form.
+ *
+ * Returns the verb phrase only; the caller owns the rest of its sentence.
+ */
+export function resolveSignInProse(options: SignInOption[]): string | null {
+  const affordance = resolveSignInAffordance(options);
+  if (affordance.kind === 'none') return null;
+  if (affordance.kind === 'provider') return `Sign in with ${affordance.option.name}`;
+  return 'Sign in';
+}

--- a/src/lib/db/creator-evidence.ts
+++ b/src/lib/db/creator-evidence.ts
@@ -1,0 +1,48 @@
+// The dashboard's evidence-records-by-creator data path, extracted so other
+// server components can key on it without duplicating the join logic (#239).
+//
+// Two steps every by-creator surface shares:
+//   1. session account key (`users.githubId` — the provider-account key
+//      column; see src/lib/auth-providers.ts) → internal user row;
+//   2. `evidenceRecords.creatorId` keyed on that row's id.
+//
+// `(app)/dashboard/page.tsx` consumes step 1 (`findDbUserByAccountKey`) and
+// runs the full record selection itself — it needs every column of every
+// record. The `/ask` first-run orientation block consumes
+// `hasPublishedEvidence`: the same keying narrowed to an existence probe —
+// one row, one column — because "has this user ever published" must not pay
+// for the dashboard's full listing on every `/ask` render.
+
+import { db } from '@/lib/db';
+import { users, evidenceRecords } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+/** The internal user row for a session's provider-account key, or null. */
+export async function findDbUserByAccountKey(
+  accountKey: string,
+): Promise<{ id: string; displayName: string } | null> {
+  const rows = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(eq(users.githubId, accountKey))
+    .limit(1);
+  return rows.length > 0 ? rows[0] : null;
+}
+
+/**
+ * Has this account ever published an evidence record? The dashboard's
+ * by-creator keying, narrowed to existence. ANY record counts — withdrawn,
+ * sealed, and public alike — because each is a publish the user performed:
+ * the #239 block orients a user who has never published, not one whose
+ * records are merely private or since withdrawn.
+ */
+export async function hasPublishedEvidence(accountKey: string): Promise<boolean> {
+  const user = await findDbUserByAccountKey(accountKey);
+  if (user === null) return false;
+  const rows = await db
+    .select({ id: evidenceRecords.id })
+    .from(evidenceRecords)
+    .where(eq(evidenceRecords.creatorId, user.id))
+    .limit(1);
+  return rows.length > 0;
+}


### PR DESCRIPTION
The s6 follow-on wave — the three issues the #229 gates ruled out of that sprint's phases, in one PR, plus two disclosed riders in separate, independently droppable commits.

Closes #239
Closes #235
Closes #236

## Commit 1 — the three issues

**#239 — first-run orientation block on `/ask`** (Q63's first-run half, decided at the #229 G0). Server-rendered in the `(app)/ask/page.tsx` mount's framing area, shown only to a signed-in user who has never published, and gone permanently after the first publish — the record itself is the state: no cookie, no dismissal flag, no client state, no new env vars. Keyed on the dashboard's evidence-records-by-creator data path, extracted to `src/lib/db/creator-evidence.ts` (account key → user row; `creatorId` keying narrowed to an existence probe) and consumed by both pages — the dashboard now uses the shared lookup instead of its inline copy. A DB error degrades to today's render rather than failing the page. Copy is provider- and instance-name-free per the #229 P1 / #217 seam discipline.

**#235 — AttestationSection's static "Sign in with GitHub" prose** — the seventh instance of the P1 provider-literal class, resolved on the P1 seam rather than as static copy: a new `resolveSignInProse()` in `src/lib/auth-provider-options.ts` (tested) derives the wording from `useSignInOptions()` — one provider names it ("Sign in with GitHub" on the reference deployment, byte-identical), several say a neutral "Sign in", zero drops the sentence entirely (the #193 dead-button principle, in copy form).

**#236 — AppChrome Dashboard link origin treatment** — mirrors exactly what the s6 P1 Ask link did: `resolveDashboardHref(process.env)` threaded through the `(app)` layout to `AppChrome` as `dashboardHref`, defaulting to today's relative `/dashboard`.

## Commit 2 — rider (disclosed; droppable at review)

Two residual host literals found by the 2026-08-10 fork-cost inventory, same class as #227. Both sit on the evidence side of `brand-config.ts`'s chrome-vs-evidence line, so both now read `EvidenceOriginProvider` (already mounted in the root layout, one hop up):

- `src/components/shared/McpResponseDisplay.tsx` — the copy-button attribution line (`_Generated via civicaitools.org …_`): travels off-site with the copied text, the same identity a published record carries.
- `src/components/notebook/ChatSignersSection.tsx` — the platform pending-signer row's `civicaitools.org` label: names WHO will sign at publish time.

A shared `toDisplayHost()` helper on the provider renders the bare host (the client-side counterpart of `getPublicationHost()`). Drop this commit if the ruling on either provider choice should go the other way.

## Commit 3 — rider (disclosed; droppable at review)

One-word wording fix flagged by the roadmap-refresh work: the `/roadmap` audience routing strip's OSS-contributors row said "how the **three** repos relate"; the project is four repos. `src/components/roadmap/AudienceRoutingStrip.tsx`, count only, nothing else in the file. Independent of everything above.

## Byte parity

Signed-out `/ask` and every apex/marketing surface render byte-identically to `main`:

- The #239 block exists only in `/ask`'s signed-in branch, behind the has-published probe; the signed-out branch is untouched.
- #235's default (`DEFAULT_SIGN_IN_OPTIONS` / the reference deployment's GitHub-only configuration) renders the exact prior sentence, "Sign in with GitHub to add an attestation."
- #236's `resolveDashboardHref` resolves to `/dashboard` with no topology configured, and the strip renders nothing signed-out anyway.
- Both rider literals resolve to the provider defaults (`DEMO_SITE_ORIGIN` → host `civicaitools.org`) when no environment is set — the rendered and copied bytes are unchanged on the reference deployment.

## Verification

- `npm test`: 599/601 pass; the 2 failures are `listen EPERM 127.0.0.1` in `openrouter-streaming.test.ts` — the sandbox forbids binding a local server; unrelated to this diff. New `resolveSignInProse` tests (3) pass.
- `npm run typecheck`: clean.
- `npm run lint`: 0 errors; the 4 warnings are pre-existing and in untouched files.

DCO adoption starts with this wave: every commit carries `Signed-off-by` alongside the co-author trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
