### PR TITLE
fix: route directory and roadmap content sources through instance config (#241)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -423,6 +423,10 @@ exactly the pre-allowlist behavior; see the sign-in section),
 the host-topology set (`APP_HOST`, `MARKETING_HOST`, `APP_ONLY` — with
 none set, every route serves on every host, exactly the single-host
 behavior; see [Host topology](#host-topology-optional)),
+the content-source set (`DIRECTORY_DATA_URL`, `ROADMAP_RAW_URL`,
+`ROADMAP_GITHUB_URL` — with none set, `/directory` and `/roadmap` fetch
+the civic-ai-tools hub repo's content byte-identically to before; see
+[Content sources](#content-sources-directory-and-roadmap)),
 rate-limit and token-budget tuning knobs
 (`ANONYMOUS_RATE_LIMIT`, `AUTHENTICATED_RATE_LIMIT`,
 `APP_TIER_RATE_LIMIT`, `TOKEN_LIMIT_PER_REQUEST`,
@@ -464,6 +468,28 @@ container configuration for the dynamic pages.
 The favicon is a file, not a variable: replace
 [`src/app/favicon.ico`](../src/app/favicon.ico) in your checkout (the
 App Router serves it at `/favicon.ico`) and rebuild.
+
+### Content sources (directory and roadmap)
+
+`/directory` and `/roadmap` fetch their content from the civic-ai-tools
+hub repo by default — its MCP-server directory JSON and its
+`ROADMAP.md`. Left unset, a self-hosted instance therefore serves the
+*reference project's* server directory and roadmap under its own name
+and brand (civic-ai-tools-website#241). Three variables re-point these
+pages at content of your own, all resolved in
+[`src/lib/site-config.ts`](../src/lib/site-config.ts); with none set,
+the fetched bytes and rendered links are identical to before.
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `DIRECTORY_DATA_URL` | `/directory` page data source — a JSON array matching the `McpServerEntry[]` shape in [`src/lib/mcp/directory-data.ts`](../src/lib/mcp/directory-data.ts). On fetch failure the page falls back to the checked-in `directory-fallback.json` snapshot regardless of this value — that snapshot is also the reference project's own data, so a from-scratch instance should supply both. | the civic-ai-tools hub repo's `data/mcp-servers.json` |
+| `ROADMAP_RAW_URL` | `/roadmap` page data source — raw Markdown. | the civic-ai-tools hub repo's `ROADMAP.md` |
+| `ROADMAP_GITHUB_URL` | The "view on GitHub" link rendered on `/roadmap` (the byline and the fetch-failure stub). The byline's visible label text is separate, hardcoded copy and does not follow this variable — see [issue #241](https://github.com/npstorey/civic-ai-tools-website/issues/241) for the open design question on no-config-instance behavior for these two pages. | the civic-ai-tools hub repo's `ROADMAP.md` GitHub URL |
+
+These three are content, not chrome or evidence: unlike the branding set
+above they only change what `/directory` and `/roadmap` fetch and link
+to, and unlike the `EVIDENCE_*` set they are never emitted inside a
+signed evidence package.
 
 ## Sign-in configuration
 

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -233,6 +233,14 @@ export const ENV_SPEC = [
   { name: 'SITE_BRAND_TAGLINE', tier: 'optional', purpose: 'Footer tagline line (default: the demo tagline)', hasFallback: true },
   { name: 'SITE_BRAND_ATTRIBUTION', tier: 'optional', purpose: 'Footer attribution line, plain text (unset: the demo authored attribution markup)', hasFallback: true },
 
+  // --- Instance content sources (#241: src/lib/site-config.ts). All
+  //     optional: with none set, /directory and /roadmap fetch the
+  //     civic-ai-tools hub repo's content byte-identically to before. An
+  //     instance with content of its own points these at it instead. ---
+  { name: 'DIRECTORY_DATA_URL', tier: 'optional', purpose: '/directory page data source — MCP-server JSON (default: the civic-ai-tools hub repo)', hasFallback: true },
+  { name: 'ROADMAP_RAW_URL', tier: 'optional', purpose: '/roadmap page data source — raw ROADMAP.md (default: the civic-ai-tools hub repo)', hasFallback: true },
+  { name: 'ROADMAP_GITHUB_URL', tier: 'optional', purpose: '/roadmap "view on GitHub" link target (default: the civic-ai-tools hub repo)', hasFallback: true },
+
   // --- Optional / feature / ops ---
   { name: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },
   { name: 'CIVICAITOOLS_SESSION_TOKEN', tier: 'optional', purpose: 'publish-evidence skill (Claude Code) auth' },

--- a/src/app/(marketing)/roadmap/page.tsx
+++ b/src/app/(marketing)/roadmap/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
-import { getRoadmapMarkdown, ROADMAP_GITHUB_URL } from '@/lib/roadmap/data';
+import { getRoadmapMarkdown } from '@/lib/roadmap/data';
 import AudienceRoutingStrip from '@/components/roadmap/AudienceRoutingStrip';
 import RoadmapBody from '@/components/roadmap/RoadmapBody';
 import { getBrandName } from '@/lib/brand-config';
+import { getRoadmapGithubUrl } from '@/lib/site-config';
 
 export const metadata: Metadata = {
   title: `Roadmap - ${getBrandName()}`,
@@ -25,7 +26,7 @@ export default async function RoadmapPage() {
         }}
       >
         Renders from{' '}
-        <a href={ROADMAP_GITHUB_URL} target="_blank" rel="noopener noreferrer">
+        <a href={getRoadmapGithubUrl()} target="_blank" rel="noopener noreferrer">
           civic-ai-tools/ROADMAP.md
         </a>
         .
@@ -60,7 +61,7 @@ function RoadmapStub() {
       </p>
       <p style={{ margin: 0 }}>
         Read the canonical version at{' '}
-        <a href={ROADMAP_GITHUB_URL} target="_blank" rel="noopener noreferrer">
+        <a href={getRoadmapGithubUrl()} target="_blank" rel="noopener noreferrer">
           civic-ai-tools/ROADMAP.md
         </a>
         .

--- a/src/lib/mcp/directory-data.ts
+++ b/src/lib/mcp/directory-data.ts
@@ -1,7 +1,9 @@
 // MCP Server Directory data fetching
 // Fetches from GitHub raw at build time, falls back to checked-in snapshot.
+// Source URL is instance configuration — see src/lib/site-config.ts (#241).
 
 import fallbackData from './directory-fallback.json';
+import { getDirectoryDataUrl } from '@/lib/site-config';
 
 // Types — compatible subset of civic-ai-tools/data/mcp-server-schema.ts
 
@@ -61,12 +63,9 @@ export interface McpServerEntry {
   priority?: PriorityTier;
 }
 
-const GITHUB_RAW_URL =
-  'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json';
-
 export async function getDirectoryData(): Promise<McpServerEntry[]> {
   try {
-    const res = await fetch(GITHUB_RAW_URL, {
+    const res = await fetch(getDirectoryDataUrl(), {
       next: { revalidate: 3600 }, // ISR: 1 hour
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/lib/roadmap/data.ts
+++ b/src/lib/roadmap/data.ts
@@ -2,12 +2,9 @@
 // Fetches ROADMAP.md from the civic-ai-tools hub repo on GitHub raw at build time with 1-hour ISR.
 // Mirrors the pattern in `src/lib/mcp/directory-data.ts` — hub repo is source of truth, drift window
 // is small because the doc refreshes quarterly and carries its own version label in the body.
+// Source URLs are instance configuration — see src/lib/site-config.ts (#241).
 
-export const ROADMAP_RAW_URL =
-  'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md';
-
-export const ROADMAP_GITHUB_URL =
-  'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md';
+import { getRoadmapRawUrl } from '@/lib/site-config';
 
 export interface RoadmapFetchResult {
   ok: boolean;
@@ -17,7 +14,7 @@ export interface RoadmapFetchResult {
 
 export async function getRoadmapMarkdown(): Promise<RoadmapFetchResult> {
   try {
-    const res = await fetch(ROADMAP_RAW_URL, {
+    const res = await fetch(getRoadmapRawUrl(), {
       next: { revalidate: 3600 }, // ISR: 1 hour
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/lib/site-config.test.ts
+++ b/src/lib/site-config.test.ts
@@ -1,0 +1,70 @@
+// Instance content-source configuration tests (#241).
+//
+// Covers the /directory and /roadmap content-source getters in
+// site-config.ts: with no environment set, each getter must return the
+// demo deployment's historical hardcoded URL byte-identically (the
+// byte-parity bar); with the corresponding variable set, the override must
+// flow through at call time, not module load — same pattern as
+// brand-config.test.ts.
+
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  DEMO_DIRECTORY_DATA_URL,
+  DEMO_ROADMAP_RAW_URL,
+  DEMO_ROADMAP_GITHUB_URL,
+  getDirectoryDataUrl,
+  getRoadmapRawUrl,
+  getRoadmapGithubUrl,
+} from './site-config.ts';
+
+const CONTENT_SOURCE_VARS = ['DIRECTORY_DATA_URL', 'ROADMAP_RAW_URL', 'ROADMAP_GITHUB_URL'];
+
+afterEach(() => {
+  for (const v of CONTENT_SOURCE_VARS) delete process.env[v];
+});
+
+describe('instance content-source getters (call-time env, demo defaults)', () => {
+  test('unset environment yields the demo civic-ai-tools hub URLs (byte-parity bar)', () => {
+    assert.equal(getDirectoryDataUrl(), DEMO_DIRECTORY_DATA_URL);
+    assert.equal(
+      getDirectoryDataUrl(),
+      'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json'
+    );
+    assert.equal(getRoadmapRawUrl(), DEMO_ROADMAP_RAW_URL);
+    assert.equal(
+      getRoadmapRawUrl(),
+      'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md'
+    );
+    assert.equal(getRoadmapGithubUrl(), DEMO_ROADMAP_GITHUB_URL);
+    assert.equal(
+      getRoadmapGithubUrl(),
+      'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md'
+    );
+  });
+
+  test('set variables override at call time, not module load', () => {
+    process.env.DIRECTORY_DATA_URL = 'https://example.org/mcp-servers.json';
+    process.env.ROADMAP_RAW_URL = 'https://example.org/ROADMAP.md';
+    process.env.ROADMAP_GITHUB_URL = 'https://github.com/example/repo/blob/main/ROADMAP.md';
+    assert.equal(getDirectoryDataUrl(), 'https://example.org/mcp-servers.json');
+    assert.equal(getRoadmapRawUrl(), 'https://example.org/ROADMAP.md');
+    assert.equal(getRoadmapGithubUrl(), 'https://github.com/example/repo/blob/main/ROADMAP.md');
+  });
+
+  test('empty strings fall back to the defaults, matching the rest of site-config.ts', () => {
+    process.env.DIRECTORY_DATA_URL = '';
+    process.env.ROADMAP_RAW_URL = '';
+    process.env.ROADMAP_GITHUB_URL = '';
+    assert.equal(getDirectoryDataUrl(), DEMO_DIRECTORY_DATA_URL);
+    assert.equal(getRoadmapRawUrl(), DEMO_ROADMAP_RAW_URL);
+    assert.equal(getRoadmapGithubUrl(), DEMO_ROADMAP_GITHUB_URL);
+  });
+
+  test('each getter is independently overridable', () => {
+    process.env.DIRECTORY_DATA_URL = 'https://example.org/mcp-servers.json';
+    assert.equal(getDirectoryDataUrl(), 'https://example.org/mcp-servers.json');
+    assert.equal(getRoadmapRawUrl(), DEMO_ROADMAP_RAW_URL);
+    assert.equal(getRoadmapGithubUrl(), DEMO_ROADMAP_GITHUB_URL);
+  });
+});

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -29,6 +29,70 @@ export const SPONSOR: { prefix: string; name: string; url: string } | null = {
   url: 'https://metagov.org',
 };
 
+// --- Instance content sources (#241) ----------------------------------------
+//
+// Every value that names where THIS deployment's `/directory` and `/roadmap`
+// pages fetch their content from resolves through the getters below. The
+// demo defaults are the civicaitools.org reference deployment's historical
+// hardcoded URLs — the civic-ai-tools hub repo's server directory JSON and
+// ROADMAP.md — so with NO environment set the fetched bytes and rendered
+// links are identical to before (the same byte-parity bar as the Evidence
+// instance identity set below).
+//
+// An instance stood up from the guide with no environment set otherwise
+// silently fetches and serves the *reference project's* directory and
+// roadmap under its own name and brand (#241). Setting these variables
+// points each page at the instance's own content instead; leaving them
+// unset is a deliberate choice too — see the PR for #241 for the tradeoffs
+// of each no-config behavior, which this seam does not decide.
+//
+// Values are read at CALL time (not module load), matching the rest of this
+// file.
+
+/** Demo default directory-JSON source (civic-ai-tools hub repo, raw). */
+export const DEMO_DIRECTORY_DATA_URL =
+  'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json';
+
+/** Demo default roadmap markdown source (civic-ai-tools hub repo, raw). */
+export const DEMO_ROADMAP_RAW_URL =
+  'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md';
+
+/** Demo default roadmap "view on GitHub" link (civic-ai-tools hub repo). */
+export const DEMO_ROADMAP_GITHUB_URL =
+  'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md';
+
+/**
+ * Source URL the `/directory` page fetches its MCP-server list from (JSON,
+ * `McpServerEntry[]`). Env: `DIRECTORY_DATA_URL`. On fetch failure the page
+ * falls back to the checked-in `directory-fallback.json` snapshot regardless
+ * of this value — see `src/lib/mcp/directory-data.ts`.
+ */
+export function getDirectoryDataUrl(): string {
+  return process.env.DIRECTORY_DATA_URL || DEMO_DIRECTORY_DATA_URL;
+}
+
+/**
+ * Source URL the `/roadmap` page fetches its markdown body from. Env:
+ * `ROADMAP_RAW_URL`. On fetch failure the page renders a stub pointing at
+ * `getRoadmapGithubUrl()` — see `src/lib/roadmap/data.ts`.
+ */
+export function getRoadmapRawUrl(): string {
+  return process.env.ROADMAP_RAW_URL || DEMO_ROADMAP_RAW_URL;
+}
+
+/**
+ * Human-facing "view on GitHub" link rendered on `/roadmap` (the "Renders
+ * from …" byline and the fetch-failure stub). Env: `ROADMAP_GITHUB_URL`.
+ * NOTE: the byline's visible label text ("civic-ai-tools/ROADMAP.md") is
+ * still hardcoded copy in `roadmap/page.tsx`, independent of this URL — an
+ * instance that overrides this var gets a correct link with a stale label.
+ * Addressing that is part of the #241 attribution design question, not this
+ * seam.
+ */
+export function getRoadmapGithubUrl(): string {
+  return process.env.ROADMAP_GITHUB_URL || DEMO_ROADMAP_GITHUB_URL;
+}
+
 // --- Evidence instance identity (ADR-0020: config, not code) ----------------
 //
 // Every value that names THIS deployment inside emitted evidence surfaces —


### PR DESCRIPTION
Closes #241

## Problem

An instance of this codebase deployed unchanged fetches and serves the *reference project's* content as its own on two surfaces:

- `/directory` — hardcoded the reference hub repo's raw `data/mcp-servers.json` URL.
- `/roadmap` — hardcoded the reference hub repo's raw `ROADMAP.md` URL, plus a second hardcoded URL for the page's "view on GitHub" link.

## Fix (Part 1 — implemented)

Routed all three hardcoded URLs through instance configuration in `src/lib/site-config.ts`, following the existing `EVIDENCE_*` / `SITE_BRAND_*` pattern: call-time env getters over exported demo defaults.

New variables (all optional, `hasFallback: true`, registered in `scripts/preflight-env.mjs`):

| Variable | Reads into | Default |
| --- | --- | --- |
| `DIRECTORY_DATA_URL` | `/directory` page data source | civic-ai-tools hub repo's `data/mcp-servers.json` |
| `ROADMAP_RAW_URL` | `/roadmap` page data source | civic-ai-tools hub repo's `ROADMAP.md` |
| `ROADMAP_GITHUB_URL` | `/roadmap` "view on GitHub" link target | civic-ai-tools hub repo's `ROADMAP.md` GitHub URL |

**Byte-parity statement:** with none of the three variables set, `getDirectoryDataUrl()`, `getRoadmapRawUrl()`, and `getRoadmapGithubUrl()` return exactly the same literal strings the code previously hardcoded — so the fetched bytes and rendered links for a no-config instance are byte-identical to before this PR. Covered by `src/lib/site-config.test.ts` (new file, following `brand-config.test.ts`'s pattern: defaults, call-time overrides, empty-string fallback, independent overridability).

**Config module choice.** `brand-config.ts` is explicitly scoped to chrome only ("CHROME, NOT EVIDENCE" — never emitted inside a signed evidence artifact, per its header comment). `site-config.ts`'s evidence-identity section is explicitly scoped to values emitted inside signed evidence surfaces. Directory and roadmap content sources are neither: they're general external URLs the page fetches and links to, which is exactly what `site-config.ts`'s top section (`TYPED_STANDARDS_URL`, `EXPRESS_INTEREST_URL`) already houses. Added a new "Instance content sources (#241)" section there rather than in either specialized module.

**One nuance surfaced, not fixed:** `/roadmap`'s byline ("Renders from civic-ai-tools/ROADMAP.md") has a hardcoded *label* text that is separate from the `ROADMAP_GITHUB_URL` it links to. An instance that sets `ROADMAP_GITHUB_URL` gets a correct link with a stale label. Flagged in the code comment and `docs/deploy.md`; addressing it is bundled into the Part 2 decision below rather than fixed here, since it's about what the page should say about its content's provenance — exactly the open question.

Also updated: `scripts/preflight-env.mjs` (new "Instance content sources" group, mirroring the branding group), `docs/deploy.md` (new "Content sources (directory and roadmap)" subsection + an entry in the "merely overrides a default" list).

## Part 2 — no-config-instance behavior (owner decision, not implemented here)

The issue raises what a no-config instance *should* render on `/directory` and `/roadmap` when it has no directory or roadmap of its own — this PR only makes the behavior *configurable*, it does not change what happens when nothing is configured (preserves today's rendering, per the conservative default the task asked for).

Options, as I see them:

1. **Keep serving upstream content, with explicit "from the upstream project" attribution.** Today's behavior, made honest: add a visible line (not just a small byline link, as `/roadmap` already half-does) stating the content is the civic-ai-tools reference project's own directory/roadmap, not this instance's. Lowest implementation cost — mostly copy — and keeps the pages populated and useful as a fallback demo. Downside: still not *this instance's* content; an operator who forgets to set the new vars still ships someone else's roadmap, just now correctly labeled as such.
2. **Hide the routes when unconfigured.** `/directory` and `/roadmap` 404 or redirect when `DIRECTORY_DATA_URL`/`ROADMAP_RAW_URL` are unset. Cleanest correctness story — a no-config instance never claims content it doesn't have — but breaks the reference deployment itself (civicaitools.org relies on the demo defaults resolving to real content) unless the demo deployment gets its own explicit env values to keep the routes live, and removes a page from the nav for every fresh clone until configured, which may look broken during initial bring-up.
3. **Render an empty/placeholder state.** "No directory configured for this instance yet" with a link to `docs/deploy.md`. Similar correctness story to (2) without a 404 — the route stays navigable and self-documenting — but is more page-content work (a real placeholder component per page) than (1) or (2).

**My recommendation: option 1** (upstream content + explicit attribution), for two reasons. First, it's the smallest change from today's actual behavior — these pages aren't broken today, they're *mislabeled*, so the fix that matches the problem is labeling, not withholding. Second, it keeps a fresh clone's `/directory` and `/roadmap` populated and demonstrable out of the box, which matters for a reference project whose whole point is being cloned and explored — hiding the routes (option 2) or blanking them (option 3) makes the very first `npm run dev` after `git clone` look emptier than it is today, for a project that leads with "clone and explore." Attribution copy should make unmistakably clear the content belongs to the upstream project when `DIRECTORY_DATA_URL`/`ROADMAP_RAW_URL` are unset, addressing the "actively wrong" framing in the issue without sacrificing the out-of-the-box demo experience.

## Test results

- `npm ci` — clean.
- `npm test` — 603 pass, 2 fail. Both failures are `src/lib/openrouter-streaming.test.ts` (`listen EPERM: operation not permitted 127.0.0.1`) — the sandbox denies socket binds, unrelated to this change (pre-existing, named in the task brief as a known artifact). All 4 new `site-config.test.ts` cases pass; all 40 `preflight-env.test.mjs` cases pass.
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors, 4 pre-existing warnings in unrelated files.
- `npm run build` — fails in this sandbox only: Turbopack can't reach `fonts.googleapis.com` for `next/font` (Noto Sans, Space Grotesk) because the sandbox's network allowlist doesn't include Google Fonts. Unrelated to the code change — this repo's font loading has always required network access to Google at build time, and the sandbox's allowlist is scoped to `registry.npmjs.org`/GitHub hosts. Flagging for a build run outside this sandbox.

## Deviations

- Removed the previously-exported `ROADMAP_RAW_URL` / `ROADMAP_GITHUB_URL` constants from `src/lib/roadmap/data.ts` and the previously-internal `GITHUB_RAW_URL` constant from `src/lib/mcp/directory-data.ts`, replacing them with the new call-time getters. A static exported constant can't honor "read at call time" (tests need to vary it per-process, same reasoning as the existing `EVIDENCE_*`/`SITE_BRAND_*` getters). Updated the one other consumer (`src/app/(marketing)/roadmap/page.tsx`) to import `getRoadmapGithubUrl` from `site-config.ts` directly, matching how that same file already imports `getBrandName` from `brand-config.ts`. Confirmed via grep these were the only usages outside the two data modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
