### PR TITLE
fix: model roster currency — delisted model, pricing gaps (#232)

### DIFF
--- a/src/app/api/evidence/generate-summary/route.ts
+++ b/src/app/api/evidence/generate-summary/route.ts
@@ -3,7 +3,7 @@ import { createModelClient } from '@/lib/model-client';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 
-const SUMMARY_MODEL = 'google/gemini-2.0-flash-001';
+const SUMMARY_MODEL = 'google/gemini-3.5-flash-lite';
 
 const SYSTEM_PROMPT = `You are writing a one-paragraph summary of an AI-assisted civic data analysis for a non-technical reader (journalist, community board member, city staff).
 

--- a/src/components/evidence/AttestationDialog.tsx
+++ b/src/components/evidence/AttestationDialog.tsx
@@ -125,7 +125,7 @@ function computeConsistencyMetrics(runs: ReplayResult[]): ConsistencyMetrics {
 const EVALUATOR_MODELS = [
   { id: 'openai/gpt-4o', name: 'GPT-4o' },
   { id: 'openai/gpt-5.4', name: 'GPT-5.4' },
-  { id: 'google/gemini-2.0-flash-001', name: 'Gemini 2.0 Flash' },
+  { id: 'google/gemini-3.5-flash-lite', name: 'Gemini 3.5 Flash Lite' },
   { id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' },
   { id: 'anthropic/claude-haiku-4.5', name: 'Claude Haiku 4.5' },
 ];

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -414,8 +414,8 @@ export const availableModels: ModelDefinition[] = [
     description: 'Highest quality analysis, newest model',
   },
   {
-    id: 'google/gemini-2.0-flash-001',
-    name: 'Gemini 2.0 Flash',
+    id: 'google/gemini-3.5-flash-lite',
+    name: 'Gemini 3.5 Flash Lite',
     tag: 'fastest',
     provider: 'Google',
     supports_tools: true,

--- a/src/lib/models.test.ts
+++ b/src/lib/models.test.ts
@@ -1,0 +1,36 @@
+// Guards the model-roster/pricing-table coupling that caused #232: the UI
+// roster (`availableModels` in mcp/tools.ts) and the cost-estimation table
+// (`MODEL_PRICING` in this file) are two separate maps kept in sync by hand.
+// A model id present in one and missing from the other is exactly the defect
+// class from #232 — `estimateCostUsd` silently returns null for it. This test
+// turns that into a CI failure instead of a silent gap.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MODEL_PRICING } from './models.ts';
+import { availableModels } from './mcp/tools.ts';
+
+test('every availableModels id has a MODEL_PRICING entry', () => {
+  const missing = availableModels
+    .map((m) => m.id)
+    .filter((id) => !(id in MODEL_PRICING));
+  assert.deepEqual(
+    missing,
+    [],
+    `availableModels ids missing from MODEL_PRICING: ${missing.join(', ')}`,
+  );
+});
+
+test('the notebook route default model has a MODEL_PRICING entry', () => {
+  // Mirrors DEFAULT_MODEL in src/app/api/query-notebook/route.ts. That file
+  // pulls in next/headers and next-auth, which aren't safe to import under
+  // node:test, so the id is duplicated here rather than imported — keep the
+  // two in sync by hand if the route's default model changes.
+  const NOTEBOOK_DEFAULT_MODEL = 'anthropic/claude-sonnet-4-6';
+  assert.ok(
+    NOTEBOOK_DEFAULT_MODEL in MODEL_PRICING,
+    `notebook route default model "${NOTEBOOK_DEFAULT_MODEL}" is missing from MODEL_PRICING`,
+  );
+});

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,15 +1,18 @@
 /**
  * Model pricing and display helpers.
  *
- * Prices per 1M tokens (USD) — current OpenRouter pricing as of 2026-04-12.
- * Update when OpenRouter pricing changes.
+ * Prices per 1M tokens (USD) — current OpenRouter pricing as of 2026-08-11.
+ * Update when OpenRouter pricing changes. Every id offered in `availableModels`
+ * (src/lib/mcp/tools.ts) must have an entry here — see models.test.ts.
  */
 
 export const MODEL_PRICING: Record<string, { input: number; output: number }> = {
   'openai/gpt-4o':                  { input: 2.50, output: 10.00 },
   'openai/gpt-5.4':                 { input: 2.50, output: 15.00 },
-  'google/gemini-2.0-flash-001':    { input: 0.10, output: 0.40 },
+  'google/gemini-3.5-flash-lite':   { input: 0.30, output: 2.50 },
   'anthropic/claude-sonnet-4':      { input: 3.00, output: 15.00 },
+  'anthropic/claude-sonnet-4-6':    { input: 3.00, output: 15.00 },
+  'anthropic/claude-opus-5':        { input: 5.00, output: 25.00 },
   'anthropic/claude-haiku-4.5':     { input: 1.00, output: 5.00 },
 };
 
@@ -38,8 +41,10 @@ export function formatModelName(id: string): string {
   const map: Record<string, string> = {
     'openai/gpt-4o':                  'GPT-4o',
     'openai/gpt-5.4':                 'GPT-5.4',
-    'google/gemini-2.0-flash-001':    'Gemini 2.0 Flash',
+    'google/gemini-3.5-flash-lite':   'Gemini 3.5 Flash Lite',
     'anthropic/claude-sonnet-4':      'Claude Sonnet 4',
+    'anthropic/claude-sonnet-4-6':    'Claude Sonnet 4.6',
+    'anthropic/claude-opus-5':        'Claude Opus 5',
     'anthropic/claude-haiku-4.5':     'Claude Haiku 4.5',
   };
   return map[id] || id;


### PR DESCRIPTION
Closes #232

## Summary

Re-verified the model roster and pricing table against OpenRouter's live API (checked 2026-08-11). `google/gemini-2.0-flash-001` is confirmed delisted (zero active endpoints) and was replaced everywhere it's hardcoded. `MODEL_PRICING` gained the two missing entries the issue flagged, and every existing entry was re-verified against live pricing.

## 1. Delisted model — confirmed and replaced

`GET https://openrouter.ai/api/v1/models/google/gemini-2.0-flash-001/endpoints` (checked 2026-08-11):
```json
{"data":{"id":"google/gemini-2.0-flash-001","name":"Google: Gemini 2.0 Flash","endpoints":[]}}
```
Zero endpoints — matches the issue's 2026-08-09 finding, still true two days later.

**Replacement: `google/gemini-3.5-flash-lite`** — chosen after checking three current Google flash-tier candidates via their `/endpoints` responses:

| Model | Endpoints | Price (in/out per 1M) | Notes |
|---|---|---|---|
| `google/gemini-3.5-flash-lite` | 7 live, status 0 | **$0.30 / $2.50** | Current cheapest live Gemini text model; description: "high-efficiency model... suited for subagents that execute focused tasks" — matches the roster's existing "fastest / budget-friendly" tag and description verbatim |
| `google/gemini-2.5-flash` | 7 endpoints, one at status -5 | $0.30 / $2.50 | Previous generation; one unhealthy endpoint |
| `google/gemini-3.6-flash` | 6 live, status 0 | $1.50 / $7.50 | Current standard-tier flash — 5x pricier, not the budget option |
| `google/gemini-3.6-flash-lite` | — | — | Does not exist (404) |

All `gemini-3.5-flash-lite` endpoints report `"tools"` in `supported_parameters` (the app calls it via OpenRouter's function-calling schema in `src/lib/mcp/tools.ts`), so it's a functional drop-in.

**Every hardcoded occurrence of the delisted id was updated** (grepped across `.ts`/`.tsx`), not just `availableModels`:
- `src/lib/mcp/tools.ts` — `availableModels` (the UI roster served via `/api/models`) — the change named in the issue
- `src/lib/models.ts` — `MODEL_PRICING` + `formatModelName`
- `src/components/evidence/AttestationDialog.tsx` — `EVALUATOR_MODELS`, a second UI list offering the same delisted model as an evaluator choice
- `src/app/api/evidence/generate-summary/route.ts` — `SUMMARY_MODEL`, the hardcoded default for the "generate summary" feature (not UI-selectable, but a real runtime dependency that would fail the same way)

These weren't named in the issue's file list but are the identical defect (same delisted id, same "zero endpoints" failure mode), so leaving them unpatched felt like an incomplete fix. Flagging here in case the scope was meant to stay narrower than that.

**Left untouched, flagged instead:** `scripts/eval-models.mjs` also lists `google/gemini-2.0-flash-001`. It's a standalone, manually-invoked offline eval harness (`OPENROUTER_API_KEY=... node scripts/eval-models.mjs`) — not imported by the app, not covered by `npm test`, and its own model list already has pre-existing inconsistencies (`anthropic/claude-sonnet-4.6` with a dot vs the app's dash form, `anthropic/claude-haiku-4-5` with a dash vs OpenRouter's actual `anthropic/claude-haiku-4.5`). Didn't want to blur this PR's focus fixing a dev script with its own separate staleness; worth a follow-up if it's still in use.

## 2. `MODEL_PRICING` gaps — added and re-verified

Checked every model's `/endpoints` response on OpenRouter (2026-08-11), using the primary (non-regional-premium) tier pricing:

| Model | Input | Output | Source | Status |
|---|---|---|---|---|
| `anthropic/claude-sonnet-4-6` | $3.00 | $15.00 | `/api/v1/models/anthropic/claude-sonnet-4-6/endpoints` (7 endpoints, Anthropic direct tier) | **Added** — this is `query-notebook/route.ts`'s own `DEFAULT_MODEL`; `estimateCostUsd` was silently returning `null` for every default-model notebook query |
| `anthropic/claude-opus-5` | $5.00 | $25.00 | `/api/v1/models/anthropic/claude-opus-5/endpoints` (9 endpoints, Anthropic direct tier) | **Added** |
| `openai/gpt-4o` | $2.50 | $10.00 | `/api/v1/models/openai/gpt-4o/endpoints` (OpenAI tier) | No drift — matches existing entry |
| `openai/gpt-5.4` | $2.50 | $15.00 | `/api/v1/models/openai/gpt-5.4/endpoints` (OpenAI standard tier) | No drift — matches existing entry |
| `anthropic/claude-sonnet-4` | $3.00 | $15.00 | `/api/v1/models/anthropic/claude-sonnet-4/endpoints` (5 endpoints, still live) | No drift — matches existing entry |
| `anthropic/claude-haiku-4.5` | $1.00 | $5.00 | `/api/v1/models/anthropic/claude-haiku-4.5/endpoints` (7 endpoints, Anthropic direct tier) | No drift — matches existing entry |
| `google/gemini-3.5-flash-lite` | $0.30 | $2.50 | see §1 above | New (replaces the delisted entry) |

Header date comment refreshed from `2026-04-12` to `2026-08-11` (the date I actually checked).

## 3. The coupling — and a guard test

`availableModels` (`src/lib/mcp/tools.ts`) and `MODEL_PRICING` (`src/lib/models.ts`) are two separate hand-maintained maps, plus a third list (`EVALUATOR_MODELS` in `AttestationDialog.tsx`) and a fourth constant (`SUMMARY_MODEL`) that all carry the same model-id strings independently. An id present in the roster but missing from the pricing table is exactly this issue's defect class — `estimateCostUsd` returns `null` silently, with no error, no log, nothing visibly broken until someone notices a missing cost figure.

Added `src/lib/models.test.ts`:
- Asserts every `availableModels` id has a `MODEL_PRICING` entry (iterates the real roster — this would have caught the original bug and will catch it again the next time a model is added to the roster without a pricing entry).
- Asserts the notebook route's default model (`anthropic/claude-sonnet-4-6`, duplicated as a literal since the route file pulls in `next/headers`/`next-auth` and isn't safe to import under `node:test`) has a pricing entry.

This turns the defect class into a CI failure (`build / test / lint / typecheck` is a required check on this repo) instead of a silent gap. It does not cover `EVALUATOR_MODELS` or `SUMMARY_MODEL` — those aren't sourced from `availableModels`, so a general "every hardcoded model id anywhere has a pricing entry" guard would need a different shape (e.g. a lint rule or a registry refactor); flagging as a possible follow-up rather than building it into this PR.

## Verification

- `npm ci` — clean install
- `npm test` — 603 tests, 601 pass, 2 fail with `listen EPERM: operation not permitted 127.0.0.1` (the documented sandbox artifact — the sandbox denies local socket binds; these two tests spin up a mock HTTP server and are unrelated to this change). The new `models.test.ts` guard test passes both subtests.
- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 4 pre-existing warnings (unrelated: `AttestationDialog.tsx` `EXPERT_RATINGS` unused-as-value, `animation.ts` `mapEventToNodes` unused — both are documented pre-existing tech debt in the repo's CLAUDE.md — plus `eval-models.mjs` and an `<img>` warning, neither touched by this change)
- `npm run build` — failed in this sandbox because Turbopack can't reach `fonts.googleapis.com` (not on the sandbox's network allowlist) to fetch Noto Sans / Space Grotesk. This is a sandbox network restriction, not a code issue — unrelated to the model roster/pricing changes, which are plain data changes with no font/build-config touch.

## Deviations from the brief

- Extended the fix to two additional hardcoded occurrences of the delisted model (`AttestationDialog.tsx`, `generate-summary/route.ts`) beyond the two files named in the issue — see §1.
- Could not run a full production build in this sandbox (network restriction on Google Fonts); typecheck + lint + test are the verification signal for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
