### PR TITLE
docs+chore: snapshot-expiry note, iteration count, preflight inventory gap (#233)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ The diagram shows the comparison path as the reference deployment runs it. The s
 - Uses `openai` npm package with `baseURL: 'https://openrouter.ai/api/v1'`
 - Tool calling follows OpenAI function calling format
 - Same model used for both with/without MCP comparisons
-- **Max 10 tool iterations** to prevent infinite loops
+- **Tool iteration cap** to prevent infinite loops — see `maxIterations` in `src/lib/openrouter-streaming.ts` for the current value (cited rather than restated here so this line can't drift out of sync with the code)
 - **Force final response**: If iteration limit hit with no content, makes one more call without tools to get a summary
 
 ### MCP Tool Execution Flow

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -844,6 +844,36 @@ a section's worth of differences, not a parallel guide:
   exactly as described above. The preflight resolves this as the default
   profile and reports accordingly.
 
+### Ops note: sandbox snapshot expiry
+
+Vercel Sandbox's platform default expires a snapshot **30 days after its
+last use**. `scripts/build-sandbox-snapshot.ts` already opts out of that
+(`sandbox.snapshot({ expiration: 0 })` — `0` is the platform's documented
+sentinel for "never expire"), so a snapshot built via
+`npm run sandbox:build-snapshot` shouldn't be on that clock at all. The
+residual risk is a `SANDBOX_SNAPSHOT_ID` that came from somewhere else —
+hand-built without an equivalent no-expiration flag, or predating this
+override.
+
+**Recognize it:** neither `execute.ts` nor `vercel-sandbox.ts` catches a
+failed snapshot boot, so a lapsed snapshot is more likely to surface as an
+outright execution failure at the sandbox-boot step than as a merely slow
+one. Check proactively with the Sandbox CLI:
+`sandbox snapshots get $SANDBOX_SNAPSHOT_ID` (`created` = healthy,
+`deleted` = expired/removed).
+
+**Refresh:** `npm run sandbox:build-snapshot`, then set the printed id on
+`SANDBOX_SNAPSHOT_ID` in both Vercel scopes.
+
+**Keep-warm:** not worth automating at the current volume (roughly one
+published run a month), and less useful here than usual — the
+`expiration: 0` override already removes the 30-day timer for anything the
+script built, so a scheduled keep-warm job would mostly be insuring
+against the residual-risk case above, not the general platform behavior.
+Left manual: rebuild on a sandbox-boot failure, or whenever pinned library
+versions change (which already forces a rebuild). Revisit if run volume or
+the failure mode changes.
+
 ## Vocabulary notes for integrators
 
 If you build against your instance's API, three vocabulary facts prevent

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -154,6 +154,14 @@ export const ENV_SPEC = [
   // fallback-backed under both (container.ts:47 → DEFAULT_CONTAINER_IMAGE), so
   // it carries no condition: it is never a miss and never a nag either way.
   { name: 'EXECUTOR_CONTAINER_IMAGE', tier: 'optional', purpose: 'Executor image tag (EXECUTOR_DRIVER=container only; default civic-notebook-executor:0.1.0)', hasFallback: true },
+  // Passed into every executed notebook's env by buildNotebookEnv
+  // (src/lib/sandbox/execute.ts), under BOTH executor drivers — read by the
+  // generated notebook's own helper functions (fetch_socrata.py,
+  // fetch_data_commons.py), not by the app itself. Both degrade gracefully
+  // (throttled / anonymous access) rather than hard-failing, so no tier
+  // promotion and no onlyWhen condition.
+  { name: 'SOCRATA_APP_TOKEN', tier: 'optional', purpose: 'Socrata app token for executed notebooks (fetch_socrata.py) — raises the anonymous per-IP rate limit; throttled but functional without it', hasFallback: true },
+  { name: 'DC_API_KEY', tier: 'optional', purpose: 'Data Commons API key for executed notebooks (fetch_data_commons.py) — distinct from DATA_COMMONS_API_KEY (the chat-flow MCP key); anonymous access works for moderate volumes without it', hasFallback: true },
   // Sandbox-only: the container driver boots a local image and reads none of
   // these four (vercel-sandbox.ts:89-96 is behind the driver's dynamic import).
   { name: 'SANDBOX_SNAPSHOT_ID', tier: 'recommended', purpose: 'Prebuilt sandbox snapshot — absent, the vercel-sandbox driver falls back to a slow fresh boot + pip install', hasFallback: true, onlyWhen: { executor: 'vercel-sandbox' } },


### PR DESCRIPTION
Closes #233

## Summary

Three small, independent follow-ups from the 2026-08-09 notebook-cost analysis.

## What I verified per item

**1. Sandbox snapshot expiry — ops note (`docs/deploy.md`, "Managed-platform deployment" section)**

Confirmed against current Vercel documentation (fetched live, dated 2026-08-04) that Vercel Sandbox snapshots default to expiring 30 days after last use. Also found that `scripts/build-sandbox-snapshot.ts` already calls `sandbox.snapshot({ expiration: 0 })`, and `0` is the platform's documented sentinel for "never expire" — this override has been in the script since its first commit (2026-05-22), so a snapshot built via `npm run sandbox:build-snapshot` shouldn't actually be on the 30-day clock. I wrote the ops note to reflect that accurately rather than restate the issue's framing verbatim: it explains the platform default, notes the script's existing opt-out, and covers the residual risk (a snapshot that didn't go through that script). I also checked `src/lib/sandbox/execute.ts` and `vercel-sandbox.ts` and found no fallback/retry path around a failed snapshot boot — `Sandbox.create()` is awaited uncaught — so the note describes the likely symptom as an outright execution failure at the sandbox-boot step rather than a silently slow one, and gives the Sandbox CLI command (`sandbox snapshots get $SANDBOX_SNAPSHOT_ID`) to check proactively. Covers refresh (`npm run sandbox:build-snapshot`) and the keep-warm tradeoff (left manual, and less necessary than usual given the existing override).

Edited only the new "### Ops note: sandbox snapshot expiry" subsection under "## Managed-platform deployment" — did not touch the "Content sources (directory and roadmap)" or "Before you start" sections other agents were concurrently editing in the same file.

**2. Stale iteration count (`CLAUDE.md`)**

Verified `maxIterations = 20` in `src/lib/openrouter-streaming.ts:186` (CLAUDE.md said "Max 10"). Fixed by citing the constant's location instead of restating a literal, per the issue's preference, so the doc can't drift out of sync again.

**3. Preflight inventory gap (`scripts/preflight-env.mjs`)**

Verified both `SOCRATA_APP_TOKEN` and `DC_API_KEY` are read in `src/lib/sandbox/execute.ts` (`buildNotebookEnv`) and passed into every executed notebook's environment, regardless of `EXECUTOR_DRIVER` — consumed by the generated notebook's own helpers (`fetch_socrata.py`, `fetch_data_commons.py`), not by the app directly. Neither was registered in `ENV_SPEC`. Confirmed neither is a rename/alias of an existing entry — `DATA_COMMONS_API_KEY` is a distinct variable for the chat-flow MCP path (mandatory-auth, already registered as `recommended`), while `DC_API_KEY` is for the executed-notebook path (optional, graceful anonymous fallback). Registered both as `optional`-tier entries with `hasFallback: true` (both degrade gracefully — throttled/anonymous access — rather than hard-failing), matching the file's existing conventions and comment style.

## Verification

- `npm ci` — clean install
- `npm test` — 605/607 pass; the 2 failures are the known `listen EPERM: operation not permitted 127.0.0.1` socket-bind sandbox artifact in `src/lib/openrouter-streaming.test.ts` (environmental, unrelated to this change)
- `node --test scripts/preflight-env.test.mjs` — 40/40 pass (the preflight's own suite, unaffected by the two new entries)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 4 pre-existing warnings (already documented in CLAUDE.md's Known Tech Debt), none introduced by this change

## Nothing skipped

All three items verified as accurate and applied as described (with the deploy.md note's framing adjusted per the verification above to reflect that the snapshot-build script already mitigates the general platform behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
