### PR TITLE
feat: instance content-source presentation — attributed directory, own-roadmap-only (#241)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -424,8 +424,10 @@ the host-topology set (`APP_HOST`, `MARKETING_HOST`, `APP_ONLY` — with
 none set, every route serves on every host, exactly the single-host
 behavior; see [Host topology](#host-topology-optional)),
 the content-source set (`DIRECTORY_DATA_URL`, `ROADMAP_RAW_URL`,
-`ROADMAP_GITHUB_URL` — with none set, `/directory` and `/roadmap` fetch
-the civic-ai-tools hub repo's content byte-identically to before; see
+`ROADMAP_GITHUB_URL` — with none set, `/directory` serves the shared
+community index with attribution; `ROADMAP_RAW_URL` is the one entry in
+this list that is not merely a default, since absent it means this
+instance has published no roadmap and `/roadmap` says so; see
 [Content sources](#content-sources-directory-and-roadmap)),
 rate-limit and token-budget tuning knobs
 (`ANONYMOUS_RATE_LIMIT`, `AUTHENTICATED_RATE_LIMIT`,
@@ -471,20 +473,37 @@ App Router serves it at `/favicon.ico`) and rebuild.
 
 ### Content sources (directory and roadmap)
 
-`/directory` and `/roadmap` fetch their content from the civic-ai-tools
-hub repo by default — its MCP-server directory JSON and its
-`ROADMAP.md`. Left unset, a self-hosted instance therefore serves the
-*reference project's* server directory and roadmap under its own name
-and brand (civic-ai-tools-website#241). Three variables re-point these
-pages at content of your own, all resolved in
-[`src/lib/site-config.ts`](../src/lib/site-config.ts); with none set,
-the fetched bytes and rendered links are identical to before.
+These three variables tell the two content pages where *your* content
+lives. All are resolved in
+[`src/lib/site-config.ts`](../src/lib/site-config.ts), and unset means
+one thing only: this instance has no content source of its own
+(civic-ai-tools-website#241). No variable here falls back to another
+project's roadmap, and the reference deployment at civicaitools.org sets
+them explicitly like any other instance.
 
-| Variable | Meaning | Default |
+| Variable | Meaning | Unset |
 | --- | --- | --- |
-| `DIRECTORY_DATA_URL` | `/directory` page data source — a JSON array matching the `McpServerEntry[]` shape in [`src/lib/mcp/directory-data.ts`](../src/lib/mcp/directory-data.ts). On fetch failure the page falls back to the checked-in `directory-fallback.json` snapshot regardless of this value — that snapshot is also the reference project's own data, so a from-scratch instance should supply both. | the civic-ai-tools hub repo's `data/mcp-servers.json` |
-| `ROADMAP_RAW_URL` | `/roadmap` page data source — raw Markdown. | the civic-ai-tools hub repo's `ROADMAP.md` |
-| `ROADMAP_GITHUB_URL` | The "view on GitHub" link rendered on `/roadmap` (the byline and the fetch-failure stub). The byline's visible label text is separate, hardcoded copy and does not follow this variable — see [issue #241](https://github.com/npstorey/civic-ai-tools-website/issues/241) for the open design question on no-config-instance behavior for these two pages. | the civic-ai-tools hub repo's `ROADMAP.md` GitHub URL |
+| `DIRECTORY_DATA_URL` | `/directory` data source — a JSON array matching the `McpServerEntry[]` shape in [`src/lib/mcp/directory-data.ts`](../src/lib/mcp/directory-data.ts). | The page serves the shared community index (the civic-ai-tools hub repo's `data/mcp-servers.json`) with a visible line attributing it to that project. |
+| `ROADMAP_RAW_URL` | `/roadmap` data source — raw Markdown. | `/roadmap` says this site has not published a roadmap, and the Roadmap link leaves the header and footer nav. |
+| `ROADMAP_GITHUB_URL` | Where `/roadmap`'s "Renders from …" byline links. | Derived from `ROADMAP_RAW_URL` — a GitHub raw URL resolves to its file page. The byline's visible label is derived from whichever URL it links to, so label and link cannot drift apart. |
+
+**Why the two pages differ.** A curated index of public MCP servers is a
+shared community resource: it is useful to any instance, so an
+unconfigured `/directory` keeps serving it and says whose it is. A
+roadmap is first-person — "our plans" — so another project's roadmap
+under your brand is wrong even when attributed, and an unconfigured
+`/roadmap` presents none. The route stays reachable and explains how to
+configure it; only the nav entry disappears.
+
+If your directory source cannot be fetched, the page falls back to the
+`directory-fallback.json` snapshot checked into this codebase and says
+so. That snapshot is a copy of the community index, so an instance that
+wants nothing upstream in its directory should supply both its own
+`DIRECTORY_DATA_URL` and its own snapshot.
+
+Set these **in the build environment as well as at run time**: both
+pages prerender with 1-hour ISR, so a change takes effect on the next
+build or revalidation, not immediately.
 
 These three are content, not chrome or evidence: unlike the branding set
 above they only change what `/directory` and `/roadmap` fetch and link

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -234,12 +234,13 @@ export const ENV_SPEC = [
   { name: 'SITE_BRAND_ATTRIBUTION', tier: 'optional', purpose: 'Footer attribution line, plain text (unset: the demo authored attribution markup)', hasFallback: true },
 
   // --- Instance content sources (#241: src/lib/site-config.ts). All
-  //     optional: with none set, /directory and /roadmap fetch the
-  //     civic-ai-tools hub repo's content byte-identically to before. An
-  //     instance with content of its own points these at it instead. ---
-  { name: 'DIRECTORY_DATA_URL', tier: 'optional', purpose: '/directory page data source — MCP-server JSON (default: the civic-ai-tools hub repo)', hasFallback: true },
-  { name: 'ROADMAP_RAW_URL', tier: 'optional', purpose: '/roadmap page data source — raw ROADMAP.md (default: the civic-ai-tools hub repo)', hasFallback: true },
-  { name: 'ROADMAP_GITHUB_URL', tier: 'optional', purpose: '/roadmap "view on GitHub" link target (default: the civic-ai-tools hub repo)', hasFallback: true },
+  //     optional, and unset means one thing: this instance has no content
+  //     source of its own. /directory then serves the shared community index
+  //     with attribution; /roadmap renders as unpublished and drops out of
+  //     the nav rather than showing another project's plans. ---
+  { name: 'DIRECTORY_DATA_URL', tier: 'optional', purpose: '/directory data source — MCP-server JSON (unset: the community index, shown with attribution)', hasFallback: true },
+  { name: 'ROADMAP_RAW_URL', tier: 'optional', purpose: '/roadmap data source — raw Markdown (unset: /roadmap says no roadmap is published and leaves the nav)', hasFallback: true },
+  { name: 'ROADMAP_GITHUB_URL', tier: 'optional', purpose: '/roadmap "view source" link and byline label (unset: derived from ROADMAP_RAW_URL)', hasFallback: true },
 
   // --- Optional / feature / ops ---
   { name: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },

--- a/src/app/(marketing)/directory/page.tsx
+++ b/src/app/(marketing)/directory/page.tsx
@@ -3,6 +3,7 @@ import { getDirectoryData } from '@/lib/mcp/directory-data';
 import { getPortalData, getPortalCounts } from '@/lib/mcp/portal-data';
 import DirectoryWrapper from '@/components/DirectoryWrapper';
 import { getBrandName } from '@/lib/brand-config';
+import { directorySourceNote } from '@/lib/content-source';
 
 export const metadata = {
   title: `Directory - ${getBrandName()}`,
@@ -11,18 +12,25 @@ export const metadata = {
 };
 
 export default async function DirectoryPage() {
-  const [servers, portals, portalCounts] = await Promise.all([
+  const [directory, portals, portalCounts] = await Promise.all([
     getDirectoryData(),
     getPortalData(),
     getPortalCounts(),
   ]);
 
+  // A curated index of public MCP servers is a shared resource, so an
+  // instance with no directory of its own keeps serving the community index
+  // — and says whose it is (#241). Computed here, server-side, because the
+  // wrapper below is a client component.
+  const sourceNote = directorySourceNote(directory.provenance, directory.sourceUrl);
+
   return (
     <Suspense>
       <DirectoryWrapper
-        servers={servers}
+        servers={directory.servers}
         portals={portals}
         portalCounts={portalCounts}
+        sourceNote={sourceNote}
       />
     </Suspense>
   );

--- a/src/app/(marketing)/roadmap/page.tsx
+++ b/src/app/(marketing)/roadmap/page.tsx
@@ -3,20 +3,40 @@ import { getRoadmapMarkdown } from '@/lib/roadmap/data';
 import AudienceRoutingStrip from '@/components/roadmap/AudienceRoutingStrip';
 import RoadmapBody from '@/components/roadmap/RoadmapBody';
 import { getBrandName } from '@/lib/brand-config';
-import { getRoadmapGithubUrl } from '@/lib/site-config';
+import { getRoadmapSource, type RoadmapSource } from '@/lib/site-config';
 
-export const metadata: Metadata = {
-  title: `Roadmap - ${getBrandName()}`,
-  description:
-    'The civic-ai-tools public roadmap — vision pillars, trust commitments, near-term plans, and how the evidence-system fork resolved (toward a domain-neutral, spec-first protocol). Mirrored from the hub repo.',
-};
+// A roadmap is first-person content: "our plans". An instance that has not
+// published one renders the unpublished state below rather than another
+// project's roadmap under its own brand (#241) — and the nav drops the link,
+// so the page is a destination for anyone who has the URL, not a dead end in
+// the header. `generateMetadata` (not a static `metadata` object) so the
+// source is read at call time, like every other instance-config read.
+export async function generateMetadata(): Promise<Metadata> {
+  const brand = getBrandName();
+  const source = getRoadmapSource();
+  return {
+    title: `Roadmap - ${brand}`,
+    description: source
+      ? `The public roadmap for ${brand} — what is planned and what is underway. Rendered from ${source.label}.`
+      : `${brand} has not published a roadmap.`,
+  };
+}
 
 export default async function RoadmapPage() {
-  const result = await getRoadmapMarkdown();
+  const source = getRoadmapSource();
+
+  if (!source) {
+    return (
+      <RoadmapShell>
+        <RoadmapUnpublished />
+      </RoadmapShell>
+    );
+  }
+
+  const result = await getRoadmapMarkdown(source.rawUrl);
 
   return (
-    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '48px 24px' }}>
-      <h1 style={{ marginBottom: '8px' }}>Roadmap</h1>
+    <RoadmapShell>
       <p
         style={{
           fontSize: '13px',
@@ -25,9 +45,12 @@ export default async function RoadmapPage() {
           marginTop: 0,
         }}
       >
+        {/* Label and link are both derived from the configured source, so an
+            instance that re-points the roadmap cannot end up with a correct
+            link under the reference project's file name. */}
         Renders from{' '}
-        <a href={getRoadmapGithubUrl()} target="_blank" rel="noopener noreferrer">
-          civic-ai-tools/ROADMAP.md
+        <a href={source.viewUrl} target="_blank" rel="noopener noreferrer">
+          {source.label}
         </a>
         .
       </p>
@@ -35,15 +58,53 @@ export default async function RoadmapPage() {
       {result.ok && result.markdown ? (
         <RoadmapBody markdown={result.markdown} />
       ) : (
-        <RoadmapStub />
+        <RoadmapStub source={source} />
       )}
 
+      {/* The routing strip's cards point at the reference project's own hub
+          docs — content that belongs with the reference project's roadmap,
+          not with an instance's. It renders only alongside a rendered
+          roadmap; making its cards configurable is a roadmap-change issue
+          (see the component header, website#94). */}
       <AudienceRoutingStrip />
+    </RoadmapShell>
+  );
+}
+
+function RoadmapShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ maxWidth: '1100px', margin: '0 auto', padding: '48px 24px' }}>
+      <h1 style={{ marginBottom: '8px' }}>Roadmap</h1>
+      {children}
     </div>
   );
 }
 
-function RoadmapStub() {
+function RoadmapUnpublished() {
+  return (
+    <div
+      style={{
+        backgroundColor: 'var(--card-background)',
+        border: '1px solid var(--border-color)',
+        borderRadius: '4px',
+        padding: '24px',
+        fontSize: '16px',
+        lineHeight: '1.7',
+        color: 'var(--text-secondary)',
+        marginTop: '24px',
+      }}
+    >
+      <p style={{ margin: 0 }}>This site has not published a roadmap.</p>
+      <p style={{ margin: '12px 0 0 0', fontSize: '13px', color: 'var(--text-muted)' }}>
+        Running this site? Point <code>ROADMAP_RAW_URL</code> at the raw Markdown of your own
+        roadmap and redeploy — this page renders it, and the link returns to the nav. See{' '}
+        <code>docs/deploy.md</code> in this codebase.
+      </p>
+    </div>
+  );
+}
+
+function RoadmapStub({ source }: { source: RoadmapSource }) {
   return (
     <div
       style={{
@@ -56,13 +117,11 @@ function RoadmapStub() {
         color: 'var(--text-secondary)',
       }}
     >
-      <p style={{ margin: '0 0 12px 0' }}>
-        The roadmap could not be loaded from GitHub right now.
-      </p>
+      <p style={{ margin: '0 0 12px 0' }}>The roadmap could not be loaded right now.</p>
       <p style={{ margin: 0 }}>
         Read the canonical version at{' '}
-        <a href={getRoadmapGithubUrl()} target="_blank" rel="noopener noreferrer">
-          civic-ai-tools/ROADMAP.md
+        <a href={source.viewUrl} target="_blank" rel="noopener noreferrer">
+          {source.label}
         </a>
         .
       </p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -98,6 +98,7 @@ export default function RootLayout({
   const brandName = getBrandName();
   const brandTagline = getBrandTagline();
   const brandAttribution = getBrandAttribution();
+  const brandAccent = getBrandAccent();
 
   /**
    * Whether this instance has a roadmap of its own (#241). An instance that
@@ -105,9 +106,9 @@ export default function RootLayout({
    * lands on it — but drops the nav entry, the same "hidden rather than
    * pointed at nothing" treatment the marketing links get on an app-only
    * instance. With `ROADMAP_RAW_URL` set, every link is exactly today's.
+   * Content, not chrome: it reads site-config.ts, not brand-config.ts.
    */
   const showRoadmap = getRoadmapSource() !== null;
-  const brandAccent = getBrandAccent();
 
   /**
    * The instance's sign-in choices (#229 P1 / Q63), derived here for the same

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ import {
   getBrandName,
   getBrandTagline,
 } from '@/lib/brand-config';
-import { getEvidenceSiteOrigin } from '@/lib/site-config';
+import { getEvidenceSiteOrigin, getRoadmapSource } from '@/lib/site-config';
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
@@ -98,6 +98,15 @@ export default function RootLayout({
   const brandName = getBrandName();
   const brandTagline = getBrandTagline();
   const brandAttribution = getBrandAttribution();
+
+  /**
+   * Whether this instance has a roadmap of its own (#241). An instance that
+   * has published none keeps the route — it explains itself to anyone who
+   * lands on it — but drops the nav entry, the same "hidden rather than
+   * pointed at nothing" treatment the marketing links get on an app-only
+   * instance. With `ROADMAP_RAW_URL` set, every link is exactly today's.
+   */
+  const showRoadmap = getRoadmapSource() !== null;
   const brandAccent = getBrandAccent();
 
   /**
@@ -171,6 +180,7 @@ export default function RootLayout({
               marketingOrigin={hostLinks.marketingOrigin}
               signInHref={hostLinks.signInHref}
               brandName={brandName}
+              showRoadmap={showRoadmap}
               signInOptions={signInOptions}
               {...(sessionProbe !== null ? { sessionProbe } : {})}
             />
@@ -199,8 +209,13 @@ export default function RootLayout({
                       <Link href={`${hostLinks.marketingOrigin}/learn`}>Learn</Link>
                       {' \u00b7 '}
                       <Link href={`${hostLinks.marketingOrigin}/about`}>About</Link>
-                      {' \u00b7 '}
-                      <Link href={`${hostLinks.marketingOrigin}/roadmap`}>Roadmap</Link>
+                      {/* Roadmap: only for an instance that has one (#241). */}
+                      {showRoadmap && (
+                        <>
+                          {' \u00b7 '}
+                          <Link href={`${hostLinks.marketingOrigin}/roadmap`}>Roadmap</Link>
+                        </>
+                      )}
                     </>
                   )}
                   {' \u00b7 '}

--- a/src/components/DirectoryWrapper.tsx
+++ b/src/components/DirectoryWrapper.tsx
@@ -66,7 +66,7 @@ export default function DirectoryWrapper({
             ) : (
               <>
                 The MCP server entries are the community snapshot bundled with this codebase — the
-                configured directory source could not be loaded.
+                live directory source could not be loaded.
               </>
             )}
           </p>

--- a/src/components/DirectoryWrapper.tsx
+++ b/src/components/DirectoryWrapper.tsx
@@ -5,6 +5,7 @@ import DirectoryClient from './DirectoryClient';
 import PortalDirectoryClient from './PortalDirectoryClient';
 import type { McpServerEntry } from '@/lib/mcp/directory-data';
 import type { PortalEntry, PortalCounts } from '@/lib/mcp/portal-data';
+import type { DirectorySourceNote } from '@/lib/content-source';
 import { prose } from '@/styles/page-styles';
 import type { CSSProperties } from 'react';
 
@@ -12,10 +13,15 @@ export default function DirectoryWrapper({
   servers,
   portals,
   portalCounts,
+  sourceNote = null,
 }: {
   servers: McpServerEntry[];
   portals: PortalEntry[];
   portalCounts: PortalCounts;
+  /** Attribution for entries that are not this instance's own (#241);
+   *  `null` — the default, and the case for a configured instance — renders
+   *  no note at all. Resolved server-side by the page. */
+  sourceNote?: DirectorySourceNote | null;
 }) {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -47,6 +53,24 @@ export default function DirectoryWrapper({
           Browse {servers.length}+ MCP servers and {portalCounts.total.toLocaleString()} open data
           portals for civic data.
         </p>
+        {sourceNote && (
+          <p style={{ fontSize: '13px', color: 'var(--text-muted)', margin: '12px 0 0 0' }}>
+            {sourceNote.kind === 'community' ? (
+              <>
+                The MCP server entries come from{' '}
+                <a href={sourceNote.source.href} target="_blank" rel="noopener noreferrer">
+                  {sourceNote.source.label}
+                </a>
+                , a shared community index maintained by that project rather than by this site.
+              </>
+            ) : (
+              <>
+                The MCP server entries are the community snapshot bundled with this codebase — the
+                configured directory source could not be loaded.
+              </>
+            )}
+          </p>
+        )}
       </div>
 
       {/* Tab bar */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,6 +49,11 @@ const DROPDOWN_ITEM_STYLE: React.CSSProperties = {
  * - `brandName` (#217) — the wordmark text, resolved by the layout from
  *   `SITE_BRAND_NAME` (src/lib/brand-config.ts). The default is the demo
  *   name, so a mount that omits the prop renders today's chrome.
+ * - `showRoadmap` (#241) — whether this instance has a roadmap of its own
+ *   (`ROADMAP_RAW_URL`). `false` hides the Roadmap nav entries rather than
+ *   pointing them at a page that says nothing has been published — the same
+ *   treatment `marketingOrigin: null` gives the marketing links. `true` is
+ *   the default and today's nav.
  * - `signInOptions` (#229 P1) — the providers this instance actually
  *   configured, derived by the layout from `buildProviders()`. Only the
  *   in-place branch below reads it (the split-host branch links to the `/ask`
@@ -65,6 +70,7 @@ export default function Header({
   marketingOrigin = '',
   signInHref = null,
   brandName = 'Civic AI Tools',
+  showRoadmap = true,
   signInOptions = DEFAULT_SIGN_IN_OPTIONS,
   sessionProbe = null,
 }: {
@@ -72,6 +78,7 @@ export default function Header({
   marketingOrigin?: string | null;
   signInHref?: string | null;
   brandName?: string;
+  showRoadmap?: boolean;
   signInOptions?: SignInOption[];
   sessionProbe?: SessionAffordanceTarget | null;
 }) {
@@ -296,6 +303,8 @@ export default function Header({
                   >
                     About
                   </Link>
+                  {/* Roadmap: only for an instance that has one (#241). */}
+                  {showRoadmap && (
                   <Link
                     href={mkt('/roadmap')}
                     onClick={() => setAboutOpen(false)}
@@ -305,6 +314,7 @@ export default function Header({
                   >
                     Roadmap
                   </Link>
+                  )}
                 </div>
               )}
             </div>
@@ -619,6 +629,8 @@ export default function Header({
           >
             About
           </Link>
+          {/* Roadmap: only for an instance that has one (#241). */}
+          {showRoadmap && (
           <Link
             href={mkt('/roadmap')}
             onClick={() => setMobileMenuOpen(false)}
@@ -632,6 +644,7 @@ export default function Header({
           >
             Roadmap
           </Link>
+          )}
             </>
           )}
           {/* Divider */}

--- a/src/lib/content-source.test.ts
+++ b/src/lib/content-source.test.ts
@@ -1,0 +1,110 @@
+// Content-source description tests (#241).
+//
+// describeContentSource is what keeps a byline honest: the visible label and
+// the link target come out of the same parse of the same URL, so an instance
+// that re-points a page cannot end up with a correct link under a stale
+// label. directorySourceNote is the /directory attribution decision in one
+// pure function.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { describeContentSource, directorySourceNote } from './content-source.ts';
+
+describe('describeContentSource', () => {
+  test('GitHub raw URL: collapses to repo/path and links to the file page', () => {
+    assert.deepEqual(
+      describeContentSource('https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md'),
+      {
+        label: 'civic-ai-tools/ROADMAP.md',
+        href: 'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md',
+      }
+    );
+  });
+
+  test('GitHub raw URL, nested path: keeps the whole path in the label', () => {
+    assert.deepEqual(
+      describeContentSource(
+        'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json'
+      ),
+      {
+        label: 'civic-ai-tools/data/mcp-servers.json',
+        href: 'https://github.com/npstorey/civic-ai-tools/blob/main/data/mcp-servers.json',
+      }
+    );
+  });
+
+  test('GitHub raw URL, fully-qualified refs/heads form', () => {
+    assert.deepEqual(
+      describeContentSource(
+        'https://raw.githubusercontent.com/acme/city-data/refs/heads/main/docs/ROADMAP.md'
+      ),
+      {
+        label: 'city-data/docs/ROADMAP.md',
+        href: 'https://github.com/acme/city-data/blob/refs/heads/main/docs/ROADMAP.md',
+      }
+    );
+  });
+
+  test('GitHub blob URL: same label, and links to itself', () => {
+    const url = 'https://github.com/acme/city-data/blob/main/ROADMAP.md';
+    assert.deepEqual(describeContentSource(url), { label: 'city-data/ROADMAP.md', href: url });
+  });
+
+  test('non-GitHub URL: host and path, linking to itself', () => {
+    const url = 'https://data.example.gov/plans/roadmap.md';
+    assert.deepEqual(describeContentSource(url), {
+      label: 'data.example.gov/plans/roadmap.md',
+      href: url,
+    });
+  });
+
+  test('bare host: the host alone', () => {
+    assert.deepEqual(describeContentSource('https://data.example.gov/'), {
+      label: 'data.example.gov',
+      href: 'https://data.example.gov/',
+    });
+  });
+
+  test('unparseable value: passed through, so a misconfiguration is visible', () => {
+    assert.deepEqual(describeContentSource('not a url'), {
+      label: 'not a url',
+      href: 'not a url',
+    });
+  });
+
+  test('a raw URL too short to name a file falls through to host and path', () => {
+    const url = 'https://raw.githubusercontent.com/acme/city-data/main';
+    assert.deepEqual(describeContentSource(url), {
+      label: 'raw.githubusercontent.com/acme/city-data/main',
+      href: url,
+    });
+  });
+});
+
+describe('directorySourceNote', () => {
+  test('instance source: no note — the entries belong to this site', () => {
+    assert.equal(directorySourceNote('instance', 'https://example.org/mcp-servers.json'), null);
+  });
+
+  test('community source: an attribution note naming the upstream file', () => {
+    assert.deepEqual(
+      directorySourceNote(
+        'community',
+        'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json'
+      ),
+      {
+        kind: 'community',
+        source: {
+          label: 'civic-ai-tools/data/mcp-servers.json',
+          href: 'https://github.com/npstorey/civic-ai-tools/blob/main/data/mcp-servers.json',
+        },
+      }
+    );
+  });
+
+  test('bundled snapshot: its own note, whichever source was configured', () => {
+    assert.deepEqual(directorySourceNote('snapshot', 'https://example.org/mcp-servers.json'), {
+      kind: 'snapshot',
+    });
+  });
+});

--- a/src/lib/content-source.ts
+++ b/src/lib/content-source.ts
@@ -1,0 +1,92 @@
+// Content-source description helpers (#241).
+//
+// The `/directory` and `/roadmap` pages tell the reader where their content
+// came from. Both the visible LABEL and the link TARGET of that byline are
+// derived here, from the one configured source URL — so an instance that
+// re-points a page can never end up with a correct link under a stale label
+// (the defect PR #242 flagged, where the label was separate hardcoded copy).
+//
+// Pure and I/O-free: no env reads, no fetches. `src/lib/site-config.ts` owns
+// the environment; this module only describes a URL.
+
+/** A content source as the page shows it: what to call it, where to link. */
+export interface ContentSourceRef {
+  /** Human label, e.g. `civic-ai-tools/ROADMAP.md`. */
+  label: string;
+  /** Human-viewable URL — the GitHub file page for a raw GitHub URL. */
+  href: string;
+}
+
+/** Where the content a page rendered actually came from. */
+export type ContentProvenance =
+  /** This instance's own configured source. */
+  | 'instance'
+  /** The shared community source this codebase ships against (no instance
+   *  source configured) — shown with attribution, never as the site's own. */
+  | 'community'
+  /** The snapshot checked into this codebase, after a fetch failure. */
+  | 'snapshot';
+
+/**
+ * Describe a content-source URL for display.
+ *
+ * GitHub raw and blob URLs collapse to `repo/path` with a link to the file
+ * page a human can read — `…/npstorey/civic-ai-tools/main/ROADMAP.md` becomes
+ * `civic-ai-tools/ROADMAP.md`. Any other URL keeps its host and path and
+ * links to itself. An unparseable value is passed through untouched rather
+ * than dropped: a misconfigured instance should see what it configured.
+ */
+export function describeContentSource(url: string): ContentSourceRef {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { label: url, href: url };
+  }
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+
+  if (parsed.host === 'raw.githubusercontent.com' && segments.length >= 4) {
+    const [owner, repo, ...rest] = segments;
+    // Two raw shapes: `/owner/repo/<ref>/path` and the fully-qualified
+    // `/owner/repo/refs/heads/<branch>/path`.
+    const refLength = rest[0] === 'refs' && rest.length >= 3 ? 3 : 1;
+    const ref = rest.slice(0, refLength).join('/');
+    const filePath = rest.slice(refLength);
+    if (filePath.length > 0) {
+      return {
+        label: `${repo}/${filePath.join('/')}`,
+        href: `https://github.com/${owner}/${repo}/blob/${ref}/${filePath.join('/')}`,
+      };
+    }
+  }
+
+  if (parsed.host === 'github.com' && segments.length >= 5 && segments[2] === 'blob') {
+    const [, repo, , , ...filePath] = segments;
+    return { label: `${repo}/${filePath.join('/')}`, href: url };
+  }
+
+  const path = segments.join('/');
+  return { label: path ? `${parsed.host}/${path}` : parsed.host, href: url };
+}
+
+/**
+ * The attribution note `/directory` shows above its entries, or `null` when
+ * the entries are the instance's own and nothing needs saying.
+ *
+ * The directory is a shared community resource — a curated index of public
+ * MCP servers is useful to any instance — so an unconfigured instance keeps
+ * serving it rather than hiding it, and says whose it is (#241). A roadmap
+ * is first-person and gets the opposite treatment; see `getRoadmapSource`.
+ */
+export function directorySourceNote(
+  provenance: ContentProvenance,
+  sourceUrl: string,
+): { kind: 'community'; source: ContentSourceRef } | { kind: 'snapshot' } | null {
+  if (provenance === 'instance') return null;
+  if (provenance === 'snapshot') return { kind: 'snapshot' };
+  return { kind: 'community', source: describeContentSource(sourceUrl) };
+}
+
+/** The `/directory` attribution note as the page passes it to the client. */
+export type DirectorySourceNote = NonNullable<ReturnType<typeof directorySourceNote>>;

--- a/src/lib/mcp/directory-data.ts
+++ b/src/lib/mcp/directory-data.ts
@@ -1,9 +1,12 @@
 // MCP Server Directory data fetching
-// Fetches from GitHub raw at build time, falls back to checked-in snapshot.
-// Source URL is instance configuration — see src/lib/site-config.ts (#241).
+// Fetches from the configured source at build time, falls back to the
+// checked-in snapshot. Source URL is instance configuration — see
+// src/lib/site-config.ts (#241). The result carries its provenance so the
+// page can attribute entries that are not this instance's own.
 
 import fallbackData from './directory-fallback.json';
-import { getDirectoryDataUrl } from '@/lib/site-config';
+import { getDirectorySource } from '@/lib/site-config';
+import type { ContentProvenance } from '@/lib/content-source';
 
 // Types — compatible subset of civic-ai-tools/data/mcp-server-schema.ts
 
@@ -63,19 +66,32 @@ export interface McpServerEntry {
   priority?: PriorityTier;
 }
 
-export async function getDirectoryData(): Promise<McpServerEntry[]> {
+export interface DirectoryData {
+  servers: McpServerEntry[];
+  /** Whose entries these are: this instance's, the community index's, or the
+   *  snapshot bundled with this codebase after a fetch failure. */
+  provenance: ContentProvenance;
+  /** The URL that was fetched — what the attribution byline points at. */
+  sourceUrl: string;
+}
+
+export async function getDirectoryData(): Promise<DirectoryData> {
+  const { url, provenance } = getDirectorySource();
   try {
-    const res = await fetch(getDirectoryDataUrl(), {
+    const res = await fetch(url, {
       next: { revalidate: 3600 }, // ISR: 1 hour
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return (await res.json()) as McpServerEntry[];
+    return { servers: (await res.json()) as McpServerEntry[], provenance, sourceUrl: url };
   } catch (error) {
     console.warn(
-      '[Directory] Failed to fetch from GitHub, using fallback:',
+      '[Directory] Failed to fetch the configured source, using bundled snapshot:',
       error instanceof Error ? error.message : error
     );
-    return fallbackData as McpServerEntry[];
+    // The snapshot is this codebase's own checked-in copy of the community
+    // index — upstream content whichever source was configured, so it is
+    // attributed as such rather than passed off as the instance's data.
+    return { servers: fallbackData as McpServerEntry[], provenance: 'snapshot', sourceUrl: url };
   }
 }
 

--- a/src/lib/roadmap/data.ts
+++ b/src/lib/roadmap/data.ts
@@ -1,10 +1,9 @@
 // Roadmap content fetching
-// Fetches ROADMAP.md from the civic-ai-tools hub repo on GitHub raw at build time with 1-hour ISR.
-// Mirrors the pattern in `src/lib/mcp/directory-data.ts` — hub repo is source of truth, drift window
-// is small because the doc refreshes quarterly and carries its own version label in the body.
-// Source URLs are instance configuration — see src/lib/site-config.ts (#241).
-
-import { getRoadmapRawUrl } from '@/lib/site-config';
+// Fetches the instance's roadmap markdown at build time with 1-hour ISR. Mirrors the pattern in
+// `src/lib/mcp/directory-data.ts` — the source repo is source of truth, drift window is small
+// because the doc refreshes quarterly and carries its own version label in the body.
+// The URL is passed in by the page: an instance with no roadmap source of its own never gets
+// here at all, because there is nothing of its own to fetch — see src/lib/site-config.ts (#241).
 
 export interface RoadmapFetchResult {
   ok: boolean;
@@ -12,9 +11,9 @@ export interface RoadmapFetchResult {
   error?: string;
 }
 
-export async function getRoadmapMarkdown(): Promise<RoadmapFetchResult> {
+export async function getRoadmapMarkdown(rawUrl: string): Promise<RoadmapFetchResult> {
   try {
-    const res = await fetch(getRoadmapRawUrl(), {
+    const res = await fetch(rawUrl, {
       next: { revalidate: 3600 }, // ISR: 1 hour
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -22,7 +21,7 @@ export async function getRoadmapMarkdown(): Promise<RoadmapFetchResult> {
     return { ok: true, markdown };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn('[Roadmap] Failed to fetch from GitHub:', message);
+    console.warn('[Roadmap] Failed to fetch the configured source:', message);
     return { ok: false, markdown: null, error: message };
   }
 }

--- a/src/lib/site-config.test.ts
+++ b/src/lib/site-config.test.ts
@@ -1,21 +1,19 @@
 // Instance content-source configuration tests (#241).
 //
 // Covers the /directory and /roadmap content-source getters in
-// site-config.ts: with no environment set, each getter must return the
-// demo deployment's historical hardcoded URL byte-identically (the
-// byte-parity bar); with the corresponding variable set, the override must
-// flow through at call time, not module load — same pattern as
-// brand-config.test.ts.
+// site-config.ts. The load-bearing property is what UNSET means: this
+// instance has no content source of its own. The two pages then split —
+// /directory keeps serving the shared community index (marked as such, so
+// the page can attribute it), /roadmap resolves to null (no roadmap of our
+// own, so none is presented as ours). Overrides are read at call time, not
+// module load — same pattern as brand-config.test.ts.
 
 import { test, describe, afterEach } from 'node:test';
 import assert from 'node:assert';
 import {
-  DEMO_DIRECTORY_DATA_URL,
-  DEMO_ROADMAP_RAW_URL,
-  DEMO_ROADMAP_GITHUB_URL,
-  getDirectoryDataUrl,
-  getRoadmapRawUrl,
-  getRoadmapGithubUrl,
+  COMMUNITY_DIRECTORY_DATA_URL,
+  getDirectorySource,
+  getRoadmapSource,
 } from './site-config.ts';
 
 const CONTENT_SOURCE_VARS = ['DIRECTORY_DATA_URL', 'ROADMAP_RAW_URL', 'ROADMAP_GITHUB_URL'];
@@ -24,47 +22,81 @@ afterEach(() => {
   for (const v of CONTENT_SOURCE_VARS) delete process.env[v];
 });
 
-describe('instance content-source getters (call-time env, demo defaults)', () => {
-  test('unset environment yields the demo civic-ai-tools hub URLs (byte-parity bar)', () => {
-    assert.equal(getDirectoryDataUrl(), DEMO_DIRECTORY_DATA_URL);
+describe('getDirectorySource (shared community index when unconfigured)', () => {
+  test('unset: the community index, marked as not belonging to this instance', () => {
+    assert.deepEqual(getDirectorySource(), {
+      url: COMMUNITY_DIRECTORY_DATA_URL,
+      provenance: 'community',
+    });
     assert.equal(
-      getDirectoryDataUrl(),
+      COMMUNITY_DIRECTORY_DATA_URL,
       'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json'
     );
-    assert.equal(getRoadmapRawUrl(), DEMO_ROADMAP_RAW_URL);
-    assert.equal(
-      getRoadmapRawUrl(),
-      'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md'
-    );
-    assert.equal(getRoadmapGithubUrl(), DEMO_ROADMAP_GITHUB_URL);
-    assert.equal(
-      getRoadmapGithubUrl(),
-      'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md'
-    );
   });
 
-  test('set variables override at call time, not module load', () => {
+  test('set: the source belongs to this instance, read at call time', () => {
     process.env.DIRECTORY_DATA_URL = 'https://example.org/mcp-servers.json';
-    process.env.ROADMAP_RAW_URL = 'https://example.org/ROADMAP.md';
-    process.env.ROADMAP_GITHUB_URL = 'https://github.com/example/repo/blob/main/ROADMAP.md';
-    assert.equal(getDirectoryDataUrl(), 'https://example.org/mcp-servers.json');
-    assert.equal(getRoadmapRawUrl(), 'https://example.org/ROADMAP.md');
-    assert.equal(getRoadmapGithubUrl(), 'https://github.com/example/repo/blob/main/ROADMAP.md');
+    assert.deepEqual(getDirectorySource(), {
+      url: 'https://example.org/mcp-servers.json',
+      provenance: 'instance',
+    });
   });
 
-  test('empty strings fall back to the defaults, matching the rest of site-config.ts', () => {
+  test('empty string counts as unset, matching the rest of site-config.ts', () => {
     process.env.DIRECTORY_DATA_URL = '';
-    process.env.ROADMAP_RAW_URL = '';
-    process.env.ROADMAP_GITHUB_URL = '';
-    assert.equal(getDirectoryDataUrl(), DEMO_DIRECTORY_DATA_URL);
-    assert.equal(getRoadmapRawUrl(), DEMO_ROADMAP_RAW_URL);
-    assert.equal(getRoadmapGithubUrl(), DEMO_ROADMAP_GITHUB_URL);
+    assert.equal(getDirectorySource().provenance, 'community');
   });
 
-  test('each getter is independently overridable', () => {
-    process.env.DIRECTORY_DATA_URL = 'https://example.org/mcp-servers.json';
-    assert.equal(getDirectoryDataUrl(), 'https://example.org/mcp-servers.json');
-    assert.equal(getRoadmapRawUrl(), DEMO_ROADMAP_RAW_URL);
-    assert.equal(getRoadmapGithubUrl(), DEMO_ROADMAP_GITHUB_URL);
+  test('the roadmap variables do not affect the directory source', () => {
+    process.env.ROADMAP_RAW_URL = 'https://example.org/ROADMAP.md';
+    assert.equal(getDirectorySource().provenance, 'community');
+  });
+});
+
+describe('getRoadmapSource (null when the instance has no roadmap of its own)', () => {
+  test('unset: null — no fallback to any other roadmap', () => {
+    assert.equal(getRoadmapSource(), null);
+  });
+
+  test('empty string counts as unset', () => {
+    process.env.ROADMAP_RAW_URL = '';
+    assert.equal(getRoadmapSource(), null);
+  });
+
+  test('raw URL alone: the view URL and label are derived from it', () => {
+    process.env.ROADMAP_RAW_URL =
+      'https://raw.githubusercontent.com/acme/city-data/main/ROADMAP.md';
+    assert.deepEqual(getRoadmapSource(), {
+      rawUrl: 'https://raw.githubusercontent.com/acme/city-data/main/ROADMAP.md',
+      viewUrl: 'https://github.com/acme/city-data/blob/main/ROADMAP.md',
+      label: 'city-data/ROADMAP.md',
+    });
+  });
+
+  test('both set: the explicit view URL wins and the label follows IT, not the raw URL', () => {
+    process.env.ROADMAP_RAW_URL = 'https://cdn.example.org/exports/plan.md';
+    process.env.ROADMAP_GITHUB_URL = 'https://github.com/acme/city-data/blob/main/docs/PLAN.md';
+    const source = getRoadmapSource();
+    assert.ok(source);
+    assert.equal(source.viewUrl, 'https://github.com/acme/city-data/blob/main/docs/PLAN.md');
+    // The label-vs-link drift PR #242 flagged: one derivation, so the visible
+    // label can never name a file the link does not point at.
+    assert.equal(source.label, 'city-data/docs/PLAN.md');
+  });
+
+  test('view URL alone (no raw URL) does not conjure a roadmap', () => {
+    process.env.ROADMAP_GITHUB_URL = 'https://github.com/acme/city-data/blob/main/ROADMAP.md';
+    assert.equal(getRoadmapSource(), null);
+  });
+
+  test('the reference deployment configured explicitly renders the byline it has today', () => {
+    process.env.ROADMAP_RAW_URL =
+      'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md';
+    process.env.ROADMAP_GITHUB_URL =
+      'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md';
+    const source = getRoadmapSource();
+    assert.ok(source);
+    assert.equal(source.label, 'civic-ai-tools/ROADMAP.md');
+    assert.equal(source.viewUrl, 'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md');
   });
 });

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,6 +1,11 @@
 // Site-wide external URLs. Import from here rather than hard-coding hrefs so
 // each destination can be changed in one place.
 
+// Relative, extension-bearing import: this module is in the `node --test`
+// graph (via the evidence modules), which resolves neither the `@/` alias nor
+// extensionless specifiers — the same convention as evidence/verify.ts.
+import { describeContentSource, type ContentProvenance } from './content-source.ts';
+
 /** The Typed Standards protocol site — spec home and neutral verifier. */
 export const TYPED_STANDARDS_URL = 'https://typedstandards.org';
 
@@ -31,66 +36,93 @@ export const SPONSOR: { prefix: string; name: string; url: string } | null = {
 
 // --- Instance content sources (#241) ----------------------------------------
 //
-// Every value that names where THIS deployment's `/directory` and `/roadmap`
-// pages fetch their content from resolves through the getters below. The
-// demo defaults are the civicaitools.org reference deployment's historical
-// hardcoded URLs — the civic-ai-tools hub repo's server directory JSON and
-// ROADMAP.md — so with NO environment set the fetched bytes and rendered
-// links are identical to before (the same byte-parity bar as the Evidence
-// instance identity set below).
+// Where THIS deployment's `/directory` and `/roadmap` pages get their content
+// resolves through the getters below. UNSET here means one thing only: "this
+// instance has no content source of its own." No getter falls back to another
+// project's roadmap, and the reference deployment configures itself
+// explicitly like any other instance — see docs/deploy.md.
 //
-// An instance stood up from the guide with no environment set otherwise
-// silently fetches and serves the *reference project's* directory and
-// roadmap under its own name and brand (#241). Setting these variables
-// points each page at the instance's own content instead; leaving them
-// unset is a deliberate choice too — see the PR for #241 for the tradeoffs
-// of each no-config behavior, which this seam does not decide.
+// The two pages then diverge, because the two kinds of content do:
+//
+//   /directory — a curated index of public MCP servers is a shared community
+//     resource, useful to any instance. With no instance source configured
+//     the page keeps serving the community index (below) and says so, with
+//     visible attribution to the project that maintains it.
+//
+//   /roadmap — a roadmap is inherently first-person ("our plans"). Another
+//     project's roadmap under an operator's brand is wrong even when
+//     attributed, so with no instance source configured `getRoadmapSource()`
+//     returns null: the page renders as unpublished and the nav drops the
+//     link, rather than presenting someone else's plans as this site's.
 //
 // Values are read at CALL time (not module load), matching the rest of this
 // file.
 
-/** Demo default directory-JSON source (civic-ai-tools hub repo, raw). */
-export const DEMO_DIRECTORY_DATA_URL =
+/**
+ * The shared community MCP-server index this codebase ships against — the
+ * civic-ai-tools hub repo's curated directory. Not a "demo default" in the
+ * sense the rest of this file uses: it is the deliberate content of the
+ * unconfigured `/directory` page, rendered with attribution rather than as
+ * the instance's own list.
+ */
+export const COMMUNITY_DIRECTORY_DATA_URL =
   'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json';
 
-/** Demo default roadmap markdown source (civic-ai-tools hub repo, raw). */
-export const DEMO_ROADMAP_RAW_URL =
-  'https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md';
-
-/** Demo default roadmap "view on GitHub" link (civic-ai-tools hub repo). */
-export const DEMO_ROADMAP_GITHUB_URL =
-  'https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md';
-
-/**
- * Source URL the `/directory` page fetches its MCP-server list from (JSON,
- * `McpServerEntry[]`). Env: `DIRECTORY_DATA_URL`. On fetch failure the page
- * falls back to the checked-in `directory-fallback.json` snapshot regardless
- * of this value — see `src/lib/mcp/directory-data.ts`.
- */
-export function getDirectoryDataUrl(): string {
-  return process.env.DIRECTORY_DATA_URL || DEMO_DIRECTORY_DATA_URL;
+/** Resolved `/directory` data source, and whether it belongs to this site. */
+export interface DirectorySource {
+  /** URL fetched for the MCP-server list (JSON, `McpServerEntry[]`). */
+  url: string;
+  /** `'instance'` when `DIRECTORY_DATA_URL` is set, else `'community'`. */
+  provenance: Extract<ContentProvenance, 'instance' | 'community'>;
 }
 
 /**
- * Source URL the `/roadmap` page fetches its markdown body from. Env:
- * `ROADMAP_RAW_URL`. On fetch failure the page renders a stub pointing at
- * `getRoadmapGithubUrl()` — see `src/lib/roadmap/data.ts`.
+ * Source the `/directory` page fetches its MCP-server list from. Env:
+ * `DIRECTORY_DATA_URL`; unset yields the community index above, marked as
+ * such so the page can attribute it. On fetch failure the page falls back to
+ * the checked-in `directory-fallback.json` snapshot either way, and says so —
+ * see `src/lib/mcp/directory-data.ts`.
  */
-export function getRoadmapRawUrl(): string {
-  return process.env.ROADMAP_RAW_URL || DEMO_ROADMAP_RAW_URL;
+export function getDirectorySource(): DirectorySource {
+  const configured = process.env.DIRECTORY_DATA_URL;
+  return configured
+    ? { url: configured, provenance: 'instance' }
+    : { url: COMMUNITY_DIRECTORY_DATA_URL, provenance: 'community' };
+}
+
+/** Resolved `/roadmap` source: what to fetch, where to link, what to call it. */
+export interface RoadmapSource {
+  /** URL the page fetches the roadmap markdown from. */
+  rawUrl: string;
+  /** Human-viewable URL behind the "Renders from …" byline. */
+  viewUrl: string;
+  /** The byline's visible label, derived from the URL it links to. */
+  label: string;
 }
 
 /**
- * Human-facing "view on GitHub" link rendered on `/roadmap` (the "Renders
- * from …" byline and the fetch-failure stub). Env: `ROADMAP_GITHUB_URL`.
- * NOTE: the byline's visible label text ("civic-ai-tools/ROADMAP.md") is
- * still hardcoded copy in `roadmap/page.tsx`, independent of this URL — an
- * instance that overrides this var gets a correct link with a stale label.
- * Addressing that is part of the #241 attribution design question, not this
- * seam.
+ * This instance's own roadmap source, or `null` when it has none.
+ *
+ * Env: `ROADMAP_RAW_URL` (the markdown) and optionally `ROADMAP_GITHUB_URL`
+ * (where the byline links). With `ROADMAP_GITHUB_URL` unset the view URL is
+ * derived from the raw URL — a GitHub raw URL resolves to its file page — so
+ * an instance that sets one variable never links out to a *different*
+ * project's roadmap. `label` is derived from whichever URL the byline links
+ * to, which is what keeps label and link from drifting apart.
+ *
+ * `null` is a first-class state, not a misconfiguration: it is what every
+ * instance that has not published a roadmap looks like.
  */
-export function getRoadmapGithubUrl(): string {
-  return process.env.ROADMAP_GITHUB_URL || DEMO_ROADMAP_GITHUB_URL;
+export function getRoadmapSource(): RoadmapSource | null {
+  const rawUrl = process.env.ROADMAP_RAW_URL;
+  if (!rawUrl) return null;
+  const explicitViewUrl = process.env.ROADMAP_GITHUB_URL;
+  const described = describeContentSource(explicitViewUrl || rawUrl);
+  return {
+    rawUrl,
+    viewUrl: explicitViewUrl || described.href,
+    label: described.label,
+  };
 }
 
 // --- Evidence instance identity (ADR-0020: config, not code) ----------------


### PR DESCRIPTION
Implements the Part 2 decision that [#242](https://github.com/npstorey/civic-ai-tools-website/pull/242) deliberately left open, for [#241](https://github.com/npstorey/civic-ai-tools-website/issues/241): **split the two pages.** `/directory` keeps serving the upstream content with visible attribution; `/roadmap` does not present itself as the instance's roadmap when the instance has none.

## ⚠️ Owner action required BEFORE merge

Merging this while civicaitools.org's environment is unset makes its `/roadmap` page render "This site has not published a roadmap" and drops Roadmap from the nav. Set these in **Vercel → civic-ai-tools-website → Settings → Environment Variables**, scope **Production**, before merging:

| Variable | Value |
| --- | --- |
| `ROADMAP_RAW_URL` | `https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md` |
| `ROADMAP_GITHUB_URL` | `https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md` |
| `DIRECTORY_DATA_URL` | `https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/data/mcp-servers.json` |

Three properties make this safe to do at any time:

1. **They are no-ops on `main` as it stands today.** Each value is byte-identical to the default the merged #242 code already resolves, so setting them changes nothing until this PR lands. There is no window where production is half-configured.
2. **No redeploy is needed first.** Both pages prerender, so the values take effect at the next build — which is the deploy this merge triggers.
3. **`DIRECTORY_DATA_URL` is not load-bearing for correctness**, only for presentation: unset, `/directory` still serves the same entries and adds one attribution line. Setting it is what tells the reference deployment "this index is mine," which suppresses that line. `ROADMAP_RAW_URL` is the one that must be set before merge.

**Preview scope, deliberately left to you.** If you leave these unset for **Preview**, this PR's preview deployment shows the *unconfigured fork* behavior — which is the thing worth eyeballing before merge. Set Preview afterward if you'd rather previews mirror production.

## The ambiguity, and how it's resolved

Before this PR, "unset" meant two different things that the code could not tell apart: *"I am the reference deployment"* and *"I am a fork that hasn't configured this."* Both took the same branch, into the same upstream URLs. Any rule keyed on "unset" would have been wrong for one of them.

**Resolution: the reference deployment stops being a special case.** It configures itself in its own environment like every other instance (the table above), and the code drops every upstream fallback for the roadmap. `getRoadmapSource()` returns `null` when `ROADMAP_RAW_URL` is unset — there is no longer a URL for it to fall back *to*. That makes unset mean exactly one thing, and the split behavior follows without a discriminator anywhere in the code.

Alternatives considered and rejected:

- **A flag (`INSTANCE_IS_REFERENCE=1`).** A variable whose only job is to say "I'm special" reintroduces the reference deployment as a code-level concept, against ADR-0020's line that instance identity is config, not code.
- **Inferring from `EVIDENCE_SITE_ORIGIN` (or a `civicaitools.org` host check).** Couples content presentation to evidence identity — two unrelated concerns — and hardcodes a host, which is the defect class #241 exists to remove.
- **Keeping the upstream default and gating presentation on a separate "is this yours" boolean.** Two variables encoding one fact; they drift.

The cost of the chosen design is exactly the pre-merge action above, stated instead of avoided. I could not find a variant that both makes unset unambiguous and leaves the reference deployment configuration-free — those are the same thing.

## What each page shows, in each configuration state

**`/directory`, `DIRECTORY_DATA_URL` unset** — the page as it looks today (title, "Browse 65+ MCP servers and 2,000+ open data portals for civic data.", tabs, entries), with one small muted line added under the intro:

> The MCP server entries come from [civic-ai-tools/data/mcp-servers.json](https://github.com/npstorey/civic-ai-tools/blob/main/data/mcp-servers.json), a shared community index maintained by that project rather than by this site.

The link goes to the GitHub *file page*, derived from the raw URL, not to raw JSON.

**`/directory`, `DIRECTORY_DATA_URL` set** — no attribution line at all. The entries are the instance's own; nothing needs saying. This is what civicaitools.org gets after the pre-merge action, i.e. today's page, unchanged.

**`/directory`, fetch failed** (either state) — the entries are the `directory-fallback.json` snapshot, and the line says so:

> The MCP server entries are the community snapshot bundled with this codebase — the live directory source could not be loaded.

Previously that fallback was silent, which meant a configured instance could serve upstream data under its own name with no indication.

**`/roadmap`, `ROADMAP_RAW_URL` unset** — heading "Roadmap", then a card:

> This site has not published a roadmap.
>
> *Running this site? Point `ROADMAP_RAW_URL` at the raw Markdown of your own roadmap and redeploy — this page renders it, and the link returns to the nav. See `docs/deploy.md` in this codebase.*

No upstream roadmap content, and — deliberately — **no link to the upstream project's roadmap either**. The directory is a shared resource, so pointing at it is a service; a fork advertising the reference project's plans is the coupling #241 wants gone. The Roadmap entry also disappears from the header nav (desktop dropdown and mobile menu) and the footer, the same "hidden rather than pointed at nothing" treatment `marketingOrigin: null` already gives marketing links on an app-only instance. The route itself stays reachable so anyone holding the URL gets an explanation rather than a 404. Page `<title>` and meta description follow the same state.

**`/roadmap`, configured** — byte-identical to today for the reference deployment: byline "Renders from [civic-ai-tools/ROADMAP.md](https://github.com/npstorey/civic-ai-tools/blob/main/ROADMAP.md).", the rendered roadmap body, the audience routing strip. For any other instance, the same page with its own label, link and content.

**`/roadmap`, configured but fetch failed** — the existing stub, now source-derived: "The roadmap could not be loaded right now. Read the canonical version at *{label}*." ("from GitHub" dropped from the copy and the log line — a configured source need not be GitHub.)

## The byline fix (#242's flagged nuance)

`/roadmap`'s byline label was hardcoded text (`civic-ai-tools/ROADMAP.md`) sitting next to a configurable `href`, so an overriding instance got a correct link under the reference project's file name. Fixed structurally rather than by adding a fourth variable: new `src/lib/content-source.ts` derives **both** the label and the link target from one parse of one URL.

- `https://raw.githubusercontent.com/npstorey/civic-ai-tools/main/ROADMAP.md` → label `civic-ai-tools/ROADMAP.md`, link to the GitHub file page. (Also handles the `refs/heads/…` raw form, `github.com/…/blob/…` URLs, non-GitHub URLs → `host/path` linking to itself, and unparseable values → passed through so a misconfiguration is visible rather than swallowed.)
- `ROADMAP_GITHUB_URL` set → the label describes *that* URL, since that is where the byline points. One derivation, so label and link cannot disagree.
- A second instance of the same defect, fixed in passing: with `ROADMAP_RAW_URL` set and `ROADMAP_GITHUB_URL` unset, the old code linked the byline at the *upstream* roadmap while rendering the instance's own. The view URL is now derived from the raw URL instead.

## Changes

| File | What |
| --- | --- |
| `src/lib/content-source.ts` *(new)* | Pure, I/O-free: `describeContentSource(url)` (label + human href), the `ContentProvenance` type, `directorySourceNote()` — the `/directory` attribution decision as one function. |
| `src/lib/site-config.ts` | `#241` section reworked. `getDirectorySource()` → `{ url, provenance }`; `getRoadmapSource()` → `{ rawUrl, viewUrl, label } \| null`. `DEMO_DIRECTORY_DATA_URL` → `COMMUNITY_DIRECTORY_DATA_URL` (it is no longer a "demo default" — it is the deliberate content of the unconfigured page). `DEMO_ROADMAP_RAW_URL` / `DEMO_ROADMAP_GITHUB_URL` deleted: with the roadmap fallback gone, a constant naming another project's roadmap has no caller, and keeping one would quietly re-create the ambiguity. |
| `src/lib/mcp/directory-data.ts` | `getDirectoryData()` returns `{ servers, provenance, sourceUrl }` — the snapshot fallback is no longer silent. |
| `src/lib/roadmap/data.ts` | `getRoadmapMarkdown(rawUrl)` takes the URL: an instance with no roadmap of its own never reaches a fetch, because there is nothing of its own to fetch. |
| `src/app/(marketing)/directory/page.tsx`, `src/components/DirectoryWrapper.tsx` | Note computed server-side, passed as an optional prop (default `null` = today's markup) to the client wrapper. |
| `src/app/(marketing)/roadmap/page.tsx` | Two states; `generateMetadata()` so the source is read at call time like every other instance-config read. |
| `src/app/layout.tsx`, `src/components/Header.tsx` | `showRoadmap` prop (default `true`, so an omitted prop renders today's nav) gates the three nav mounts. |
| `scripts/preflight-env.mjs` | Purposes now describe what *unset* does, not a default that no longer exists. |
| `docs/deploy.md` | "Content sources (directory and roadmap)" rewritten: an **Unset** column instead of **Default**, the why-the-two-pages-differ rationale, the snapshot caveat, and the build-time note. |

## Deviations and judgment calls

- **Two-line edit outside the named subsection in `docs/deploy.md`.** The "Merely overrides a default" list said the content-source set leaves both pages "byte-identically to before," which this PR makes false. Rather than ship a known-wrong sentence, I edited that one clause (`docs/deploy.md` ~line 424) to say `ROADMAP_RAW_URL` is the one entry in that list that is *not* merely a default. It is a different section from either concurrent edit (Before you start / executor), so it should merge cleanly. Arguably `ROADMAP_RAW_URL` now belongs in the "Feature disabled when absent" table instead; I left that restructure alone.
- **`site-config.ts` now imports a sibling with a relative, extension-bearing specifier** (`./content-source.ts`). It has to: the module is in the `node --test` graph via the evidence modules, which resolve neither the `@/` alias nor extensionless specifiers. Same convention as `evidence/verify.ts`. (Found the hard way — the first run failed 21 tests across the evidence suite.)
- **Not fixed, flagged:** `AudienceRoutingStrip` (rendered under a loaded roadmap) has six cards pointing at the reference project's own hub docs and naming civicaitools.org — the same class of upstream coupling, on a component whose header declares its content governed by website#94 ("a roadmap-change issue, not a drive-by UI edit"). I left it, added a comment at the mount, and it does not render in the unconfigured state. Same for `/project`'s two prose links to `/roadmap`: prose about the reference project is content, not chrome, per deploy.md's own line.
- **`/directory`'s page metadata** still hardcodes "65+ MCP servers and 2,000+ open data portals" — pre-existing, unrelated to the source seam, left alone.

## Test results

- `npm ci` — clean.
- `npm test` — **622 pass, 2 fail**. Both failures are `src/lib/openrouter-streaming.test.ts` (`listen EPERM: operation not permitted 127.0.0.1`), the known sandbox socket-bind artifact, unrelated. 21 cases here: 11 new in `src/lib/content-source.test.ts`, 10 in a rewritten `src/lib/site-config.test.ts` (was 4) (including the label-vs-link drift case and a "the reference deployment configured explicitly renders the byline it has today" case).
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors, 4 pre-existing warnings in unrelated files.
- `npm run build` — fails in this sandbox only: Turbopack cannot reach `fonts.googleapis.com` for `next/font`. Environmental, same as #242. CI is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
