### PR TITLE
docs: sandbox build limitation + ROADMAP_RAW_URL table placement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,20 @@ CSS keyframes (`blink`, `spin`, `pulse`) and component-specific styles use style
 
 ## Known Tech Debt
 
+### `next build` cannot run in a sandboxed agent session
+
+The default (Turbopack) builder cannot complete inside a Claude Code sandbox on
+any branch: its PostCSS worker pool binds a TCP port, and the sandbox denies
+port binding (`Operation not permitted`) — the same restriction behind the
+`listen EPERM` failures in `openrouter-streaming.test.ts`. Agents should build
+with `next build --webpack`, and treat CI's `build` check as the real gate.
+
+Note for anyone diagnosing a build failure here: this is **not** a network
+problem. Google Fonts was blamed for it for two days; the sandbox reaches
+`fonts.googleapis.com` fine, and since #246 the fonts are self-hosted anyway
+(`src/fonts/`), so no build path needs font egress at all.
+
+
 1. **Duplicated SSE event handling** — `useLiveTrace` and `useStreamingComparison` both build progress groups from SSE events. A shared utility could extract the group-building logic.
 2. **`@keyframes` duplication** — `blink` is defined in multiple styled-jsx blocks and could move to `globals.css`. `spin` exists in both `globals.css` and component styles.
 3. **`useLiveTrace` responsibility accumulation** — Manages SSE connection, diagram animation, progress logs, tool tracking, trace capture, slow timers, elapsed time, and abort control. Works but is a code smell.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -404,6 +404,7 @@ doesn't):
 | `KV_REST_API_URL` + `KV_REST_API_TOKEN` | Durable rate limiting — the counter falls back to per-process memory (resets on restart; not shared across instances). Fine for a single-node instance. |
 | `SANDBOX_SNAPSHOT_ID` | (vercel-sandbox executor only) Prebuilt snapshot — absent, every execution pays a slow fresh boot + pip install. Not read by the container executor. |
 | `SOCRATA_APP_TOKEN` | Socrata API app token passed into executed notebooks — absent, requests run anonymously against Socrata's lower rate limits. |
+| `ROADMAP_RAW_URL` | `/roadmap` — absent, the page states that this instance has published no roadmap and the Roadmap link leaves the header and footer nav. An instance serves its own roadmap or none; there is no upstream fallback. |
 
 **Merely overrides a default.** Everything else, including:
 `MODEL_API_BASE_URL` (endpoint override), the instance-identity set
@@ -420,11 +421,11 @@ exactly the pre-allowlist behavior; see the sign-in section),
 the host-topology set (`APP_HOST`, `MARKETING_HOST`, `APP_ONLY` — with
 none set, every route serves on every host, exactly the single-host
 behavior; see [Host topology](#host-topology-optional)),
-the content-source set (`DIRECTORY_DATA_URL`, `ROADMAP_RAW_URL`,
-`ROADMAP_GITHUB_URL` — with none set, `/directory` serves the shared
-community index with attribution; `ROADMAP_RAW_URL` is the one entry in
-this list that is not merely a default, since absent it means this
-instance has published no roadmap and `/roadmap` says so; see
+the remaining content-source overrides (`DIRECTORY_DATA_URL`,
+`ROADMAP_GITHUB_URL` — with `DIRECTORY_DATA_URL` unset, `/directory`
+serves the shared community index with attribution; `ROADMAP_GITHUB_URL`
+is derived from `ROADMAP_RAW_URL` when unset. `ROADMAP_RAW_URL` itself is
+in the disable-when-absent table above, not here; see
 [Content sources](#content-sources-directory-and-roadmap)),
 rate-limit and token-budget tuning knobs
 (`ANONYMOUS_RATE_LIMIT`, `AUTHENTICATED_RATE_LIMIT`,


### PR DESCRIPTION
Two small documentation corrections decided at review of #245 and #246.

**1. `ROADMAP_RAW_URL` moves to the disable-when-absent table** (`docs/deploy.md`). After #245 an absent `ROADMAP_RAW_URL` disables a page rather than falling back to a default, so listing it under "merely overrides a default" was misleading — the previous text even carried an inline apology for the mismatch. It now has a row in the table above, and the overrides list keeps only the two variables that really are overrides.

**2. The sandbox build limitation is recorded** (`CLAUDE.md`, Known Tech Debt). The default Turbopack builder cannot complete inside a Claude Code sandbox on any branch: its PostCSS worker pool binds a TCP port and the sandbox denies port binding — the same restriction behind the `listen EPERM` test failures. Agents should use `next build --webpack` and treat CI's `build` check as the gate.

The note also corrects the record: this was misattributed to blocked Google Fonts egress for two days across several agent sessions. The sandbox reaches `fonts.googleapis.com` fine (verified), and since #246 the fonts are self-hosted, so no build path needs font egress at all. Writing it down is the point — memory reaches planning sessions, but `CLAUDE.md` reaches every agent that works in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
