### PR TITLE
fix: pass the full documented environment through to the container, and guard it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      # Compose environment coverage. The app service passes an explicit
+      # `environment` map, so a variable absent from it never reaches the
+      # container — silently, with nothing to debug against. This compares that
+      # map against the app's own inventory (scripts/preflight-env.mjs
+      # ENV_SPEC) and fails on a variable the app reads that compose cannot
+      # deliver. Credential-free like every step here: it reads two checked-in
+      # files and no environment. `npm test` above also gates it (the guard's
+      # test file globs in), and the dedicated step is what makes the failure
+      # legible in the log.
+      - name: Compose env coverage
+        run: npm run check:compose-env
+
       # ADR-0012 §3 / spec §8.3.3 parallel-serve: /.well-known/typed-publisher.json
       # (the canonical path) and /.well-known/evidence-public-keys.json (the
       # legacy path) MUST emit byte-identical content. The canonical path is a

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,10 @@
 #   docker build -t civic-app:dev .
 #   docker build -t civic-app-migrate:dev --target migrate .
 #
-# Configuration is RUN-time only (see .dockerignore): no environment file
-# ever enters the build context.
+# Configuration is RUN-time wherever it can be: no environment file ever
+# enters the build context (see .dockerignore). The exception is the set of
+# values Next.js reads at build and inlines — those arrive as named build
+# args, declared on the builder stage below and nowhere else.
 
 ARG NODE_IMAGE=node:22-bookworm-slim
 # Static docker CLI, copied into the runtime layer for EXECUTOR_DRIVER=container.
@@ -28,6 +30,30 @@ RUN npm ci
 FROM ${NODE_IMAGE} AS builder
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
+
+# BUILD-TIME CONFIGURATION. Two kinds, and neither can be supplied at run
+# time — hence args rather than container environment:
+#
+#   NEXT_PUBLIC_*    inlined into the emitted bundles by Next.js. A run-time
+#                    value cannot change them; there is nothing left to read.
+#   branding /       read on the server, but ALSO baked into statically
+#   content sources  prerendered pages. docker-compose.yml passes these in
+#                    both places so prerendered and dynamic pages agree.
+#
+# An ARG left unpassed stays unset, so an operator who configures none of
+# them builds exactly the image this file built before they existed. Nothing
+# secret may be added here: build args are readable in image history.
+ARG NEXT_PUBLIC_GA_MEASUREMENT_ID
+ARG NEXT_PUBLIC_SOCRATA_MCP_URL
+ARG NEXT_PUBLIC_CAPTURE_TRACES
+ARG SITE_BRAND_NAME
+ARG SITE_BRAND_ACCENT
+ARG SITE_BRAND_TAGLINE
+ARG SITE_BRAND_ATTRIBUTION
+ARG DIRECTORY_DATA_URL
+ARG ROADMAP_RAW_URL
+ARG ROADMAP_GITHUB_URL
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 # `npm run build:standalone` = BUILD_STANDALONE=1 next build (which flips

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,15 @@
 #
 #   docker compose --env-file <your env file> up
 #
+# TWO ARRIVAL TIMES. Most values are read by the running server and arrive
+# through the app service's `environment`. A few are read at `next build`
+# instead — NEXT_PUBLIC_* are inlined into bundles, and the branding and
+# content-source variables are additionally baked into prerendered pages —
+# so those also appear under the app service's `build.args`. Use the same
+# env file for both; `docker compose --env-file <file> up --build` supplies
+# each side from it. Changing a build-time value takes effect on the next
+# build, not on restart.
+#
 # An instance that publishes signed evidence supplies EVIDENCE_SIGNING_KEY,
 # EVIDENCE_KEY_ID, and its own identity values; with none set the app runs
 # in the unsigned tier by design (ADR-0020) — publish stays gated off and
@@ -125,6 +134,26 @@ services:
     build:
       context: .
       target: runner
+      # BUILD-TIME values (see the "two arrival times" note in this file's
+      # header). Bare NAME, same pass-through rule as `environment` below: an
+      # arg absent from your environment is not passed, and the image keeps
+      # the coded default. Nothing secret belongs here — build args are
+      # readable in image history.
+      args:
+        # Inlined into bundles at build; a run-time value cannot change them.
+        NEXT_PUBLIC_GA_MEASUREMENT_ID:
+        NEXT_PUBLIC_SOCRATA_MCP_URL:
+        NEXT_PUBLIC_CAPTURE_TRACES:
+        # Read at BOTH times: prerendered pages bake these at build, dynamic
+        # pages read the container's environment. Passed in both places so
+        # every page agrees (docs/deploy.md, branding + content sources).
+        SITE_BRAND_NAME:
+        SITE_BRAND_ACCENT:
+        SITE_BRAND_TAGLINE:
+        SITE_BRAND_ATTRIBUTION:
+        DIRECTORY_DATA_URL:
+        ROADMAP_RAW_URL:
+        ROADMAP_GITHUB_URL:
     restart: unless-stopped
     depends_on:
       postgres:
@@ -169,6 +198,8 @@ services:
       # a browser can reach — not the in-network endpoint above. Keep the
       # last path segment equal to S3_BUCKET.
       S3_PUBLIC_BASE_URL: ${S3_PUBLIC_BASE_URL:-http://localhost:9000/evidence}
+      S3_REGION:
+      S3_FORCE_PATH_STYLE:
       EXECUTOR_DRIVER: container
       EXECUTOR_CONTAINER_IMAGE: ${EXECUTOR_CONTAINER_IMAGE:-civic-notebook-executor:0.1.0}
       # --- instance identity (ADR-0020; neutral local values) ---
@@ -186,8 +217,22 @@ services:
       #   EVIDENCE_SIGNING_KEY / EVIDENCE_KEY_ID  unset ⇒ unsigned tier
       #   NEXTAUTH_SECRET                         unset ⇒ sign-in unavailable
       #   CRON_SECRET                             unset ⇒ scheduler rejected (401)
-      # NEXT_PUBLIC_* values are not here: those are inlined into client
-      # bundles at build time, so they belong to the image build, not to run.
+      #
+      # WHY BARE `NAME:` AND NOT `${NAME:-}`: the two are not the same
+      # variable. `${NAME:-}` always sets the variable, to the empty string
+      # when your environment has none — and the app distinguishes the two.
+      # EVIDENCE_TRUST_REGISTRY_LEGACY_URL is the sharpest case: unset means
+      # "emit the legacy registry URL in the signed sidecar", empty string
+      # means "omit it" (src/lib/site-config.ts getSidecarTrustRegistryUrls),
+      # so `${NAME:-}` would silently change signed output on every instance.
+      # Bare NAME is the only form that leaves an unset variable unset.
+      # scripts/check-compose-env.mjs rejects the `${NAME:-}` form here.
+      #
+      # This list is checked against the app's own environment inventory
+      # (scripts/preflight-env.mjs ENV_SPEC) by scripts/check-compose-env.mjs,
+      # which runs in `npm test` and in CI. A new variable the app reads fails
+      # that check until it is added here — which is what keeps a documented
+      # variable from being inert on this path.
       EVIDENCE_SIGNING_KEY:
       EVIDENCE_KEY_ID:
       NEXTAUTH_SECRET:
@@ -197,16 +242,42 @@ services:
       OIDC_CLIENT_ID:
       OIDC_CLIENT_SECRET:
       OIDC_PROVIDER_NAME:
+      SIGN_IN_ALLOWLIST:
       OPENROUTER_API_KEY:
       MODEL_API_BASE_URL:
       SOCRATA_MCP_URL:
       SOCRATA_APP_TOKEN:
       DATA_COMMONS_MCP_URL:
       DATA_COMMONS_API_KEY:
+      BOSTON_OPENCONTEXT_MCP_URL:
       DC_API_KEY:
       CRON_SECRET:
       KV_REST_API_URL:
       KV_REST_API_TOKEN:
+      # Host topology: unset ⇒ no host routing, every route on every host.
+      APP_HOST:
+      MARKETING_HOST:
+      APP_ONLY:
+      # Evidence identity overrides not already given a local default above.
+      EVIDENCE_PLATFORM_AGENT_URL:
+      EVIDENCE_TRUST_REGISTRY_CANONICAL_URL:
+      EVIDENCE_TRUST_REGISTRY_LEGACY_URL:
+      EVIDENCE_TRUST_REGISTRY_URL:
+      # Chrome branding and content sources. Also passed as build args above:
+      # prerendered pages bake them, dynamic pages read them here.
+      SITE_BRAND_NAME:
+      SITE_BRAND_ACCENT:
+      SITE_BRAND_TAGLINE:
+      SITE_BRAND_ATTRIBUTION:
+      DIRECTORY_DATA_URL:
+      ROADMAP_RAW_URL:
+      ROADMAP_GITHUB_URL:
+      # Tuning knobs; each falls back to a coded default when absent.
+      ANONYMOUS_RATE_LIMIT:
+      AUTHENTICATED_RATE_LIMIT:
+      APP_TIER_RATE_LIMIT:
+      TOKEN_LIMIT_PER_REQUEST:
+      MAX_TOOL_RESULT_CHARS:
 
   # Periodic caller for the scheduler endpoint. The endpoint is a plain
   # bearer-authenticated GET (src/app/api/cron/blob-gc/route.ts), so any

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -142,10 +142,10 @@ database; substitute your own values wherever you override
 
 ### Supplying your environment
 
-Configuration is run-time only — no environment file enters the image
-build. Entries the compose file lists as a bare `NAME` (no value) are
-pass-through: set in the container only when your environment has them,
-absent otherwise. Put your values in a file of `KEY=value` lines.
+Put your values in one file of `KEY=value` lines and hand it to compose;
+that single file feeds both the running container and the image build.
+No environment file enters the build *context* — the build reads only
+the named arguments listed in the compose file's `build.args`.
 
 A minimal first environment file (placeholders — substitute your own,
 and never commit this file):
@@ -166,13 +166,40 @@ GITHUB_CLIENT_ID=<your OAuth app>
 GITHUB_CLIENT_SECRET=<your OAuth app>
 ```
 
-Anything spelled `${VAR:-default}` in the compose file is overridable
-this way — the service passwords, host ports, bucket name,
-`S3_PUBLIC_BASE_URL`, `APP_BIND`/`APP_PORT`, the executor image tag, the
-identity variables, `NEXTAUTH_URL`, and the GC knobs — in addition to
-the bare-`NAME` pass-throughs. The three driver selectors,
-`S3_ENDPOINT`, and the constructed `DATABASE_URL` are hardcoded wiring:
-changing those means editing the compose file, not the env file.
+**How a value reaches the app.** Every variable in this guide is spelled
+one of three ways in `docker-compose.yml`, and the spelling tells you
+what your env file can do with it:
+
+| Spelling | What it means | Examples |
+| --- | --- | --- |
+| bare `NAME:` | Pass-through. Set in the container only when your environment has it, **absent otherwise** — which matters, because for several variables absence is the configured state, not a missing value. | the credentials, `SIGN_IN_ALLOWLIST`, `ROADMAP_RAW_URL`, the branding set, the tuning knobs |
+| `${NAME:-default}` | Overridable, with a working local default if you say nothing. | service passwords, host ports, bucket name, `S3_PUBLIC_BASE_URL`, `APP_BIND` / `APP_PORT`, the executor image tag, the identity variables, `NEXTAUTH_URL`, the GC knobs |
+| a literal value | Hardcoded wiring. Changing it means editing the compose file, not your env file. | the three driver selectors, `S3_ENDPOINT`, the constructed `DATABASE_URL` |
+
+There is no fourth category. A variable this guide documents but the
+compose file does not list would be inert on this path — set it, restart,
+and nothing happens, with no error to debug. That was a real fourth
+category once — the branding set, the content sources, host topology and
+the tuning knobs were all documented here and none of them were listed
+there. `scripts/check-compose-env.mjs` now compares the compose file
+against the app's own variable inventory (`scripts/preflight-env.mjs`) on
+every CI run, so a variable that reaches this guide without reaching the
+container fails the build.
+
+**Build time versus run time.** Most variables are read by the running
+server and arrive through the container's environment. A few are read at
+`next build` instead: `NEXT_PUBLIC_*` values are inlined into the emitted
+bundles, and the branding and content-source variables are additionally
+baked into statically prerendered pages. Those appear under the app
+service's `build.args` as well, resolved from the same env file, so:
+
+```bash
+docker compose --env-file /path/to/your.env up -d --build
+```
+
+supplies both sides at once. A change to a build-time value takes effect
+on the next build, not on the next restart — `--build` is what makes that
+one command rather than two.
 
 > **Reset the dev volumes before switching to your own passwords.**
 > Postgres reads `POSTGRES_PASSWORD` only when its data volume is first

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "build:standalone": "BUILD_STANDALONE=1 next build && npm run check:standalone",
     "check:standalone": "node scripts/check-standalone-assets.mjs",
+    "check:compose-env": "node scripts/check-compose-env.mjs",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-compose-env.mjs
+++ b/scripts/check-compose-env.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+/**
+ * Compose environment-coverage guard.
+ *
+ * THE DEFECT THIS EXISTS TO PREVENT. `docker-compose.yml` hands the app
+ * service an explicit `environment` map, so a variable not named there never
+ * reaches the container — no error, no warning, no log line. Twenty-three
+ * documented variables had accumulated in that gap: the whole branding seam,
+ * the content-source seam, host topology, the rate-limit and token knobs.
+ * An operator could set `SITE_BRAND_NAME`, restart, watch nothing change, and
+ * have nothing to debug against. Each of those features shipped with its own
+ * deploy-guide section and none of them touched the compose file; per-feature
+ * review cannot see a gap that is defined by absence.
+ *
+ * WHAT IT CHECKS. `scripts/preflight-env.mjs` ENV_SPEC already enumerates
+ * every variable the app reads, and is the authority here. This script reads
+ * the compose file, resolves the profile the compose file itself pins (its
+ * literal DB_DRIVER / BLOB_DRIVER / EXECUTOR_DRIVER values), and demands that
+ * every variable that profile actually reads is deliverable:
+ *
+ *   1. COVERAGE — a variable the app reads at run time must appear in the app
+ *      service's `environment`; a variable read at build time must appear in
+ *      its `build.args`; one read at both must appear in both (see `readBy`
+ *      in ENV_SPEC). Not-applicable variables (a driver this profile does not
+ *      select) and `external-tool` variables are excluded — an instance must
+ *      not be asked to deliver what it will never read.
+ *   2. FORM — an `environment` entry written `${NAME:-}` is rejected. That
+ *      form does NOT pass a variable through: it always sets the variable, to
+ *      the empty string when the caller's environment has none. Empty is not
+ *      absent. `EVIDENCE_TRUST_REGISTRY_LEGACY_URL` is the proof — unset means
+ *      "emit the legacy registry URL in the signed sidecar", empty means "omit
+ *      it" (src/lib/site-config.ts) — and `SIGN_IN_ALLOWLIST`, `ROADMAP_RAW_URL`
+ *      and the host-topology trio all carry meaning in their absence too. Bare
+ *      `NAME:` is the form that leaves an unset variable unset.
+ *   3. DRIFT, the other way — a variable in the app service's `environment`
+ *      that ENV_SPEC does not declare. Either the app stopped reading it, or
+ *      the inventory is stale; both are worth knowing.
+ *
+ * It reads NO values from the environment and prints none: it compares two
+ * checked-in files. Exit 0 clean, 1 on any failure.
+ *
+ *   node scripts/check-compose-env.mjs        # or: npm run check:compose-env
+ *
+ * The pure functions are exported and covered by
+ * scripts/check-compose-env.test.mjs, which `npm test` globs — so the guard
+ * gates locally and in CI even if the dedicated CI step is ever dropped.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { ENV_SPEC, resolveDrivers, resolveSpec } from './preflight-env.mjs';
+
+/** The service the app runs in. */
+export const APP_SERVICE = 'app';
+
+/**
+ * Minimal reader for the one compose shape this repo uses: a top-level
+ * `services:` map, service keys at 2 spaces, service fields at 4, and
+ * `environment` / `build.args` as mappings (`KEY: value` or bare `KEY:`).
+ *
+ * Deliberately NOT a general YAML parser — the repo has no YAML dependency
+ * and a guard that silently mis-parses is worse than no guard. Every shape it
+ * does not understand (sequence-form `environment`, tabs, a missing service)
+ * throws rather than returning an empty result that would pass the check.
+ *
+ * @param {string} text
+ * @param {string} service
+ * @returns {{ environment: Map<string, string|null>, buildArgs: Map<string, string|null>, envFiles: string[] }}
+ */
+export function parseComposeService(text, service = APP_SERVICE) {
+  if (/^\t| \t/m.test(text)) throw new Error('compose file contains tab indentation; this reader assumes spaces');
+
+  const lines = text.split('\n');
+  const environment = new Map();
+  const buildArgs = new Map();
+  const envFiles = [];
+
+  /** Indentation of a line, or null for blank/comment lines (which are skipped). */
+  const indentOf = (line) => {
+    if (!line.trim() || line.trim().startsWith('#')) return null;
+    return line.length - line.trimStart().length;
+  };
+
+  let inServices = false;
+  let inTarget = false; // inside the requested service
+  /** @type {null | 'environment' | 'args' | 'env_file'} */
+  let block = null;
+  let blockIndent = 0;
+  let inBuild = false;
+  let seenService = false;
+
+  for (const line of lines) {
+    const indent = indentOf(line);
+    if (indent === null) continue;
+    const body = line.trim();
+
+    if (indent === 0) {
+      inServices = body === 'services:';
+      inTarget = false;
+      block = null;
+      inBuild = false;
+      continue;
+    }
+    if (!inServices) continue;
+
+    if (indent === 2) {
+      const m = /^([A-Za-z0-9_.-]+):$/.exec(body);
+      if (!m) throw new Error(`unexpected service-level line: ${body}`);
+      inTarget = m[1] === service;
+      if (inTarget) seenService = true;
+      block = null;
+      inBuild = false;
+      continue;
+    }
+    if (!inTarget) continue;
+
+    if (indent === 4) {
+      block = null;
+      inBuild = body === 'build:';
+      if (body === 'environment:') {
+        block = 'environment';
+        blockIndent = 6;
+      } else if (body === 'env_file:') {
+        block = 'env_file';
+        blockIndent = 6;
+      }
+      continue;
+    }
+
+    // Inside `build:` — find its `args:` sub-mapping.
+    if (inBuild && indent === 6) {
+      if (body === 'args:') {
+        block = 'args';
+        blockIndent = 8;
+      } else if (block === 'args') {
+        block = null;
+      }
+      continue;
+    }
+
+    if (!block || indent !== blockIndent) {
+      // Deeper nesting inside a block we track would mean a shape this reader
+      // does not model (e.g. a mapping value). Fail loudly rather than skip.
+      if (block && indent > blockIndent) throw new Error(`unsupported nesting under ${block}: ${body}`);
+      continue;
+    }
+
+    if (block === 'env_file') {
+      if (!body.startsWith('- ')) throw new Error(`unsupported env_file entry: ${body}`);
+      envFiles.push(body.slice(2).trim());
+      continue;
+    }
+
+    if (body.startsWith('- ')) {
+      throw new Error(
+        `sequence-form \`${block}\` is not supported by this guard (found: ${body}). ` +
+          'Use the mapping form (`KEY: value`, or bare `KEY:` for pass-through).',
+      );
+    }
+    const m = /^([A-Za-z_][A-Za-z0-9_]*):(.*)$/.exec(body);
+    if (!m) throw new Error(`unparsable ${block} entry: ${body}`);
+    const value = m[2].trim();
+    (block === 'args' ? buildArgs : environment).set(m[1], value === '' ? null : value);
+  }
+
+  if (!seenService) throw new Error(`compose file declares no \`${service}\` service`);
+  return { environment, buildArgs, envFiles };
+}
+
+/**
+ * The `${NAME:-}` form — interpolation with an EMPTY default. Always sets the
+ * variable; sets it to '' when the caller has none. `${NAME:-something}` is
+ * fine (a real default) and `${NAME}` is not (blank when unset, with a compose
+ * warning), so both no-value forms are matched.
+ */
+const EMPTY_DEFAULT_FORM = /^\$\{[A-Za-z_][A-Za-z0-9_]*(:-)?\}$/;
+
+/**
+ * Compare the compose file against the app's own environment inventory.
+ * Pure: takes text and a spec, returns findings. Reads no environment.
+ *
+ * @param {string} composeText
+ * @param {typeof ENV_SPEC} [spec]
+ * @param {string} [service]
+ */
+export function checkComposeEnvCoverage(composeText, spec = ENV_SPEC, service = APP_SERVICE) {
+  const { environment, buildArgs, envFiles } = parseComposeService(composeText, service);
+
+  // The compose file pins its own profile. Resolve the spec against THOSE
+  // drivers so the check demands exactly what this deployment shape reads:
+  // no Vercel Blob token under BLOB_DRIVER=s3, no sandbox knobs under the
+  // container executor. A driver written as an interpolation rather than a
+  // literal leaves the seam unpinned, and resolveDrivers takes its default.
+  const driverEnv = {};
+  for (const [name, value] of environment) {
+    if (typeof value === 'string' && !value.includes('$')) driverEnv[name] = value;
+  }
+  const { drivers } = resolveDrivers(driverEnv);
+  const { applicable, notApplicable } = resolveSpec(drivers, spec, {});
+
+  // An `env_file:` on the service delivers whatever the operator's file holds,
+  // which no static check can enumerate — so coverage becomes unprovable.
+  const coverageProvable = envFiles.length === 0;
+
+  const missingRuntime = [];
+  const missingBuildArg = [];
+  const emptyDefaultForm = [];
+  const runtimeInert = [];
+
+  for (const entry of applicable) {
+    const readBy = entry.readBy ?? 'runtime';
+    if (readBy === 'external-tool') continue;
+
+    const needsRuntime = readBy === 'runtime' || readBy === 'build-and-runtime';
+    const needsBuildArg = readBy === 'build' || readBy === 'build-and-runtime';
+
+    if (needsRuntime && coverageProvable && !environment.has(entry.name)) {
+      missingRuntime.push(entry);
+    }
+    if (needsBuildArg && !buildArgs.has(entry.name)) {
+      missingBuildArg.push(entry);
+    }
+    // A build-only value in `environment` reads as though setting it at run
+    // time would do something. It cannot: the value is already inlined.
+    if (readBy === 'build' && environment.has(entry.name)) {
+      runtimeInert.push(entry);
+    }
+  }
+
+  for (const [name, value] of environment) {
+    if (typeof value === 'string' && EMPTY_DEFAULT_FORM.test(value)) emptyDefaultForm.push(name);
+  }
+
+  const declared = new Set(spec.map((s) => s.name));
+  const notApplicableNames = new Set(notApplicable.map((s) => s.name));
+  const undeclared = [...environment.keys()].filter((n) => !declared.has(n));
+  // Present but inert under this profile: not a failure (an operator may be
+  // keeping a lane open), but worth naming — it is dead configuration.
+  const inapplicablePresent = [...environment.keys()].filter((n) => notApplicableNames.has(n));
+
+  const ok =
+    missingRuntime.length === 0 &&
+    missingBuildArg.length === 0 &&
+    emptyDefaultForm.length === 0 &&
+    runtimeInert.length === 0 &&
+    undeclared.length === 0;
+
+  return {
+    ok,
+    drivers,
+    coverageProvable,
+    envFiles,
+    missingRuntime,
+    missingBuildArg,
+    emptyDefaultForm,
+    runtimeInert,
+    undeclared,
+    inapplicablePresent,
+    counts: { environment: environment.size, buildArgs: buildArgs.size, applicable: applicable.length },
+  };
+}
+
+/** Render findings as text. Pure; names only, never values. */
+export function renderComposeReport(result, service = APP_SERVICE) {
+  const lines = [''];
+  lines.push('  docker-compose.yml — environment coverage');
+  lines.push(`  (service "${service}"; compared against scripts/preflight-env.mjs ENV_SPEC)`);
+  lines.push('');
+  const pairs = Object.entries(result.drivers).map(([seam, d]) => `${seam}=${d}`);
+  lines.push(`  PROFILE: ${pairs.join('  ')}`);
+  lines.push(
+    `  ${result.counts.environment} environment entr${result.counts.environment === 1 ? 'y' : 'ies'}, ` +
+      `${result.counts.buildArgs} build arg(s), ${result.counts.applicable} applicable spec entr(ies)`,
+  );
+  lines.push('');
+
+  if (!result.coverageProvable) {
+    lines.push(`  NOTE: the service declares env_file (${result.envFiles.join(', ')}); run-time`);
+    lines.push('        coverage cannot be proven statically and was not checked.');
+    lines.push('');
+  }
+
+  if (result.missingRuntime.length > 0) {
+    lines.push(`  FAIL: ${result.missingRuntime.length} variable(s) the app reads at run time are absent from`);
+    lines.push('        the service environment — set them and nothing reaches the container:');
+    for (const e of result.missingRuntime) lines.push(`          - ${e.name} (${e.tier}) — ${e.purpose}`);
+    lines.push('        Fix: add each as a bare `NAME:` pass-through under `environment:`.');
+    lines.push('');
+  }
+  if (result.missingBuildArg.length > 0) {
+    lines.push(`  FAIL: ${result.missingBuildArg.length} variable(s) are read at BUILD time and absent from build.args:`);
+    for (const e of result.missingBuildArg) lines.push(`          - ${e.name} (readBy: ${e.readBy}) — ${e.purpose}`);
+    lines.push('        Fix: add each under the service\'s `build.args`, and declare a');
+    lines.push('        matching `ARG` in the Dockerfile builder stage.');
+    lines.push('');
+  }
+  if (result.runtimeInert.length > 0) {
+    lines.push(`  FAIL: ${result.runtimeInert.length} build-time variable(s) also listed under environment, where`);
+    lines.push('        they do nothing — the value was inlined at build and nothing reads it:');
+    for (const e of result.runtimeInert) lines.push(`          - ${e.name}`);
+    lines.push('');
+  }
+  if (result.emptyDefaultForm.length > 0) {
+    lines.push(`  FAIL: ${result.emptyDefaultForm.length} entr(ies) use an empty-default interpolation, which sets the`);
+    lines.push('        variable to "" rather than leaving it unset. Empty is not absent —');
+    lines.push('        EVIDENCE_TRUST_REGISTRY_LEGACY_URL="" omits a URL from signed output:');
+    for (const n of result.emptyDefaultForm) lines.push(`          - ${n}`);
+    lines.push('        Fix: write the bare `NAME:` form, or give a real default.');
+    lines.push('');
+  }
+  if (result.undeclared.length > 0) {
+    lines.push(`  FAIL: ${result.undeclared.length} variable(s) passed to the container that ENV_SPEC does not`);
+    lines.push('        declare — either the app stopped reading them, or the inventory is stale:');
+    for (const n of result.undeclared) lines.push(`          - ${n}`);
+    lines.push('');
+  }
+  if (result.inapplicablePresent.length > 0) {
+    lines.push(`  NOTE: ${result.inapplicablePresent.length} variable(s) present but not read under this profile:`);
+    for (const n of result.inapplicablePresent) lines.push(`          - ${n}`);
+    lines.push('');
+  }
+
+  lines.push(
+    result.ok
+      ? '  RESULT: PASS — every variable this profile reads can reach the container.'
+      : '  RESULT: FAIL — the compose path cannot deliver part of the documented environment.',
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Entry point when run directly. */
+function main() {
+  const path = fileURLToPath(new URL('../docker-compose.yml', import.meta.url));
+  const result = checkComposeEnvCoverage(readFileSync(path, 'utf8'));
+  process.stdout.write(renderComposeReport(result));
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/check-compose-env.test.mjs
+++ b/scripts/check-compose-env.test.mjs
@@ -1,0 +1,183 @@
+// Unit tests for the compose environment-coverage guard.
+//
+// Run with:  node --test scripts/check-compose-env.test.mjs
+// (`npm test` globs scripts/**/*.test.mjs, so this runs there and in CI.)
+//
+// The last test in this file is the gate: it runs the check against the real
+// docker-compose.yml. Everything above it pins the behavior that makes that
+// gate meaningful.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  APP_SERVICE,
+  checkComposeEnvCoverage,
+  parseComposeService,
+  renderComposeReport,
+} from './check-compose-env.mjs';
+import { ENV_SPEC } from './preflight-env.mjs';
+
+/** A compose file in the shape this repo uses, small enough to reason about. */
+function fixture({ env = [], args = null, envFile = null } = {}) {
+  const lines = ['services:', '  postgres:', '    image: postgres:17-bookworm', '  app:', '    build:', '      context: .', '      target: runner'];
+  if (args) {
+    lines.push('      args:');
+    for (const a of args) lines.push(`        ${a}`);
+  }
+  if (envFile) {
+    lines.push('    env_file:');
+    lines.push(`      - ${envFile}`);
+  }
+  lines.push('    environment:');
+  lines.push('      # a comment inside the block');
+  for (const e of env) lines.push(`      ${e}`);
+  return lines.join('\n') + '\n';
+}
+
+/** A tiny spec, so a test is not hostage to the real inventory's contents. */
+const SPEC = [
+  { name: 'RUNTIME_ONE', tier: 'required', purpose: 'runtime' },
+  { name: 'RUNTIME_TWO', tier: 'optional', purpose: 'runtime' },
+  { name: 'BOTH_ONE', readBy: 'build-and-runtime', tier: 'optional', purpose: 'both' },
+  { name: 'BUILD_ONE', readBy: 'build', tier: 'optional', purpose: 'build' },
+  { name: 'TOOL_ONE', readBy: 'external-tool', tier: 'optional', purpose: 'a script reads it' },
+];
+
+const COMPLETE = fixture({
+  env: ['RUNTIME_ONE:', 'RUNTIME_TWO:', 'BOTH_ONE:'],
+  args: ['BOTH_ONE:', 'BUILD_ONE:'],
+});
+
+// --- parsing ---------------------------------------------------------------
+
+test('bare NAME parses as null (pass-through) and NAME: value as its value', () => {
+  const { environment } = parseComposeService(
+    fixture({ env: ['BARE:', 'LITERAL: container', 'INTERP: ${X:-y}'] }),
+  );
+  assert.equal(environment.get('BARE'), null);
+  assert.equal(environment.get('LITERAL'), 'container');
+  assert.equal(environment.get('INTERP'), '${X:-y}');
+});
+
+test('build.args and env_file are read; comments and other services are ignored', () => {
+  const parsed = parseComposeService(fixture({ env: ['A:'], args: ['B:'], envFile: 'ops.env' }));
+  assert.deepEqual([...parsed.environment.keys()], ['A']);
+  assert.deepEqual([...parsed.buildArgs.keys()], ['B']);
+  assert.deepEqual(parsed.envFiles, ['ops.env']);
+});
+
+test('sequence-form environment throws rather than silently reading nothing', () => {
+  const text = 'services:\n  app:\n    environment:\n      - FOO=bar\n';
+  assert.throws(() => parseComposeService(text), /sequence-form/);
+});
+
+test('a missing app service throws rather than passing vacuously', () => {
+  assert.throws(() => parseComposeService('services:\n  postgres:\n    image: postgres\n'), /no `app` service/);
+});
+
+// --- coverage --------------------------------------------------------------
+
+test('a complete compose file passes', () => {
+  const r = checkComposeEnvCoverage(COMPLETE, SPEC);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.missingRuntime, []);
+  assert.deepEqual(r.missingBuildArg, []);
+});
+
+test('THE DEFECT: a variable the app reads but compose omits fails, by name', () => {
+  const r = checkComposeEnvCoverage(fixture({ env: ['RUNTIME_ONE:'], args: ['BOTH_ONE:', 'BUILD_ONE:'] }), SPEC);
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.missingRuntime.map((e) => e.name), ['RUNTIME_TWO', 'BOTH_ONE']);
+  assert.match(renderComposeReport(r), /RUNTIME_TWO/);
+});
+
+test('a build-time variable missing from build.args fails even when the environment lists it', () => {
+  const r = checkComposeEnvCoverage(fixture({ env: ['RUNTIME_ONE:', 'RUNTIME_TWO:', 'BOTH_ONE:'], args: ['BUILD_ONE:'] }), SPEC);
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.missingBuildArg.map((e) => e.name), ['BOTH_ONE']);
+});
+
+test('a build-only variable listed under environment is flagged as inert there', () => {
+  const r = checkComposeEnvCoverage(
+    fixture({ env: ['RUNTIME_ONE:', 'RUNTIME_TWO:', 'BOTH_ONE:', 'BUILD_ONE:'], args: ['BOTH_ONE:', 'BUILD_ONE:'] }),
+    SPEC,
+  );
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.runtimeInert.map((e) => e.name), ['BUILD_ONE']);
+});
+
+test('an external-tool variable is never demanded of the container', () => {
+  const r = checkComposeEnvCoverage(COMPLETE, SPEC);
+  assert.equal(r.missingRuntime.some((e) => e.name === 'TOOL_ONE'), false);
+  assert.equal(r.missingBuildArg.some((e) => e.name === 'TOOL_ONE'), false);
+});
+
+test('a variable compose passes that the spec does not declare is reported as drift', () => {
+  const r = checkComposeEnvCoverage(
+    fixture({ env: ['RUNTIME_ONE:', 'RUNTIME_TWO:', 'BOTH_ONE:', 'GHOST:'], args: ['BOTH_ONE:', 'BUILD_ONE:'] }),
+    SPEC,
+  );
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.undeclared, ['GHOST']);
+});
+
+// --- the empty-string-vs-unset rule ---------------------------------------
+
+test('EMPTY VS UNSET: ${NAME:-} is rejected — it sets "" where unset was meant', () => {
+  const r = checkComposeEnvCoverage(
+    fixture({ env: ['RUNTIME_ONE:', 'RUNTIME_TWO: ${RUNTIME_TWO:-}', 'BOTH_ONE:'], args: ['BOTH_ONE:', 'BUILD_ONE:'] }),
+    SPEC,
+  );
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.emptyDefaultForm, ['RUNTIME_TWO']);
+  assert.match(renderComposeReport(r), /Empty is not absent/);
+});
+
+test('bare ${NAME} is rejected too (compose blanks it when unset)', () => {
+  const r = checkComposeEnvCoverage(
+    fixture({ env: ['RUNTIME_ONE: ${RUNTIME_ONE}', 'RUNTIME_TWO:', 'BOTH_ONE:'], args: ['BOTH_ONE:', 'BUILD_ONE:'] }),
+    SPEC,
+  );
+  assert.deepEqual(r.emptyDefaultForm, ['RUNTIME_ONE']);
+});
+
+test('a real default ${NAME:-value} is fine — it is a choice, not an accident', () => {
+  const r = checkComposeEnvCoverage(
+    fixture({ env: ['RUNTIME_ONE: ${RUNTIME_ONE:-hello}', 'RUNTIME_TWO:', 'BOTH_ONE:'], args: ['BOTH_ONE:', 'BUILD_ONE:'] }),
+    SPEC,
+  );
+  assert.equal(r.ok, true);
+});
+
+// --- profile awareness -----------------------------------------------------
+
+test('the compose file pins the profile; variables it will never read are not demanded', () => {
+  // BLOB_READ_WRITE_TOKEN is onlyWhen blob=vercel-blob, so a file that pins
+  // BLOB_DRIVER: s3 must not be told to pass it.
+  const text = fixture({ env: ['BLOB_DRIVER: s3', 'EXECUTOR_DRIVER: container'] });
+  const r = checkComposeEnvCoverage(text, ENV_SPEC);
+  assert.equal(r.drivers.blob, 's3');
+  assert.equal(r.drivers.executor, 'container');
+  const demanded = r.missingRuntime.map((e) => e.name);
+  assert.equal(demanded.includes('BLOB_READ_WRITE_TOKEN'), false);
+  assert.equal(demanded.includes('SANDBOX_SNAPSHOT_ID'), false);
+  // …and it IS told about the ones that profile reads.
+  assert.equal(demanded.includes('S3_BUCKET'), true);
+});
+
+test('env_file makes run-time coverage unprovable, and the report says so', () => {
+  const r = checkComposeEnvCoverage(fixture({ env: ['RUNTIME_ONE:'], args: ['BOTH_ONE:', 'BUILD_ONE:'], envFile: 'ops.env' }), SPEC);
+  assert.equal(r.coverageProvable, false);
+  assert.deepEqual(r.missingRuntime, []);
+  assert.match(renderComposeReport(r), /coverage cannot be proven statically/);
+});
+
+// --- the gate --------------------------------------------------------------
+
+test("GATE: the repo's docker-compose.yml can deliver every variable the app reads", () => {
+  const path = fileURLToPath(new URL('../docker-compose.yml', import.meta.url));
+  const result = checkComposeEnvCoverage(readFileSync(path, 'utf8'));
+  assert.equal(result.ok, true, renderComposeReport(result, APP_SERVICE));
+});

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -91,6 +91,23 @@ export const DRIVER_SEAMS = {
  *   - `requiredWhen: { <seam>: '<driver>' }` — tier becomes 'required' under
  *     that driver; otherwise the declared `tier` stands.
  *
+ * An orthogonal field records WHERE a value is consumed, which is what a
+ * deployment needs in order to deliver it (scripts/check-compose-env.mjs reads
+ * this field; it has no effect on the preflight report):
+ *   - `readBy` omitted — the running server process. A container deployment
+ *     delivers it in the container's environment.
+ *   - `readBy: 'build'` — inlined at `next build` and unreadable afterwards
+ *     (every NEXT_PUBLIC_* value). A run-time pass-through cannot change it;
+ *     it must be a build argument.
+ *   - `readBy: 'build-and-runtime'` — read by the server AND baked into
+ *     statically prerendered pages, so it must be supplied at both times or
+ *     prerendered and dynamic pages disagree. Constraint: because a build
+ *     argument that is not passed can arrive as an empty string rather than
+ *     absent, a variable marked either build tier must treat empty as absent.
+ *   - `readBy: 'external-tool'` — not read by the app at all (an operator
+ *     script or an eval harness); enumerated here for completeness only, and
+ *     never something a deployment must deliver to the container.
+ *
  * A third conditional field expresses ALTERNATIVES rather than drivers — the
  * case where two variable sets satisfy the same need and an instance picks
  * one:
@@ -236,25 +253,25 @@ export const ENV_SPEC = [
   //     byte-identically. Chrome only — nothing here is emitted inside signed
   //     evidence (that is the EVIDENCE_* identity set above), so these can
   //     never invalidate a package or a registry cross-check. ---
-  { name: 'SITE_BRAND_NAME', tier: 'optional', purpose: 'Instance display name — header wordmark, page titles, citation labels (default "Civic AI Tools")', hasFallback: true },
-  { name: 'SITE_BRAND_ACCENT', tier: 'optional', purpose: 'Accent color (#rgb/#rrggbb) — overrides the accent tokens site-wide; unset or invalid = stylesheet default', hasFallback: true },
-  { name: 'SITE_BRAND_TAGLINE', tier: 'optional', purpose: 'Footer tagline line (default: the demo tagline)', hasFallback: true },
-  { name: 'SITE_BRAND_ATTRIBUTION', tier: 'optional', purpose: 'Footer attribution line, plain text (unset: the demo authored attribution markup)', hasFallback: true },
+  { name: 'SITE_BRAND_NAME', readBy: 'build-and-runtime', tier: 'optional', purpose: 'Instance display name — header wordmark, page titles, citation labels (default "Civic AI Tools")', hasFallback: true },
+  { name: 'SITE_BRAND_ACCENT', readBy: 'build-and-runtime', tier: 'optional', purpose: 'Accent color (#rgb/#rrggbb) — overrides the accent tokens site-wide; unset or invalid = stylesheet default', hasFallback: true },
+  { name: 'SITE_BRAND_TAGLINE', readBy: 'build-and-runtime', tier: 'optional', purpose: 'Footer tagline line (default: the demo tagline)', hasFallback: true },
+  { name: 'SITE_BRAND_ATTRIBUTION', readBy: 'build-and-runtime', tier: 'optional', purpose: 'Footer attribution line, plain text (unset: the demo authored attribution markup)', hasFallback: true },
 
   // --- Instance content sources (#241: src/lib/site-config.ts). All
   //     optional, and unset means one thing: this instance has no content
   //     source of its own. /directory then serves the shared community index
   //     with attribution; /roadmap renders as unpublished and drops out of
   //     the nav rather than showing another project's plans. ---
-  { name: 'DIRECTORY_DATA_URL', tier: 'optional', purpose: '/directory data source — MCP-server JSON (unset: the community index, shown with attribution)', hasFallback: true },
-  { name: 'ROADMAP_RAW_URL', tier: 'optional', purpose: '/roadmap data source — raw Markdown (unset: /roadmap says no roadmap is published and leaves the nav)', hasFallback: true },
-  { name: 'ROADMAP_GITHUB_URL', tier: 'optional', purpose: '/roadmap "view source" link and byline label (unset: derived from ROADMAP_RAW_URL)', hasFallback: true },
+  { name: 'DIRECTORY_DATA_URL', readBy: 'build-and-runtime', tier: 'optional', purpose: '/directory data source — MCP-server JSON (unset: the community index, shown with attribution)', hasFallback: true },
+  { name: 'ROADMAP_RAW_URL', readBy: 'build-and-runtime', tier: 'optional', purpose: '/roadmap data source — raw Markdown (unset: /roadmap says no roadmap is published and leaves the nav)', hasFallback: true },
+  { name: 'ROADMAP_GITHUB_URL', readBy: 'build-and-runtime', tier: 'optional', purpose: '/roadmap "view source" link and byline label (unset: derived from ROADMAP_RAW_URL)', hasFallback: true },
 
   // --- Optional / feature / ops ---
   { name: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },
-  { name: 'CIVICAITOOLS_SESSION_TOKEN', tier: 'optional', purpose: 'publish-evidence skill (Claude Code) auth' },
+  { name: 'CIVICAITOOLS_SESSION_TOKEN', readBy: 'external-tool', tier: 'optional', purpose: 'publish-evidence skill (Claude Code) auth' },
   { name: 'CRON_SECRET', tier: 'optional', purpose: 'Cron endpoint auth (blob-gc, portal refresh)' },
-  { name: 'NEXT_PUBLIC_GA_MEASUREMENT_ID', tier: 'optional', purpose: 'Google Analytics 4' },
+  { name: 'NEXT_PUBLIC_GA_MEASUREMENT_ID', readBy: 'build', tier: 'optional', purpose: 'Google Analytics 4' },
 
   // --- Tuning knobs with coded defaults (previously unenumerated; the app
   //     reads them but runs on built-in defaults when absent) ---
@@ -266,12 +283,12 @@ export const ENV_SPEC = [
   { name: 'APP_TIER_RATE_LIMIT', tier: 'optional', purpose: 'Per-day query limit for signed-in users of a gated instance (default: AUTHENTICATED_RATE_LIMIT)', hasFallback: true },
   { name: 'TOKEN_LIMIT_PER_REQUEST', tier: 'optional', purpose: 'Streaming token budget per request (coded default)', hasFallback: true },
   { name: 'MAX_TOOL_RESULT_CHARS', tier: 'optional', purpose: 'Tool-result truncation budget (coded default)', hasFallback: true },
-  { name: 'NEXT_PUBLIC_CAPTURE_TRACES', tier: 'optional', purpose: 'Dev-only BPMN trace capture toggle', hasFallback: true },
-  { name: 'NEXT_PUBLIC_SOCRATA_MCP_URL', tier: 'optional', purpose: 'Client-side Socrata MCP URL for notebook output links', hasFallback: true },
+  { name: 'NEXT_PUBLIC_CAPTURE_TRACES', readBy: 'build', tier: 'optional', purpose: 'Dev-only BPMN trace capture toggle', hasFallback: true },
+  { name: 'NEXT_PUBLIC_SOCRATA_MCP_URL', readBy: 'build', tier: 'optional', purpose: 'Client-side Socrata MCP URL for notebook output links', hasFallback: true },
 
   // --- scripts/-only (not read by the app; enumerated for completeness) ---
-  { name: 'EVAL_MODELS', tier: 'optional', purpose: 'Model-eval harness roster (scripts/eval-models.mjs only)', hasFallback: true },
-  { name: 'EVAL_QUERIES', tier: 'optional', purpose: 'Model-eval harness query set (scripts/eval-models.mjs only)', hasFallback: true },
+  { name: 'EVAL_MODELS', readBy: 'external-tool', tier: 'optional', purpose: 'Model-eval harness roster (scripts/eval-models.mjs only)', hasFallback: true },
+  { name: 'EVAL_QUERIES', readBy: 'external-tool', tier: 'optional', purpose: 'Model-eval harness query set (scripts/eval-models.mjs only)', hasFallback: true },
 ];
 
 /**

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -90,6 +90,40 @@ test('every spec entry has a known tier and a purpose', () => {
   }
 });
 
+// `readBy` is what scripts/check-compose-env.mjs uses to decide HOW a
+// deployment must deliver a variable (container environment, build argument,
+// or neither). An unrecognized value would be read as the default — "the
+// server reads this at run time" — and could send a build-time variable down
+// a path that cannot deliver it: documented, and inert.
+test('every readBy marker is one of the known consumption sites', () => {
+  for (const s of ENV_SPEC) {
+    if (s.readBy === undefined) continue;
+    assert.ok(
+      ['build', 'build-and-runtime', 'external-tool'].includes(s.readBy),
+      `${s.name}.readBy is a known value (got ${s.readBy})`,
+    );
+  }
+});
+
+// Both build tiers can arrive as an unpassed build argument, which the code
+// must be able to treat as absence. Every NEXT_PUBLIC_* value is inlined at
+// build by definition, so none of them may be marked run-time-only.
+test('every NEXT_PUBLIC_ variable is marked as read at build time', () => {
+  for (const s of ENV_SPEC) {
+    if (!s.name.startsWith('NEXT_PUBLIC_')) continue;
+    assert.equal(s.readBy, 'build', `${s.name} is inlined at build and must say so`);
+  }
+});
+
+test('readBy does not disturb the report: the default profile is unchanged by it', () => {
+  const stripped = ENV_SPEC.map((s) => {
+    const copy = { ...s };
+    delete copy.readBy;
+    return copy;
+  });
+  assert.equal(renderReport(evaluateEnv({}, stripped)), renderReport(evaluateEnv({})));
+});
+
 // --- Driver-aware resolution (instance profiles) ---------------------------
 
 /** Env selecting the plain-Postgres + S3 + container profile. */


### PR DESCRIPTION
## The defect

The `app` service in `docker-compose.yml` passes an explicit `environment:`
map and has no `env_file:`. A variable not named in that map **never reaches
the container** — no error, no warning, no log line. Twenty-three documented
variables had accumulated in that gap.

Verified list (the guard reproduces it exactly against `origin/main`):

| Group | Variables |
| --- | --- |
| Branding seam | `SITE_BRAND_NAME`, `SITE_BRAND_ACCENT`, `SITE_BRAND_TAGLINE`, `SITE_BRAND_ATTRIBUTION` |
| Content sources | `DIRECTORY_DATA_URL`, `ROADMAP_RAW_URL`, `ROADMAP_GITHUB_URL` |
| Host topology | `APP_HOST`, `MARKETING_HOST`, `APP_ONLY` |
| Sign-in gate | `SIGN_IN_ALLOWLIST` |
| Data source | `BOSTON_OPENCONTEXT_MCP_URL` |
| Tuning knobs | `ANONYMOUS_RATE_LIMIT`, `AUTHENTICATED_RATE_LIMIT`, `APP_TIER_RATE_LIMIT`, `TOKEN_LIMIT_PER_REQUEST`, `MAX_TOOL_RESULT_CHARS` |
| S3 knobs | `S3_REGION`, `S3_FORCE_PATH_STYLE` |
| Evidence identity | `EVIDENCE_PLATFORM_AGENT_URL`, `EVIDENCE_TRUST_REGISTRY_CANONICAL_URL`, `EVIDENCE_TRUST_REGISTRY_LEGACY_URL`, `EVIDENCE_TRUST_REGISTRY_URL` |
| Build-time | `NEXT_PUBLIC_GA_MEASUREMENT_ID`, `NEXT_PUBLIC_SOCRATA_MCP_URL`, `NEXT_PUBLIC_CAPTURE_TRACES` |

`EVIDENCE_TRUST_REGISTRY_URL` and the two extra `NEXT_PUBLIC_*` were not in
the original report; the guard found them. Correctly **not** in scope:
`BLOB_READ_WRITE_TOKEN`, `SANDBOX_SNAPSHOT_ID`, `VERCEL_TOKEN` /
`VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` — the compose profile pins
`BLOB_DRIVER=s3` and `EXECUTOR_DRIVER=container`, under which the app never
reads them. Also out of scope: `CIVICAITOOLS_SESSION_TOKEN`, `EVAL_MODELS`,
`EVAL_QUERIES`, which no server process reads.

**Blast radius.** On the guide's primary self-hosting path the instance-branding
seam, the content-source configuration, and host topology were all inert. An
operator sets `SITE_BRAND_NAME`, restarts, sees the reference deployment's
branding, and has nothing to debug against.

**Root cause.** Each of those features shipped with its own deploy-guide
section, and none of them touched the compose file or the section explaining
how a variable reaches the container. Per-feature review cannot see a defect
that is defined by absence — hence the guard, which is the more important half
of this PR.

## The wiring choice: bare `NAME:`, not `${NAME:-}`, not `env_file:`

Bare `NAME:` pass-through, extending the form the file already used.

- **Not `${NAME:-}`** — see the finding below. It is not a pass-through.
- **Not `env_file:`** — it would deliver whatever the operator's file holds
  and never need another compose edit, which is superficially the more
  future-proof answer. But it also makes the compose file stop being an
  explicit inventory of what the app consumes, and that inventory is what
  makes a mechanical guard possible at all: with an `env_file` present,
  coverage is unprovable by static comparison. (The guard detects this and
  says so rather than passing vacuously.) Explicit list + enforced guard beats
  implicit delivery + no guard.

## The empty-string-vs-unset finding — the subtle part

`${VAR:-}` and a bare `VAR:` are **different variables**, and the difference is
load-bearing. Observed with `docker compose config` (v5.1.2), nothing set:

```
BARE_KEY: null        # bare `BARE_KEY:`   → omitted from the container
DEFAULTED: ""         # `${DEFAULTED:-}`   → SET, to the empty string
```

`null` is compose's rendering of "resolve from the caller's environment; if
absent, do not set it." `""` is a value.

The app distinguishes the two. Observed by running the real consumers
(`node --experimental-strip-types`, `src/lib/site-config.ts`):

```
unset  EVIDENCE_TRUST_REGISTRY_LEGACY_URL → legacy = "https://…/.well-known/evidence-public-keys.json"
empty  EVIDENCE_TRUST_REGISTRY_LEGACY_URL → legacy = undefined
```

`getSidecarTrustRegistryUrls()` treats `''` as "omit `trustRegistryUrlLegacy`
entirely" and `undefined` as "derive it from the origin". Wiring that variable
as `${VAR:-}` would therefore have **silently changed signed sidecar output on
every compose instance**, flipping the default from emit to omit, while looking
like a pure plumbing change. That is the crux, and it is why every addition
here uses the bare form.

The rest of the set happens to be falsy-safe (`SITE_BRAND_NAME=''` and
`ROADMAP_RAW_URL=''` behave as unset — both consumers test truthiness), but
"happens to be" is not a property to build on: `SIGN_IN_ALLOWLIST`,
`ROADMAP_RAW_URL` and the host-topology trio all carry meaning in their
absence, and the next such variable may not be falsy-safe. So the guard bans
the `${NAME:-}` and `${NAME}` forms in the app service outright.

## How `NEXT_PUBLIC_*` was handled

`docs/deploy.md`'s claim is correct — those values are inlined into the emitted
bundles at `next build`, so a run-time pass-through has nothing left to change.
Listing them under `environment:` would be a lie in YAML. They are passed as
**build args** instead, with matching `ARG`s on the Dockerfile's builder stage.

The same treatment covers a second set the guide already flags but compose had
no mechanism for: the branding and content-source variables are read by the
server **and** baked into statically prerendered pages ("Set these in the build
environment as well as at run time"). They are now passed in both places from
the same env file, so prerendered and dynamic pages agree.

Compose **omits** an unpassed build arg entirely (verified: the rendered
`args:` map contains only the variables the env file set), so an operator who
configures none of them builds exactly the image this repo built before the
args existed. Nothing secret may go here — build args are readable in image
history — and only non-secret display/URL values were added.

## The guard

`scripts/check-compose-env.mjs`. `scripts/preflight-env.mjs` `ENV_SPEC` is the
authority; the guard is a pure comparison of two checked-in files, reading no
environment and printing no values.

1. **Coverage** — every variable the app reads must be deliverable. Resolved
   against the profile *the compose file itself pins* (its literal
   `DB_DRIVER` / `BLOB_DRIVER` / `EXECUTOR_DRIVER` values), reusing
   `resolveDrivers` / `resolveSpec`, so it demands the S3 credentials and not
   the Vercel Blob token. A new `readBy` field on `ENV_SPEC` records *where* a
   value is consumed — run-time (default), `build`, `build-and-runtime`, or
   `external-tool` — and each is checked against `environment`, `build.args`,
   both, or neither.
2. **Form** — `${NAME:-}` and `${NAME}` under `environment` are rejected, with
   the legacy-registry case quoted in the failure text.
3. **Drift the other way** — a variable compose passes that `ENV_SPEC` does not
   declare fails too: either the app stopped reading it or the inventory is
   stale.

It fails loudly on any compose shape it does not model (sequence-form
`environment`, a missing `app` service, tabs) rather than returning an empty
result that would pass. No new dependency: the repo has no YAML parser and the
reader is a ~90-line strict extractor for the one shape this file uses.

**Where it runs.** `npm run check:compose-env`, a dedicated `Compose env
coverage` step in `.github/workflows/ci.yml`, and — via
`scripts/check-compose-env.test.mjs`, whose last test runs the check against
the real `docker-compose.yml` — inside `npm test`, which the CI `Test` step
already globs. Two independent paths on purpose: the test gates it locally and
survives a workflow edit; the step makes the failure legible in the log. Both
stay credential-free, consistent with this workflow's charter.

## What was proven end to end, and what was not

The sandbox has the Docker CLI but the daemon socket is permission-denied, so
**no container was started**. Stating that plainly rather than implying a
running-stack result.

Proven:

- **Delivery.** `docker compose config` with an env file setting
  `SITE_BRAND_NAME=Riverside Open Data` renders it into both the app service's
  `build.args` and its `environment`; every unset pass-through renders `null`
  (omitted), never `""`. Compose validates clean (`config -q`, exit 0) with a
  completely empty environment.
- **Resolution source.** A bare `NAME:` resolves from `--env-file`, not only
  from the shell — so the documented `docker compose --env-file <file> up`
  workflow actually populates these.
- **Consumption.** The real `getBrandName()` returns `"Riverside Open Data"`
  with the variable set and `"Civic AI Tools"` unset; `getRoadmapSource()`
  returns the configured source vs. `null`; the legacy-registry empty-vs-unset
  divergence above.
- **The guard catches the real defect.** Run against `origin/main`'s compose
  file it reports exactly 23 run-time and 10 build-arg failures, by name.

Not proven: that a built image serves the changed wordmark end to end. The two
halves — compose delivers the variable, the app reads it and changes output —
are each demonstrated against the real artifacts; the join is the container
boundary, which this environment cannot cross. Worth one manual
`docker compose --env-file … up -d --build` on a machine with a daemon before
relying on it.

## Verification

`npm ci`, `npm run typecheck` (clean), `npm run lint` (0 errors; 4 pre-existing
warnings, none new), `npm test` — 642/644, the two failures being the
documented `listen EPERM` socket-bind artifacts in
`openrouter-streaming.test.ts` (#249). `npx next build --webpack` exits 0
(Turbopack cannot bind a port in this sandbox). New: 16 guard tests, 4
preflight tests.

## Scope note

`docs/deploy.md` edits are confined to the `### Supplying your environment`
section, per the concurrent work on the signing/disable-when-absent surfaces.
The section now describes three spellings — pass-through, defaulted, hardcoded
— and states that there is no fourth category, which is the framing whose
absence created this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
