### PR TITLE
fix: no signing key-id fallback — an instance emits its own kid or none

### DIFF
--- a/docs/api/evidence-publish.md
+++ b/docs/api/evidence-publish.md
@@ -371,7 +371,7 @@ Callers publishing through `POST /api/evidence` do not set these themselves — 
 | Env var                        | Purpose                                                                 |
 |--------------------------------|-------------------------------------------------------------------------|
 | `EVIDENCE_SIGNING_KEY`         | Base64 DER PKCS8 Ed25519 private key. Sensitive.                        |
-| `EVIDENCE_KEY_ID`              | Stable kid string (e.g. `platform:evidence-2026-04`). Non-sensitive.    |
+| `EVIDENCE_KEY_ID`              | Stable kid string naming **your** active trust-registry entry (e.g. `platform:evidence-2026-04`). Non-sensitive, no coded default: with a signing key set and this unset, the instance refuses to seal or publish rather than sign under an undeclared key id. |
 | `EVIDENCE_PUBLIC_KEY`          | Public half of the signing key. Used only for registry updates.         |
 | `EVIDENCE_TRUST_REGISTRY_URL`  | Optional override for the default `${NEXTAUTH_URL}/.well-known/...` URL. Useful for previews. |
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -396,7 +396,7 @@ doesn't):
 
 | Variable(s) | Feature disabled when absent |
 | --- | --- |
-| `EVIDENCE_SIGNING_KEY` + `EVIDENCE_KEY_ID` | Evidence commit/publish — the instance stays in the unsigned tier: banner shows, seal and publish are gated off. |
+| `EVIDENCE_SIGNING_KEY` + `EVIDENCE_KEY_ID` | Evidence commit/publish. **All-or-nothing: both are required, and neither has a coded default.** With neither set the instance stays in the unsigned tier (banner shows, seal and publish gated off). With the key set but no `EVIDENCE_KEY_ID` it still cannot publish — it refuses rather than sign under a key id it never declared, since a kid it did not configure would misattribute the signature and fail verification. |
 | `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, and an OAuth app (`GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` or the `OIDC_*` set) | Sign-in — and with it the sign-in-gated notebook execution feature, the dashboard, and the higher authenticated rate limit. |
 | `DATA_COMMONS_MCP_URL` + `DATA_COMMONS_API_KEY` | The Data Commons data source — its tool calls fail without the key (the hosted endpoint mandates it). `DC_API_KEY` is the separate key passed into *executed notebooks* for their own Data Commons requests. |
 | `BOSTON_OPENCONTEXT_MCP_URL` | The Boston OpenContext data source. |
@@ -736,7 +736,9 @@ Two facts worth restating from the deploy side:
 
 - With the signing pair unset, the compose stack runs the unsigned tier
   correctly — this guide's bring-up **is** the unsigned tier. Configuring
-  signing is what makes the seal/publish actions reachable.
+  signing is what makes the seal/publish actions reachable, and it takes
+  **both** variables: an instance with a key but no `EVIDENCE_KEY_ID` refuses
+  to publish rather than sign under an undeclared key id.
 - `EVIDENCE_SIGNING_KEY` is the most sensitive value your instance
   holds. Keep it in your secret manager; never commit it, paste it into
   an agent session, or bake it into an image.

--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -101,7 +101,22 @@ Signing custody (both required to sign; the app runs unsigned without them):
 | Variable | Meaning |
 | --- | --- |
 | `EVIDENCE_SIGNING_KEY` | Base64 DER PKCS8 private key from step 1. **Sensitive.** |
-| `EVIDENCE_KEY_ID` | The kid from step 2. Must match the registry's active entry. |
+| `EVIDENCE_KEY_ID` | The kid from step 2. Must match the registry's active entry. No default — see below. |
+
+**Neither half has a coded default, and half of the pair is not half of the
+feature.** With a signing key set but no `EVIDENCE_KEY_ID`, the instance
+refuses to seal or publish: it will not substitute a key id it was not given.
+That refusal is deliberate. A kid is an identity claim — the handle a verifier
+uses to look a public key up in a trust registry — so emitting one you did not
+configure would label your signature with someone else's registry entry. The
+package then fails verification (that entry holds a different public key)
+while appearing to claim another party's identity. Your private key is never
+involved either way; the damage is misattribution and unverifiable evidence,
+which is why the instance stops instead of guessing.
+
+You will see the half-configured state three ways: a site-wide banner naming
+`EVIDENCE_KEY_ID`, a `signing_key_id_missing` refusal from any seal/publish
+attempt, and a preflight warning that the signing pair is partially set.
 
 Instance identity (ADR-0020: everything that names your instance inside
 emitted evidence is configuration, resolved in

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -6,8 +6,8 @@
  * instance of civic-ai-tools-website needs to run, and prints a grouped
  * pass/fail table. Several of these vars fail silently or with a generic
  * error when absent (DATABASE_URL, the storage credentials,
- * EVIDENCE_SIGNING_KEY, EVIDENCE_KEY_ID, the MCP endpoints, the model key),
- * so a one-shot "is everything wired?" check removes that failure mode.
+ * EVIDENCE_SIGNING_KEY, the MCP endpoints, the model key), so a one-shot
+ * "is everything wired?" check removes that failure mode.
  *
  * INSTANCE-AWARE: an instance is not one fixed deployment shape. The three
  * driver-selector variables — DB_DRIVER, BLOB_DRIVER, EXECUTOR_DRIVER — pick
@@ -169,8 +169,13 @@ export const ENV_SPEC = [
   { name: 'VERCEL_TEAM_ID', tier: 'optional', purpose: 'Vercel Sandbox auth for off-platform runs (with VERCEL_TOKEN + VERCEL_PROJECT_ID)', onlyWhen: { executor: 'vercel-sandbox' } },
   { name: 'VERCEL_PROJECT_ID', tier: 'optional', purpose: 'Vercel Sandbox auth for off-platform runs (with VERCEL_TOKEN + VERCEL_TEAM_ID)', onlyWhen: { executor: 'vercel-sandbox' } },
 
+  // The signing pair. NEITHER has a coded fallback: signing.ts has no default
+  // key id, because a substituted kid would label this instance's signature
+  // with another deployment's registry entry (misattribution + unverifiable
+  // evidence). Both halves are hard requirements of a signing instance, and
+  // the SIGNING_PAIR group below adds the all-or-nothing semantics on top.
   { name: 'EVIDENCE_SIGNING_KEY', tier: 'required', purpose: 'Ed25519 private key — signs evidence packages' },
-  { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry', hasFallback: true }, // signing.ts: `EVIDENCE_KEY_ID || DEFAULT_KEY_ID`; the default mirrors the registry's active kid
+  { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry; no coded default' },
 
   // --- Sign-in path (the rate-limit headroom option; OAuth) ---
   { name: 'NEXTAUTH_SECRET', tier: 'required', purpose: 'NextAuth session encryption' },
@@ -276,11 +281,14 @@ export const ENV_SPEC = [
 
 /**
  * All-or-nothing variable groups (#195). Each names a set the code consumes
- * only as a complete set: with any member absent the whole set is ignored —
- * no error, no log — so a partially set group means the operator configured
- * something that is silently not in effect, and preflight is the only place
- * that can be surfaced. Detection is presence-only, same test as everywhere
- * else; no value is ever read or echoed.
+ * only as a complete set: with any member absent the whole set is ignored, so
+ * a partially set group means the operator configured something that is not
+ * in effect. For most groups that is entirely silent at run time and
+ * preflight is the only place it can surface. The signing pair is the one
+ * exception — it refuses loudly at run time — and is listed anyway, because
+ * preflight is where the operator learns the RELATIONSHIP before a deploy
+ * rather than from a refused publish afterwards. Detection is presence-only,
+ * same test as everywhere else; no value is ever read or echoed.
  *
  * Fields:
  *   - members: the variable names (each must also be declared in ENV_SPEC —
@@ -320,6 +328,19 @@ export const ENV_GROUPS = [
     // optional (requiredUnlessAllPresent above), so a half-set pair is
     // otherwise fully silent.
     feature: 'the GitHub provider is not offered on the sign-in screen',
+  },
+  {
+    name: 'Evidence signing',
+    members: ['EVIDENCE_SIGNING_KEY', 'EVIDENCE_KEY_ID'],
+    // src/lib/evidence/unsigned-tier.ts `isSigningConfigured` requires BOTH
+    // halves: custody plus the declared key id. #195 deliberately left this
+    // pair out because the kid then had a coded default, so the set was not
+    // all-or-nothing. That default is gone, so the pair now belongs here.
+    // Unlike the other groups this one is not silent at run time — the gate
+    // refuses and the banner shows — but preflight is where the operator sees
+    // the RELATIONSHIP: a key alone does not turn signing on.
+    feature: 'evidence seal/publish stays gated off — the instance cannot sign',
+    note: 'A key without a key id is not a partial success: the instance refuses to sign rather than emit a kid it never declared. Set EVIDENCE_KEY_ID to the active entry in your trust registry (docs/instance-setup.md).',
   },
   {
     name: 'Durable rate limiting',
@@ -474,10 +495,10 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
   });
 
   // A required var with a coded fallback (`hasFallback`) is NOT a hard miss when
-  // absent — the app substitutes a built-in default (e.g. signing.ts uses
-  // DEFAULT_KEY_ID for EVIDENCE_KEY_ID). It is surfaced separately so the
-  // default's continued correctness (e.g. the kid still matching the trust
-  // registry across a key rotation) can be confirmed, without failing the run.
+  // absent — the app substitutes a built-in default or a degraded in-process
+  // path (e.g. rate-limit.ts falls back to a per-process counter without the
+  // KV pair). It is surfaced separately so the fallback's continued
+  // acceptability can be confirmed, without failing the run.
   const missingRequired = rows.filter((r) => r.tier === 'required' && !r.present && !r.hasFallback);
   const requiredOnFallback = rows.filter((r) => r.tier === 'required' && !r.present && r.hasFallback);
   const missingRecommended = rows.filter((r) => r.tier === 'recommended' && !r.present);

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -56,14 +56,31 @@ test('empty string and whitespace-only count as absent (not present)', () => {
 
 test('a required var with a coded fallback is soft when absent (fallbk, run still passes)', () => {
   const env = envWithAllRequired();
-  delete env.EVIDENCE_KEY_ID; // required, but hasFallback (signing.ts → DEFAULT_KEY_ID)
+  delete env.SOCRATA_MCP_URL; // required, but hasFallback (the hosted endpoint)
   const result = evaluateEnv(env);
   assert.equal(result.ok, true, 'a fallback-backed required var does not fail the run');
   assert.equal(result.missingRequired.length, 0);
-  assert.deepEqual(result.requiredOnFallback.map((r) => r.name), ['EVIDENCE_KEY_ID']);
+  assert.deepEqual(result.requiredOnFallback.map((r) => r.name), ['SOCRATA_MCP_URL']);
   const report = renderReport(result);
   assert.match(report, /fallbk/);
   assert.match(report, /built-in fallback/);
+});
+
+test('EVIDENCE_KEY_ID has NO coded fallback: absent, it is a hard miss that fails the run', () => {
+  // The kid used to carry `hasFallback: true`, pointing at a hardcoded
+  // default in signing.ts that substituted the reference deployment's kid.
+  // That default is gone — an instance emits the kid it declared or none —
+  // so an absent kid is a real miss, not a soft note.
+  const entry = ENV_SPEC.find((s) => s.name === 'EVIDENCE_KEY_ID');
+  assert.equal(entry.tier, 'required');
+  assert.ok(!entry.hasFallback, 'EVIDENCE_KEY_ID must not claim a coded fallback');
+
+  const env = envWithAllRequired();
+  delete env.EVIDENCE_KEY_ID;
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.missingRequired.map((r) => r.name), ['EVIDENCE_KEY_ID']);
+  assert.ok(!result.requiredOnFallback.some((r) => r.name === 'EVIDENCE_KEY_ID'));
 });
 
 test('missing recommended variables do not fail the run', () => {
@@ -522,6 +539,28 @@ test('a partial KV pair warns that durable rate limiting is off, while the run s
   assert.ok(partial);
   assert.deepEqual(partial.missing, ['KV_REST_API_TOKEN']);
   assert.match(renderReport(result), /falls back to per-process memory/);
+});
+
+test('a half-set signing pair warns, naming the missing half and the misattribution risk', () => {
+  // #195 left this pair out of ENV_GROUPS because the kid then had a coded
+  // fallback, so the set was not all-or-nothing. The fallback is gone and
+  // `isSigningConfigured` now requires both halves, so the pair belongs here.
+  const env = envWithAllRequired();
+  delete env.EVIDENCE_KEY_ID; // key set, kid absent — the defect state
+  const result = evaluateEnv(env);
+
+  const partial = result.partialGroups.find((g) => g.name === 'Evidence signing');
+  assert.ok(partial, 'the half-set signing pair is reported as partial');
+  assert.deepEqual(partial.present, ['EVIDENCE_SIGNING_KEY']);
+  assert.deepEqual(partial.missing, ['EVIDENCE_KEY_ID']);
+
+  const report = renderReport(result);
+  assert.match(report, /Evidence signing: 1 of 2 present; off until all 2 are set\. Missing: EVIDENCE_KEY_ID/);
+  assert.match(report, /cannot sign/);
+  assert.match(report, /not a partial success/);
+  // Unlike the other groups, this one ALSO fails the run — both halves are
+  // required with no fallback, so the warning rides on top of a hard miss.
+  assert.equal(result.ok, false);
 });
 
 test('group detection uses the same presence test as everything else: whitespace-only is absent', () => {

--- a/src/app/api/evidence/[slug]/attestations/route.ts
+++ b/src/app/api/evidence/[slug]/attestations/route.ts
@@ -8,6 +8,7 @@ import { evidenceRecords, attestationPackages, users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { putPackage } from '@/lib/storage';
 import { signPackage, getRfc3161Timestamp } from '@/lib/evidence/signing';
+import { evaluateSealCommitGate } from '@/lib/evidence/unsigned-tier';
 import {
   buildExpertAttestationPayload,
   validateExpertAttestation,
@@ -93,6 +94,15 @@ export async function POST(
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  // This legacy surface (#173, pending consolidation with the ratified
+  // attestation/* node system) also reaches the signing path, so it takes the
+  // same gate as every other route that does. A half-configured instance is
+  // refused specifically here instead of throwing out of `signPackage` below.
+  const gate = evaluateSealCommitGate();
+  if (gate) {
+    return NextResponse.json(gate.body, { status: gate.status });
   }
 
   // Look up DB user

--- a/src/app/api/evidence/[slug]/reinstate/route.ts
+++ b/src/app/api/evidence/[slug]/reinstate/route.ts
@@ -16,6 +16,7 @@ import {
   ATTESTATION_REINSTATES,
   ATTESTATION_WITHDRAWS,
 } from '@/lib/evidence/attestation';
+import { evaluateSealCommitGate } from '@/lib/evidence/unsigned-tier';
 
 /**
  * POST /api/evidence/[slug]/reinstate
@@ -45,6 +46,14 @@ export async function POST(
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  // Same gate as withdraw: a reinstatement is a separately-signed attestation
+  // node, so it must not be emitted by an instance that has no key id to put
+  // in it (see unsigned-tier.ts).
+  const gate = evaluateSealCommitGate();
+  if (gate) {
+    return NextResponse.json(gate.body, { status: gate.status });
   }
 
   // Look up DB user

--- a/src/app/api/evidence/[slug]/withdraw/route.ts
+++ b/src/app/api/evidence/[slug]/withdraw/route.ts
@@ -12,6 +12,7 @@ import {
   getActiveSigner,
 } from '@/lib/evidence/signing';
 import { buildAttestationNode, ATTESTATION_WITHDRAWS } from '@/lib/evidence/attestation';
+import { evaluateSealCommitGate } from '@/lib/evidence/unsigned-tier';
 
 /**
  * POST /api/evidence/[slug]/withdraw
@@ -43,6 +44,16 @@ export async function POST(
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  // A withdrawal is a separately-signed node, so it reaches the same signing
+  // path as a content publish and takes the same gate: an instance that
+  // cannot sign honestly (no key, or a key with no declared EVIDENCE_KEY_ID)
+  // is refused specifically here rather than emitting an attestation labeled
+  // with a key id it never configured.
+  const gate = evaluateSealCommitGate();
+  if (gate) {
+    return NextResponse.json(gate.body, { status: gate.status });
   }
 
   // Look up DB user

--- a/src/app/api/evidence/signing-status/route.ts
+++ b/src/app/api/evidence/signing-status/route.ts
@@ -5,12 +5,19 @@ import { isSigningConfigured } from '@/lib/evidence/unsigned-tier';
  * GET /api/evidence/signing-status
  *
  * Producer-tier disclosure for client surfaces (S3a P3, #166; ADR-0020):
- * whether this instance holds a signing key — i.e. whether the seal/commit
- * actions are reachable. Client components (the publish dialog) cannot read
- * server env, so they ask here and render the gate-off affordance (disabled
- * action + explanation) instead of a dead button that errors.
+ * whether this instance can sign — i.e. whether the seal/commit actions are
+ * reachable. Client components (the publish dialog) cannot read server env,
+ * so they ask here and render the gate-off affordance (disabled action +
+ * explanation) instead of a dead button that errors.
  *
- * SECRET HYGIENE: presence-only. This endpoint never reads the key's value
+ * "Can sign" means BOTH halves of the signing pair: key custody and a
+ * declared `EVIDENCE_KEY_ID`. A half-configured instance answers `false`
+ * here, same as one with no key at all — it is not a partial success, and
+ * the client must not offer an action the server will refuse. Which half is
+ * missing is operator-facing detail and stays on the site-wide banner and in
+ * the server's refusal, not in this client-facing boolean.
+ *
+ * SECRET HYGIENE: presence-only. This endpoint never reads either value
  * beyond non-emptiness and returns a single boolean. The tier is not a
  * secret — the same fact is disclosed by the running-unsigned banner and by
  * every gate refusal.

--- a/src/app/api/query-notebook/route.ts
+++ b/src/app/api/query-notebook/route.ts
@@ -30,7 +30,7 @@ import {
   type StreamCallbacks,
 } from '@/lib/openrouter-streaming';
 import { TraceBuilder, hash as traceHash } from '@/lib/evidence/trace';
-import { getActiveKeyId } from '@/lib/evidence/signing';
+import { getConfiguredKeyId } from '@/lib/evidence/signing';
 import {
   type PhaseAToolCall,
   stampExecutedNotebook,
@@ -53,7 +53,11 @@ type NotebookEvent =
   | { type: 'phase_a_progress'; message: string; phase?: string; iteration?: number }
   | { type: 'phase_a_tool_call'; name: string; operationType?: string; reason?: string; resultSummary?: { rows: number; columns: number }; args?: Record<string, unknown>; duration_ms?: number }
   | { type: 'phase_a_answer'; content: string }
-  | { type: 'metadata'; composedSystemPrompt: string; composedSystemPromptHash: string; signingKeyId: string }
+  // `signingKeyId` is null when this instance has declared no EVIDENCE_KEY_ID:
+  // the Signers section then shows honest absence rather than some other
+  // deployment's kid. This is a DISPLAY surface, so it reads the non-throwing
+  // probe; nothing here commits to the value.
+  | { type: 'metadata'; composedSystemPrompt: string; composedSystemPromptHash: string; signingKeyId: string | null }
   | { type: 'notebook'; notebook: unknown; sandboxId: string; executionDuration_ms: number; validation: { ok: boolean; issues: { path: string; message: string }[] } }
   // Publish-path inputs (civic-ai-tools-website#112): everything the client
   // needs to publish the executed session through POST /api/evidence without
@@ -140,7 +144,7 @@ export async function POST(request: NextRequest) {
         type: 'metadata',
         composedSystemPrompt: systemPrompt,
         composedSystemPromptHash: systemPromptHash,
-        signingKeyId: getActiveKeyId(),
+        signingKeyId: getConfiguredKeyId(),
       });
       await emit({ type: 'phase', name: 'A', message: 'Discovering datasets…' });
       const phaseAResult = await runPhaseA({

--- a/src/components/PublishEvidenceDialog.tsx
+++ b/src/components/PublishEvidenceDialog.tsx
@@ -455,10 +455,14 @@ export default function PublishEvidenceDialog({
                 </div>
               </div>
 
-              {/* Unsigned-tier gate-off (ADR-0020, S3a P3): with no signing
-                  key, neither Seal (sealed) nor Publish (public) is
-                  reachable — the action renders disabled with an explanation,
-                  mirroring the server-side gate. */}
+              {/* Unsigned-tier gate-off (ADR-0020, S3a P3): unless this
+                  instance can sign — which takes BOTH a signing key and a
+                  declared key id — neither Seal (sealed) nor Publish (public)
+                  is reachable, and the action renders disabled with an
+                  explanation, mirroring the server-side gate. The copy names
+                  the state, not one particular missing variable: the
+                  operator-facing detail (which half is missing) is on the
+                  site-wide banner and in the server's refusal. */}
               {signingConfigured === false && (
                 <div style={{
                   padding: '12px',
@@ -473,10 +477,10 @@ export default function PublishEvidenceDialog({
                   <strong style={{ color: 'var(--text-primary)' }}>
                     This instance is running unsigned.
                   </strong>{' '}
-                  No signing key is configured, so evidence cannot be sealed
-                  or published — an unsigned package can reach neither the
-                  sealed nor the public state. The analysis itself still works;
-                  an operator enables signing via the instance setup guide.
+                  Signing is not configured, so evidence cannot be sealed or
+                  published — an unsigned package can reach neither the sealed
+                  nor the public state. The analysis itself still works; an
+                  operator enables signing via the instance setup guide.
                 </div>
               )}
 

--- a/src/components/RunningUnsignedBanner.tsx
+++ b/src/components/RunningUnsignedBanner.tsx
@@ -1,21 +1,61 @@
-import { shouldShowRunningUnsignedIndicator } from '@/lib/evidence/unsigned-tier';
+import { resolveUnsignedIndicator } from '@/lib/evidence/unsigned-tier';
+
+const SETUP_GUIDE_URL =
+  'https://github.com/npstorey/civic-ai-tools-website/blob/main/docs/instance-setup.md';
 
 /**
  * Running-unsigned indicator (S3a P3, #166; ADR-0020 §Consequences: "a
  * running-unsigned indicator/banner shows outside a dev environment").
  *
  * Server component: renders a site-wide amber strip under the header when
- * this instance has no signing key configured AND is not running in a dev
- * environment. Dev stays calm — the unsigned tier is the intended first-run
- * state there. The banner is what keeps "stayed unsigned" a legitimate but
- * never SILENT choice (guard against silent opt-out).
+ * this instance cannot sign. Two reasons, two messages:
+ *
+ *   - no signing key — the unsigned tier, a legitimate state; shown outside a
+ *     dev environment so "stayed unsigned" is never a SILENT choice.
+ *   - a signing key but no `EVIDENCE_KEY_ID` — a misconfiguration, shown in
+ *     every environment including dev, because it is not an intended state
+ *     anywhere and dev is where it should be caught.
  *
  * Note: on statically prerendered pages the condition is evaluated with the
  * build-time environment; on dynamic routes, at request time. Both reflect
  * the deploy's configuration.
  */
 export default function RunningUnsignedBanner() {
-  if (!shouldShowRunningUnsignedIndicator()) return null;
+  const reason = resolveUnsignedIndicator();
+  if (reason === null) return null;
+
+  if (reason === 'no_key_id') {
+    return (
+      <div
+        role="status"
+        style={{
+          backgroundColor: 'rgba(255, 179, 32, 0.15)',
+          borderBottom: '1px solid var(--nyc-caution, #FFB320)',
+          padding: '8px 24px',
+          fontSize: '13px',
+          lineHeight: 1.5,
+          color: 'var(--text-primary)',
+          textAlign: 'center',
+        }}
+      >
+        <strong>Signing is half-configured</strong> — this instance has a
+        signing key but no <code>EVIDENCE_KEY_ID</code>, so seal and publish
+        are refused. It will not sign under a key id it never declared:
+        evidence labeled with another deployment&rsquo;s key id cannot verify
+        and misattributes the publisher. Set <code>EVIDENCE_KEY_ID</code> to
+        your trust registry&rsquo;s active kid — see the{' '}
+        <a
+          href={SETUP_GUIDE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: 'underline' }}
+        >
+          instance setup guide
+        </a>
+        .
+      </div>
+    );
+  }
 
   return (
     <div
@@ -35,7 +75,7 @@ export default function RunningUnsignedBanner() {
       carries no cryptographic commitment. Signing is the go-to-production
       step; see the{' '}
       <a
-        href="https://github.com/npstorey/civic-ai-tools-website/blob/main/docs/instance-setup.md"
+        href={SETUP_GUIDE_URL}
         target="_blank"
         rel="noopener noreferrer"
         style={{ textDecoration: 'underline' }}

--- a/src/components/dashboard/DashboardTabs.tsx
+++ b/src/components/dashboard/DashboardTabs.tsx
@@ -368,7 +368,7 @@ function MyEvidenceTab({ rows, signingConfigured }: { rows: EvidenceRow[]; signi
                          than left as a dead button that errors. */
                       <button
                         disabled
-                        title="Publishing is unavailable \u2014 this instance is running unsigned (no signing key is configured). Signing is the go-to-production step; see docs/instance-setup.md."
+                        title="Publishing is unavailable \u2014 this instance is running unsigned (signing is not configured). Signing is the go-to-production step and takes both EVIDENCE_SIGNING_KEY and EVIDENCE_KEY_ID; see docs/instance-setup.md."
                         style={{
                           background: 'none', border: 'none', padding: 0,
                           fontSize: '12px', color: 'var(--text-muted)',

--- a/src/hooks/useNotebookStream.ts
+++ b/src/hooks/useNotebookStream.ts
@@ -194,7 +194,9 @@ export function useNotebookStream() {
           // Signers section honest pre-publish UX).
           const composedSystemPrompt = raw.composedSystemPrompt as string | undefined;
           const composedSystemPromptHash = raw.composedSystemPromptHash as string | undefined;
-          const signingKeyId = raw.signingKeyId as string | undefined;
+          // Null when the instance declared no key id — keep the prior value
+          // (initially null) so the Signers row renders honest absence.
+          const signingKeyId = raw.signingKeyId as string | null | undefined;
           setState((prev) => ({
             ...prev,
             composedSystemPrompt: composedSystemPrompt ?? prev.composedSystemPrompt,

--- a/src/lib/evidence/attestation.test.ts
+++ b/src/lib/evidence/attestation.test.ts
@@ -22,6 +22,12 @@ import {
   LEGACY_JSON_CANONICALIZATION,
 } from './canonicalization.ts';
 
+// Every attestation envelope carries `metadata.signingKeyId`, and there is no
+// coded default for it (signing.ts) — an instance emits the kid it declared
+// or none. `node --test` runs each file in its own process, so this
+// declaration is local to this suite.
+process.env.EVIDENCE_KEY_ID ??= 'platform:test-suite-kid';
+
 const SIGNER = {
   bindingTier: 'platform',
   identifier: 'platform:civic-ai-tools',

--- a/src/lib/evidence/instance-config.test.ts
+++ b/src/lib/evidence/instance-config.test.ts
@@ -55,6 +55,13 @@ import { evidenceRecords, users } from '../db/schema.ts';
 type EvidenceRecord = typeof evidenceRecords.$inferSelect;
 type UserRecord = typeof users.$inferSelect;
 
+// Packages built below carry `metadata.signingKeyId`, and there is no coded
+// default for it (signing.ts) — an instance emits the kid it declared or
+// none. Deliberately NOT one of IDENTITY_VARS: the helpers below unset every
+// name in that list, and the kid is custody-side config the packager requires
+// on every path. `node --test` runs each file in its own process.
+process.env.EVIDENCE_KEY_ID ??= 'platform:test-suite-kid';
+
 /** Every instance-identity variable the getters read. */
 const IDENTITY_VARS = [
   'EVIDENCE_SITE_ORIGIN',

--- a/src/lib/evidence/packager.test.ts
+++ b/src/lib/evidence/packager.test.ts
@@ -17,6 +17,12 @@ import {
 } from './canonicalization.ts';
 import type { BlobRef } from './blob-ref.ts';
 
+// Every envelope carries `metadata.signingKeyId`, and there is no coded
+// default for it (signing.ts) — an instance emits the kid it declared or
+// none. So this suite declares one, as any signing instance must. `node
+// --test` runs each file in its own process, so it is local to this suite.
+process.env.EVIDENCE_KEY_ID ??= 'platform:test-suite-kid';
+
 function sha256Hex(content: string): string {
   return crypto.createHash('sha256').update(content).digest('hex');
 }

--- a/src/lib/evidence/signing.test.ts
+++ b/src/lib/evidence/signing.test.ts
@@ -11,7 +11,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { signPackage, getActiveKeyId, rekorHashForPackage } from './signing.ts';
+import {
+  signPackage,
+  getActiveKeyId,
+  getConfiguredKeyId,
+  rekorHashForPackage,
+} from './signing.ts';
 import { verifySignature } from './verify.ts';
 
 function generateTestKeyEnv(): { privB64: string; pubB64: string } {
@@ -92,17 +97,79 @@ test('verifySignature rejects a malformed signature', () => {
   assert.equal(verifySignature(SAMPLE_HASH, 'AAAA', pubB64), false);
 });
 
-test('getActiveKeyId returns EVIDENCE_KEY_ID when set, default otherwise', () => {
+/** Run `fn` with EVIDENCE_KEY_ID set (or deleted), restoring after. */
+function withKeyId<T>(kid: string | undefined, fn: () => T): T {
   const orig = process.env.EVIDENCE_KEY_ID;
+  if (kid === undefined) delete process.env.EVIDENCE_KEY_ID;
+  else process.env.EVIDENCE_KEY_ID = kid;
   try {
-    process.env.EVIDENCE_KEY_ID = 'platform:custom-kid';
-    assert.equal(getActiveKeyId(), 'platform:custom-kid');
-    delete process.env.EVIDENCE_KEY_ID;
-    assert.equal(getActiveKeyId(), 'platform:evidence-2026-04');
+    return fn();
   } finally {
     if (orig === undefined) delete process.env.EVIDENCE_KEY_ID;
     else process.env.EVIDENCE_KEY_ID = orig;
   }
+}
+
+test('getActiveKeyId returns the configured EVIDENCE_KEY_ID verbatim', () => {
+  withKeyId('platform:custom-kid', () => {
+    assert.equal(getActiveKeyId(), 'platform:custom-kid');
+  });
+});
+
+test('NO FALLBACK KID: getActiveKeyId throws when EVIDENCE_KEY_ID is unset', () => {
+  // The defect this pins: a coded default used to substitute the reference
+  // deployment's kid here, so an instance with a key but no kid signed its
+  // own packages under someone else's registry entry — unverifiable evidence
+  // carrying another party's identity. There is no default to fall back to.
+  withKeyId(undefined, () => {
+    assert.throws(
+      () => getActiveKeyId(),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        // Actionable: names the variable and the guide, and is explicit that
+        // the private key is not what is at stake here.
+        assert.match(err.message, /EVIDENCE_KEY_ID/);
+        assert.match(err.message, /instance-setup/);
+        assert.match(err.message, /misattributes/);
+        // Platform-neutral: instances run on containers, VMs, and PaaS hosts.
+        assert.ok(!/vercel|render|heroku|aws/i.test(err.message));
+        return true;
+      },
+    );
+  });
+});
+
+test('NO FALLBACK KID: a whitespace-only EVIDENCE_KEY_ID is not a key id', () => {
+  withKeyId('   ', () => {
+    assert.equal(getConfiguredKeyId(), null);
+    assert.throws(() => getActiveKeyId(), /EVIDENCE_KEY_ID/);
+  });
+});
+
+test('getConfiguredKeyId is the non-throwing probe: value when set, null when not', () => {
+  withKeyId('platform:custom-kid', () => {
+    assert.equal(getConfiguredKeyId(), 'platform:custom-kid');
+  });
+  withKeyId(undefined, () => {
+    assert.equal(getConfiguredKeyId(), null);
+  });
+});
+
+test('getConfiguredKeyId never normalizes the value it returns', () => {
+  // A configured kid lands in a signed field; silently rewriting it would be
+  // its own defect. Presence is trimmed, the returned string is not.
+  withKeyId(' platform:padded ', () => {
+    assert.equal(getConfiguredKeyId(), ' platform:padded ');
+    assert.equal(getActiveKeyId(), ' platform:padded ');
+  });
+});
+
+test('KEY WITHOUT KID: signPackage refuses rather than signing under a substituted kid', () => {
+  const { privB64 } = generateTestKeyEnv();
+  assert.throws(
+    () => withSigningEnv(privB64, undefined, () => signPackage(SAMPLE_HASH)),
+    /EVIDENCE_KEY_ID/,
+  );
 });
 
 test('rekorHashForPackage: SHA-512 of UTF-8 of hex package hash', () => {

--- a/src/lib/evidence/signing.ts
+++ b/src/lib/evidence/signing.ts
@@ -30,6 +30,7 @@ import {
 } from '@typedstandards/produce-core';
 import { rekorHashForPackage } from './verify-core/signature.ts';
 import { getEvidenceSignerIdentity } from '../site-config.ts';
+import { isSigningKeyIdConfigured } from './unsigned-tier.ts';
 
 export { rekorHashForPackage };
 
@@ -44,22 +45,61 @@ export { rekorHashForPackage };
  */
 export type { SignerIdentity, SignResult };
 
-// Default key identifier used when `EVIDENCE_KEY_ID` is not set — the DEMO
-// deployment's active kid (it mirrors the registry's `kid` the same way the
-// demo signer identity in site-config mirrors the registry's
-// `signerIdentity`). The `platform:` prefix leaves room for per-user scopes
-// in the future (e.g. `user:<uuid>:<key-name>`) without a trust-registry
-// schema migration. An instance sets `EVIDENCE_KEY_ID` to its own kid —
-// see docs/instance-setup.md.
-const DEFAULT_KEY_ID = 'platform:evidence-2026-04';
+// THERE IS NO DEFAULT KEY ID. The kid is the registry lookup handle a
+// verifier uses to find the public key that must validate this instance's
+// signature, so it is an identity claim, not a formatting detail. A coded
+// default here used to substitute the REFERENCE deployment's kid whenever
+// `EVIDENCE_KEY_ID` was unset — which meant any instance with a signing key
+// and no kid signed with its own key and labeled the result with someone
+// else's identifier. Such a package cannot verify (the registry entry for
+// that kid holds a different public key) and misattributes the publisher.
+// The private key was never at risk; the damage was misattribution and
+// unverifiable evidence. So: an instance emits the kid it configured, or it
+// does not sign. See docs/instance-setup.md.
+
+/** The one message every "no kid configured" failure carries. Platform-
+ *  neutral on purpose — instances run on containers, VMs, and PaaS hosts
+ *  alike, so it names the variable and the guide, never a hosting product. */
+export const MISSING_KEY_ID_MESSAGE =
+  'EVIDENCE_KEY_ID is not set in this environment. This instance has no ' +
+  'signing key id to emit and will not substitute one: a package labeled ' +
+  "with a kid it never configured cannot verify and misattributes the " +
+  'publisher. Set EVIDENCE_KEY_ID to the kid of the active entry in this ' +
+  "instance's trust registry — see docs/instance-setup.md.";
 
 /**
- * Read the active key identifier. Returns `EVIDENCE_KEY_ID` when set, and
- * falls back to the default platform kid otherwise. The kid is not secret —
- * it's the registry lookup handle for the matching public key.
+ * The configured key identifier, or `null` when none is set.
+ *
+ * The non-throwing probe, for surfaces that DISPLAY the active kid rather
+ * than commit to it (they can render honest absence). The value is returned
+ * verbatim — presence is tested after trimming, but the string itself is
+ * never normalized, because silently rewriting a value that lands in a
+ * signed field is its own defect. The kid is not secret: it is the registry
+ * lookup handle for the matching public key.
+ */
+export function getConfiguredKeyId(): string | null {
+  return isSigningKeyIdConfigured(process.env)
+    ? (process.env.EVIDENCE_KEY_ID as string)
+    : null;
+}
+
+/**
+ * The active key identifier for anything that COMMITS to it — the value
+ * emitted into `metadata.signingKeyId` (covered by the envelope hash) and
+ * into the signature envelope's `kid`.
+ *
+ * Throws when unset, rather than returning `undefined`, because every caller
+ * writes the result into a required envelope field: returning an absent value
+ * would only move the same guess out to each call site (and the format layer
+ * types the field as a required `string`, so there is no honest empty to
+ * emit). Callers reach this only behind `evaluateSealCommitGate`, which turns
+ * the same condition into a specific, actionable refusal; this throw is the
+ * last-resort guard for any path that forgets the gate.
  */
 export function getActiveKeyId(): string {
-  return process.env.EVIDENCE_KEY_ID || DEFAULT_KEY_ID;
+  const kid = getConfiguredKeyId();
+  if (kid === null) throw new Error(`[signing] ${MISSING_KEY_ID_MESSAGE}`);
+  return kid;
 }
 
 /**
@@ -84,6 +124,11 @@ export function getActiveSigner(): SignerIdentity {
  * to, which is also what Rekor stores as `spec.data.hash`. The mechanism
  * (and the SPKI public-key derivation retained in `SignResult.publicKey`)
  * is produce-core's; only the key custody lives here.
+ *
+ * Null is the answer for "no key" ONLY. With a key but no `EVIDENCE_KEY_ID`
+ * this throws via `getActiveKeyId` instead of degrading: silently skipping
+ * the signature there would hide a misconfiguration behind a state
+ * (deliberately unsigned) that the operator did not choose.
  */
 export function signPackage(packageHash: string): SignResult | null {
   const privKeyB64 = process.env.EVIDENCE_SIGNING_KEY;

--- a/src/lib/evidence/unsigned-tier.test.ts
+++ b/src/lib/evidence/unsigned-tier.test.ts
@@ -15,21 +15,45 @@ import assert from 'node:assert/strict';
 
 import {
   isSigningConfigured,
+  isSigningKeyConfigured,
+  isSigningKeyIdConfigured,
   evaluateSealCommitGate,
   evaluateUnsignedRecordPublishGate,
   shouldShowRunningUnsignedIndicator,
+  resolveUnsignedIndicator,
 } from './unsigned-tier.ts';
 
 // Deliberately inert stand-in — presence is all the tier logic reads, so the
 // fixture never needs to look like key material.
 const KEY_PRESENT = 'presence-only-stand-in';
+const KID_PRESENT = 'platform:this-instance-2026-08';
+/** Both halves of the signing pair, the only fully-configured state. */
+const SIGNED = { EVIDENCE_SIGNING_KEY: KEY_PRESENT, EVIDENCE_KEY_ID: KID_PRESENT };
+/** The defect state: custody without a declared identity. */
+const KEY_NO_KID = { EVIDENCE_SIGNING_KEY: KEY_PRESENT };
 
-test('isSigningConfigured: presence-only — set means signed tier, unset/empty means unsigned', () => {
-  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: KEY_PRESENT }), true);
+test('isSigningConfigured: BOTH halves required — a key alone is not configured', () => {
+  assert.equal(isSigningConfigured(SIGNED), true);
+  // The defect state. A key with no declared kid used to read as configured,
+  // which is what let an instance sign under the reference deployment's kid.
+  assert.equal(isSigningConfigured(KEY_NO_KID), false);
+  // And the mirror image: a kid with no key cannot sign either.
+  assert.equal(isSigningConfigured({ EVIDENCE_KEY_ID: KID_PRESENT }), false);
   assert.equal(isSigningConfigured({}), false);
-  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: undefined }), false);
-  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: '' }), false);
-  assert.equal(isSigningConfigured({ EVIDENCE_SIGNING_KEY: '   ' }), false);
+});
+
+test('isSigningConfigured: presence-only, whitespace-only counts as absent on either half', () => {
+  assert.equal(isSigningConfigured({ ...SIGNED, EVIDENCE_SIGNING_KEY: '' }), false);
+  assert.equal(isSigningConfigured({ ...SIGNED, EVIDENCE_SIGNING_KEY: '   ' }), false);
+  assert.equal(isSigningConfigured({ ...SIGNED, EVIDENCE_KEY_ID: '' }), false);
+  assert.equal(isSigningConfigured({ ...SIGNED, EVIDENCE_KEY_ID: '   ' }), false);
+  assert.equal(isSigningConfigured({ ...SIGNED, EVIDENCE_KEY_ID: undefined }), false);
+});
+
+test('the halves are separately observable (the gate and the banner branch on them)', () => {
+  assert.equal(isSigningKeyConfigured(KEY_NO_KID), true);
+  assert.equal(isSigningKeyIdConfigured(KEY_NO_KID), false);
+  assert.equal(isSigningKeyIdConfigured(SIGNED), true);
 });
 
 test('gate-off (ADR-0020 C): an unsigned run cannot reach seal/commit — the gate refuses server-side', () => {
@@ -44,8 +68,28 @@ test('gate-off (ADR-0020 C): an unsigned run cannot reach seal/commit — the ga
   assert.match(refusal!.body.error, /instance-setup/);
 });
 
-test('gate-off: a signed instance passes the gate (the action proceeds)', () => {
-  assert.equal(evaluateSealCommitGate({ EVIDENCE_SIGNING_KEY: KEY_PRESENT }), null);
+test('KEY WITHOUT KID: refused loudly and specifically, not as a generic unsigned tier', () => {
+  const refusal = evaluateSealCommitGate(KEY_NO_KID);
+  assert.ok(refusal, 'a half-configured instance must not pass the gate');
+  // A server misconfiguration, not a policy "you may not" — and a distinct
+  // code so the state is diagnosable from the response alone.
+  assert.equal(refusal!.status, 500);
+  assert.equal(refusal!.body.code, 'signing_key_id_missing');
+  // Actionable: names the missing variable and the guide.
+  assert.match(refusal!.body.error, /EVIDENCE_KEY_ID/);
+  assert.match(refusal!.body.error, /instance-setup/);
+  // States the real consequence — misattribution and unverifiable evidence —
+  // and explicitly rules out the wrong reading (a leaked signing key).
+  assert.match(refusal!.body.error, /misattribution/);
+  assert.match(refusal!.body.error, /not a key disclosure/);
+  // Platform-neutral: instances run on containers, VMs, and PaaS hosts alike.
+  assert.ok(!/vercel|render|heroku|aws/i.test(refusal!.body.error));
+  // NOT the generic tier refusal an operator has already moved past.
+  assert.notEqual(refusal!.body.code, 'unsigned_tier');
+});
+
+test('gate-off: a fully configured instance passes the gate (the action proceeds)', () => {
+  assert.equal(evaluateSealCommitGate(SIGNED), null);
 });
 
 test('per-record gate: a historical unsigned-persisted record cannot be promoted to published', () => {
@@ -73,13 +117,26 @@ test('running-unsigned indicator: shows outside dev, calm in dev/test (ADR-0020 
   assert.equal(shouldShowRunningUnsignedIndicator({ NODE_ENV: 'test' }), false);
 });
 
-test('running-unsigned indicator: never shows when signing is configured', () => {
-  assert.equal(
-    shouldShowRunningUnsignedIndicator({ EVIDENCE_SIGNING_KEY: KEY_PRESENT, NODE_ENV: 'production' }),
-    false,
-  );
-  assert.equal(
-    shouldShowRunningUnsignedIndicator({ EVIDENCE_SIGNING_KEY: KEY_PRESENT, NODE_ENV: 'development' }),
-    false,
-  );
+test('running-unsigned indicator: never shows when BOTH halves are configured', () => {
+  assert.equal(shouldShowRunningUnsignedIndicator({ ...SIGNED, NODE_ENV: 'production' }), false);
+  assert.equal(shouldShowRunningUnsignedIndicator({ ...SIGNED, NODE_ENV: 'development' }), false);
+  assert.equal(resolveUnsignedIndicator({ ...SIGNED, NODE_ENV: 'production' }), null);
+});
+
+test('indicator reason: the two states get different copy', () => {
+  assert.equal(resolveUnsignedIndicator({ NODE_ENV: 'production' }), 'no_signing_key');
+  assert.equal(resolveUnsignedIndicator({ ...KEY_NO_KID, NODE_ENV: 'production' }), 'no_key_id');
+});
+
+test('KEY WITHOUT KID: the indicator shows even in dev — it is not an intended state anywhere', () => {
+  // The dev-calm rule exists because the unsigned tier is the intended
+  // first-run dev state. A half-configured pair is intended nowhere, and dev
+  // is exactly where an operator wiring signing up should catch it.
+  for (const NODE_ENV of ['development', 'test', 'production', undefined]) {
+    assert.equal(
+      resolveUnsignedIndicator({ ...KEY_NO_KID, NODE_ENV }),
+      'no_key_id',
+      `half-configured must surface under NODE_ENV=${NODE_ENV}`,
+    );
+  }
 });

--- a/src/lib/evidence/unsigned-tier.ts
+++ b/src/lib/evidence/unsigned-tier.ts
@@ -25,17 +25,50 @@
 // Everything here is PURE over an env-shaped record (default `process.env`,
 // read at call time) so the decisions are unit-testable without touching the
 // process environment. No values are ever read beyond presence.
+//
+// SIGNING IS A PAIR. Custody is `EVIDENCE_SIGNING_KEY`; identity is
+// `EVIDENCE_KEY_ID` — the kid a verifier uses to look this instance's public
+// key up in its trust registry. Both halves are required, with no coded
+// default for either. A hardcoded default kid used to stand in for the second
+// half, which meant an operator who set a key but no kid left this tier
+// silently and signed every package under the REFERENCE deployment's kid: the
+// signature is theirs, the label points at someone else's registry entry, so
+// the evidence fails verification while appearing to claim another party's
+// identity. That is a misattribution and verifiability defect (the private
+// key is never involved — a clone always supplies its own). There is now no
+// case in which an instance emits a kid it did not configure.
 
 type EnvLike = Record<string, string | undefined>;
 
+/** THE presence test — non-empty after trim. Presence only; no value is ever
+ *  inspected further. Whitespace-only is absent, matching the preflight. */
+function isPresent(raw: string | undefined): boolean {
+  return typeof raw === 'string' && raw.trim().length > 0;
+}
+
+/** Whether this instance holds signing-key custody (`EVIDENCE_SIGNING_KEY`). */
+export function isSigningKeyConfigured(env: EnvLike = process.env): boolean {
+  return isPresent(env.EVIDENCE_SIGNING_KEY);
+}
+
 /**
- * Whether this instance holds a signing key — the producer-tier discriminator
- * (ADR-0020 §B: unsigned dev → per-instance signed). Presence-only; the value
- * is never inspected beyond non-emptiness.
+ * Whether this instance has declared its signing identity
+ * (`EVIDENCE_KEY_ID`). No default: the kid names a specific entry in a
+ * specific trust registry, so guessing one is asserting an identity.
+ */
+export function isSigningKeyIdConfigured(env: EnvLike = process.env): boolean {
+  return isPresent(env.EVIDENCE_KEY_ID);
+}
+
+/**
+ * Whether this instance can sign — the producer-tier discriminator (ADR-0020
+ * §B: unsigned dev → per-instance signed). Requires BOTH halves: key custody
+ * AND a configured kid. A half-configured instance is `false` here, i.e. it
+ * is treated as not configured rather than as a partial success — it must not
+ * pass any gate that a fully-signed instance passes.
  */
 export function isSigningConfigured(env: EnvLike = process.env): boolean {
-  const key = env.EVIDENCE_SIGNING_KEY;
-  return typeof key === 'string' && key.trim().length > 0;
+  return isSigningKeyConfigured(env) && isSigningKeyIdConfigured(env);
 }
 
 /** The refusal a seal/commit attempt receives in the unsigned tier. */
@@ -45,18 +78,48 @@ export interface SealCommitGateRefusal {
 }
 
 /**
- * Guard 1 (instance form): the seal/commit action is unreachable in the
- * unsigned tier. Returns `null` when signing is configured (the action may
- * proceed) and a refusal otherwise. Wired server-side into the publish/commit
- * routes so an unsigned run cannot persist a `sealed`- or
- * `public`-labeled record — per Decision C an unsigned package may reach
- * neither state, so the whole persist action is gated, not just one
- * visibility value.
+ * Guard 1 (instance form): the seal/commit action is unreachable unless BOTH
+ * halves of the signing pair are configured. Returns `null` when they are
+ * (the action may proceed) and a refusal otherwise. Wired server-side in
+ * front of every route that reaches the signing path, so a run that cannot
+ * sign honestly cannot persist a `sealed`- or `public`-labeled record — per
+ * Decision C an unsigned package may reach neither state, so the whole
+ * persist action is gated, not just one visibility value.
+ *
+ * Two distinct refusals, because they are two distinct operator situations:
+ *
+ *   - `unsigned_tier` (403) — no signing key at all. A legitimate tier;
+ *     signing is the go-to-production step the operator has not taken yet.
+ *   - `signing_key_id_missing` (500) — a key but no `EVIDENCE_KEY_ID`. NOT a
+ *     legitimate state: the operator intends to sign and the instance is
+ *     misconfigured, so this is a server fault, named specifically rather
+ *     than folded into the tier message an operator has already moved past.
  */
 export function evaluateSealCommitGate(
   env: EnvLike = process.env,
 ): SealCommitGateRefusal | null {
   if (isSigningConfigured(env)) return null;
+
+  if (isSigningKeyConfigured(env)) {
+    return {
+      status: 500,
+      body: {
+        error:
+          'This instance has a signing key but has not declared its signing ' +
+          'key id: EVIDENCE_KEY_ID is not set in this environment. Sealing ' +
+          'and publishing are refused rather than signed under a key id this ' +
+          'instance never configured — a package labeled with a kid that ' +
+          "resolves to some other deployment's public key cannot verify, and " +
+          'claims an identity that is not this instance\'s. (The signing key ' +
+          'itself is unaffected: this is a misattribution and verifiability ' +
+          'failure, not a key disclosure.) Set EVIDENCE_KEY_ID to the kid of ' +
+          "the active entry in this instance's trust registry — see " +
+          'docs/instance-setup.md.',
+        code: 'signing_key_id_missing',
+      },
+    };
+  }
+
   return {
     status: 403,
     body: {
@@ -65,7 +128,8 @@ export function evaluateSealCommitGate(
         'Sealing or publishing evidence requires a signature: an unsigned ' +
         'package can reach neither the sealed nor the public state (ADR-0020). ' +
         'Analyses still run and can be inspected locally; an operator enables ' +
-        'signing via docs/instance-setup.md.',
+        'signing (EVIDENCE_SIGNING_KEY and EVIDENCE_KEY_ID, both required) ' +
+        'via docs/instance-setup.md.',
       code: 'unsigned_tier',
     },
   };
@@ -97,15 +161,33 @@ export function evaluateUnsignedRecordPublishGate(
 }
 
 /**
- * Whether the running-unsigned indicator/banner should render (ADR-0020
- * §Consequences: "a running-unsigned indicator/banner shows outside a dev
- * environment"). Dev (and test) stay calm — the unsigned tier is the intended
- * first-run state there; anywhere else, running unsigned must never be
- * silent, so an unknown NODE_ENV shows the indicator too.
+ * Why this instance cannot sign, for the site-wide indicator — or `null` when
+ * nothing should be shown.
+ *
+ *   - `no_signing_key` — the unsigned tier (ADR-0020 §Consequences: "a
+ *     running-unsigned indicator/banner shows outside a dev environment").
+ *     Dev (and test) stay calm: the unsigned tier is the intended first-run
+ *     state there. Anywhere else, running unsigned must never be silent, so
+ *     an unknown NODE_ENV shows the indicator too.
+ *   - `no_key_id` — a signing key with no `EVIDENCE_KEY_ID`. Shown in EVERY
+ *     environment, dev included: it is not an intended state anywhere, and
+ *     dev is precisely where an operator wiring signing up should see it
+ *     before the same half-configuration reaches a deploy.
  */
+export type UnsignedIndicatorReason = 'no_signing_key' | 'no_key_id';
+
+export function resolveUnsignedIndicator(
+  env: EnvLike = process.env,
+): UnsignedIndicatorReason | null {
+  if (isSigningConfigured(env)) return null;
+  if (isSigningKeyConfigured(env)) return 'no_key_id';
+  if (env.NODE_ENV === 'development' || env.NODE_ENV === 'test') return null;
+  return 'no_signing_key';
+}
+
+/** Whether the indicator/banner renders at all. */
 export function shouldShowRunningUnsignedIndicator(
   env: EnvLike = process.env,
 ): boolean {
-  if (isSigningConfigured(env)) return false;
-  return env.NODE_ENV !== 'development' && env.NODE_ENV !== 'test';
+  return resolveUnsignedIndicator(env) !== null;
 }

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -39,6 +39,13 @@ import {
 import type { BlobRef } from './blob-ref.ts';
 import { ed25519, ed25519ph } from '@noble/curves/ed25519.js';
 
+// The attestation-node cases below build envelopes, which carry
+// `metadata.signingKeyId`; there is no coded default for it (signing.ts), so
+// this suite declares one. `node --test` runs each file in its own process.
+process.env.EVIDENCE_KEY_ID ??= 'platform:test-suite-kid';
+
+// Registry fixtures below — the kid strings a verifier LOOKS UP, unrelated to
+// what this process would emit.
 const KID = 'platform:evidence-2026-04';
 const NEW_KID = 'platform:evidence-2027-04';
 const PUB = 'MCowBQYDK2VwAyEA-PLACEHOLDER-ACTIVE-KEY';


### PR DESCRIPTION
## The defect

`getActiveKeyId()` fell back to a hardcoded default when `EVIDENCE_KEY_ID` was
unset:

```ts
const DEFAULT_KEY_ID = 'platform:evidence-2026-04';
export function getActiveKeyId(): string {
  return process.env.EVIDENCE_KEY_ID || DEFAULT_KEY_ID;
}
```

That literal is the reference deployment's kid, and it is the active entry in
the trust registry this repo serves at `/.well-known/typed-publisher.json`.
Alongside it, `isSigningConfigured()` looked only at `EVIDENCE_SIGNING_KEY`.

Together those two facts produced this: an operator who set a signing key but
no key id **left the unsigned tier** — the running-unsigned banner cleared, the
publish action enabled, the seal/commit gate opened — and then signed every
package under the reference deployment's identifier. `metadata.signingKeyId`
(covered by the envelope hash) and the signature envelope's `kid` both carried
a kid that instance never configured.

### What that costs — misattribution, not key disclosure

Worth stating precisely, because the failure mode is easy to over- or
under-read. **The private signing key never leaks.** A clone always supplies
its own via `EVIDENCE_SIGNING_KEY`; nothing in this path ever exposed the
reference deployment's key material.

What it produced instead is **misattribution and unverifiable evidence**. The
signature is genuinely the operator's, but it is labeled with a kid that
resolves — in the registry a verifier consults — to a *different* public key.
So every such package fails verification, while presenting itself as having
been signed under another party's identity. Both halves of that are bad
independently: the evidence does not work, and it points at someone who did
not produce it.

## The fix

**No fallback, in either direction.** An instance emits the key id it
configured, or it does not sign.

- `DEFAULT_KEY_ID` is deleted. `getActiveKeyId()` returns the configured value
  or **throws**.
- `getConfiguredKeyId(): string | null` is the new non-throwing probe, for
  surfaces that *display* the kid rather than commit to it.
- `isSigningConfigured()` requires **both** halves. A key without a kid is
  treated as *not configured* everywhere — never as a partial success.

### Why throw rather than return absent

Every caller of `getActiveKeyId()` writes the result straight into a required
envelope field (`metadata.signingKeyId`, and the signature envelope's `kid`) —
`packager.ts`, `attestation.ts`, and `signPackage` itself. The format layer
types that field as a required `string`, so there is no honest empty to emit.
Returning `undefined` would not remove the guess; it would relocate it to
three call sites, each of which would have to invent something. Throwing puts
the stop at the one place where a fabricated identity would otherwise be
minted.

The display surface is the exception that proves it: `/api/query-notebook`
only *shows* the active kid in the pre-publish Signers row, so it takes
`getConfiguredKeyId()` and renders honest absence when there is none. It used
to show the reference kid to users of any instance.

### The loud, specific failure

`evaluateSealCommitGate()` now returns two distinct refusals, following the
existing `SealCommitGateRefusal` shape:

| State | Status | Code | Reading |
| --- | --- | --- | --- |
| No signing key | 403 | `unsigned_tier` | A legitimate tier. Signing is the go-to-production step, not yet taken. |
| Key, no `EVIDENCE_KEY_ID` | 500 | `signing_key_id_missing` | Not a legitimate state anywhere: the operator intends to sign and the instance is misconfigured, so it is a server fault. |

The new refusal names `EVIDENCE_KEY_ID`, points at `docs/instance-setup.md`,
states the real consequence, and explicitly rules out the wrong reading ("this
is a misattribution and verifiability failure, not a key disclosure"). It is
platform-neutral: it names the variable and the guide, never a hosting
product.

Three routes reach the signing path **without** the gate today —
`withdraw`, `reinstate`, and the legacy `attestations` POST. Each builds
and/or signs an attestation node, so each would now throw a bare 500 out of
`getActiveKeyId()`. They take the same gate, which converts that into the
specific refusal. On a fully unsigned instance this also stops those routes
emitting attestation nodes that no key backs — consistent with ADR-0020
Decision C, and there is nothing published to withdraw on such an instance
anyway.

The site-wide banner distinguishes the two states as well. The unsigned-tier
banner stays dev-calm (the unsigned tier is the intended first-run state
there); the half-configured banner shows in **every** environment including
dev, because it is not an intended state anywhere and dev is where an operator
wiring signing up should catch it.

## Verification and the reference deployment

The reference deployment sets `EVIDENCE_KEY_ID` explicitly in its production
environment — confirmed by the owner — so removing the fallback is a **no-op
for it**: it was already emitting the same kid from configuration rather than
from the coded default. This change protects every *other* instance, which is
where the defect actually bit.

## Preflight (`scripts/preflight-env.mjs`)

- `EVIDENCE_KEY_ID` loses `hasFallback: true`. It stays `required`, so an
  absent kid is now a hard miss that fails the run rather than a soft
  "running on the built-in default" note. Its inline comment documented the
  fallback being deleted here and is rewritten.
- **`ENV_GROUPS` now covers the signing pair.** #195 deliberately excluded it
  *because* the kid had a coded fallback, which meant the set was not
  all-or-nothing. That reason is gone: `isSigningConfigured` requires both
  halves, so the pair is literally all-or-nothing in the code. It is the one
  group that is *not* silent at run time — the gate refuses and the banner
  shows — and it is listed anyway, because preflight is where the operator
  learns the relationship (a key alone does not turn signing on) before a
  deploy rather than from a refused publish afterwards. The group header
  comment now says so, so the list's stated criterion still matches its
  contents.
- The `requiredOnFallback` explanation no longer cites `DEFAULT_KEY_ID` as its
  worked example.

## Docs

- `docs/instance-setup.md` §4 — the kid row is marked "no default", plus a
  short passage on why half of the pair is not half of the feature, and the
  three places the half-configured state surfaces.
- `docs/deploy.md` — the disable-when-absent row now states the all-or-nothing
  requirement and what the key-without-kid state does; the compose-side
  restatement gains the same clause.
- `docs/api/evidence-publish.md` — the signing-side env table row says "no
  coded default" and that the example kid names *your* registry entry.

Deliberately **not** touched: `docker-compose.yml` and its preflight section
(a concurrent PR owns those; its existing wording stays accurate under this
change).

**One follow-up the sandbox could not make:** `.env.example:41` still reads
`# kid of the active key — must match the trust registry (unset = demo kid)`.
That parenthetical documents the fallback this PR deletes. Agent sessions are
denied read/write on `.env*` paths by policy, so it needs a one-line manual
edit — suggested: `(no default; required to sign)`.

## Tests

New coverage in `signing.test.ts` and `unsigned-tier.test.ts` for the three
states the charter asks for:

- **key without kid → refused**: `getActiveKeyId()` throws; `signPackage()`
  throws rather than signing under a substituted kid; the gate returns
  `signing_key_id_missing` with actionable, platform-neutral text; the
  indicator reports `no_key_id` under every `NODE_ENV`.
- **both set → works**: the gate passes, the banner stays hidden,
  `getActiveKeyId()` returns the configured value verbatim (no silent
  normalization of a value that lands in a signed field).
- **neither → unsigned tier**: unchanged `unsigned_tier` 403 and dev-calm
  banner behavior.

Plus whitespace-only handling on both halves, and a preflight test pinning
that `EVIDENCE_KEY_ID` carries no `hasFallback` and that a half-set signing
pair warns by name.

Four evidence suites (`packager`, `attestation`, `verify`, `instance-config`)
build envelopes and were implicitly relying on the fallback to supply a kid.
Each now declares one at module scope — as any signing instance must. That
they needed it is itself part of the finding.

`npm ci` / `npm test` / `npm run typecheck` / `npm run lint`: 635 pass, 0 type
errors, 0 lint errors (4 pre-existing warnings). The only failures are the two
known sandbox `listen EPERM` socket-bind artifacts in
`openrouter-streaming.test.ts` (#249). `next build --webpack` completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
