### PR TITLE
docs: .env.example — EVIDENCE_KEY_ID has no default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ BLOB_READ_WRITE_TOKEN=     # Vercel Blob token (the default blob driver; S3: see
 # --- Evidence signing (unset = the unsigned tier: banner shows, seal/publish gated off) ---
 # Generate with: npx tsx scripts/generate-signing-key.ts
 EVIDENCE_SIGNING_KEY=      # Base64-encoded Ed25519 private key (PKCS8 DER)
-# EVIDENCE_KEY_ID=         # kid of the active key — must match the trust registry (unset = demo kid)
+# EVIDENCE_KEY_ID=         # kid of the active key — must match the trust registry (no default; required to sign)
 
 # --- Sign-in (unlocks notebook execution, the dashboard, the higher rate limit) ---
 NEXTAUTH_SECRET=           # Generate with: openssl rand -base64 32


### PR DESCRIPTION
One line. Line 41's `(unset = demo kid)` documented the fallback #251 deleted. Follow-up flagged in that PR; agent sessions can't write `.env*` paths.