### PR TITLE
fix: retire "commit" from user-facing copy — the action is seal, the state is sealed (ADR-0016)

### DIFF
--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -10,7 +10,7 @@ An instance works unsigned out of the box — analyses run and packages can be
 produced and inspected. Signing is the **go-to-production** step: keygen →
 registry → environment. Nothing unsigned can reach the `sealed` or `public`
 states, and the application enforces this (ADR-0020 Decisions B/C): with no
-signing key configured, the evidence **commit and publish actions are gated
+signing key configured, the evidence **seal and publish actions are gated
 off** server-side and in the UI, verification labels unsigned output
 prominently ("Unsigned package — no cryptographic commitment"), and a
 **running-unsigned banner** shows site-wide outside a dev environment

--- a/src/components/RunningUnsignedBanner.tsx
+++ b/src/components/RunningUnsignedBanner.tsx
@@ -71,7 +71,7 @@ export default function RunningUnsignedBanner() {
       }}
     >
       <strong>Running unsigned</strong> — no signing key is configured, so
-      evidence commit and publish are disabled and any output produced here
+      evidence seal and publish are disabled and any output produced here
       carries no cryptographic commitment. Signing is the go-to-production
       step; see the{' '}
       <a


### PR DESCRIPTION
Bounded sweep of **user-facing copy** for retired ADR-0016 vocabulary. The settled vocabulary: the states are `sealed` and `public`; the actions are *seal* and *publish*. `commit`/`committed` (as action or state) and `published` *as a status label* are retired spellings.

Two strings changed. Everything else that matched the grep was classified and deliberately left — the inventory is below, because on this task what was **not** touched is the more important half.

## What changed (2 strings)

**1. `src/components/RunningUnsignedBanner.tsx:74`** — the site-wide unsigned banner

> before: `evidence commit and publish are disabled and any output produced here`
> after:  `evidence seal and publish are disabled and any output produced here`

This was the anchor defect: line 42 of the *same component* (the half-configured branch) already read "so seal and publish are refused". One banner, two vocabularies, depending on which misconfiguration you hit. The one-word swap makes the two branches agree and matches the server refusals in `unsigned-tier.ts`, which already say "Sealing and publishing are refused" / "Sealing or publishing evidence requires a signature".

Line 75's **"carries no cryptographic commitment" is untouched** — different term, see below.

**2. `docs/instance-setup.md:13`** — the operator guide the banner links to

> before: `signing key configured, the evidence **commit and publish actions are gated`
> after:  `signing key configured, the evidence **seal and publish actions are gated`

Same sentence also contains `("Unsigned package — no cryptographic commitment")`, untouched.

## What was deliberately left, and why

| Category | Count (representative) | Disposition |
|---|---|---|
| **Cryptographic commitment** (the hash/commitment sense) | ~90 hits | **Leave — different term entirely.** `src/lib/evidence/commitment.ts`, `GET /api/evidence/<id>/commitment`, `buildCommitmentView`, `commitmentUrl` threading through `VerifyBadge`/`EvidenceActions`/the detail page, `docs/api/evidence-commitment.md` in full, the Attention-tier label `Unsigned package — no cryptographic commitment` (`trust-signal.ts:633`, rendered on the detail page and documented in `trust-signal-vocabulary.md`), and "the value the package commits to" in the blob-ref failure details. A node in **either** visibility state carries a public transparency-log commitment; retiring `committed` as a visibility label has nothing to do with this noun. |
| **ADR-0016 alias / compatibility layer** | 9 in `visibility.ts` + tests | **Leave — permanent by design.** `VisibilityDbValue`, `SEALED_DB_VALUES`, `PUBLIC_DB_VALUES`, `ACCEPTED_VISIBILITY_INPUTS`, and the `visibility.test.ts` cases that pin legacy-row behaviour. |
| **Database values / migrations / enum labels** | `db/schema.ts` (documented dead enum values), `drizzle/meta/*_snapshot.json` | **Leave.** |
| **Frozen storage literal** | `src/lib/storage/index.ts:64,79,83` — `evidence-packages/committed/<random>.json`, `putCommittedPackage` | **Leave.** Already carries a `DELIBERATELY NOT RENAMED by the ADR-0016 §A sweep` comment; it is a capability-URL path segment baked into every already-stored sealed package, never a state label, never client-visible. |
| **Internal identifiers** | `evaluateSealCommitGate`, `SealCommitGateRefusal`, and the code comments that name them (`PublishEvidenceDialog.tsx:94`, `evidence/[slug]/page.tsx:279`, `api/evidence/signing-status/route.ts:8`, `unsigned-tier.ts:11,74,81`) | **Leave — that is a refactor, not a copy fix.** Renaming the symbol and its referring comments together is a separable change. |
| **API request-value documentation** | `docs/api/evidence-publish.md` lines 110, 390, 401, 427, 446 | **Leave.** These document the accepted-input aliases and the original issue-framing mapping — i.e. they describe the compatibility surface accurately. |
| **Historical records / change logs** | `docs/api/evidence-publish.md` change-log entries (2026-08-05, 2026-08-02, 2026-06-12 ×3, 2026-06-11), `docs/deploy.md:716,740` (migration notes), `docs/RETROSPECTIVE.md` | **Leave — they quote a past state accurately.** The 2026-08-05 entry is the rename's own record and would be falsified by "fixing" it. |
| **Git-commit sense** | `README.md:61`, `CONTRIBUTING.md:40`, `docs/deploy.md:151,770,1068`, `docs/instance-setup.md:37`, `docs/rate-limit-headroom.md:50,62`, sprint docs | **Leave — unrelated homonym.** |
| **Ordinary prose ("published" as past participle)** | `(app)/evidence/page.tsx:9,17` "Published evidence packages from…", `EvidenceIndex.tsx:187` "No evidence packages published yet.", `DashboardTabs.tsx:274` "You haven't published any evidence yet.", `EvidenceActions.tsx:63` + `ChatCitationPreview.tsx:88` citation `Published: <date>`, `ChatNotebookOutput.tsx:142` "not yet published", `PositioningBand.tsx` ×6, `project/page.tsx:133` "what's committed" (roadmap commitments) | **Leave.** None of these name a status. |

## Verified already-current (no change needed)

Worth recording, because it bounds the sweep: the surfaces most likely to carry the retired vocabulary had already been converted.

- Status badges (`DashboardTabs.tsx:92`, `evidence/[slug]/page.tsx:157`, `EvidenceIndex.tsx:47`) — the visibility badge key is `sealed`; no `committed`/`published` badge exists.
- Publish dialog (`PublishEvidenceDialog.tsx`) — radio labels "Seal (default)" / "Publish now", result label `Sealed` / `Public`, action button `Seal` / `Publish`, unsigned notice "evidence cannot be sealed or published".
- Detail-page banners — "Sealed — not published", "An unsigned package can reach neither the sealed nor the public state".
- Server refusal messages (`unsigned-tier.ts`) — "Sealing and publishing are refused…", "Sealing or publishing evidence requires a signature…".

## Ambiguous — left for the owner

**`src/app/(app)/evidence/[slug]/page.tsx:654`** — the Status History section renders `**Published** on <date>` alongside `**Withdrawn** on …` and `**Reinstated** on …`. Read as a lifecycle *event* label (its siblings are events, and the date is `record.createdAt`) this is correct as-is; read as a *state* label it is the retired spelling of `public`. It is genuinely ambiguous, so it was left rather than guessed at. If it should change, "Created" or "Sealed" would be the candidates depending on what that timestamp is meant to mark — a semantic decision, not a copy decision.

## Footnote disposition — `docs/deploy.md` NOT touched

**#253 has not merged** (state: OPEN as of this PR), so per the task's own condition the deploy guide was left alone. Its only changed file is `docs/deploy.md`, so touching that file here would have conflicted directly.

Flagging for whoever lands #253, because this PR makes two of its lines stale:

- **`docs/deploy.md:113-116`** quotes the banner verbatim, including `so evidence commit and publish are disabled`. That quote no longer matches the UI after this PR. If #253's footnote explains that this quote uses retired vocabulary, the footnote should be dropped and the quote updated to `so evidence seal and publish are disabled` — then guide and UI agree.
- **`docs/deploy.md:117`** — `Evidence **commit and publish actions are gated off**` — is an independent assertion (not a quote) carrying the retired action name. It is the exact sentence fixed here in `instance-setup.md:13` and should get the same one-word swap.
- **`docs/deploy.md:426`** — `| \`EVIDENCE_SIGNING_KEY\` + \`EVIDENCE_KEY_ID\` | Evidence commit/publish. …` — same class; the same row already says "seal and publish gated off" a few clauses later, so it has the internal-inconsistency shape as the banner did.

## Verification

- `npm ci` — clean
- `npm test` — 654/656 pass; the 2 failures are the known sandbox `listen EPERM: operation not permitted 127.0.0.1` socket-bind artifacts in `openrouter-streaming.test.ts` (#249), unrelated to this diff
- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 4 pre-existing warnings (all in files untouched here)
- `node scripts/check-compose-env.mjs` — `RESULT: PASS`
- No test asserts either changed string; no snapshot files exist in this repo. The only test matching `/running unsigned/` (`unsigned-tier.test.ts:66`) asserts the *server refusal* text, which is unchanged.
- `next build` not run — cannot complete in a sandboxed agent session (documented in CLAUDE.md § Known Tech Debt); CI's `build` check is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
