### PR TITLE
docs: deploy guide — match the banner's current wording, drop the footnote (#254 follow-up)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -113,12 +113,9 @@ reaches it too.
 What you will see, and why it is correct:
 
 - A **"Running unsigned" banner** on every page: *"Running unsigned — no
-  signing key is configured, so evidence commit and publish are disabled
+  signing key is configured, so evidence seal and publish are disabled
   and any output produced here carries no cryptographic commitment.
   Signing is the go-to-production step; see the instance setup guide."*
-  (Quoted verbatim, including its "commit" — that string predates the
-  [ADR-0016] rename and means what this guide and the API now call
-  **seal**.)
 - Evidence **seal and publish actions are gated off**, server-side and
   in the UI. An unsigned package can reach neither the `sealed` nor the
   `public` state ([ADR-0020]) — the unsigned tier is confined to local


### PR DESCRIPTION
## Summary

Small documentation follow-up to #254 (banner wording change) — three stale spots in `docs/deploy.md` cleaned up now that both dependencies are merged: #253 (guide consolidation + footnote) and #254 (banner now says "seal" instead of "commit").

## Changes

1. **Verbatim banner quote** (in "Quick bring-up: the unsigned tier"): updated the quoted banner text from *"...so evidence commit and publish are disabled..."* to *"...so evidence seal and publish are disabled..."* — matching the string `RunningUnsignedBanner.tsx` now actually renders after #254. The rest of the quote (including "carries no cryptographic commitment," which is unrelated hash-sense language the banner still uses) is unchanged.
2. **Footnote added by #253**: removed the parenthetical *"(Quoted verbatim, including its 'commit' — that string predates the [ADR-0016] rename and means what this guide and the API now call **seal**.)"* — it explained why the quote still said "commit"; now that the quote matches current UI, the explanation is unnecessary.

## Left alone (already fixed by #253, or out of scope)

- The task brief for this follow-up expected two more edits — a prose assertion ("Evidence commit and publish actions are gated off") and a table row ("Evidence commit/publish") — but both already read with "seal" vocabulary on current `main` (#253's "deploy-guide consolidation" evidently updated them already). No changes needed there; verified by reading the current file rather than trusting the brief's stale line numbers.
- `docs/deploy.md:140` and `:811` — DB verification output listing `published, committed, sealed, public` as the four visibility-enum labels. Left alone: these describe the database's accepted enum values, which ADR-0016 keeps permanently (legacy labels are never dropped).
- `docs/deploy.md:787-788` — migration section describing the `committed → sealed`, `published → public` rename historically. Left alone: accurate history, not live vocabulary.
- `docs/deploy.md:156`, `:841`, `:1139` — "never commit this file" / "never commit it" / "...committed. With the 1Password convention..." — all the literal git-commit sense, unrelated to evidence vocabulary. Left alone.

## Verification (in a worktree off `origin/main`)

- `npm ci` — clean
- `npm test` — 654 passed / 2 failed; the 2 failures are the documented `listen EPERM` socket-bind failures in `openrouter-streaming.test.ts` (#249), unrelated to this change
- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 4 pre-existing warnings (unrelated files)
- `node scripts/check-compose-env.mjs` — PASS
- No headings were touched, so the TOC and internal anchors are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
