### PR TITLE
docs: correct a stale comment about produce-core's visibility default

### DIFF
--- a/src/lib/evidence/commitment.ts
+++ b/src/lib/evidence/commitment.ts
@@ -206,9 +206,9 @@ export function buildCommitmentView(
     packageUrl: record.basePackageStorageKey as unknown as string | undefined,
     // Visibility state (ADR-0010): lets a verifier render "sealed — content
     // not publicly located" instead of treating a missing packageUrl as an
-    // error. (The core defaults an ABSENT value to 'published'; the column is
-    // `NOT NULL`, so that branch is unreachable from this adapter — the
-    // fallback exists for callers whose row shape predates the column.)
+    // error. (The core now REFUSES an absent value rather than defaulting it
+    // — see ADR-0024; the column is `NOT NULL`, so the `: undefined` branch is
+    // unreachable from this adapter and would throw if it ever were reached.)
     //
     // SERVED CANONICAL (ADR-0016 §A, P2). The row's raw label is normalized
     // through the vocabulary boundary before it is emitted, so a historical row


### PR DESCRIPTION
Three lines of comment, no behaviour change.

`typedstandards#42` (merged) removed produce-core's `visibility ?? 'published'` fallback and made an absent value an error instead, per [ADR-0024](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0024-evidence-path-configuration.md) — a default must not assert a disclosure state nobody supplied, inside a view a verifier resolves.

This adapter's comment still described that default. Its *behaviour* is unchanged and remains correct: `visibility` is `NOT NULL`, so the `: undefined` branch is unreachable from here. What changed is what would happen if it ever were reached — a throw rather than a silent `'published'`. The comment now says so.

Found by the agent that made the produce-core change, which flagged it rather than reaching across repos to edit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
