### PR TITLE
harness: pass explicit config at every default-relying call site (sprint 153 P1)

### DIFF
--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -9,7 +9,7 @@ import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-li
 import { headers } from 'next/headers';
 import { encodeSSE, panelsForRun, type ModelErrorCode, type PanelType, type StreamEvent } from '@/lib/streaming';
 import { getMissingModelCredentialError } from '@/lib/model-client';
-import { TraceBuilder, hash } from '@/lib/evidence/trace';
+import { TraceBuilder, hash, CIVICAITOOLS_TRACE_CONFIG } from '@/lib/evidence/trace';
 
 const SSE_HEADERS = {
   'Content-Type': 'text/event-stream',
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
     await incrementRateLimit(identifier, isAuthenticated);
 
     // --- Evidence trace: initialize ---
-    const trace = new TraceBuilder();
+    const trace = new TraceBuilder(CIVICAITOOLS_TRACE_CONFIG);
     trace.startRoot('analysis', {
       'analysis.prompt_hash': hash(query),
       'analysis.model': model,

--- a/src/app/api/query-notebook/route.ts
+++ b/src/app/api/query-notebook/route.ts
@@ -29,7 +29,7 @@ import {
   type CompletionResult,
   type StreamCallbacks,
 } from '@/lib/openrouter-streaming';
-import { TraceBuilder, hash as traceHash } from '@/lib/evidence/trace';
+import { TraceBuilder, hash as traceHash, CIVICAITOOLS_TRACE_CONFIG } from '@/lib/evidence/trace';
 import { getConfiguredKeyId } from '@/lib/evidence/signing';
 import {
   type PhaseAToolCall,
@@ -124,7 +124,7 @@ export async function POST(request: NextRequest) {
     await writer.write(encoder.encode(encodeNotebookEvent(event)));
   };
 
-  const trace = new TraceBuilder();
+  const trace = new TraceBuilder(CIVICAITOOLS_TRACE_CONFIG);
   trace.startRoot('executed_notebook', {
     'analysis.prompt_hash': traceHash(body.query),
     'analysis.model': model,

--- a/src/lib/evidence/data-sources.ts
+++ b/src/lib/evidence/data-sources.ts
@@ -8,28 +8,49 @@
 // APP-SIDE knowledge (the MCP registry lives in `../mcp/`), so this shim
 // passes `sourceIdForToolName` into the harness's injectable resolver rather
 // than relying on the harness's exported civic default — the app's own map
-// stays authoritative, per the S3a contract. The display helpers re-export
-// the harness's civic-registry-backed versions (same names, same output,
+// stays authoritative, per the S3a contract. The display helpers wrap the
+// harness's civic-registry-backed versions, passing this instance's registry
+// (`CIVIC_SOURCE_REGISTRY`, the harness's own demo default) explicitly rather
+// than letting the harness apply it implicitly — same names, same output,
 // including the socrata coercion for pre-M9.3 packages and the middle-dot
-// separator).
+// separator. Wiring a non-demo registry is P2 parameterization work, not this
+// shim's.
 
 import { sourceIdForToolName } from '../mcp/operation-types.ts';
 import {
   buildDataSources as harnessBuildDataSources,
   resolveToolSource as harnessResolveToolSource,
-  displayNameForSource,
-  formatDataSourcesSummary,
+  displayNameForSource as harnessDisplayNameForSource,
+  formatDataSourcesSummary as harnessFormatDataSourcesSummary,
+  CIVIC_SOURCE_REGISTRY,
+  type CivicSourceRegistry,
   type DataSourceEntry,
   type ToolCallSummary,
   type ToolSourceResolver,
 } from '@typedstandards/civic-typed-harness';
 
-export {
-  displayNameForSource,
-  formatDataSourcesSummary,
-  type DataSourceEntry,
-  type ToolCallSummary,
-};
+export { CIVIC_SOURCE_REGISTRY, type CivicSourceRegistry, type DataSourceEntry, type ToolCallSummary };
+
+/** Human-friendly display label for a `sourceId`, against this instance's
+ *  source registry. Thin wrapper over the harness function — always passes
+ *  `registry` explicitly (defaulting to `CIVIC_SOURCE_REGISTRY` here at the
+ *  shim boundary) so the harness call never relies on its own default. */
+export function displayNameForSource(
+  sourceId: string | undefined | null,
+  registry: CivicSourceRegistry = CIVIC_SOURCE_REGISTRY,
+): string {
+  return harnessDisplayNameForSource(sourceId, registry);
+}
+
+/** Compact, de-duplicated `dataSources` summary string, against this
+ *  instance's source registry. Same explicit-registry thin-wrapper pattern
+ *  as `displayNameForSource`. */
+export function formatDataSourcesSummary(
+  entries: DataSourceEntry[] | undefined,
+  registry: CivicSourceRegistry = CIVIC_SOURCE_REGISTRY,
+): string | null {
+  return harnessFormatDataSourcesSummary(entries, registry);
+}
 
 /** The app's static tool-name → source-id map (`../mcp/operation-types.ts`)
  *  as a harness resolver — the fallback when a trace span carries no

--- a/src/lib/evidence/provenance.test.ts
+++ b/src/lib/evidence/provenance.test.ts
@@ -10,6 +10,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { buildProvenanceGraph } from './provenance.ts';
+// The graph-build config is otherwise a P1-parameterization concern
+// (`../packager.ts` supplies the per-instance version); these tests exercise
+// the builder directly, so they take the harness's own demo default
+// explicitly rather than relying on the harness's implicit default.
+import { CIVICAITOOLS_PROVENANCE_CONFIG } from '@typedstandards/civic-typed-harness';
 
 interface SpanStub {
   name: string;
@@ -74,14 +79,14 @@ function mcpAgents(graph: Array<{ '@id': string; [k: string]: unknown }>): strin
 
 test('Data-Commons-only analysis emits only the data-commons MCP agent', () => {
   const trace = traceOf([skillSpan('skill-hash'), toolSpan('data-commons', 'get_observations', 'span-1')]);
-  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CIVICAITOOLS_PROVENANCE_CONFIG);
   const agents = mcpAgents(graph['@graph']);
   assert.deepEqual(agents, ['urn:civic-evidence:mcp-server:data-commons']);
 });
 
 test('Socrata-only analysis emits only the socrata MCP agent', () => {
   const trace = traceOf([skillSpan('skill-hash'), toolSpan('socrata', 'get_data', 'span-1')]);
-  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CIVICAITOOLS_PROVENANCE_CONFIG);
   const agents = mcpAgents(graph['@graph']);
   assert.deepEqual(agents, ['urn:civic-evidence:mcp-server:socrata']);
 });
@@ -92,7 +97,7 @@ test('Multi-source analysis emits both MCP agents', () => {
     toolSpan('socrata', 'get_data', 'span-1'),
     toolSpan('data-commons', 'get_observations', 'span-2'),
   ]);
-  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CIVICAITOOLS_PROVENANCE_CONFIG);
   const agents = mcpAgents(graph['@graph']);
   assert.equal(agents.length, 2);
   assert.ok(agents.includes('urn:civic-evidence:mcp-server:socrata'));
@@ -101,7 +106,7 @@ test('Multi-source analysis emits both MCP agents', () => {
 
 test('Boston OpenContext only analysis emits only the boston-opencontext MCP agent with correct title', () => {
   const trace = traceOf([skillSpan('skill-hash'), toolSpan('boston-opencontext', 'ckan__search_datasets', 'span-1')]);
-  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CIVICAITOOLS_PROVENANCE_CONFIG);
   const agents = mcpAgents(graph['@graph']);
   assert.deepEqual(agents, ['urn:civic-evidence:mcp-server:boston-opencontext']);
 
@@ -121,7 +126,7 @@ test('Three-source analysis emits all three MCP agents, no stray sources', () =>
     toolSpan('data-commons', 'get_observations', 'span-2'),
     toolSpan('boston-opencontext', 'ckan__aggregate_data', 'span-3'),
   ]);
-  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CIVICAITOOLS_PROVENANCE_CONFIG);
   const agents = mcpAgents(graph['@graph']);
   assert.equal(agents.length, 3);
   assert.ok(agents.includes('urn:civic-evidence:mcp-server:socrata'));
@@ -133,7 +138,7 @@ test('Skill fetched but no tool calls emits no MCP agent', () => {
   // Regression: pre-M9.3 behaviour always added a socrata agent here even
   // though nothing was ever queried. New rule: no tool calls → no MCP agent.
   const trace = traceOf([skillSpan('skill-hash')]);
-  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CIVICAITOOLS_PROVENANCE_CONFIG);
   assert.deepEqual(mcpAgents(graph['@graph']), []);
 });
 
@@ -153,6 +158,6 @@ test('Pre-M9.1 Socrata span without mcp.source attribute still emits the socrata
     }),
   };
   const trace = traceOf([skillSpan('skill-hash'), legacyToolSpan]);
-  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CIVICAITOOLS_PROVENANCE_CONFIG);
   assert.deepEqual(mcpAgents(graph['@graph']), ['urn:civic-evidence:mcp-server:socrata']);
 });

--- a/src/lib/evidence/trace.ts
+++ b/src/lib/evidence/trace.ts
@@ -3,18 +3,23 @@
 // pattern of #116-WS3 applied to the capture layer).
 //
 // The types + `TraceBuilder` live in the harness's capture group (ADR-0022
-// §C). The harness's default config (`CIVICAITOOLS_TRACE_CONFIG`) carries this
-// deployment's identity values (service.name, scope name/version, semconv
-// version), so `new TraceBuilder()` emits byte-identical resource/scope
-// blocks. `hash()` is re-backed by the @noble/hashes SHA-256 the stack
-// single-sources through verify-core — same digest bytes as the prior
-// node:crypto implementation. Wiring instance config (a non-demo service
-// name) is P2 parameterization work, not this shim's.
+// §C). This deployment's identity values (service.name, scope name/version,
+// semconv version) are the harness's demo default (`CIVICAITOOLS_TRACE_CONFIG`),
+// re-exported here so call sites construct `new TraceBuilder(CIVICAITOOLS_TRACE_CONFIG)`
+// explicitly rather than relying on the constructor's own default — same
+// byte-identical resource/scope blocks, now passed explicitly at the call
+// site instead of applied implicitly inside the harness. `hash()` is
+// re-backed by the @noble/hashes SHA-256 the stack single-sources through
+// verify-core — same digest bytes as the prior node:crypto implementation.
+// Wiring instance config (a non-demo service name) is P2 parameterization
+// work, not this shim's.
 export {
   TraceBuilder,
   hash,
+  CIVICAITOOLS_TRACE_CONFIG,
   type SpanEvent,
   type OTelAttribute,
   type Span,
   type OTelTrace,
+  type TraceBuilderConfig,
 } from '@typedstandards/civic-typed-harness';


### PR DESCRIPTION
## What

Every call site that relied on a `@typedstandards/civic-typed-harness` default parameter now passes the config explicitly — `new TraceBuilder(CIVICAITOOLS_TRACE_CONFIG)` in both API routes, explicit-registry thin wrappers for `displayNameForSource`/`formatDataSourcesSummary` in the data-sources shim, and `CIVICAITOOLS_PROVENANCE_CONFIG` as the third argument in `provenance.test.ts`.

## Why

Pre-PR for harness 0.2.0 (civic-ai-tools#153, portability charter 2 from the civic-ai-tools#148 audit): 0.2.0 makes identity-bearing config parameters required. Explicit config is valid under 0.1.x, so this lands first — compatible both ways, zero behavior change (same config objects the defaults applied; all outputs byte-identical).

## Evidence

- typecheck clean; 656/656 tests pass; lint 0 errors (4 pre-existing warnings in unrelated files); webpack build green, 27 routes.
- Repo-wide grep: no remaining bare calls to `buildProvenanceGraph`, `deriveDatHereEnvelopeFields`, `new TraceBuilder`, `isDatasetKeyedSource`, `displayNameForSource`, `formatDataSourcesSummary` in `src/` or `scripts/`.
- No `package.json`/lockfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)