### PR TITLE
deps: bump @typedstandards/civic-typed-harness to ^0.2.0 (sprint 153 P4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@neondatabase/serverless": "^1.0.2",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@typedstandards/civic-typed-harness": "^0.1.0",
+        "@typedstandards/civic-typed-harness": "^0.2.0",
         "@typedstandards/produce-core": "^0.2.0",
         "@typedstandards/verify-core": "^0.8.0",
         "@vercel/blob": "^2.3.3",
@@ -2954,9 +2954,9 @@
       }
     },
     "node_modules/@typedstandards/civic-typed-harness": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@typedstandards/civic-typed-harness/-/civic-typed-harness-0.1.0.tgz",
-      "integrity": "sha512-4SHTuG/4kB3oRe2lRUCzcvcTsynr1FVRIzOMIPD+f2FdgRwrAUZ7E2SJA8XxsYWdeSECrAmb15O0u/2unfc8dg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@typedstandards/civic-typed-harness/-/civic-typed-harness-0.2.0.tgz",
+      "integrity": "sha512-sNAW1dU7YB7f+YuAN+lKv91cKVbzXy2OO/3QVzecbbz9hDpA7+o0VEOMkSyJfSyn/ZMjHDZXfP8foxiPWn3BUA==",
       "license": "MIT",
       "dependencies": {
         "@typedstandards/produce-core": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@typedstandards/civic-typed-harness": "^0.1.0",
+    "@typedstandards/civic-typed-harness": "^0.2.0",
     "@typedstandards/produce-core": "^0.2.0",
     "@typedstandards/verify-core": "^0.8.0",
     "@vercel/blob": "^2.3.3",


### PR DESCRIPTION
## What

`@typedstandards/civic-typed-harness` `^0.1.0` → `^0.2.0` (package.json + lockfile only; 2 files, ±5 lines). Completes the publish-order sequence of civic-ai-tools#153: explicit-config pre-PR (#260) → harness 0.2.0 (civic-ai-tools#157) → npm publish → this bump.

0.2.0 makes identity-bearing config required — no silently-applied reference-identity defaults. #260 already made every call site here explicit, and typecheck against the new required-param API surface confirms it: **zero source changes needed**.

## Merge-order note (charter coordination)

This is the second and final charter-2 wiring PR into this repo. Per the coordinated order it merges ahead of the #258 integration branch, which rebases on top.

## Evidence

- `npm ls`: @typedstandards/civic-typed-harness@0.2.0.
- typecheck clean; **656/656 tests**; lint 0 errors (4 pre-existing warnings, unrelated files); `next build --webpack` green, 27 routes.
- No remaining `^0.1` pin anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)