### PR TITLE
Generic-only Socrata skill fallback + sync-fallback guard (civic#154 P4)

### DIFF
--- a/scripts/sync-fallback.mjs
+++ b/scripts/sync-fallback.mjs
@@ -1,12 +1,61 @@
 #!/usr/bin/env node
 
 /**
- * Fetches the current skill guidance from the MCP server's prompt endpoint
- * and updates the SOCRATA_SKILL_FALLBACK constant in socrata-skill.ts.
+ * DO NOT RUN — the verbatim-paste model this script implements is UNSOUND
+ * post-#258 and post-posture-split (sprint 154 P4, portability charter 4).
  *
- * Usage: node scripts/sync-fallback.mjs
- *        npm run sync-fallback
+ * What it does: fetches the composed skill guidance from the configured MCP
+ * server's prompt endpoint and pastes it verbatim over the entire body of the
+ * SOCRATA_SKILL_FALLBACK template literal in src/lib/mcp/socrata-skill.ts.
+ *
+ * Why that is now destructive:
+ *
+ *   1. POSTURE RE-IMPORT: the fallback is generic-only by owner-ratified
+ *      decision — it must never carry deployment posture. The MCP server's
+ *      prompts/get response is composed at serve time and includes whatever
+ *      posture overlay the fetched server has configured (SKILL_POSTURE).
+ *      Pasting it verbatim re-imports that posture into every instance's
+ *      fallback — exactly the defect the portability program removed.
+ *   2. STRUCTURE CLOBBER: the fallback constant is hand-shaped (markdown
+ *      links flattened to plain URLs, no reproducible-notebook section, one
+ *      combined base+overlay body). A verbatim paste clobbers those
+ *      adaptations.
+ *   3. BACKTICK BREAKAGE: the fetched markdown contains raw backticks (code
+ *      fences, inline code). The constant is a template literal whose
+ *      backticks are escaped by hand; pasting unescaped content very likely
+ *      breaks the file syntactically.
+ *
+ * Fallback updates are HAND-SHAPED under test coverage instead — see the
+ * governance notes in src/lib/mcp/socrata-skill.ts and the source-of-truth
+ * skill docs at
+ * https://github.com/npstorey/civic-ai-tools/blob/main/docs/skills/README.md
+ * (tests: src/lib/evidence/instance-config.test.ts,
+ * src/lib/mcp/skill-instance-config.test.ts).
+ *
+ * The script refuses to run unless --force-clobber is passed. Kept only so
+ * its fetch plumbing remains inspectable; if you think you need to force it,
+ * you almost certainly want a hand-shaped edit instead.
+ *
+ * Usage: node scripts/sync-fallback.mjs --force-clobber   (discouraged)
+ *        npm run sync-fallback                             (prints this refusal)
  */
+
+const REFUSAL = `
+sync-fallback: REFUSING to run.
+
+This script's verbatim-paste model is unsound post-#258 / post-posture-split:
+  - it would re-import whatever posture overlay the fetched MCP server has
+    configured into the generic-only SOCRATA_SKILL_FALLBACK,
+  - it would clobber the fallback's hand-shaped structural adaptations, and
+  - the fetched markdown's raw backticks would likely break the template
+    literal syntactically.
+
+Fallback updates are hand-shaped under test coverage per the skill-guidance
+governance (https://github.com/npstorey/civic-ai-tools/blob/main/docs/skills/README.md);
+see the header of this script and of src/lib/mcp/socrata-skill.ts.
+
+To override anyway (discouraged), pass --force-clobber.
+`;
 
 import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
@@ -94,6 +143,14 @@ async function fetchGuidance() {
 }
 
 async function main() {
+  if (!process.argv.includes('--force-clobber')) {
+    console.error(REFUSAL);
+    process.exit(1);
+  }
+  console.warn(
+    'sync-fallback: --force-clobber passed — proceeding with the unsound verbatim paste. ' +
+      'Review the result by hand and expect test failures (posture/backtick hazards; see header).',
+  );
   const guidance = await fetchGuidance();
   console.log(`Fetched ${guidance.length} chars of guidance.`);
 

--- a/src/lib/evidence/instance-config.test.ts
+++ b/src/lib/evidence/instance-config.test.ts
@@ -230,22 +230,37 @@ test('absence: notebook surfaces honestly OMIT attribution (no host, no title, n
   });
 });
 
-test('skill text: with no config the host mention is omitted at module load', async () => {
+test('skill text: with no config no host appears, and the fallback is generic-only', async () => {
   // The skill constants are module-level template literals — this first (and
-  // only) import in this process happens under a cleared identity env, so the
-  // baked strings honestly omit the host. The override direction is proven in
-  // src/lib/mcp/skill-instance-config.test.ts (its own process sets the env
-  // BEFORE importing).
+  // only) import in this process happens under a cleared identity env.
+  // DATA_COMMONS_SKILL interpolates the instance host and must honestly omit
+  // it here; SOCRATA_SKILL_FALLBACK is generic-only post-P4 (sprint 154) —
+  // host-free and posture-free under EVERY env. The override direction is
+  // proven in src/lib/mcp/skill-instance-config.test.ts (its own process sets
+  // the env BEFORE importing).
   await withIdentityEnvAsync({}, async () => {
     const { SOCRATA_SKILL_FALLBACK } = await import('../mcp/socrata-skill.ts');
     const { DATA_COMMONS_SKILL } = await import('../mcp/data-commons-skill.ts');
     assert.ok(
       SOCRATA_SKILL_FALLBACK.includes(
-        'Applies to: Web demo and other HTTP-connected clients.',
+        'Applies to: HTTP-connected web clients, on any deployment of the web app.',
       ),
-      'fallback skill should omit the host with no identity declared',
+      'fallback skill should carry the host-free generic Applies-to line',
     );
     assert.ok(!SOCRATA_SKILL_FALLBACK.includes('civicaitools.org'));
+    // Generic-only: no reference-demo posture text on the fallback path.
+    for (const marker of [
+      'This is a public demo',
+      'github.com/npstorey/civic-ai-tools',
+      'Web Demo Limits',
+      'Reference-Demo Posture',
+      'Local Tools CTA',
+    ]) {
+      assert.ok(
+        !SOCRATA_SKILL_FALLBACK.includes(marker),
+        `fallback skill must not contain posture marker: ${marker}`,
+      );
+    }
     assert.ok(
       DATA_COMMONS_SKILL.includes(
         'published as an evidence package, the evidence chain captures',

--- a/src/lib/mcp/skill-instance-config.test.ts
+++ b/src/lib/mcp/skill-instance-config.test.ts
@@ -1,15 +1,20 @@
 // Skill-text instance-identity override test (S3a P2 blast-zone extension,
-// #166; ADR-0020).
+// #166; ADR-0020 — updated for sprint 154 P4, portability charter 4).
 //
 // NEW file, and deliberately a SIBLING of instance-config.test.ts: the skill
 // constants (`SOCRATA_SKILL_FALLBACK`, `DATA_COMMONS_SKILL`) are module-level
-// template literals, so the instance host resolves at MODULE LOAD. Proving
-// the override therefore requires setting the environment BEFORE the module's
-// first import — node's test runner gives each test file its own process, so
-// this file sets the env at top level and then dynamically imports. The
-// default direction (no env → demo host baked in) is pinned in
+// template literals, so any instance-host interpolation resolves at MODULE
+// LOAD. Proving behavior under an override therefore requires setting the
+// environment BEFORE the module's first import — node's test runner gives each
+// test file its own process, so this file sets the env at top level and then
+// dynamically imports. The default direction (no env) is pinned in
 // src/lib/evidence/instance-config.test.ts, whose process imports the same
 // modules under a cleared identity env.
+//
+// What each constant does with the override, post-P4:
+//   - DATA_COMMONS_SKILL still interpolates the publication host (unchanged).
+//   - SOCRATA_SKILL_FALLBACK is GENERIC-ONLY: host-free Applies-to line, no
+//     deployment posture, regardless of env. The override must NOT appear.
 //
 // Run with: npm test
 
@@ -19,19 +24,28 @@ import assert from 'node:assert/strict';
 // MUST run before the skill modules load (imports below are dynamic).
 process.env.EVIDENCE_PUBLICATION_HOST = 'skills.example.org';
 
-test('skill text: override host is baked into both skill constants at module load', async () => {
+test('skill text: override host bakes into DATA_COMMONS_SKILL; SOCRATA fallback stays host-free', async () => {
   const { SOCRATA_SKILL_FALLBACK } = await import('./socrata-skill.ts');
   const { DATA_COMMONS_SKILL } = await import('./data-commons-skill.ts');
 
+  // Socrata fallback (P4): generic-only. The Applies-to line is host-free
+  // even when the instance declares a publication host.
   assert.ok(
-    SOCRATA_SKILL_FALLBACK.includes('Web demo (skills.example.org)'),
-    'socrata fallback skill should carry the override host',
+    SOCRATA_SKILL_FALLBACK.includes(
+      'Applies to: HTTP-connected web clients, on any deployment of the web app.',
+    ),
+    'socrata fallback should carry the host-free generic Applies-to line',
   );
   assert.ok(
-    !SOCRATA_SKILL_FALLBACK.includes('Web demo (civicaitools.org)'),
-    'socrata fallback skill should not carry the demo host under override',
+    !SOCRATA_SKILL_FALLBACK.includes('skills.example.org'),
+    'socrata fallback must not bake the override host',
+  );
+  assert.ok(
+    !SOCRATA_SKILL_FALLBACK.includes('civicaitools.org'),
+    'socrata fallback must not carry the reference host under any env',
   );
 
+  // Data Commons skill: host interpolation unchanged (out of P4 scope).
   assert.ok(
     DATA_COMMONS_SKILL.includes(
       'published as an evidence package on skills.example.org',
@@ -44,4 +58,42 @@ test('skill text: override host is baked into both skill constants at module loa
     ),
     'data-commons skill should not carry the demo host under override',
   );
+});
+
+test('skill text: the fallback carries no reference-demo posture under override env', async () => {
+  const { SOCRATA_SKILL_FALLBACK } = await import('./socrata-skill.ts');
+
+  // Posture markers that must never appear in the generic-only fallback
+  // (the old posture text, the CTA, and the posture overlay's own heading).
+  // Note: the marker for the row cap is the posture PHRASING, not the bare
+  // number — the base guidance's Pagination section legitimately carries
+  // "Never request more than 10,000 rows in a single call" (generic content,
+  // civic-ai-tools docs/skills/base.md).
+  for (const marker of [
+    'This is a public demo',
+    'github.com/npstorey/civic-ai-tools',
+    'Web Demo Limits',
+    'Reference-Demo Posture',
+    'Local Tools CTA',
+    'Limit queries to 10,000 rows max',
+  ]) {
+    assert.ok(
+      !SOCRATA_SKILL_FALLBACK.includes(marker),
+      `socrata fallback must not contain posture marker: ${marker}`,
+    );
+  }
+
+  // The generic overlay's sections are all present.
+  for (const heading of [
+    '# Socrata MCP Skill — Web Overlay',
+    '## Date Filter Enforcement',
+    '## Deployment Limits',
+    '## Token-Conscious Formatting',
+    '## Suggesting a Local Client',
+  ]) {
+    assert.ok(
+      SOCRATA_SKILL_FALLBACK.includes(heading),
+      `socrata fallback must contain generic section: ${heading}`,
+    );
+  }
 });

--- a/src/lib/mcp/socrata-skill.ts
+++ b/src/lib/mcp/socrata-skill.ts
@@ -20,23 +20,24 @@
 import { callMcpPrompt, getServerInstructions } from './client.ts';
 import { DATA_COMMONS_SKILL } from './data-commons-skill.ts';
 import { BOSTON_OPENCONTEXT_SKILL } from './boston-skill.ts';
-// Instance-identity config (ADR-0020): skill text lands inside signed
-// packages (skillMetadata.skillText + skill.text_hash), so the demo-host
-// mention below resolves through config. Evaluated at MODULE LOAD (the
-// constant is a template literal) — boot-time env; with no identity declared
-// the host mention is honestly OMITTED (#258), never defaulted.
-// CAVEATS (flagged in the S3a P2 phase record): `npm run sync-fallback`
-// rewrites this constant's entire body from the MCP server and would clobber
-// the interpolation; the primary runtime path also fetches skill text from
-// the MCP server, whose copy of this line is outside this repo.
-import { getPublicationHost } from '../site-config.ts';
 
-// Fallback constant used when the MCP server is unreachable.
-// NOTE: This may be stale — it was last synced at PR #19 and may be missing
-// guidance added since then (pagination, date interpretation, clarification,
-// planning/phase narration). The runtime fetches fresh guidance from the MCP
-// server's prompt endpoint; this fallback only activates if that fetch fails.
-// To sync: npm run sync-fallback
+// Fallback constant used when the MCP server is unreachable. The runtime
+// fetches fresh guidance from the MCP server's prompt endpoint; this fallback
+// only activates if that fetch fails.
+//
+// GENERIC-ONLY, by design (sprint 154 P4, portability charter): the web-overlay
+// portion below tracks the deployment-NEUTRAL overlay from the source-of-truth
+// skill docs in the civic-ai-tools repo —
+// https://github.com/npstorey/civic-ai-tools/blob/main/docs/skills/README.md
+// — and carries no deployment posture (no host names, no demo-limit numbers,
+// no CTA links). Posture overlays are appended by the MCP server at serve time
+// (SKILL_POSTURE); deployment limits are enforced server-side, so the fallback
+// losing the reference deployment's limits prose on this rare path is accepted.
+//
+// Updates are HAND-SHAPED under test coverage (instance-config.test.ts,
+// skill-instance-config.test.ts) — NOT via scripts/sync-fallback.mjs, whose
+// verbatim-paste model predates the posture split and the fallback's
+// structural adaptations (see that script's header).
 export const SOCRATA_SKILL_FALLBACK = `
 # Socrata MCP Companion Skill — Base Guidance
 
@@ -369,7 +370,7 @@ ORDER BY total_requests DESC
 
 # Socrata MCP Skill — Web Overlay
 
-> Applies to: Web demo${getPublicationHost() ? ` (${getPublicationHost()})` : ''} and other HTTP-connected clients.
+> Applies to: HTTP-connected web clients, on any deployment of the web app.
 
 ## Date Filter Enforcement
 
@@ -378,30 +379,23 @@ ORDER BY total_requests DESC
 If a user's question is open-ended (e.g., "What are the top complaints in NYC?"), default to the last 30 days and tell them:
 - That you scoped to the last 30 days for performance
 - They can ask for a different range
-- For all-time analysis, suggest using the local CLI tools
+- For all-time analysis, suggest using a local (stdio) client
 
-## Web Demo Limits
+## Deployment Limits
 
-This is a public demo with shared resources. Enforce these limits:
-
-- **Result sets**: Limit queries to 10,000 rows max. If more data is needed, suggest narrowing the date range or filters.
-- **Tool calls per response**: Keep to 5 or fewer tool calls. If a query would require more, simplify or break it into follow-up questions.
-- **Response length**: Keep responses concise and token-conscious. Prefer tables and bullet points over long prose. Aim for key findings, not exhaustive analysis.
-- **No cross-portal comparisons**: Do not compare data across multiple cities in a single response. Each city query consumes resources — suggest the user ask about one city at a time, or use the local CLI tools for multi-city analysis.
+Follow the limits your deployment declares; where none are declared, prefer conservative defaults appropriate to shared web environments — modest result sets, few tool calls per response, and concise output.
 
 ## Token-Conscious Formatting
 
 - Lead with the answer, then supporting data
 - Use compact tables rather than verbose explanations
-- Limit to 3–5 key findings per response
+- Keep to a small set of key findings per response
 - Skip the full "Methodology" section — include a brief "Data source" line instead
 - Omit the "Queries Used" table unless the user asks for it
 
-## Local Tools CTA
+## Suggesting a Local Client
 
-When a user hits a limit (complex multi-city query, long date range, deep analysis), suggest:
-
-> For more complex analysis — like cross-city comparisons, longer date ranges, or deeper dives — try the Civic AI Tools CLI (https://github.com/npstorey/civic-ai-tools), which connects directly to these same data sources with no demo limits.
+When a user hits a limit (complex multi-city query, long date range, deep analysis), suggest a local (stdio) client for heavier analysis — local clients connect directly to the same data sources without web-environment constraints. Keep the suggestion neutral unless your deployment declares a specific alternative.
 `;
 
 export const getSkillForPortal = (portal: string): string => {


### PR DESCRIPTION
## Sprint 154 P4 — skill-text family, charter 4 (anchor: civic-ai-tools#154)

Final surface of the three-surface sync (source split: civic-ai-tools#158; server posture config: socrata-mcp-server#51, deployed and verified byte-identical on both hostnames).

- **`SOCRATA_SKILL_FALLBACK` becomes generic-only** (C1/C3): the web-overlay portion now tracks the deployment-neutral overlay — host-free Applies-to, Deployment Limits principles (no demo numbers), URL-free local-client suggestion. No posture text under any env; the `getPublicationHost()` interpolation is gone because nothing host-shaped remains. Hand-shaped per the owner-ratified process, under test coverage in both module-load test processes (default + override env), with posture-marker absence assertions.
- **`scripts/sync-fallback.mjs` refuses to run without `--force-clobber`**: its verbatim-paste model post-#258/post-split would re-import the fetched server's posture, clobber the fallback's structural adaptations, and break the template literal on raw backticks. Header + runtime message document the hand-shaped process.
- **C3 verified, no schema change:** the signed `skill.text` is instance-true — live path serves whatever the configured MCP server composes; the fallback path (cold-cache fetch failure) embeds the generic-only constant.

Tests: 696/696 pass; lint 0 errors; `next build --webpack` exit 0.

Part of the portability program (civic-ai-tools#148). Deploys on merge (Vercel) — merge is owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)