### PR TITLE
fix: app-layer host canonicalization + real 404 for withheld routes (#259 P2)

### DIFF
--- a/src/lib/allowed-origins.test.ts
+++ b/src/lib/allowed-origins.test.ts
@@ -65,7 +65,12 @@ test('unset topology: the trusted set is exactly NEXTAUTH_URL — pre-#213 behav
   const env = { NEXTAUTH_URL: 'https://example.test' };
   assert.deepEqual(resolveTrustedOrigins(env), ['https://example.test']);
   assert.equal(isTrustedRequestOrigin('https://example.test', null, env), true);
-  // www-insensitive in both directions (the production apex→www redirect).
+  // www-insensitive in BOTH directions, and both directions are real:
+  // `/api/*` is exempt from host canonicalization (#263), so a browser on
+  // either spelling reaches the API on that spelling and sends that
+  // Origin. (This note used to cite a production apex→www redirect;
+  // measured against production on 2026-08-18 the redirect ran www→apex
+  // and was platform-level, not ours. Corrected in #259 P2.)
   assert.equal(isTrustedRequestOrigin('https://www.example.test', null, env), true);
   assert.equal(
     isTrustedRequestOrigin('https://example.test', null, { NEXTAUTH_URL: 'https://www.example.test' }),

--- a/src/lib/allowed-origins.ts
+++ b/src/lib/allowed-origins.ts
@@ -34,9 +34,19 @@
 //     (an explicit non-default port must match; default ports are elided
 //     by URL parsing on both sides).
 //   - `www.`-insensitive on the host, matching `normalizeHost` in
-//     host-routing.ts (see the comment there): the production deployment
-//     307-redirects apex → www for GET, so browsers send the `www.` form
-//     of an origin the operator configured as the apex.
+//     host-routing.ts (see the comment there). Direction corrected in
+//     #259 P2: this used to cite a production "307 apex → www for GET"
+//     redirect. Measured with curl against the PRODUCTION deployment on
+//     2026-08-18, the redirect ran the other way and was platform-level
+//     rather than ours — a 308 www → apex. The rule survives on firmer
+//     ground than the story it replaced. Since #263 the app canonicalizes
+//     PAGES to the configured spelling, while `/api/*` and
+//     `/.well-known/*` are EXEMPT and serve directly on whichever
+//     spelling was addressed (a cross-origin fetch cannot follow a
+//     redirect carrying no CORS header). So an API request from a browser
+//     on the `www.` spelling genuinely arrives here bearing a `www.`
+//     Origin, by design — and must still match the apex value the
+//     operator configured.
 //
 // Pure module: no Next.js imports, env passed as a record — runs under
 // `node --test` like host-routing.ts and host-links.ts.

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -80,10 +80,25 @@ export function hasScope(auth: AuthResult, required: string): boolean {
  * token-revoke POST from the app host 403'd. With topology unset the set
  * is exactly `{NEXTAUTH_URL}` — the pre-#213 behavior.
  *
- * Matching is www-insensitive (the production deployment 307-redirects
- * apex → www for GET, so browsers send the www form even when the
- * configured value is the apex), scheme- and port-sensitive, and always
+ * Matching is www-insensitive, scheme- and port-sensitive, and always
  * exact — see the predicate module for the full rules.
+ *
+ * WHY www-insensitive — direction corrected, rationale re-founded
+ * (#259 P2). This note used to justify the rule with a production
+ * "307 apex → www for GET" redirect. Measured with curl against the
+ * PRODUCTION deployment on 2026-08-18, the redirect ran the other way and
+ * was not ours at all: a platform-level 308 www → apex. The stated
+ * direction was wrong; the behavior it justified is right, and the real
+ * reason is stronger than the one it replaces. Since #263 this app
+ * canonicalizes PAGES to the spelling the operator configured (a 307
+ * www → apex for the reference deployment), while `/api/*` and
+ * `/.well-known/*` are EXEMPT and serve directly on whichever spelling was
+ * addressed — a cross-origin fetch cannot follow a redirect that carries
+ * no CORS header, so redirecting them would break the fetch outright.
+ * A browser on the `www.` spelling therefore reaches this check ON the
+ * www host and sends a `www.` Origin by design, not as the residue of a
+ * bounce. www-insensitive matching is exactly what lets that request pass
+ * instead of 403.
  *
  * Returns false for cross-origin POSTs and for requests with no Origin
  * header (e.g. plain curl without `-H Origin`) — callers who want to

--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -11,8 +11,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  bareHost,
+  canonicalHostRedirect,
   classifyPath,
   decideRoute,
+  isCanonicalizationExempt,
   normalizeHost,
   originFromHostValue,
   parseBooleanFlag,
@@ -24,6 +27,7 @@ import {
   resolvePublicSiteHref,
   APP_PRIVATE_PATHS,
   APP_ROOT_ACTION,
+  CANONICALIZATION_EXEMPT_PREFIXES,
   MARKETING_PATHS,
 } from './host-routing.ts';
 
@@ -341,4 +345,239 @@ test('originFromHostValue trims and never emits a trailing slash', () => {
   assert.equal(originFromHostValue('https://app.example.org///'), 'https://app.example.org');
   assert.equal(originFromHostValue(''), null);
   assert.equal(originFromHostValue(undefined), null);
+});
+
+
+// --- Host canonicalization (#263) -----------------------------------------
+//
+// THE RULE, stated once: matching is `www.`-insensitive, serving is not.
+// When a request's host matches a CONFIGURED host by normalization but
+// differs from it in `www.` presence, redirect (307) to the spelling the
+// operator configured, carrying the path and query. Never for a host that
+// matched nothing, never under APP_ONLY, never for the CORS-sensitive path
+// families, and never for a difference that is only case, port or a
+// trailing dot — those are one name written differently, and steering on
+// them would break ports and loop on localhost.
+//
+// NOTE ON SCOPE: these tests pin the DECISION. None of them observes an
+// HTTP response. The app-layer redirect also ships inert while the hosting
+// platform's own domain redirect is enabled.
+
+const WWW_MARKETING = readHostRoutingConfig({
+  APP_HOST: 'app.example.org',
+  MARKETING_HOST: 'www.example.org', // the inverse: operator configures www
+});
+
+test('canonicalize: www → the configured apex, path and query preserved', () => {
+  assert.deepEqual(decideRoute('www.example.org', '/about', SPLIT), {
+    kind: 'redirect',
+    destination: 'https://example.org/about',
+  });
+  assert.deepEqual(decideRoute('www.example.org', '/explore', SPLIT, '?trace=abc'), {
+    kind: 'redirect',
+    destination: 'https://example.org/explore?trace=abc',
+  });
+  // Deep paths and the dual-served evidence surface too.
+  assert.deepEqual(decideRoute('www.example.org', '/evidence/some-slug', SPLIT), {
+    kind: 'redirect',
+    destination: 'https://example.org/evidence/some-slug',
+  });
+  // And on the app host, toward ITS configured spelling.
+  assert.deepEqual(decideRoute('www.app.example.org', '/evidence', SPLIT), {
+    kind: 'redirect',
+    destination: 'https://app.example.org/evidence',
+  });
+});
+
+test('canonicalize: a request already on the configured spelling is untouched', () => {
+  for (const path of [...MARKETING_SAMPLES, ...DUAL_SAMPLES]) {
+    assert.deepEqual(decideRoute('example.org', path, SPLIT), { kind: 'serve' }, path);
+  }
+  // Case, port and trailing dot are the same name — never a redirect.
+  for (const host of ['EXAMPLE.ORG', 'example.org:8443', 'example.org.']) {
+    assert.deepEqual(decideRoute(host, '/about', SPLIT), { kind: 'serve' }, host);
+  }
+});
+
+test('canonicalize: the inverse — an operator who configures www gets apex → www', () => {
+  assert.deepEqual(decideRoute('example.org', '/about', WWW_MARKETING), {
+    kind: 'redirect',
+    destination: 'https://www.example.org/about',
+  });
+  assert.deepEqual(decideRoute('www.example.org', '/about', WWW_MARKETING), { kind: 'serve' });
+});
+
+test('canonicalize: a configured scheme and port are honored, not replaced by https', () => {
+  const local = readHostRoutingConfig({ MARKETING_HOST: 'http://www.localhost:3000' });
+  assert.deepEqual(decideRoute('localhost:3000', '/about', local), {
+    kind: 'redirect',
+    destination: 'http://www.localhost:3000/about',
+  });
+});
+
+test('canonicalize: a bare-host config served on a port does NOT lose the port', () => {
+  // The regression the literal-spelling rule would have caused: the config
+  // string and the Host header differ, but only in port — not a redirect.
+  const config = readHostRoutingConfig({ MARKETING_HOST: 'example.org' });
+  assert.deepEqual(decideRoute('example.org:8443', '/about', config), { kind: 'serve' });
+});
+
+test('canonicalize: a scheme-carrying config never redirects to itself (no localhost loop)', () => {
+  // `http://localhost:3000` never literally equals the `localhost:3000`
+  // Host header a browser sends back — a literal-spelling rule would loop.
+  const config = readHostRoutingConfig({ MARKETING_HOST: 'http://localhost:3000' });
+  for (const host of ['localhost:3000', 'localhost', 'LOCALHOST:3000']) {
+    assert.deepEqual(decideRoute(host, '/about', config), { kind: 'serve' }, host);
+  }
+});
+
+test('canonicalize TERMINATES: the destination host is itself canonical, one hop', () => {
+  for (const [host, config] of [
+    ['www.example.org', SPLIT],
+    ['www.app.example.org', SPLIT],
+    ['example.org', WWW_MARKETING],
+  ] as const) {
+    // /evidence is dual-served, so it SERVES under either role — the point
+    // here is the host hop, not the path decision.
+    const first = decideRoute(host, '/evidence', config);
+    assert.equal(first.kind, 'redirect', host);
+    if (first.kind !== 'redirect') return;
+    // Feed the redirect target's host back through: it must settle.
+    const next = decideRoute(bareHost(first.destination), '/evidence', config);
+    assert.deepEqual(next, { kind: 'serve' }, `${host} did not settle in one hop`);
+  }
+});
+
+test('canonicalize: rule zero — nothing configured, nothing canonicalized', () => {
+  for (const host of ['www.example.org', 'example.org', 'www.app.example.org']) {
+    for (const path of EVERY_PATH) {
+      assert.deepEqual(decideRoute(host, path, UNSET), { kind: 'serve' }, `${host} ${path}`);
+    }
+  }
+});
+
+test('canonicalize: a passthrough host has no configured spelling to steer toward', () => {
+  // Preview URLs, IP health checks and unnamed aliases match no variable.
+  for (const host of ['www.preview-abc.vercel.app', 'preview-abc.vercel.app', '127.0.0.1:3000']) {
+    for (const path of EVERY_PATH) {
+      assert.deepEqual(decideRoute(host, path, SPLIT), { kind: 'serve' }, `${host} ${path}`);
+    }
+  }
+});
+
+test('canonicalize: APP_ONLY ignores the host variables, so it canonicalizes nothing', () => {
+  const config = readHostRoutingConfig({
+    APP_ONLY: '1',
+    APP_HOST: 'app.example.org',
+    MARKETING_HOST: 'example.org',
+  });
+  assert.deepEqual(decideRoute('www.app.example.org', '/ask', config), { kind: 'serve' });
+  assert.deepEqual(decideRoute('www.example.org', '/evidence', config), { kind: 'serve' });
+  // The app-root hop stays a bare path — no host is imposed on it.
+  assert.deepEqual(decideRoute('www.app.example.org', '/', config), APP_ROOT_ACTION);
+});
+
+test('canonicalize: the CORS-sensitive families are exempt on every host spelling', () => {
+  const exempt = [
+    '/api/evidence/some-slug/commitment',
+    '/api/session-status',
+    '/api',
+    '/.well-known/typed-publisher.json',
+    '/.well-known',
+    '/_next/static/chunk.js',
+    '/favicon.ico',
+    '/robots.txt',
+  ];
+  for (const path of exempt) {
+    for (const host of ['www.example.org', 'www.app.example.org']) {
+      assert.deepEqual(decideRoute(host, path, SPLIT), { kind: 'serve' }, `${host} ${path}`);
+    }
+    assert.equal(canonicalHostRedirect('www.example.org', path, SPLIT), null, path);
+  }
+  // And the inverse configuration must not redirect them either.
+  assert.deepEqual(
+    decideRoute('example.org', '/api/evidence/x/commitment', WWW_MARKETING),
+    { kind: 'serve' },
+  );
+});
+
+test('the exemption list mirrors the proxy matcher exclusions', () => {
+  // If this drifts, #263 can come back through the other file. The matcher
+  // in src/proxy.ts excludes exactly: api/, _next/, .well-known/,
+  // favicon.ico, robots.txt.
+  assert.deepEqual([...CANONICALIZATION_EXEMPT_PREFIXES], ['/api', '/_next', '/.well-known']);
+  for (const p of ['/api', '/api/x', '/_next/x', '/.well-known/x', '/favicon.ico', '/robots.txt']) {
+    assert.equal(isCanonicalizationExempt(p), true, p);
+  }
+  // Prefix-collision guards: these are pages, not exempt families.
+  for (const p of ['/apiary', '/about', '/', '/robots.txt.bak', '/_nextish']) {
+    assert.equal(isCanonicalizationExempt(p), false, p);
+  }
+});
+
+test('canonicalize vs APP_ROOT_ACTION: ONE redirect to the canonical host + /ask', () => {
+  // The precedence the contract asked to be pinned: composed, not stacked.
+  assert.deepEqual(decideRoute('www.app.example.org', '/', SPLIT), {
+    kind: 'redirect',
+    destination: 'https://app.example.org/ask',
+  });
+  // The destination is served on the canonical host — so it settles.
+  assert.deepEqual(decideRoute('app.example.org', '/ask', SPLIT), { kind: 'serve' });
+  // On the canonical spelling the app root hop is unchanged (relative).
+  assert.deepEqual(decideRoute('app.example.org', '/', SPLIT), APP_ROOT_ACTION);
+  // The marketing host's root is a page, so it canonicalizes as a page.
+  assert.deepEqual(decideRoute('www.example.org', '/', SPLIT), {
+    kind: 'redirect',
+    destination: 'https://example.org/',
+  });
+});
+
+test('canonicalize: withholding wins — a withheld route 404s on the spelling asked', () => {
+  // Not a redirect-then-404: the status must not depend on the spelling.
+  for (const path of APP_PRIVATE_SAMPLES) {
+    assert.deepEqual(decideRoute('www.example.org', path, SPLIT), { kind: 'withhold' }, path);
+    assert.deepEqual(decideRoute('example.org', path, SPLIT), { kind: 'withhold' }, path);
+  }
+  for (const path of MARKETING_SAMPLES) {
+    assert.deepEqual(decideRoute('www.app.example.org', path, SPLIT), { kind: 'withhold' }, path);
+    assert.deepEqual(decideRoute('app.example.org', path, SPLIT), { kind: 'withhold' }, path);
+  }
+});
+
+test('bareHost keeps www. and drops everything normalizeHost drops besides it', () => {
+  assert.equal(bareHost('https://www.Example.org:8443/path?q=1'), 'www.example.org');
+  assert.equal(bareHost('Example.Org.'), 'example.org');
+  assert.equal(bareHost('[::1]:3000'), '[::1]');
+  assert.equal(bareHost(''), null);
+  assert.equal(bareHost(undefined), null);
+  // The one dimension the two functions disagree on — and only that one.
+  for (const h of ['example.org', 'EXAMPLE.ORG:443', 'https://example.org/x', 'example.org.']) {
+    assert.equal(bareHost(h), normalizeHost(h), h);
+  }
+  assert.notEqual(bareHost('www.example.org'), normalizeHost('www.example.org'));
+});
+
+test('canonicalHostRedirect: null when there is nothing to canonicalize', () => {
+  assert.equal(canonicalHostRedirect(null, '/about', SPLIT), null);
+  assert.equal(canonicalHostRedirect(undefined, '/about', SPLIT), null);
+  assert.equal(canonicalHostRedirect('www.example.org', '/about', UNSET), null);
+  assert.equal(canonicalHostRedirect('unknown.example.net', '/about', SPLIT), null);
+  assert.equal(
+    canonicalHostRedirect('www.example.org', '/about', SPLIT),
+    'https://example.org/about',
+  );
+});
+
+test('canonicalize: APP_HOST precedence is the same one resolveHostRole uses', () => {
+  // Both variables spelled the same host: the app role wins, so the app
+  // spelling is the one canonicalized toward — never a cross-role steer.
+  const config = readHostRoutingConfig({
+    APP_HOST: 'www.x.example.org',
+    MARKETING_HOST: 'x.example.org',
+  });
+  assert.equal(resolveHostRole('x.example.org', config), 'app');
+  assert.deepEqual(decideRoute('x.example.org', '/evidence', config), {
+    kind: 'redirect',
+    destination: 'https://www.x.example.org/evidence',
+  });
 });

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -36,10 +36,58 @@
  * access classification), the whole `/api/*` family, `_next`, and static
  * assets.
  *
- * Host matching mirrors `api-auth.ts`'s origin normalization:
- * case-insensitive, port-insensitive, and `www.`-insensitive — the
- * production deployment 307-redirects apex → www for GET, so browsers land
- * on `www.` even when the configured host is the apex.
+ * Host MATCHING mirrors `api-auth.ts`'s origin normalization:
+ * case-insensitive, port-insensitive, and `www.`-insensitive, so an
+ * operator names a host once and either spelling of it resolves to the
+ * role they configured.
+ *
+ * HOST CANONICALIZATION (#263). Matching is `www.`-insensitive; SERVING is
+ * not. A request whose host matches a configured value but spells it with
+ * the other `www.` form is 307-redirected to the spelling the operator
+ * actually configured — www→apex or apex→www, whichever direction the
+ * configuration points. Four properties are load-bearing:
+ *
+ *  - CONFIG-DERIVED, never a literal. The canonical spelling IS the
+ *    `APP_HOST` / `MARKETING_HOST` value; this module knows no host names
+ *    and needs no new variable to learn one.
+ *  - Rule zero survives. A `passthrough` host — a preview URL, a health
+ *    check by IP, an unnamed alias — has no configured spelling to be
+ *    steered toward, so it is never canonicalized. Neither is an
+ *    `APP_ONLY` instance, which ignores both host variables by definition.
+ *  - The CORS-sensitive path families are EXEMPT — see
+ *    `CANONICALIZATION_EXEMPT_PREFIXES`, which is the entire point of
+ *    #263. Per the Fetch spec, a cross-origin request that meets a
+ *    redirect requires the REDIRECT RESPONSE ITSELF to pass the CORS
+ *    check; a redirect carrying no `access-control-allow-origin` turns
+ *    the fetch into a network error no matter how simple the request is.
+ *    So `/api/*` and `/.well-known/*` must serve DIRECTLY on whichever
+ *    spelling was addressed, and a third-party verifier resolving a
+ *    commitment URL gets an answer instead of "Failed to fetch".
+ *  - It composes with the path decision instead of stacking on top of it:
+ *    a `www.` request to `/` on the app host produces ONE redirect
+ *    straight to the canonical host's `/ask`, not a host hop followed by
+ *    a path hop. Withholding wins outright — a route this host does not
+ *    serve 404s on the spelling it was asked on, rather than redirecting
+ *    to a second 404.
+ *
+ * 307, NOT 308, deliberately: browsers cache permanent redirects (the same
+ * reasoning already recorded at `APP_ROOT_ACTION` below), and the platform
+ * redirect this replaces is exactly why that matters — a cached 308
+ * outlives its own fix. No `rel=canonical` work accompanies this; the
+ * reference deployment sets `SITE_NOINDEX=1` (its `robots.txt` is
+ * `Disallow: /`), so search-engine canonicalization is moot there.
+ *
+ * WHERE THIS WAS MEASURED — and where it was not. The redirect and CORS
+ * behavior described above was measured against the PRODUCTION deployment
+ * with `curl` and an explicit `Origin` header on 2026-08-18. It has not
+ * been observed in a preview deployment or locally, and cannot be: a
+ * preview host matches neither variable, so nothing is canonicalized or
+ * withheld there. This app-layer canonicalization also ships INERT — while
+ * the hosting platform's own domain-level redirect is enabled it fires at
+ * the edge and no `www.` request ever reaches this module. That is
+ * intentional: canonicalization and the CORS fix then go live in the same
+ * instant the platform setting is turned off, with no window in which
+ * `www.` serves duplicate, uncanonicalized content.
  */
 
 /** What a request's host entitles it to. */
@@ -47,10 +95,17 @@ export type HostRole = 'app' | 'marketing' | 'passthrough';
 
 /** Parsed host-topology configuration (see module doc). */
 export interface HostRoutingConfig {
-  /** Normalized `APP_HOST`, or null when unset. */
+  /** Normalized `APP_HOST` — what MATCHING compares against. Null when unset. */
   appHost: string | null;
-  /** Normalized `MARKETING_HOST`, or null when unset. */
+  /** Normalized `MARKETING_HOST` — what MATCHING compares against. Null when unset. */
   marketingHost: string | null;
+  /**
+   * `APP_HOST` as an origin, preserving the spelling the operator
+   * configured — what CANONICALIZATION steers toward. Null when unset.
+   */
+  appOrigin: string | null;
+  /** `MARKETING_HOST` as an origin, preserving the configured spelling. */
+  marketingOrigin: string | null;
   /** `APP_ONLY` flag. */
   appOnly: boolean;
 }
@@ -58,10 +113,19 @@ export interface HostRoutingConfig {
 /**
  * The action the middleware should take for one request.
  * - `serve`    — pass through untouched (NextResponse.next()).
- * - `withhold` — 404: rewrite to a path no route claims, so the standard
- *                not-found page renders and the response status is 404 —
- *                indistinguishable from a route that does not exist.
- * - `redirect` — temporary (307) redirect to `destination`.
+ * - `withhold` — render the not-found page WITH a 404 status. The adapter
+ *                in `src/proxy.ts` carries the mechanism and the exact
+ *                limits of what has been verified about it.
+ * - `redirect` — temporary (307) redirect to `destination`: a path for the
+ *                app-root hop, an absolute URL for a host canonicalization.
+ *
+ * CORRECTION (#259 P2). This comment previously claimed a withheld route
+ * was "indistinguishable from a route that does not exist". It was not.
+ * Measured on the production deployment on 2026-08-18, a withheld route
+ * returned HTTP 200 carrying a not-found BODY, while a genuinely unknown
+ * URL on the same host returned 404 — so the two were distinguishable by
+ * status alone. The content withholding always worked; only the status was
+ * wrong. Nothing in the code had ever set the 404 the comment promised.
  */
 export type RouteAction =
   | { kind: 'serve' }
@@ -152,13 +216,14 @@ export function classifyPath(pathname: string): PathClass {
 }
 
 /**
- * Normalize a host for comparison: lowercase, scheme/path/port stripped,
- * leading `www.` and trailing dot dropped. Accepts a bare hostname
- * (recommended), a `host:port`, or a full origin — so the same variable
- * value works for matching and for origin construction (below). Returns
- * null for unset/empty input.
+ * The shared parse: lowercase, trim, and strip scheme, path/query and port
+ * from a host-shaped value. Accepts a bare hostname (recommended), a
+ * `host:port`, or a full origin — so one variable value works for
+ * matching, for canonicalization, and for origin construction (below).
+ * Leaves both the leading `www.` and any trailing dot alone; the two
+ * exported wrappers differ only in what they do about those.
  */
-export function normalizeHost(raw: string | null | undefined): string | null {
+function hostPart(raw: string | null | undefined): string | null {
   if (typeof raw !== 'string') return null;
   let host = raw.trim().toLowerCase();
   if (host.length === 0) return null;
@@ -173,9 +238,44 @@ export function normalizeHost(raw: string | null | undefined): string | null {
   } else {
     host = host.split(':')[0];
   }
-  // www-insensitive, matching api-auth.ts isSameOrigin.
-  host = host.replace(/^www\./, '').replace(/\.$/, '');
   return host.length > 0 ? host : null;
+}
+
+/**
+ * A host reduced to the form CANONICALIZATION compares on: everything
+ * `normalizeHost` does EXCEPT dropping the leading `www.`.
+ *
+ * The asymmetry is the whole design. `www.` presence is the only thing
+ * `normalizeHost` erases that names a genuinely different host; case, port
+ * and trailing dot are one name written differently. Steering on those
+ * would be actively harmful rather than merely useless — an instance
+ * configured as `example.org` but addressed on `example.org:8443` would be
+ * redirected to a port it does not listen on, and one configured as
+ * `http://localhost:3000` would redirect to itself forever, because the
+ * literal config string never equals the Host header the browser sends
+ * back. Comparing bare hosts makes both of those no-ops by construction.
+ */
+export function bareHost(raw: string | null | undefined): string | null {
+  const host = hostPart(raw);
+  if (host === null) return null;
+  const trimmed = host.replace(/\.$/, '');
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Normalize a host for MATCHING: lowercase, scheme/path/port stripped,
+ * leading `www.` and trailing dot dropped. Returns null for unset/empty
+ * input. `www.`-insensitive, matching api-auth.ts `isSameOrigin` — which
+ * is why a request can match a configured host and still be spelled
+ * differently from it, and why `bareHost` above exists.
+ */
+export function normalizeHost(raw: string | null | undefined): string | null {
+  const host = hostPart(raw);
+  if (host === null) return null;
+  // Order matters: `www.` first, then the trailing dot, so the degenerate
+  // input `www.` reduces to empty (null) rather than to the host `www`.
+  const stripped = host.replace(/^www\./, '').replace(/\.$/, '');
+  return stripped.length > 0 ? stripped : null;
 }
 
 /** `1`/`true` (any case, trimmed) is on; anything else — including unset — is off. */
@@ -195,6 +295,11 @@ export function readHostRoutingConfig(
   return {
     appHost: normalizeHost(env.APP_HOST),
     marketingHost: normalizeHost(env.MARKETING_HOST),
+    // The same values a second time, un-normalized, because matching and
+    // canonicalization need different things from them: matching wants the
+    // `www.`-insensitive form, canonicalization wants the literal spelling.
+    appOrigin: originFromHostValue(env.APP_HOST),
+    marketingOrigin: originFromHostValue(env.MARKETING_HOST),
     appOnly: parseBooleanFlag(env.APP_ONLY),
   };
 }
@@ -220,18 +325,96 @@ export function resolveHostRole(
 }
 
 /**
- * THE decision function: (host, pathname, config) → action. Pure; the
- * middleware adapter contributes nothing but the translation to
- * NextResponse. See the module doc for the full behavior matrix.
+ * Path families that are NEVER host-canonicalized, whatever the topology.
+ *
+ * This list is the #263 fix. `/api/*` and `/.well-known/*` are the paths
+ * third parties fetch cross-origin — evidence commitments, the trust
+ * registry — and per the Fetch spec a redirect met by a cross-origin
+ * request must ITSELF carry `access-control-allow-origin` or the fetch
+ * fails as a network error. Redirecting them is therefore not a detour,
+ * it is an outage for every browser caller, preflights included. They
+ * serve directly on whichever spelling was addressed.
+ *
+ * It deliberately DUPLICATES the matcher exclusions in `src/proxy.ts`
+ * rather than trusting them. The matcher already keeps these requests out
+ * of the proxy entirely — that is the primary mechanism and it is the one
+ * that runs in production — but the matcher is a deployment-time
+ * optimization living in a different file, while this function is the
+ * documented authority for what happens to a request. Encoding the
+ * exemption in both places means a future edit to the matcher cannot
+ * silently reintroduce the defect.
  */
-export function decideRoute(
+export const CANONICALIZATION_EXEMPT_PREFIXES = [
+  '/api',
+  '/_next',
+  '/.well-known',
+] as const;
+
+/** Exact paths that are never canonicalized (see the prefixes above). */
+export const CANONICALIZATION_EXEMPT_PATHS = ['/favicon.ico', '/robots.txt'] as const;
+
+/** True when `pathname` must serve on the host it was addressed on. Pure. */
+export function isCanonicalizationExempt(pathname: string): boolean {
+  if (CANONICALIZATION_EXEMPT_PATHS.some((p) => p === pathname)) return true;
+  return CANONICALIZATION_EXEMPT_PREFIXES.some((p) => underPath(pathname, p));
+}
+
+/**
+ * The origin whose SPELLING this request's host should be canonicalized
+ * to, or null when there is none to steer toward.
+ *
+ * Mirrors `resolveHostRole`'s precedence exactly — `APP_HOST` before
+ * `MARKETING_HOST` — so a request can never be matched as one role and
+ * canonicalized toward the other. Returns null for `APP_ONLY`, which
+ * ignores both host variables by definition and therefore has no
+ * configured spelling, and null for a host that matched neither (rule
+ * zero: a preview URL or an unnamed alias is not steered anywhere).
+ */
+function matchedOrigin(
+  rawHost: string | null | undefined,
+  config: HostRoutingConfig,
+): string | null {
+  if (config.appOnly) return null;
+  const host = normalizeHost(rawHost);
+  if (host === null) return null;
+  if (config.appHost !== null && host === config.appHost) return config.appOrigin;
+  if (config.marketingHost !== null && host === config.marketingHost) {
+    return config.marketingOrigin;
+  }
+  return null;
+}
+
+/**
+ * Where a non-canonical spelling of a configured host should be sent, or
+ * null when the request is already canonical (or must not be moved).
+ *
+ * TERMINATION is a property, not a hope: the destination's host IS
+ * `bareHost(origin)`, so the follow-up request compares equal and returns
+ * null here. Exactly one hop, always — pinned by a test that feeds the
+ * redirect target back through this function.
+ */
+export function canonicalHostRedirect(
   rawHost: string | null | undefined,
   pathname: string,
   config: HostRoutingConfig,
-): RouteAction {
-  const role = resolveHostRole(rawHost, config);
-  if (role === 'passthrough') return SERVE;
+  search = '',
+): string | null {
+  if (isCanonicalizationExempt(pathname)) return null;
+  const origin = matchedOrigin(rawHost, config);
+  if (origin === null) return null;
+  const requested = bareHost(rawHost);
+  const canonical = bareHost(origin);
+  if (requested === null || canonical === null) return null;
+  if (requested === canonical) return null;
+  return `${origin}${pathname}${search}`;
+}
 
+/**
+ * What this role does with this PATH, before any host spelling is
+ * considered. Extracted from `decideRoute` so canonicalization can compose
+ * with the answer rather than run before or after it.
+ */
+function decidePathAction(role: 'app' | 'marketing', pathname: string): RouteAction {
   const pathClass = classifyPath(pathname);
 
   if (role === 'marketing') {
@@ -252,6 +435,55 @@ export function decideRoute(
       // under a non-excluded matcher miss, unknown URLs → natural 404).
       return SERVE;
   }
+}
+
+/**
+ * THE decision function: (host, pathname, config) → action. Pure; the
+ * middleware adapter contributes nothing but the translation to
+ * NextResponse. See the module doc for the full behavior matrix.
+ *
+ * `search` is optional and defaults to empty, so every existing caller and
+ * test keeps its exact meaning. It exists only so a canonicalizing
+ * redirect can carry the query string — `/explore?trace=…` is a documented
+ * deep link, and dropping its query would break the link rather than move
+ * it. The app-root hop deliberately does not take it: that redirect
+ * discarded the query before this change and still does.
+ *
+ * PRECEDENCE, decided rather than inherited from evaluation order:
+ *
+ *  1. `passthrough` short-circuits everything. Rule zero.
+ *  2. `withhold` beats canonicalization. A route this host does not serve
+ *     404s on the spelling it was asked on. Redirecting first would spend
+ *     a hop to arrive at the same 404, and would make the withheld status
+ *     depend on which spelling the caller happened to use.
+ *  3. Otherwise canonicalization COMPOSES with the path decision: the path
+ *     action picks the destination path, the host check picks the host,
+ *     and the two are emitted as ONE redirect. A `www.` request to `/` on
+ *     the app host lands on the canonical host's `/ask` in a single hop,
+ *     never a host hop followed by a path hop, and never a loop.
+ */
+export function decideRoute(
+  rawHost: string | null | undefined,
+  pathname: string,
+  config: HostRoutingConfig,
+  search = '',
+): RouteAction {
+  const role = resolveHostRole(rawHost, config);
+  if (role === 'passthrough') return SERVE;
+
+  const pathAction = decidePathAction(role, pathname);
+  if (pathAction.kind === 'withhold') return pathAction;
+
+  // Compose: where the path decision already redirects, canonicalize its
+  // destination instead of the requested path, collapsing two hops to one.
+  const isPathRedirect = pathAction.kind === 'redirect';
+  const destination = canonicalHostRedirect(
+    rawHost,
+    isPathRedirect ? pathAction.destination : pathname,
+    config,
+    isPathRedirect ? '' : search,
+  );
+  return destination === null ? pathAction : { kind: 'redirect', destination };
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,21 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { decideRoute, readHostRoutingConfig } from '@/lib/host-routing';
 
 /**
+ * The framework's own not-found route. Next's App Router always builds one
+ * (`app/_not-found/page`) whether or not the app supplies a
+ * `not-found.tsx`, and — verified in this repo's build output — it is the
+ * ONLY route in the manifest that carries a 404: `.next/server/
+ * _not-found.meta` records `"status": 404` and the prerender manifest
+ * records `"initialStatus": 404` for it.
+ *
+ * The path this replaced, `/404`, matches no route at all. That is why a
+ * withheld route returned 200: the rewrite destination resolved to
+ * nothing, the not-found BODY rendered, and no route's status ever
+ * applied.
+ */
+const NOT_FOUND_ROUTE = '/_not-found';
+
+/**
  * Host-topology routing proxy (app front-door v0.1.0, P3) — a thin
  * adapter over the pure decision function in `src/lib/host-routing.ts`.
  * All behavior (the role matrix, the withheld route list, the seam
@@ -24,18 +39,49 @@ export function proxy(request: NextRequest) {
     request.headers.get('host'),
     request.nextUrl.pathname,
     readHostRoutingConfig(process.env),
+    // Only a canonicalizing redirect consumes this; see decideRoute.
+    request.nextUrl.search,
   );
 
   switch (action.kind) {
     case 'withhold':
-      // Rewrite to a path no route claims: Next renders the standard
-      // not-found page with a 404 status while the browser URL stays put —
-      // indistinguishable from a route that does not exist.
-      return NextResponse.rewrite(new URL('/404', request.url));
+      // 404, via two independent mechanisms that point the same way,
+      // because neither can be observed from here (see below):
+      //
+      //  1. The DESTINATION is a route that genuinely exists and whose
+      //     build artifact carries a 404 status, so the status comes from
+      //     rendering it rather than from anything middleware asserts.
+      //  2. The STATUS ON THE REWRITE. Reading Next 16.3.0's router
+      //     (`server/lib/router-utils/resolve-routes.js`), the middleware
+      //     response's status is assigned to the outgoing response before
+      //     the rewrite destination is resolved, and the rewrite branch —
+      //     unlike the redirect branch beside it — never overwrites it.
+      //     That also explains the 200 this replaces: a rewrite with no
+      //     init defaults to 200, and nothing downstream corrected it.
+      //
+      // The browser URL stays put either way; only the status changes.
+      //
+      // WHAT IS NOT VERIFIED. Neither mechanism has been observed
+      // end-to-end. A local server cannot run here (an agent sandbox
+      // denies port binding), and a preview deployment withholds nothing
+      // because its host matches neither topology variable — so there is
+      // no withheld route to probe. Production is the first place this is
+      // observable. Both mechanisms are also strictly additive: if each
+      // one fails, the response is the 200-plus-not-found-body it already
+      // was, so the change cannot regress below the defect it targets.
+      return NextResponse.rewrite(new URL(NOT_FOUND_ROUTE, request.url), { status: 404 });
     case 'redirect':
-      // Temporary on purpose: where the app root points is a product
-      // decision (APP_ROOT_ACTION), and browsers cache permanent redirects
-      // past the point where changing it would take effect.
+      // Temporary on purpose, for BOTH redirect kinds. Where the app root
+      // points is a product decision (APP_ROOT_ACTION), and a canonical
+      // host spelling is an operator's configuration — browsers cache
+      // permanent redirects past the point where changing either would
+      // take effect. The platform-level 308 this replaces is the standing
+      // demonstration: it outlived its own fix in every browser that had
+      // already seen it.
+      //
+      // `action.destination` is a path for the app-root hop and an
+      // absolute URL for a canonicalization; `new URL(dest, base)` handles
+      // both, ignoring the base when the destination is absolute.
       return NextResponse.redirect(new URL(action.destination, request.url), 307);
     default:
       return NextResponse.next();
@@ -54,6 +100,18 @@ export const config = {
    * Public-folder files that still match (e.g. /bpmn/*, /talks/*, root
    * SVGs) fall through decideRoute unclassified and are served unchanged —
    * the matcher is an optimization, the function is the authority.
+   *
+   * The /api/ and /.well-known/ exclusions are load-bearing for #263, not
+   * just a performance nicety: they are why a cross-origin fetch of an
+   * evidence commitment or the trust registry meets a real response on
+   * EITHER host spelling instead of a redirect it cannot follow. Because
+   * that matters, `host-routing.ts` re-states the same exemption in
+   * `CANONICALIZATION_EXEMPT_PREFIXES`, so editing this regex alone cannot
+   * bring the defect back.
+   *
+   * Note the exclusions are prefix-with-slash: bare `/api` and bare
+   * `/.well-known` DO reach the proxy. Neither names a route; both
+   * classify as unclassified and serve, so the behavior is unchanged.
    */
   matcher: ['/((?!api/|_next/|\\.well-known/|favicon\\.ico|robots\\.txt).*)'],
 };


### PR DESCRIPTION
Sprint #259 phase 2. Two defects in the same two files, both of which must land before the topology default flip makes their blast radius instance-wide.

**Refs #263** — deliberately not `Closes`. The fix does not take effect until a hosting-platform setting is turned off, and the acceptance probe runs against production after that. The issue closes when the probe passes, not when this merges.

## Defect 1 — the www→apex redirect breaks cross-origin browser fetches (#263)

Per the Fetch spec, a cross-origin request that receives a redirect requires **the redirect response itself** to pass the CORS check. The platform-level `www` → apex redirect carries no `access-control-allow-origin`, so any third-party verifier resolving a commitment URL against the `www` spelling gets a network error rather than an informative status. The apex spelling works, which is what makes the failure spelling-dependent and invisible.

**Fix:** app-layer host canonicalization. Pages on a non-canonical spelling get a **307** to the configured spelling; `/api/*` and `/.well-known/*` serve **directly on whichever spelling was addressed**, so the CORS-breaking redirect ceases to exist for exactly the paths that need CORS — preflights included.

### The rule, and a correction to the one this phase was handed

The rule proposed at contract time compared the **literal spelling** of the request host against the literal configured value. That is wrong, and two configurations already covered by existing tests demonstrate it:

- `MARKETING_HOST=example.org` addressed on `example.org:8443` — literal spellings differ, so it would redirect to a port the instance does not listen on.
- `MARKETING_HOST=http://localhost:3000` — a form the existing suite already blesses. The config string never equals the `Host` header a browser sends back, so it would redirect to itself forever.

**Implemented instead:** matching stays `www.`-insensitive; **serving is not**. Canonicalization compares *bare hosts* — everything `normalizeHost` does **except** dropping the leading `www.`. That asymmetry is the whole design: `www.` presence is the only dimension `normalizeHost` erases that names a genuinely different host, while case, port and trailing dot are one name written differently. Both configurations above become no-ops by construction.

The canonical spelling **is** the configured value, so no host literal appears anywhere in the module and **no new environment variable is introduced**. The inverse case falls out for free: an operator who configures `www.example.org` gets apex→www.

### Precedence, decided rather than inherited from evaluation order

1. `passthrough` short-circuits everything — rule zero holds, and an unnamed host has no configured spelling to be steered toward.
2. **Withhold beats canonicalization.** A route this host does not serve 404s on the spelling it was asked on; redirecting first would spend a hop to reach an identical 404 and would make the withheld status depend on which spelling the caller used.
3. Otherwise canonicalization **composes** with the path decision — a `www.` request to `/` on the app host emits **one** redirect straight to the canonical host's `/ask`, never a host hop followed by a path hop, and never a loop.

`decideRoute` gains an optional 4th `search` parameter so a canonicalizing redirect preserves the query string (`/explore?trace=…` is a documented deep link). The app-root hop deliberately does not take it — that redirect discarded the query before this change and still does.

### Defense in depth on the exemption

The `/api/` and `/.well-known/` exclusions in the proxy matcher are load-bearing for #263, not a performance nicety. Because the whole fix would otherwise rest on a regex in a different file, the same exemption is re-stated in `host-routing.ts` as `CANONICALIZATION_EXEMPT_PREFIXES` and checked before any canonicalization. Editing the matcher alone can no longer bring the defect back.

Verified against the compiled matcher from a fresh build rather than by reading the source regex — worth recording that on Next 16.3.0 `middleware-manifest.json` is empty even after a clean successful build, and the compiled matcher actually lives in `functions-config-manifest.json` under `/_middleware`.

## Defect 2 — withheld routes returned HTTP 200, not 404

Measured on production with a control: withheld routes returned **200** carrying a not-found body, while a genuinely unknown URL on the same host returned **404**. So withheld and nonexistent were distinguishable by status alone — while `host-routing.ts` and `proxy.ts` both claimed the opposite. Nothing in the code had ever set the 404 the comments promised.

**Root cause found:** the rewrite destination was `/404`, which matches no route at all. The not-found *body* rendered and no route's status ever applied.

**Fix, two additive mechanisms:**
1. The destination is now `/_not-found` — the framework's own not-found route, which the App Router always builds whether or not the app supplies a `not-found.tsx` (this one does not). Verified in this repo's build output as the only route in the manifest carrying a 404.
2. An explicit `{ status: 404 }` on the rewrite.

Both point the same way and neither can regress below the current behavior: if both fail, the response is the 200-plus-not-found-body it already was.

## What is NOT verified, and why

**This change ships inert.** While the platform's own domain-level redirect is enabled it fires at the edge and no `www.` request ever reaches this module. That is intentional — canonicalization and the CORS fix then go live in the same instant the platform setting is turned off, with no window where `www` serves duplicate uncanonicalized content.

Neither fix has been observed end-to-end, and both of the obvious ways to try are structurally blocked: a local server cannot run in this environment, and a preview deployment withholds nothing because its host matches neither topology variable — so there is no withheld route to probe and no canonicalization to trigger. **Production is the first observable place for both.** The code comments say so explicitly, and scope every behavioral claim to the environment it was measured in.

## Comment corrections — six sites

Four sites stated "the production deployment 307-redirects apex → www". Measured reality is the opposite: a 308 `www` → apex, becoming an app-layer 307 `www` → apex here. These are also the recorded **rationale** for `www.`-insensitive origin matching, so they are corrected and re-founded rather than deleted — and the rationale gets stronger: `/api/*` is *exempt* from canonicalization, so a browser on the `www` spelling genuinely reaches those checks on `www` and sends a `www` Origin **by design**, rather than as the residue of a bounce.

Two further sites carried the false "indistinguishable from a route that does not exist" claim and now record the measured 200-vs-404 control.

A fifth cite sometimes grouped with the first four (`session-status/route.ts`) was reviewed and deliberately **not** changed: it carries no directional redirect claim, and this change makes its reasoning more accurate rather than less.

## Gates

`npm test` 719/719 · lint 0 errors (4 pre-existing warnings, none in these files) · typecheck clean · webpack build succeeds. The path-array drift guard added in #265 still passes, untouched.
