### PR TITLE
feat: app-only by default — SERVE_MARKETING governs unnamed hosts (#259 P3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,10 +254,14 @@ services:
       CRON_SECRET:
       KV_REST_API_URL:
       KV_REST_API_TOKEN:
-      # Host topology: unset ⇒ no host routing, every route on every host.
+      # Host topology. Unset ⇒ the app surface only: marketing routes 404 and
+      # `/` hops to `/ask`. Bare `NAME:` passes the variable through only when
+      # the environment has it — which is the point for SERVE_MARKETING,
+      # whose ABSENCE is the configured state for an instance.
       APP_HOST:
       MARKETING_HOST:
       APP_ONLY:
+      SERVE_MARKETING:
       # Evidence identity overrides not already given a local default above.
       EVIDENCE_PLATFORM_AGENT_URL:
       EVIDENCE_TRUST_REGISTRY_CANONICAL_URL:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -512,9 +512,11 @@ byte-identically; see [Branding and
 theming](#branding-and-theming-chrome-only) below), `OIDC_PROVIDER_NAME`
 (button label), `SIGN_IN_ALLOWLIST` (unset or empty = open sign-in,
 exactly the pre-allowlist behavior; see the sign-in section),
-the host-topology set (`APP_HOST`, `MARKETING_HOST`, `APP_ONLY` — with
-none set, every route serves on every host, exactly the single-host
-behavior; see [Host topology](#host-topology-optional)),
+the host-topology set (`APP_HOST`, `MARKETING_HOST`, `SERVE_MARKETING`,
+`APP_ONLY` — with none set, the instance serves the app surface only:
+the marketing pages 404 and `/` redirects to `/ask`. `SERVE_MARKETING`
+is the one variable whose unset state is the correct state for an
+instance; see [Host topology](#host-topology-optional)),
 `SITE_NOINDEX` (unset/empty = indexable, the standard web default; see
 [Indexing](#indexing-optional)),
 the remaining content-source overrides (`DIRECTORY_DATA_URL`,
@@ -701,31 +703,65 @@ recorded in the instance's own database on first sign-in.
 
 ## Host topology (optional)
 
-By default an instance is a single host and every route serves on it —
-nothing in this section is required, and with none of the three
-variables set the routing middleware passes every request through
-untouched. Set them to split the public face from the gated app
-surface, or to run an app-only instance with no public face at all.
-The decision logic lives in `src/lib/host-routing.ts` (unit-tested;
-`src/proxy.ts` is a thin adapter over it).
+**Every variable in this section is optional. An instance that sets none
+of them serves the app surface only** — the marketing pages return 404
+and `/` redirects to `/ask`. That is the portable default, and for most
+instances it is also the finished configuration: nothing here needs to be
+set at all.
 
-| Variable | Meaning |
-| --- | --- |
-| `APP_HOST` | The host that serves the gated app surface. On it, `/` redirects (307) to `/ask` — the signed-in query surface — the marketing pages return 404, and `/ask`, the dashboard, device pairing, and evidence routes all serve. |
-| `MARKETING_HOST` | The host that serves the public face. On it, the marketing pages and the public evidence registry serve exactly as on a single host, and the app-private routes — `/ask`, `/dashboard`, `/auth/device`, `/dev/notebook-preview` — return 404. |
-| `APP_ONLY` | `1` or `true`: an app-only instance. Every request on every host gets the app-surface behavior above; `APP_HOST`/`MARKETING_HOST` are ignored. For operators deploying only the gated surface, with no marketing site. |
+The marketing site — the home page, `/about`, `/explore`, `/learn`,
+`/project`, `/roadmap`, `/directory` — is the reference deployment's own
+website, not part of what an instance is expected to publish. It is
+withheld by **configuration, never by deleting files**, so your instance
+stays cleanly `git pull`-able from upstream; the pages remain in the tree
+and simply do not serve.
 
-Values are host names (`app.example.org`); a full origin
-(`http://localhost:3000`) is also accepted, and matching is
-case-, port-, and `www.`-insensitive. Three properties worth
+Set the variables below to serve that marketing face anyway, or to split
+it onto a separate host from the gated app surface. The decision logic
+lives in `src/lib/host-routing.ts` (unit-tested; `src/proxy.ts` is a thin
+adapter over it).
+
+| Variable | Required? | Meaning |
+| --- | --- | --- |
+| `APP_HOST` | Optional — unset means no host is named | The host that serves the gated app surface. On it, `/` redirects (307) to `/ask` — the signed-in query surface — the marketing pages return 404, and `/ask`, the dashboard, device pairing, and evidence routes all serve. |
+| `MARKETING_HOST` | Optional — unset means no host is named | The host that serves the public face. On it, the marketing pages and the public evidence registry serve exactly as on a single host, and the app-private routes — `/ask`, `/dashboard`, `/auth/device`, `/dev/notebook-preview` — return 404. |
+| `SERVE_MARKETING` | Optional — **leave it unset** | `1` or `true`: hosts matching *neither* variable above serve everything, marketing pages included. Unset, those hosts get the app surface only. Governs unnamed hosts and nothing else: a host you *have* named behaves identically either way. |
+| `APP_ONLY` | Optional — rarely needed | `1` or `true`: every request on every host gets the app-surface behavior, and `APP_HOST`/`MARKETING_HOST` are ignored entirely. Redundant with the default unless you have named a marketing host and want to override it. |
+
+`SERVE_MARKETING` is the one variable here whose **unset state is the
+correct state for an instance**. It exists for the reference deployment
+and for anyone deliberately republishing the marketing pages; if you are
+standing up your own instance, do not set it, and the marketing site
+stays withheld with no further action.
+
+Values for the two host variables are host names (`app.example.org`); a
+full origin (`http://localhost:3000`) is also accepted, and matching is
+case-, port-, and `www.`-insensitive. Four properties worth
 internalizing:
 
-- **Roles are claimed, never assumed.** A request on a host matching
-  neither variable — a preview deployment, a health check by IP, an
-  alias you have not named — is served exactly as if no topology were
-  configured. That makes the rollout incremental: set `APP_HOST` first
-  and verify the app host, then set `MARKETING_HOST` to switch on the
-  withholding.
+- **Named hosts claim their role; unnamed hosts take the default.** A
+  host you named behaves exactly as its row above says, and nothing else
+  changes that. A request on a host matching *neither* variable — a
+  preview deployment, a health check by IP, an alias you have not named —
+  gets the app surface, unless `SERVE_MARKETING` says otherwise. This
+  reverses the previous behavior, under which an unnamed host was served
+  exactly as if no topology were configured, so it changes what an
+  **incremental rollout** looks like. The sequence is now:
+
+  1. Set `SERVE_MARKETING=1` **first**. Every host you have not named
+     keeps serving everything, which is what makes the following steps
+     verifiable one at a time.
+  2. Set `APP_HOST` and verify the app host in isolation — the apex is
+     still unnamed, so it is unaffected.
+  3. Set `MARKETING_HOST` to switch on the withholding there, and verify
+     the split.
+  4. Decide about `SERVE_MARKETING`. Keep it if you want preview
+     deployments and unnamed aliases to serve the full site; drop it to
+     have every host but the two you named behave as the app surface.
+
+  Skipping step 1 is not dangerous, but it means the apex starts
+  withholding its marketing pages the moment you deploy, before you have
+  had a chance to verify anything on the app host.
 - **The evidence registry is dual-served on purpose.** `/evidence` and
   `/evidence/<slug>` are public product surface; published links must
   keep resolving on the public face, and the app surface serves them
@@ -737,6 +773,26 @@ internalizing:
   identically on every host. `/ask` is the visible case: a signed-out
   visitor gets a sign-in prompt there rather than a redirect, on any
   host that serves it.
+- **The chrome follows the routing.** Whether the instance serves a
+  marketing surface at all is derived from these same variables, so the
+  header nav's marketing links, the footer funnels, and the app
+  surface's "Public site" exit link hide themselves on an instance that
+  serves no marketing face, rather than pointing at pages that would
+  404. Nothing extra to configure — but it does mean that setting
+  `SERVE_MARKETING` changes the chrome as well as the routing, in step
+  with each other.
+
+Two notes on host spellings. A request that matches a configured host but
+spells it with the other `www.` form is 307-redirected to the spelling
+you configured (`/api/*` and `/.well-known/*` are exempt, so cross-origin
+verifier fetches are never broken by a redirect). Unnamed hosts are never
+steered anywhere, since there is no configured spelling for them to be
+steered toward — that holds under the app-surface default just as it did
+when unnamed hosts passed through. And a follow-up worth recording rather
+than doing now: **if indexing is ever enabled on a host that has aliases,
+add `<link rel=canonical>` at that point.** No `rel=canonical` work is
+warranted while `SITE_NOINDEX` is set, since search-engine
+canonicalization is moot for a site that disallows crawling outright.
 
 Two split-host interactions to plan for: `NEXTAUTH_URL` can point at
 only one host, and sessions are per-host cookies — decide which host

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -219,14 +219,20 @@ export const ENV_SPEC = [
   // coded default, never load-bearing for an instance that does not want it.
   { name: 'SIGN_IN_ALLOWLIST', tier: 'optional', purpose: 'Allowlist of provider-account keys permitted to sign in (unset/empty = open)', hasFallback: true },
 
-  // --- Host topology (app front door P3; src/lib/host-routing.ts). All three
-  //     are pure opt-ins whose coded default is "no host routing": with none
-  //     set the middleware passes every request through and every route keeps
-  //     serving on every host, exactly the pre-topology behavior — so none is
-  //     ever load-bearing for a single-host instance. ---
-  { name: 'APP_HOST', tier: 'optional', purpose: 'Split-host: host serving the gated app surface (unset = no host routing)', hasFallback: true },
-  { name: 'MARKETING_HOST', tier: 'optional', purpose: 'Split-host: host serving the marketing site — withholds the app-private routes there (unset = no withholding)', hasFallback: true },
-  { name: 'APP_ONLY', tier: 'optional', purpose: 'App-only instance: every host serves the gated surface; marketing routes 404 (unset = off)', hasFallback: true },
+  // --- Host topology (app front door P3; src/lib/host-routing.ts). All four
+  //     are optional with coded defaults, so none may ever fail or nag a run.
+  //     What the CODED DEFAULT IS changed in #259 P3: an instance that sets
+  //     none of them now serves the app surface only — the marketing routes
+  //     404 and `/` hops to `/ask` — because the marketing face is the
+  //     reference deployment's own website rather than part of what an
+  //     instance ships. SERVE_MARKETING is the flagship "unset is correct"
+  //     variable of this set: instances leave it alone, and the reference
+  //     deployment sets it so its own site and its preview URLs keep serving
+  //     both route groups. ---
+  { name: 'APP_HOST', tier: 'optional', purpose: 'Split-host: host serving the gated app surface (unset = no host named)', hasFallback: true },
+  { name: 'MARKETING_HOST', tier: 'optional', purpose: 'Split-host: host serving the marketing site — withholds the app-private routes there (unset = no host named)', hasFallback: true },
+  { name: 'APP_ONLY', tier: 'optional', purpose: 'App-only instance: every host serves the gated surface even when a marketing host is named (unset = off; the default is already app-only)', hasFallback: true },
+  { name: 'SERVE_MARKETING', tier: 'optional', purpose: 'Serve the marketing site on hosts matching neither APP_HOST nor MARKETING_HOST — previews, aliases, a single-host site (unset = app surface only, the portable default)', hasFallback: true },
 
   // --- Indexing posture (#258 E1, owner ruling G0-3; src/lib/site-indexing.ts).
   //     A pure opt-in, same shape as the host-topology set above: the coded

--- a/src/lib/allowed-origins.test.ts
+++ b/src/lib/allowed-origins.test.ts
@@ -244,3 +244,46 @@ test('session affordance rule zero: null topology, app-only, and partial rollout
   // NEXTAUTH_URL alone never conjures an affordance.
   assert.equal(resolveSessionAffordance({ NEXTAUTH_URL: 'https://example.test' }), null);
 });
+
+// --- #259 P3: the flip must not widen any origin set ------------------------
+
+test('SERVE_MARKETING changes nothing here, in any combination', () => {
+  // The consumer-audit verdict, pinned. Every origin this module can emit
+  // has to be NAMED by a host variable first, so a flag that names no host
+  // cannot move any of these answers. Stated as an equality across the knob
+  // rather than as literals, so it keeps holding if the values change.
+  const envs = [
+    {},
+    { NEXTAUTH_URL: 'https://example.test' },
+    { APP_HOST: 'app.example.test' },
+    { MARKETING_HOST: 'example.test' },
+    SPLIT,
+    { ...SPLIT, APP_ONLY: '1' },
+  ];
+  for (const env of envs) {
+    const label = JSON.stringify(env);
+    for (const on of ['1', 'true']) {
+      const knobbed = { ...env, SERVE_MARKETING: on };
+      assert.deepEqual(resolveTrustedOrigins(knobbed), resolveTrustedOrigins(env), label);
+      assert.equal(resolveMarketingCorsOrigin(knobbed), resolveMarketingCorsOrigin(env), label);
+      assert.deepEqual(resolveSessionAffordance(knobbed), resolveSessionAffordance(env), label);
+    }
+  }
+});
+
+test('an unconfigured instance still trusts exactly NEXTAUTH_URL and grants no CORS', () => {
+  // The post-flip default, spelled out: routing behaves app-only, but the
+  // instance still owns exactly one origin and has no marketing host to
+  // grant the session-status CORS header to. Nothing about the flip may
+  // turn the inert endpoint on.
+  const env = { NEXTAUTH_URL: 'https://instance.example.test' };
+  assert.deepEqual(resolveTrustedOrigins(env), ['https://instance.example.test']);
+  assert.equal(resolveMarketingCorsOrigin(env), null);
+  assert.equal(
+    isConfiguredMarketingOrigin('https://instance.example.test', env),
+    false,
+    'the endpoint stays inert — its own origin is not a marketing origin',
+  );
+  assert.equal(isTrustedRequestOrigin('https://instance.example.test', 'instance.example.test', env), true);
+  assert.equal(isTrustedRequestOrigin('https://evil.example.test', 'instance.example.test', env), false);
+});

--- a/src/lib/allowed-origins.ts
+++ b/src/lib/allowed-origins.ts
@@ -48,6 +48,21 @@
 //     Origin, by design — and must still match the apex value the
 //     operator configured.
 //
+// `SERVE_MARKETING` DELIBERATELY DOES NOT APPEAR HERE (#259 P3 consumer
+// audit). All three `APP_ONLY` branches below survived the flip unchanged,
+// and the reason is the same one each time: every origin this module can
+// emit has to be NAMED by a host variable before it exists at all. Change
+// the role an UNNAMED host takes and none of these answers move —
+// `resolveTrustedOrigins` adds only origins `APP_HOST`/`MARKETING_HOST`
+// spell out, and both `resolveMarketingCorsOrigin` and
+// `resolveSessionAffordance` are already null whenever `MARKETING_HOST` is
+// unset, whatever `APP_ONLY` says. An instance with nothing configured
+// therefore keeps exactly the singleton `{NEXTAUTH_URL}` trust set and the
+// inert session-status endpoint it had before, which is correct: it owns no
+// second origin and has no marketing host to grant CORS to. Wiring the new
+// flag in would have widened a security-relevant set on the strength of a
+// flag that names no origin.
+//
 // Pure module: no Next.js imports, env passed as a record — runs under
 // `node --test` like host-routing.ts and host-links.ts.
 

--- a/src/lib/host-links.test.ts
+++ b/src/lib/host-links.test.ts
@@ -1,9 +1,15 @@
-// Tests for the cross-host link derivation (app front-door v0.1.0, P4c).
+// Tests for the cross-host link derivation (app front-door v0.1.0, P4c;
+// marketing gate re-keyed in #259 P3).
 //
-// Rule zero, the same one every other seam in this sprint obeys: with none of
-// the three host-topology variables set, the derivation reproduces today's
-// behavior exactly — relative marketing hrefs (empty prefix) and in-place
-// sign-in (null href).
+// THE TWO FIELDS ANSWER DIFFERENT QUESTIONS, and #259 P3 moved exactly one:
+//
+//   - `marketingOrigin` asks "does a marketing surface exist, and where?"
+//     Its unset-topology answer CHANGED from `''` (relative) to `null`
+//     (hide), because the portable default no longer serves the marketing
+//     routes anywhere — relative hrefs to `/learn`, `/about` and `/roadmap`
+//     would have rendered into a 404.
+//   - `signInHref` asks "where do sessions live?", which only `APP_HOST`
+//     answers. Unchanged: null still means sign in in place.
 //
 // Run with: npm test
 
@@ -12,10 +18,21 @@ import assert from 'node:assert/strict';
 import { DEFAULT_HOST_LINKS, resolveHostLinks } from './host-links.ts';
 import { SIGN_IN_INTENT_PARAM } from './sign-in-intent.ts';
 
-test('unset topology: relative marketing links, sign in place', () => {
-  assert.deepEqual(resolveHostLinks({}), { marketingOrigin: '', signInHref: null });
+test('portable default: no marketing surface, so the links are hidden (#259 P3)', () => {
+  assert.deepEqual(resolveHostLinks({}), { marketingOrigin: null, signInHref: null });
+});
+
+test('SERVE_MARKETING: relative marketing links, sign in place — the pre-#259 answer', () => {
+  assert.deepEqual(resolveHostLinks({ SERVE_MARKETING: '1' }), {
+    marketingOrigin: '',
+    signInHref: null,
+  });
   // ...which is exactly what a consumer rendered outside the provider sees.
-  assert.deepEqual(resolveHostLinks({}), DEFAULT_HOST_LINKS);
+  // DEFAULT_HOST_LINKS is the CONTEXT default (a consumer with no provider
+  // above it), not the unset-env answer — the two stopped coinciding at the
+  // flip, and the safe context default is the permissive one: a component
+  // mounted outside the provider keeps rendering what it always did.
+  assert.deepEqual(resolveHostLinks({ SERVE_MARKETING: '1' }), DEFAULT_HOST_LINKS);
 });
 
 test('split host: marketing links carry the marketing origin, sign-in goes to the app surface', () => {
@@ -40,16 +57,40 @@ test('app-only: no marketing site to link to, sign-in is a relative path', () =>
 });
 
 test('the two halves are independent — an incremental rollout is coherent at every step', () => {
-  // Stage 1: APP_HOST only. Sign-in already redirects to the app surface;
-  // marketing links stay relative because no marketing origin is named yet.
-  assert.deepEqual(resolveHostLinks({ APP_HOST: 'app.example.org' }), {
+  // Stage 0 (new in #259 P3): SERVE_MARKETING, before any host is named.
+  // Every host passes through, so both halves read as a single-host instance.
+  assert.deepEqual(resolveHostLinks({ SERVE_MARKETING: '1' }), {
     marketingOrigin: '',
-    signInHref: 'https://app.example.org/ask?signin=1',
+    signInHref: null,
   });
-  // Stage 2: MARKETING_HOST only. The mirror image.
+  // Stage 1: APP_HOST added. Sign-in redirects to the app surface; marketing
+  // links stay relative because the unnamed apex is still passing through.
+  assert.deepEqual(
+    resolveHostLinks({ APP_HOST: 'app.example.org', SERVE_MARKETING: '1' }),
+    { marketingOrigin: '', signInHref: 'https://app.example.org/ask?signin=1' },
+  );
+  // Stage 2: MARKETING_HOST added — the origin is now named, and the knob
+  // stops mattering for the marketing half.
+  assert.deepEqual(
+    resolveHostLinks({ APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }),
+    { marketingOrigin: 'https://example.org', signInHref: 'https://app.example.org/ask?signin=1' },
+  );
+  // MARKETING_HOST alone is still the mirror image of stage 1.
   assert.deepEqual(resolveHostLinks({ MARKETING_HOST: 'example.org' }), {
     marketingOrigin: 'https://example.org',
     signInHref: null,
+  });
+});
+
+test('APP_HOST alone WITHOUT the knob hides the marketing links, and must', () => {
+  // The stage that changed at the flip. With only APP_HOST named and no
+  // knob, NO host serves the marketing routes — the app host withholds them
+  // and every unnamed host now takes the app role too — so a relative
+  // prefix would have pointed the footer and nav at guaranteed 404s.
+  // signInHref is untouched: it answers a different question.
+  assert.deepEqual(resolveHostLinks({ APP_HOST: 'app.example.org' }), {
+    marketingOrigin: null,
+    signInHref: 'https://app.example.org/ask?signin=1',
   });
 });
 
@@ -61,11 +102,18 @@ test('host values accept a full origin, and a dev instance keeps its scheme and 
 });
 
 test('empty and whitespace values are unset, not configuration', () => {
-  assert.deepEqual(resolveHostLinks({ APP_HOST: '', MARKETING_HOST: '   ', APP_ONLY: '' }), {
-    marketingOrigin: '',
-    signInHref: null,
-  });
-  assert.deepEqual(resolveHostLinks({ APP_ONLY: '0' }).marketingOrigin, '');
+  assert.deepEqual(
+    resolveHostLinks({ APP_HOST: '', MARKETING_HOST: '   ', APP_ONLY: '', SERVE_MARKETING: '' }),
+    { marketingOrigin: null, signInHref: null },
+  );
+  // An empty MARKETING_HOST does not count as "a marketing host is named",
+  // so the knob still decides — the same reading normalizeHost gives it.
+  assert.deepEqual(
+    resolveHostLinks({ MARKETING_HOST: '   ', SERVE_MARKETING: '1' }).marketingOrigin,
+    '',
+  );
+  assert.deepEqual(resolveHostLinks({ APP_ONLY: '0' }).marketingOrigin, null);
+  assert.deepEqual(resolveHostLinks({ APP_ONLY: '0', SERVE_MARKETING: 'true' }).marketingOrigin, '');
   assert.deepEqual(resolveHostLinks({ APP_ONLY: 'false' }).signInHref, null);
 });
 
@@ -90,8 +138,20 @@ test('every non-null sign-in href carries the intent parameter, relative one inc
 test('concatenation property: an empty prefix yields exactly the relative href', () => {
   // This is the byte-identity argument, expressed as an assertion: every
   // consumer builds `${marketingOrigin}${path}`.
-  const { marketingOrigin } = resolveHostLinks({});
+  const { marketingOrigin } = resolveHostLinks({ SERVE_MARKETING: '1' });
   for (const path of ['/about', '/directory', '/explore', '/learn', '/project', '/roadmap']) {
     assert.equal(`${marketingOrigin}${path}`, path);
   }
+});
+
+test('null is never concatenated: every consumer must guard, and the value says so', () => {
+  // The counterpart to the property above, and the reason the "hide" signal
+  // is `null` rather than some sentinel string: `${null}${path}` produces
+  // the visibly broken `null/about`, so a consumer that forgets to guard
+  // fails loudly in the markup instead of silently linking somewhere wrong.
+  // The four live consumers all guard on `!== null` (root layout footer,
+  // Header.showMarketingNav, and two McpResponseDisplay /learn links).
+  const { marketingOrigin } = resolveHostLinks({});
+  assert.equal(marketingOrigin, null);
+  assert.equal(`${marketingOrigin}/about`, 'null/about');
 });

--- a/src/lib/host-links.ts
+++ b/src/lib/host-links.ts
@@ -1,7 +1,10 @@
 // Cross-host link targets (app front-door v0.1.0, P4c).
 //
-// THE PROBLEM THIS SOLVES. Once host topology is configured, two families of
-// in-place affordance break, each in the mirror-image way:
+// THE PROBLEM THIS SOLVES. Wherever the app surface and the marketing face
+// are not the same thing, two families of in-place affordance break, each in
+// the mirror-image way. That used to require configuring host topology;
+// since #259 P3 it is also the DEFAULT, because an instance that configures
+// nothing serves the app surface alone:
 //
 //   - SIGN-IN affordances on the MARKETING host. `signIn('github')` starts an
 //     OAuth flow whose state cookie is written for the host the click
@@ -26,6 +29,7 @@
 // own.
 
 import {
+  instanceServesMarketing,
   originFromHostValue,
   parseBooleanFlag,
   resolveAppOrigin,
@@ -64,14 +68,17 @@ export interface HostLinks {
   /**
    * Prefix to put in front of a marketing route's path.
    *
-   * - `''` — no topology configured: hrefs stay exactly the relative ones
-   *   they are today. This is the seam convention, and it is what makes the
-   *   unset case byte-identical rather than merely equivalent.
+   * - `''` — the marketing routes serve on whatever host the visitor is on
+   *   (`SERVE_MARKETING`, and any deployment that has not split its hosts):
+   *   hrefs stay exactly the relative ones they have always been.
    * - an origin — a split-host instance: marketing routes resolve on the
    *   marketing host from wherever they are rendered.
-   * - `null` — an app-only instance: there IS no marketing site, so the
-   *   affordances are hidden rather than pointed somewhere. Same treatment
-   *   `resolvePublicSiteHref` gives the `AppChrome` exit link (P3).
+   * - `null` — the instance serves NO marketing surface: the affordances
+   *   are hidden rather than pointed somewhere. Same treatment
+   *   `resolvePublicSiteHref` gives the `AppChrome` exit link (P3), and
+   *   every consumer already guards on this exact null — the root layout's
+   *   footer funnels, `Header`'s `showMarketingNav`, and the two
+   *   `McpResponseDisplay` `/learn` deep links.
    */
   marketingOrigin: string | null;
 
@@ -94,12 +101,27 @@ export const DEFAULT_HOST_LINKS: HostLinks = {
  * argument (never `process.env` directly) so tests pass fixtures, matching
  * `readHostRoutingConfig`.
  *
- * The two fields are independent on purpose, because the rollout is
- * incremental (P3: "set `APP_HOST` first and verify the app host, then set
- * `MARKETING_HOST` to switch on the withholding"). With only `APP_HOST` set,
- * sign-in already redirects to the app surface while marketing links stay
- * relative — there is no marketing origin to name yet. With only
- * `MARKETING_HOST` set, the reverse. Neither half waits for the other.
+ * The two fields are independent on purpose, and they answer two DIFFERENT
+ * topology questions — which is what let #259 P3 move one without the other:
+ *
+ *   - `marketingOrigin` asks "does a marketing surface exist, and where?"
+ *     It is gated by `instanceServesMarketing`, so it goes null the moment
+ *     the instance serves no marketing face. This CHANGED at the flip:
+ *     it used to fall through to `''` (relative) for anything short of
+ *     `APP_ONLY`, which after the flip would have rendered footer and nav
+ *     links to `/learn`, `/about` and `/roadmap` on a host where those
+ *     paths 404.
+ *   - `signInHref` asks "where do sessions live?" — a question only
+ *     `APP_HOST` answers, and one the flip does not touch. Null still means
+ *     sign in IN PLACE, which is correct on any instance with no separate
+ *     app host to send anyone to.
+ *
+ * INCREMENTAL ROLLOUT, restated for the post-flip world. It used to be "set
+ * `APP_HOST` first, then `MARKETING_HOST`", on the strength of unnamed hosts
+ * passing through in the meantime. They no longer do, so the sequence gains
+ * a step at the front: set `SERVE_MARKETING=1` FIRST — that reinstates the
+ * pass-through for every host you have not named yet — then `APP_HOST`, then
+ * `MARKETING_HOST`. Neither host half waits for the other, exactly as before.
  */
 export function resolveHostLinks(
   env: Record<string, string | undefined>,
@@ -114,7 +136,7 @@ export function resolveHostLinks(
   const marketingOrigin = originFromHostValue(env.MARKETING_HOST);
 
   return {
-    marketingOrigin: marketingOrigin ?? '',
+    marketingOrigin: instanceServesMarketing(env) ? (marketingOrigin ?? '') : null,
     signInHref: appOrigin !== null ? `${appOrigin}${SIGN_IN_HREF}` : null,
   };
 }

--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -1,10 +1,18 @@
-// Tests for the host-topology decision logic (app front-door v0.1.0, P3).
+// Tests for the host-topology decision logic (app front-door v0.1.0, P3;
+// portable default flipped in #259 P3).
 //
-// The core property, matching the seam convention everywhere else in this
-// codebase: with none of APP_HOST / MARKETING_HOST / APP_ONLY set, every
-// (host, path) pair resolves to `serve` — no withholding, no rewrites,
-// anywhere. The full matrix (two-host split × every route class, app-only ×
-// every route class, unmatched hosts, partial configuration) is pinned below.
+// THE CORE PROPERTY CHANGED, and this file is where the change is pinned.
+// It used to be "with none of APP_HOST / MARKETING_HOST / APP_ONLY set,
+// every (host, path) pair resolves to `serve`". The portable default is now
+// APP-ONLY: an instance that configures nothing withholds the marketing
+// routes and hops `/` to `/ask`, because the marketing face is the
+// reference deployment's own website rather than part of what an instance
+// ships. The former default did not disappear — it is `SERVE_MARKETING=1`,
+// and both halves are pinned side by side below.
+//
+// The full matrix (two-host split × every route class, app-only × every
+// route class, UNNAMED hosts in both knob states, partial configuration,
+// and the canonicalization non-interaction) is pinned below.
 //
 // Run with: npm test
 
@@ -23,6 +31,7 @@ import {
   resolveAppOrigin,
   resolveAskHref,
   resolveDashboardHref,
+  instanceServesMarketing,
   resolveHostRole,
   resolvePublicSiteHref,
   APP_PRIVATE_PATHS,
@@ -38,7 +47,16 @@ const SPLIT = readHostRoutingConfig({
   MARKETING_HOST: 'example.org',
 });
 const APP_ONLY = readHostRoutingConfig({ APP_ONLY: '1' });
+/** Nothing configured — the PORTABLE DEFAULT, app-only since #259 P3. */
 const UNSET = readHostRoutingConfig({});
+/** Nothing configured but the knob: the pre-#259 pass-through default. */
+const SERVE_MARKETING = readHostRoutingConfig({ SERVE_MARKETING: '1' });
+/** A split-host instance that also keeps unnamed hosts (previews) passing through. */
+const SPLIT_SERVING = readHostRoutingConfig({
+  APP_HOST: 'app.example.org',
+  MARKETING_HOST: 'example.org',
+  SERVE_MARKETING: '1',
+});
 
 // One representative per route class, plus depth and edge variants.
 const ROOT = '/';
@@ -59,19 +77,79 @@ const OTHER_SAMPLES = [
 ];
 const EVERY_PATH = [ROOT, ...MARKETING_SAMPLES, ...APP_PRIVATE_SAMPLES, ...DUAL_SAMPLES, ...OTHER_SAMPLES];
 
-// --- Rule zero: unset config is a universal pass-through ---------------------
+// --- THE PORTABLE DEFAULT and the knob that restores the old one -------------
 
-test('unset config: every route class on every host passes through', () => {
-  const hosts = ['example.org', 'app.example.org', 'localhost:3000', 'preview-abc.vercel.app', null];
-  for (const host of hosts) {
+// Every host an unconfigured instance can be addressed on, including the
+// degenerate no-Host-header case, which takes the same branch on purpose.
+const UNNAMED_HOSTS = [
+  'example.org',
+  'app.example.org',
+  'localhost:3000',
+  'preview-abc.vercel.app',
+  '127.0.0.1:3000',
+  null,
+];
+
+test('portable default: nothing configured serves the app surface only', () => {
+  for (const host of UNNAMED_HOSTS) {
+    // The marketing face is withheld — this is the flip, and the whole
+    // reason instances need no deletion script to not ship it.
+    for (const path of MARKETING_SAMPLES) {
+      assert.deepEqual(decideRoute(host, path, UNSET), { kind: 'withhold' }, `${host} ${path}`);
+    }
+    // The app front door hops to the query mount...
+    assert.deepEqual(decideRoute(host, ROOT, UNSET), APP_ROOT_ACTION, String(host));
+    // ...and everything the app surface owns still serves.
+    for (const path of [...APP_PRIVATE_SAMPLES, ...DUAL_SAMPLES, ...OTHER_SAMPLES]) {
+      assert.deepEqual(decideRoute(host, path, UNSET), { kind: 'serve' }, `${host} ${path}`);
+    }
+  }
+});
+
+test('portable default and APP_ONLY agree on every (host, path) pair', () => {
+  // APP_ONLY stays honored as the EXPLICIT form (it is the only way to say
+  // "app-only even though a marketing host is named"), and where both apply
+  // they must not disagree — two spellings of one behavior, not two
+  // behaviors. Redundancy here is the property, not an accident.
+  for (const host of UNNAMED_HOSTS) {
     for (const path of EVERY_PATH) {
       assert.deepEqual(
         decideRoute(host, path, UNSET),
-        { kind: 'serve' },
-        `unset config must serve ${path} on host ${host}`,
+        decideRoute(host, path, APP_ONLY),
+        `${host} ${path}`,
       );
     }
   }
+});
+
+test('SERVE_MARKETING=1 restores the pre-#259 universal pass-through', () => {
+  for (const host of UNNAMED_HOSTS) {
+    for (const path of EVERY_PATH) {
+      assert.deepEqual(
+        decideRoute(host, path, SERVE_MARKETING),
+        { kind: 'serve' },
+        `SERVE_MARKETING must serve ${path} on host ${host}`,
+      );
+    }
+  }
+});
+
+test('the knob is a boolean parsed exactly like APP_ONLY — nothing else turns it on', () => {
+  for (const on of ['1', 'true', 'TRUE', ' True ']) {
+    assert.equal(readHostRoutingConfig({ SERVE_MARKETING: on }).serveMarketing, true, on);
+    assert.equal(resolveHostRole('anything.example.net', readHostRoutingConfig({ SERVE_MARKETING: on })), 'passthrough', on);
+  }
+  for (const off of [undefined, '', '0', 'false', 'yes', 'on', 'marketing']) {
+    const config = readHostRoutingConfig({ SERVE_MARKETING: off });
+    assert.equal(config.serveMarketing, false, String(off));
+    assert.equal(resolveHostRole('anything.example.net', config), 'app', String(off));
+  }
+});
+
+test('APP_ONLY beats SERVE_MARKETING: the explicit form wins over the unnamed-host default', () => {
+  const config = readHostRoutingConfig({ APP_ONLY: '1', SERVE_MARKETING: '1' });
+  assert.equal(resolveHostRole('anything.example.net', config), 'app');
+  assert.deepEqual(decideRoute('anything.example.net', '/about', config), { kind: 'withhold' });
 });
 
 // --- Split-host: the marketing host ------------------------------------------
@@ -137,10 +215,13 @@ test('the query mount is app-private: served on the app host, withheld on the ma
   assert.equal(classifyPath('/ask'), 'app-private');
   assert.deepEqual(decideRoute('app.example.org', '/ask', SPLIT), { kind: 'serve' });
   assert.deepEqual(decideRoute('example.org', '/ask', SPLIT), { kind: 'withhold' });
-  // ...and with no topology configured it serves everywhere, like every
-  // other route on a single-host instance.
+  // ...and it serves on every host under BOTH portable defaults: it is
+  // app-private, so the app role serves it, and `passthrough` serves
+  // everything. There is no instance shape on which the app front door's
+  // own destination fails to resolve.
   for (const host of ['example.org', 'app.example.org', 'localhost:3000']) {
     assert.deepEqual(decideRoute(host, '/ask', UNSET), { kind: 'serve' }, host);
+    assert.deepEqual(decideRoute(host, '/ask', SERVE_MARKETING), { kind: 'serve' }, host);
   }
 });
 
@@ -167,38 +248,95 @@ test('split: the app host passes through assets, API paths, and unknown URLs', (
 
 // --- Split-host: hosts that match neither variable ---------------------------
 
-test('split: an unmatched host (preview, IP, unnamed alias) is untouched everywhere', () => {
-  for (const host of ['preview-abc.vercel.app', '127.0.0.1:3000', 'staging.example.net']) {
+const UNMATCHED = ['preview-abc.vercel.app', '127.0.0.1:3000', 'staging.example.net'];
+
+test('split: an unmatched host takes the app role, named hosts unaffected', () => {
+  // #259 P3. A host the operator never named is not a marketing host, so on
+  // a split-host instance WITHOUT the knob it now behaves as the app
+  // surface. This is the flip's one visible effect on a configured
+  // deployment — and it is confined to hosts the configuration does not
+  // mention, which is exactly the blast radius the knob was shaped for.
+  for (const host of UNMATCHED) {
+    for (const path of MARKETING_SAMPLES) {
+      assert.deepEqual(decideRoute(host, path, SPLIT), { kind: 'withhold' }, `${host} ${path}`);
+    }
+    assert.deepEqual(decideRoute(host, ROOT, SPLIT), APP_ROOT_ACTION, host);
+  }
+});
+
+test('split + SERVE_MARKETING: unmatched hosts are untouched, named hosts still split', () => {
+  // The reference deployment's shape: preview URLs match neither variable
+  // and cannot be made to (they are minted per deployment), so the knob is
+  // the only thing that keeps them serving both route groups.
+  for (const host of UNMATCHED) {
     for (const path of EVERY_PATH) {
-      assert.deepEqual(decideRoute(host, path, SPLIT), { kind: 'serve' }, `${host} ${path}`);
+      assert.deepEqual(decideRoute(host, path, SPLIT_SERVING), { kind: 'serve' }, `${host} ${path}`);
+    }
+  }
+  // ...while the NAMED hosts behave identically with and without the knob.
+  for (const host of ['app.example.org', 'example.org', 'www.example.org']) {
+    for (const path of EVERY_PATH) {
+      assert.deepEqual(
+        decideRoute(host, path, SPLIT_SERVING),
+        decideRoute(host, path, SPLIT),
+        `${host} ${path}`,
+      );
     }
   }
 });
 
-test('a missing Host header is passthrough, never a role', () => {
-  assert.deepEqual(decideRoute(null, '/dashboard', SPLIT), { kind: 'serve' });
-  assert.deepEqual(decideRoute(undefined, '/', SPLIT), { kind: 'serve' });
+test('a missing Host header takes the unnamed-host branch, in both knob states', () => {
+  // Maximally unnamed: it matched nothing, so it gets whatever an unnamed
+  // host gets. Splitting it out would leave the withholding with a hole
+  // that depends on whether a client sent a header HTTP/1.1 requires.
+  assert.deepEqual(decideRoute(null, '/dashboard', SPLIT), { kind: 'serve' }); // app role serves it
+  assert.deepEqual(decideRoute(null, '/about', SPLIT), { kind: 'withhold' });
+  assert.deepEqual(decideRoute(undefined, '/', SPLIT), APP_ROOT_ACTION);
+  assert.equal(resolveHostRole(null, SPLIT), 'app');
+  assert.equal(resolveHostRole(undefined, SPLIT_SERVING), 'passthrough');
+  assert.deepEqual(decideRoute(null, '/about', SPLIT_SERVING), { kind: 'serve' });
 });
 
 // --- Partial configuration ----------------------------------------------------
 
-test('APP_HOST alone: app role on that host, NO withholding anywhere else', () => {
+test('APP_HOST alone: app role on that host, and on every unnamed host too', () => {
   const config = readHostRoutingConfig({ APP_HOST: 'app.example.org' });
   // The app host takes its role...
   assert.deepEqual(decideRoute('app.example.org', '/about', config), { kind: 'withhold' });
-  assert.deepEqual(decideRoute('app.example.org', '/', config), { kind: 'redirect', destination: '/ask' });
-  // ...and every other host keeps today's behavior — withholding on the
-  // marketing face starts only when MARKETING_HOST is set (incremental
-  // rollout: stand up the app host first, flip the apex second).
+  assert.deepEqual(decideRoute('app.example.org', '/', config), APP_ROOT_ACTION);
+  // ...and since #259 P3 so does every host the operator has not named,
+  // because naming NO marketing host is now a statement rather than a gap.
+  for (const path of MARKETING_SAMPLES) {
+    assert.deepEqual(decideRoute('example.org', path, config), { kind: 'withhold' }, path);
+  }
+});
+
+test('APP_HOST alone + SERVE_MARKETING: the incremental-rollout stage, unnamed hosts intact', () => {
+  // The rollout sequence gained a step at the front: set SERVE_MARKETING
+  // FIRST, then APP_HOST, then MARKETING_HOST. This pins the middle stage —
+  // the app host verifiable in isolation while the apex still serves
+  // everything, which is what made the old sequence safe.
+  const config = readHostRoutingConfig({ APP_HOST: 'app.example.org', SERVE_MARKETING: '1' });
+  assert.deepEqual(decideRoute('app.example.org', '/about', config), { kind: 'withhold' });
   for (const path of EVERY_PATH) {
     assert.deepEqual(decideRoute('example.org', path, config), { kind: 'serve' }, path);
   }
 });
 
-test('MARKETING_HOST alone: withholding on that host, all other hosts untouched', () => {
+test('MARKETING_HOST alone: withholding on that host, unnamed hosts take the app role', () => {
   const config = readHostRoutingConfig({ MARKETING_HOST: 'example.org' });
   assert.deepEqual(decideRoute('example.org', '/dashboard', config), { kind: 'withhold' });
   assert.deepEqual(decideRoute('example.org', '/', config), { kind: 'serve' });
+  // The named marketing host still serves the marketing face; an unnamed
+  // host no longer does.
+  assert.deepEqual(decideRoute('example.org', '/about', config), { kind: 'serve' });
+  assert.deepEqual(decideRoute('app.example.org', '/about', config), { kind: 'withhold' });
+  assert.deepEqual(decideRoute('app.example.org', '/dashboard', config), { kind: 'serve' });
+});
+
+test('MARKETING_HOST alone + SERVE_MARKETING: unnamed hosts untouched', () => {
+  const config = readHostRoutingConfig({ MARKETING_HOST: 'example.org', SERVE_MARKETING: '1' });
+  assert.deepEqual(decideRoute('example.org', '/dashboard', config), { kind: 'withhold' });
   for (const path of EVERY_PATH) {
     assert.deepEqual(decideRoute('app.example.org', path, config), { kind: 'serve' }, path);
   }
@@ -243,13 +381,18 @@ test('host matching is case-, port-, and www-insensitive', () => {
 });
 
 test('config values accept a full origin as well as a bare host', () => {
-  const config = readHostRoutingConfig({
+  const origins = {
     APP_HOST: 'https://app.example.org/',
     MARKETING_HOST: 'http://localhost:3000',
-  });
+  };
+  const config = readHostRoutingConfig(origins);
   assert.equal(resolveHostRole('app.example.org', config), 'app');
   assert.equal(resolveHostRole('localhost:4000', config), 'marketing'); // port never participates in matching
-  assert.equal(resolveHostRole('other.example.org', config), 'passthrough');
+  assert.equal(resolveHostRole('other.example.org', config), 'app'); // unnamed → the portable default
+  assert.equal(
+    resolveHostRole('other.example.org', readHostRoutingConfig({ ...origins, SERVE_MARKETING: '1' })),
+    'passthrough',
+  );
 });
 
 test('normalizeHost edge cases', () => {
@@ -293,8 +436,85 @@ test('classifyPath covers every declared prefix and resists prefix collisions', 
 
 // --- URL helpers (AppChrome exit link, device-flow pairing origin) ---------------
 
-test('resolvePublicSiteHref: unset topology keeps the relative link', () => {
-  assert.equal(resolvePublicSiteHref({}), '/');
+// --- instanceServesMarketing: the predicate the chrome branches on -----------
+
+test('instanceServesMarketing mirrors resolveHostRole row for row', () => {
+  // Explicit app-only: no, whatever else is set.
+  assert.equal(instanceServesMarketing({ APP_ONLY: '1' }), false);
+  assert.equal(instanceServesMarketing({ APP_ONLY: '1', MARKETING_HOST: 'example.org' }), false);
+  assert.equal(instanceServesMarketing({ APP_ONLY: '1', SERVE_MARKETING: '1' }), false);
+  // A NAMED marketing host serves marketing, on that host — true on both
+  // hosts of a split instance, because the hrefs it gates are absolute.
+  assert.equal(instanceServesMarketing({ MARKETING_HOST: 'example.org' }), true);
+  assert.equal(
+    instanceServesMarketing({ APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }),
+    true,
+  );
+  // No marketing host named: the unnamed-host default decides.
+  assert.equal(instanceServesMarketing({ SERVE_MARKETING: '1' }), true);
+  assert.equal(instanceServesMarketing({ APP_HOST: 'app.example.org', SERVE_MARKETING: '1' }), true);
+  assert.equal(instanceServesMarketing({}), false); // ← the flip
+  assert.equal(instanceServesMarketing({ APP_HOST: 'app.example.org' }), false);
+  // Empty/whitespace values are unset, exactly as everywhere else here.
+  assert.equal(instanceServesMarketing({ MARKETING_HOST: '   ', SERVE_MARKETING: '' }), false);
+});
+
+test('instanceServesMarketing agrees with what decideRoute actually serves', () => {
+  // The predicate must not become a second, drifting reading of the
+  // topology: whenever it says a marketing surface exists, SOME host must
+  // actually serve a marketing path, and when it says none does, none may.
+  const cases: Array<[Record<string, string | undefined>, string[]]> = [
+    [{}, ['example.org', 'app.example.org', 'anything.example.net']],
+    [{ SERVE_MARKETING: '1' }, ['example.org', 'anything.example.net']],
+    [{ APP_ONLY: '1' }, ['example.org', 'anything.example.net']],
+    [{ APP_HOST: 'app.example.org' }, ['app.example.org', 'other.example.net']],
+    [{ APP_HOST: 'app.example.org', MARKETING_HOST: 'example.org' }, ['example.org', 'app.example.org']],
+  ];
+  for (const [env, hosts] of cases) {
+    const config = readHostRoutingConfig(env);
+    const anyHostServesMarketing = hosts.some(
+      (h) => decideRoute(h, '/about', config).kind === 'serve',
+    );
+    assert.equal(
+      instanceServesMarketing(env),
+      anyHostServesMarketing,
+      `predicate disagrees with routing for ${JSON.stringify(env)}`,
+    );
+  }
+});
+
+// --- Chrome affordances -------------------------------------------------------
+
+test('resolvePublicSiteHref: nothing configured now HIDES the exit link (#259 P3)', () => {
+  // It used to return '/', and after the flip '/' is the path that redirects
+  // to /ask — so the "Public site" exit out of the app would have led back
+  // into the app, past no error, to no public site. AppChrome guards on
+  // this exact null.
+  assert.equal(resolvePublicSiteHref({}), null);
+  assert.equal(resolvePublicSiteHref({ APP_HOST: 'app.example.org' }), null);
+});
+
+test('resolvePublicSiteHref: SERVE_MARKETING keeps the relative link', () => {
+  assert.equal(resolvePublicSiteHref({ SERVE_MARKETING: '1' }), '/');
+  assert.equal(resolvePublicSiteHref({ APP_HOST: 'app.example.org', SERVE_MARKETING: '1' }), '/');
+});
+
+test('resolvePublicSiteHref never points at a path the same config withholds or hops', () => {
+  // The property the '/' regression violated, stated directly: whatever
+  // this returns as a RELATIVE path must `serve` on every host that config
+  // can produce. An absolute origin is out of scope — it names another host.
+  for (const env of [{}, { SERVE_MARKETING: '1' }, { APP_ONLY: '1' }, { APP_HOST: 'app.example.org' }]) {
+    const href = resolvePublicSiteHref(env);
+    if (href === null || href.startsWith('http')) continue;
+    const config = readHostRoutingConfig(env);
+    for (const host of ['example.org', 'app.example.org', 'anything.example.net']) {
+      assert.deepEqual(
+        decideRoute(host, href, config),
+        { kind: 'serve' },
+        `${JSON.stringify(env)} → ${href} does not serve on ${host}`,
+      );
+    }
+  }
 });
 
 test('resolvePublicSiteHref: split-host points at the marketing origin', () => {
@@ -307,6 +527,28 @@ test('resolvePublicSiteHref: split-host points at the marketing origin', () => {
 
 test('resolvePublicSiteHref: app-only hides the affordance (null)', () => {
   assert.equal(resolvePublicSiteHref({ APP_ONLY: '1', MARKETING_HOST: 'example.org' }), null);
+  // ...and the explicit form still beats the knob.
+  assert.equal(resolvePublicSiteHref({ APP_ONLY: '1', SERVE_MARKETING: '1' }), null);
+});
+
+test('the app-private hrefs are UNCHANGED by the flip (audited, not assumed)', () => {
+  // Both name app-private paths, and the flip gives an unnamed host the role
+  // that SERVES app-private paths — so the relative fallbacks were already
+  // right. Pinned so a future edit cannot quietly move them onto the
+  // marketing predicate, which would be wrong for a different reason.
+  for (const env of [{}, { SERVE_MARKETING: '1' }, { APP_ONLY: '1' }]) {
+    const config = readHostRoutingConfig(env);
+    for (const href of [resolveDashboardHref(env), resolveAskHref(env)]) {
+      assert.ok(!href.startsWith('http'), `${JSON.stringify(env)} → ${href} should stay relative`);
+      for (const host of ['example.org', 'anything.example.net']) {
+        assert.deepEqual(
+          decideRoute(host, href, config),
+          { kind: 'serve' },
+          `${JSON.stringify(env)} → ${href} does not serve on ${host}`,
+        );
+      }
+    }
+  }
 });
 
 test('resolveDashboardHref: relative today and on app-only; app origin on a split host', () => {
@@ -448,20 +690,48 @@ test('canonicalize TERMINATES: the destination host is itself canonical, one hop
   }
 });
 
-test('canonicalize: rule zero — nothing configured, nothing canonicalized', () => {
-  for (const host of ['www.example.org', 'example.org', 'www.app.example.org']) {
-    for (const path of EVERY_PATH) {
-      assert.deepEqual(decideRoute(host, path, UNSET), { kind: 'serve' }, `${host} ${path}`);
+test('canonicalize: nothing configured, nothing canonicalized — in either knob state', () => {
+  // #259 P3 made this worth stating as its own property rather than folding
+  // it into "everything serves". An unnamed host now has a ROLE, so for the
+  // first time the canonicalization question is live on one — and the
+  // answer must still be "never", because `matchedOrigin` keys on the MATCH
+  // and not on the role. The assertion is therefore about the ABSENCE of a
+  // host hop, not about the path decision, which legitimately differs.
+  for (const config of [UNSET, SERVE_MARKETING]) {
+    for (const host of ['www.example.org', 'example.org', 'www.app.example.org', 'WWW.Example.Org']) {
+      for (const path of EVERY_PATH) {
+        assert.equal(canonicalHostRedirect(host, path, config), null, `${host} ${path}`);
+        const action = decideRoute(host, path, config);
+        assert.ok(
+          action.kind !== 'redirect' || action.destination === '/ask',
+          `${host} ${path} must never redirect to another HOST (got ${JSON.stringify(action)})`,
+        );
+      }
     }
   }
 });
 
-test('canonicalize: a passthrough host has no configured spelling to steer toward', () => {
-  // Preview URLs, IP health checks and unnamed aliases match no variable.
-  for (const host of ['www.preview-abc.vercel.app', 'preview-abc.vercel.app', '127.0.0.1:3000']) {
-    for (const path of EVERY_PATH) {
-      assert.deepEqual(decideRoute(host, path, SPLIT), { kind: 'serve' }, `${host} ${path}`);
+test('canonicalize: an unnamed host is never steered, whatever role it takes', () => {
+  // Preview URLs, IP health checks and unnamed aliases match no variable, so
+  // there is no configured spelling to steer them toward. Under SPLIT they
+  // now take the app role (the flip); under SPLIT_SERVING they pass
+  // through. Neither is canonicalized, and the `www.` spellings are the
+  // point — those are the ones a steer would have moved.
+  for (const config of [SPLIT, SPLIT_SERVING]) {
+    for (const host of ['www.preview-abc.vercel.app', 'preview-abc.vercel.app', '127.0.0.1:3000']) {
+      for (const path of EVERY_PATH) {
+        assert.equal(canonicalHostRedirect(host, path, config), null, `${host} ${path}`);
+        const action = decideRoute(host, path, config);
+        assert.ok(
+          action.kind !== 'redirect' || action.destination === '/ask',
+          `${host} ${path} must never redirect to another HOST (got ${JSON.stringify(action)})`,
+        );
+      }
     }
+  }
+  // ...and under the knob they are untouched entirely, as before.
+  for (const path of EVERY_PATH) {
+    assert.deepEqual(decideRoute('www.preview-abc.vercel.app', path, SPLIT_SERVING), { kind: 'serve' }, path);
   }
 });
 

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -6,10 +6,17 @@
  * no Next.js imports so the module runs under `node --test` and in the edge
  * runtime alike.
  *
- * THE SEAM CONVENTION (rule zero): with none of the three variables below
- * set, every request passes through untouched — no withholding, no
- * rewrites, anywhere. An instance that has never heard of host topology
- * behaves exactly as before this module existed.
+ * THE PORTABLE DEFAULT (#259 P3): an instance that configures NOTHING
+ * serves the app surface only. Every host it is addressed on takes the
+ * `app` role — `/` redirects to `/ask`, the marketing routes 404. The
+ * marketing face is the reference deployment's own website, not part of
+ * what an instance ships, and this is how it is withheld: by
+ * configuration, never by deleting files, so instances stay cleanly
+ * `git pull`-able.
+ *
+ * This REPLACED an earlier default (rule zero) under which nothing was
+ * configured meant every request passed through untouched. The old
+ * behavior did not disappear; it is now spelled `SERVE_MARKETING=1`.
  *
  * Configuration (all optional; host names are env-driven, never literals):
  *
@@ -22,13 +29,27 @@
  *   everything else serves byte-identically to a single-host deployment.
  * - `APP_ONLY` — `1`/`true`: a single-host instance that deploys ONLY the
  *   gated surface (no marketing site). Every request, on every host, gets
- *   the app role; `APP_HOST`/`MARKETING_HOST` are ignored.
+ *   the app role; `APP_HOST`/`MARKETING_HOST` are ignored. Redundant with
+ *   the default above for an instance that configures nothing else, and
+ *   deliberately KEPT: it is the explicit way to say "app-only even
+ *   though a marketing host is named", which the default cannot express.
+ * - `SERVE_MARKETING` — `1`/`true`: an UNNAMED host (one matching neither
+ *   `APP_HOST` nor `MARKETING_HOST`) passes through and serves both route
+ *   groups, the pre-#259 default. Governs unnamed hosts ONLY; a
+ *   configured split-host deployment is unaffected by it either way.
  *
- * Roles are claimed EXPLICITLY: a request on a host that matches neither
- * variable (a preview deployment, a health check by IP, a not-yet-flipped
- * alias) passes through — today's behavior, on purpose. Withholding is
- * topology, not security: the access gate is sign-in
- * (`SIGN_IN_ALLOWLIST`), and routes keep enforcing their own sessions.
+ * WHY THE MARKETING KNOB IS HOST-INDEPENDENT, which is the whole reason it
+ * is a boolean and not a third host name. Hosting-platform preview URLs
+ * match neither host variable, so before this change they resolved
+ * `passthrough` and served everything. Naming hosts in the preview
+ * environment would not help — a preview URL still matches neither, being
+ * freshly minted per deployment. Only a host-independent boolean can keep
+ * preview deployments serving both route groups after the flip.
+ *
+ * Roles are otherwise claimed EXPLICITLY: a named host takes the role it
+ * was named for, and nothing else changes it. Withholding is topology,
+ * not security: the access gate is sign-in (`SIGN_IN_ALLOWLIST`), and
+ * routes keep enforcing their own sessions.
  *
  * Deliberately DUAL-SERVED either way: `/evidence` and `/evidence/[slug]`
  * (public product surface — published URLs must keep resolving on the
@@ -50,10 +71,14 @@
  *  - CONFIG-DERIVED, never a literal. The canonical spelling IS the
  *    `APP_HOST` / `MARKETING_HOST` value; this module knows no host names
  *    and needs no new variable to learn one.
- *  - Rule zero survives. A `passthrough` host — a preview URL, a health
- *    check by IP, an unnamed alias — has no configured spelling to be
- *    steered toward, so it is never canonicalized. Neither is an
- *    `APP_ONLY` instance, which ignores both host variables by definition.
+ *  - UNNAMED HOSTS ARE NEVER STEERED. A preview URL, a health check by
+ *    IP, an unnamed alias — none of them matched a configured value, so
+ *    there is no spelling to steer them toward. That holds whatever role
+ *    the unnamed host ends up with: since #259 P3 an unnamed host takes
+ *    the `app` role by default rather than `passthrough`, and it is still
+ *    canonicalized nowhere, because `matchedOrigin` keys on the MATCH and
+ *    not on the role. Neither is an `APP_ONLY` instance canonicalized,
+ *    which ignores both host variables by definition.
  *  - The CORS-sensitive path families are EXEMPT — see
  *    `CANONICALIZATION_EXEMPT_PREFIXES`, which is the entire point of
  *    #263. Per the Fetch spec, a cross-origin request that meets a
@@ -108,6 +133,13 @@ export interface HostRoutingConfig {
   marketingOrigin: string | null;
   /** `APP_ONLY` flag. */
   appOnly: boolean;
+  /**
+   * `SERVE_MARKETING` flag — the role an UNNAMED host takes. True gives it
+   * `passthrough` (the pre-#259 default, and what preview deployments
+   * need); false gives it `app` (the portable default). Named hosts do not
+   * consult it.
+   */
+  serveMarketing: boolean;
 }
 
 /**
@@ -301,16 +333,30 @@ export function readHostRoutingConfig(
     appOrigin: originFromHostValue(env.APP_HOST),
     marketingOrigin: originFromHostValue(env.MARKETING_HOST),
     appOnly: parseBooleanFlag(env.APP_ONLY),
+    serveMarketing: parseBooleanFlag(env.SERVE_MARKETING),
   };
 }
 
 /**
  * Which role does this request's host get?
  *
- * Precedence: `APP_ONLY` beats host matching; `APP_HOST` beats
- * `MARKETING_HOST` if both are (mis)configured to the same value; a host
- * matching neither is `passthrough` — today's behavior, so previews and
- * unnamed aliases are never withheld from.
+ * PRECEDENCE, in evaluation order and decided rather than inherited:
+ *
+ *   1. `APP_ONLY` set             → `app`, on every host.
+ *   2. host === `APP_HOST`        → `app`.
+ *   3. host === `MARKETING_HOST`  → `marketing`.
+ *   4. otherwise (an UNNAMED host) → `SERVE_MARKETING` ? `passthrough` : `app`.
+ *
+ * Rows 1-3 are untouched by #259 P3, which is the property that makes the
+ * flip safe: a configured split-host deployment behaves exactly as it did
+ * before, and `APP_HOST` still beats `MARKETING_HOST` when both are
+ * (mis)configured to the same value.
+ *
+ * Row 4 is the flip. It used to be `passthrough` unconditionally; the
+ * portable default is now `app`, with `SERVE_MARKETING` restoring the old
+ * answer. A MISSING or unparseable Host header takes row 4 as well — it is
+ * maximally unnamed, and splitting it out would leave the withholding with
+ * a hole that depends on whether a client sent a header HTTP/1.1 requires.
  */
 export function resolveHostRole(
   rawHost: string | null | undefined,
@@ -318,10 +364,11 @@ export function resolveHostRole(
 ): HostRole {
   if (config.appOnly) return 'app';
   const host = normalizeHost(rawHost);
-  if (host === null) return 'passthrough';
-  if (config.appHost !== null && host === config.appHost) return 'app';
-  if (config.marketingHost !== null && host === config.marketingHost) return 'marketing';
-  return 'passthrough';
+  if (host !== null) {
+    if (config.appHost !== null && host === config.appHost) return 'app';
+    if (config.marketingHost !== null && host === config.marketingHost) return 'marketing';
+  }
+  return config.serveMarketing ? 'passthrough' : 'app';
 }
 
 /**
@@ -451,7 +498,9 @@ function decidePathAction(role: 'app' | 'marketing', pathname: string): RouteAct
  *
  * PRECEDENCE, decided rather than inherited from evaluation order:
  *
- *  1. `passthrough` short-circuits everything. Rule zero.
+ *  1. `passthrough` short-circuits everything — no withholding, no
+ *     canonicalization, no root hop. Since #259 P3 an unnamed host reaches
+ *     this only when `SERVE_MARKETING` says so; a named host never does.
  *  2. `withhold` beats canonicalization. A route this host does not serve
  *     404s on the spelling it was asked on. Redirecting first would spend
  *     a hop to arrive at the same 404, and would make the withheld status
@@ -511,12 +560,55 @@ export function resolveAppOrigin(env: Record<string, string | undefined>): strin
 }
 
 /**
+ * DOES THIS INSTANCE SERVE A MARKETING SURFACE AT ALL? — the predicate the
+ * chrome needs, and the one #259 P3 had to introduce because `APP_ONLY`
+ * stopped being able to answer it.
+ *
+ * Before the flip, "no marketing site" and "`APP_ONLY`" were the same
+ * statement, so every affordance that had to hide itself branched on
+ * `APP_ONLY` directly. After the flip they came apart: an instance with
+ * NOTHING configured routes as app-only while `APP_ONLY` is still false,
+ * and a consumer still asking `APP_ONLY` would take the has-a-marketing-site
+ * branch and render links into a surface that now 404s.
+ *
+ * So this asks the question the consumers actually mean, and it mirrors
+ * `resolveHostRole` row for row rather than inventing a second topology
+ * reading:
+ *
+ *   | `APP_ONLY` | `MARKETING_HOST` | `SERVE_MARKETING` | serves marketing |
+ *   | set        | any              | any               | NO  (explicit)   |
+ *   | unset      | named            | any               | YES (that host)  |
+ *   | unset      | unnamed          | set               | YES (unnamed →   |
+ *   |            |                  |                   |      passthrough)|
+ *   | unset      | unnamed          | unset             | NO  (the flip)   |
+ *
+ * INSTANCE-level, not host-level, and deliberately: every resolver in this
+ * file is env-only and host-independent (see the note in host-links.ts),
+ * because reading request headers in a layout would force the static
+ * marketing pages to render dynamically. On a split-host instance marketing
+ * IS served — on the marketing host — so this is true on BOTH hosts, and the
+ * hrefs the consumers build are absolute, which is what makes that correct.
+ */
+export function instanceServesMarketing(env: Record<string, string | undefined>): boolean {
+  if (parseBooleanFlag(env.APP_ONLY)) return false;
+  if (normalizeHost(env.MARKETING_HOST) !== null) return true;
+  return parseBooleanFlag(env.SERVE_MARKETING);
+}
+
+/**
  * Where the site header's Dashboard links should point. The header renders
  * on EVERY page — including the marketing host, where `/dashboard` is
  * withheld once a split topology is configured — so on a split-host
  * deployment the link must carry the app origin. Relative everywhere else:
  * unset topology is today's exact href, and an app-only instance serves
  * the dashboard on whatever host the request came in on.
+ *
+ * UNCHANGED BY #259 P3, audited rather than assumed. The relative fallback
+ * names an APP-PRIVATE path, and the flip gives an unnamed host the `app`
+ * role — the role that SERVES app-private paths — so the href was already
+ * right for the post-flip default. The `APP_ONLY` branch stays: here it
+ * answers "where does the app surface live", not "does a marketing surface
+ * exist", and only the latter question moved.
  */
 export function resolveDashboardHref(env: Record<string, string | undefined>): string {
   if (parseBooleanFlag(env.APP_ONLY)) return '/dashboard';
@@ -533,6 +625,12 @@ export function resolveDashboardHref(env: Record<string, string | undefined>): s
  * href there is a 404, so a split-host instance must carry the app origin.
  * Relative everywhere else: unset topology serves `/ask` on whatever host the
  * request arrived on, and an app-only instance is its own app host.
+ *
+ * UNCHANGED BY #259 P3, for `resolveDashboardHref`'s reason exactly —
+ * `/ask` is app-private, an unnamed host now takes the role that serves
+ * app-private paths, and the relative fallback lands on a route that
+ * serves. It is also the destination `APP_ROOT_ACTION` sends `/` to, so
+ * this href and the root hop cannot disagree.
  */
 export function resolveAskHref(env: Record<string, string | undefined>): string {
   if (parseBooleanFlag(env.APP_ONLY)) return '/ask';
@@ -543,16 +641,23 @@ export function resolveAskHref(env: Record<string, string | undefined>): string 
 /**
  * Where the app surface's "Public site" affordances should point (the
  * `AppChrome` exit link):
- * - app-only instance → null: there IS no public marketing site — hide the
- *   affordance rather than link a gated user to a 404 or back to the
- *   dashboard.
+ * - instance serves no marketing surface → null: there IS no public site —
+ *   hide the affordance rather than link a gated user to a 404 or back to
+ *   the dashboard. `AppChrome` guards on exactly this null.
  * - split-host → the marketing origin.
- * - no topology configured → `/` (today's relative link, byte-identical).
+ * - unnamed hosts passing through (`SERVE_MARKETING`) → `/`, the relative
+ *   link this has always emitted for a single-host instance.
+ *
+ * THE GATE MOVED FROM `APP_ONLY` TO `instanceServesMarketing` (#259 P3),
+ * and it had to. Left on `APP_ONLY`, an instance with nothing configured
+ * would have returned `/` — and `/` is precisely the path that now
+ * redirects to `/ask`. The exit link out of the app would have led back
+ * into the app: one hop, no error, and no public site at the end of it.
  */
 export function resolvePublicSiteHref(
   env: Record<string, string | undefined>,
 ): string | null {
-  if (parseBooleanFlag(env.APP_ONLY)) return null;
+  if (!instanceServesMarketing(env)) return null;
   const marketingOrigin = originFromHostValue(env.MARKETING_HOST);
   if (marketingOrigin !== null) return marketingOrigin;
   return '/';

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,8 +28,13 @@ const NOT_FOUND_ROUTE = '/_not-found';
  * interception file convention, and the old name emits a deprecation
  * warning on every build. Same standard mechanism, current name.
  *
- * With none of APP_HOST / MARKETING_HOST / APP_ONLY set, every request
- * resolves to `serve` and this proxy is a pass-through.
+ * THE DEFAULT CHANGED IN #259 P3. With nothing configured, every request
+ * now resolves to the APP role: `/` redirects to `/ask` and the marketing
+ * routes 404, because the marketing face is the reference deployment's own
+ * website rather than part of what an instance ships. The former default —
+ * every request a pass-through — is now spelled `SERVE_MARKETING=1`, which
+ * governs hosts matching neither `APP_HOST` nor `MARKETING_HOST` and is
+ * what keeps preview deployments serving both route groups.
  */
 export function proxy(request: NextRequest) {
   const action = decideRoute(


### PR DESCRIPTION
Sprint #259 phase 3 — the charter's headline change. Makes the **portable default app-only**: a deployment that has never heard of host topology now serves the app surface and withholds the marketing site, instead of serving everything.

Refs #259. Does not close it — P4 (chrome relocation) still follows.

## What changed, and what deliberately did not

The switch already existed (`APP_ONLY=1`, shipped and tested). What was missing was the *default*. Today an unnamed host resolves `passthrough` and everything serves; after this, it takes the `app` role unless told otherwise.

```
APP_ONLY set                     → app everywhere        (unchanged)
host == APP_HOST                 → app                   (unchanged)
host == MARKETING_HOST           → marketing             (unchanged)
otherwise (incl. no Host header) → SERVE_MARKETING ? passthrough : app     ← the flip
```

**Named hosts never consult the new knob**, so a configured split-host deployment is bit-for-bit unchanged — asserted by a test that walks every `(host, path)` pair for named hosts and requires both knob states to agree.

This is the flip half of an **expand→flip**: the reference deployment set `SERVE_MARKETING=1` in its hosting environment (Production and Preview) before this code existed to read it, so there is no window in which it is unprotected.

### Why the knob is host-independent

Preview-deployment URLs match neither `APP_HOST` nor `MARKETING_HOST`. Setting those variables in a Preview environment would not help, because a preview URL still matches neither — so only a host-independent boolean keeps preview deployments serving both route groups after the flip. That shape is the reason the knob exists, and it is why `SERVE_MARKETING` governs unnamed hosts and nothing else.

### Two judgment calls, both pinned by tests

- **A missing or unparseable `Host` header now takes the unnamed-host row** rather than staying `passthrough`. It is maximally unnamed, and excepting it would leave a hole in the withholding keyed on whether a client sent a header HTTP/1.1 already requires.
- **`APP_ONLY` is kept and honored**, not deprecated into the new default. It remains the way to say "app-only *even though* a marketing host is named." A test asserts it and the new default produce identical decisions wherever both apply — two spellings of one behavior, not two behaviors.

## The consumer audit — the larger half of this change

A flip that routes correctly while leaving dead links in the chrome is not done. Nine call sites read topology config; each was audited against the post-flip reality rather than assumed.

**Changed (2).** Both would have produced links to things that no longer exist:

- `resolvePublicSiteHref` returned `'/'` — but `/` now redirects to `/ask`, so the "Public site" *exit* link would have led back into the app, at a public site that does not exist.
- `resolveHostLinks.marketingOrigin` returned `''` (relative), rendering footer and nav links to marketing pages that now 404 on that very host.

Both are re-keyed onto a new shared predicate, `instanceServesMarketing(env)`, which mirrors `resolveHostRole` row for row: `APP_ONLY` → false; a named `MARKETING_HOST` → true (split-host still serves marketing); otherwise `SERVE_MARKETING`. The question those consumers ask is "does this instance serve a marketing surface at all" — which is what actually moved — rather than "is this app-only," which is a different question.

**Correct as-is (7), each for a stated reason:**

- `resolveDashboardHref` and `resolveAskHref` — their relative fallbacks name *app-private* paths, and the flip grants unnamed hosts precisely the role that **serves** those. Already right. Their `APP_ONLY` branch answers "where does the app surface live," which did not move.
- `allowed-origins.ts` (three sites) — every origin that module can emit must be **named by a host variable** before it exists, so a flag that names no host cannot move any answer. Wiring it in would have widened a security-relevant set on the strength of a flag naming no origin. Pinned as an equality across the knob for six environment shapes.
- `proxy.ts` — comment only, updated.

**No component changed.** All four `marketingOrigin` consumers and `AppChrome`'s exit link already guard on `!== null`, so the fix landed entirely in the resolvers.

**Canonicalization does not fire on unnamed hosts** — confirmed rather than assumed: the origin match keys on the *match*, not the role, so a role change cannot reach it. Pinned in both knob states. This mattered because the flip is the first time an unnamed host has held a non-`passthrough` role.

**The app-root hop terminates.** `/ask` serves under the app role and renders a sign-in prompt in place for signed-out visitors rather than redirecting — so the chain ends in one render.

## Docs, preflight, compose

`docs/deploy.md`'s Host topology section is rewritten for the new default: `SERVE_MARKETING` named as the one variable whose **unset state is the correct state for an instance**, a required-vs-optional column across the whole topology set, and the incremental-rollout guidance **rewritten rather than deleted** — it now opens with "set `SERVE_MARKETING=1` first," which is what incremental rollout means once unnamed hosts stop serving everything by default. It also records the follow-up that if indexing is ever enabled on a host with aliases, that is when to add a canonical link. Preflight gains a row; compose gains the bare pass-through form, where absence is itself the configured state.

## Expected after deploy

- **Preview** (knob set): unchanged — marketing paths 200, `/` renders the marketing home. A preview that starts 404ing `/about` means the knob did not reach that environment.
- **Production apex and app host** (both named): **nothing changes.** Apex `/about` 200, apex `/dashboard` 404, app host `/` 307 → `/ask`.
- **A fresh instance with nothing set**: app surface only. The six marketing paths 404, `/` 307s to `/ask`, `/ask` + dashboard + `/evidence/*` serve, and the marketing links and "Public site" exit are absent from the chrome.

## Follow-ups, not blocking

- `.env.example` needs a one-line append — deliberately untouched here.
- `scripts/preflight-env.test.mjs` was outside this phase's blast zone, so its topology loop still names three variables; the new row is exercised by the compose-env check but not by that assertion.

## Gates

`npm test` 736/736 · lint 0 errors (4 pre-existing warnings, none in touched files) · typecheck clean · webpack build compiles. The path-array drift guard from #265 still passes, untouched.
