### PR TITLE
fix: omit the publication date the record does not have (#256)

### DIFF
--- a/src/app/(app)/evidence/[slug]/page.tsx
+++ b/src/app/(app)/evidence/[slug]/page.tsx
@@ -27,6 +27,10 @@ import DashboardLink from '@/components/evidence/DashboardLink';
 import ProvenanceGraphSection from '@/components/evidence/ProvenanceGraphSection';
 import NotebookSection from '@/components/evidence/NotebookSection';
 import SkillSection from '@/components/evidence/SkillSection';
+// Machine-readable metadata shapes (JSON-LD + Highwire citation tags). Pure
+// builders in lib so the SHAPE is unit-testable — including what it omits
+// (#256: no publication date is stored, so none is asserted).
+import { buildEvidenceJsonLd, buildEvidenceCitationTags } from '@/lib/evidence/page-metadata';
 import { formatModelName, estimateCostUsd } from '@/lib/models';
 import { formatDataSourcesSummary } from '@/lib/evidence/data-sources';
 import { isBlobRef, fetchBlobRefText, type BlobRef } from '@/lib/evidence/blob-ref';
@@ -149,12 +153,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       title: `Evidence: ${record.title}`,
       description,
     },
-    other: {
-      'citation_title': record.title,
-      'citation_author': creator?.displayName || 'Unknown',
-      'citation_date': record.createdAt.toISOString().split('T')[0],
-      ...(url ? { 'citation_public_url': url } : {}),
-    },
+    // Highwire-Press citation tags — what Zotero and Google Scholar read.
+    // #256: no `citation_date`. That tag is a publication-date assertion in
+    // this vocabulary, and no publication timestamp is stored (`created_at` is
+    // row-insert time = SEAL time for a sealed-then-published record). Its
+    // absence is deliberate and unconditional; see lib/evidence/page-metadata.ts.
+    other: buildEvidenceCitationTags({
+      title: record.title,
+      creatorName: creator?.displayName || 'Unknown',
+      url,
+    }),
   };
 }
 
@@ -227,6 +235,12 @@ export default async function EvidencePage({ params }: PageProps) {
   // (the vast majority of historical records), `resolution.pkg === pkg`
   // modulo the shallow clone.
   const renderPkg = resolution?.pkg ?? pkg;
+  // Byline date. Deliberately LEFT as `created_at` by #256, and deliberately
+  // left UNLABELLED: it names no field, so unlike `datePublished`,
+  // `citation_date`, and the former "Published on" row it asserts nothing a
+  // machine or a citation manager will read as a publication date. Not an
+  // oversight in the #256 sweep — the other three sites were changed and this
+  // one was examined and kept.
   const dateStr = record.createdAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
   // Absolute, publicly-fetchable commitment endpoint for the verify badge
@@ -264,16 +278,20 @@ export default async function EvidencePage({ params }: PageProps) {
 
   // Schema.org JSON-LD. `url` only when this instance declared an origin
   // (#258: honest omission, never another deployment's URL).
+  // #256 applies the same rule to dates: the block carries NO `datePublished`,
+  // because no publication timestamp is stored — `created_at` is row-insert
+  // time, which for a record sealed first and published later is the SEAL
+  // time. `datePublished` is exactly the field search engines and citation
+  // tooling read to date a work, so emitting seal time there is a
+  // machine-readable false claim. Absent on purpose, not an oversight; the
+  // reasoning and the regression tests live in lib/evidence/page-metadata.ts.
   const jsonLdOrigin = getEvidenceSiteOrigin();
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'Dataset',
-    name: record.title,
-    description: record.summary,
-    creator: { '@type': 'Person', name: creator?.displayName || 'Unknown' },
-    datePublished: record.createdAt.toISOString().split('T')[0],
-    ...(jsonLdOrigin ? { url: `${jsonLdOrigin}/evidence/${slug}` } : {}),
-  };
+  const jsonLd = buildEvidenceJsonLd({
+    title: record.title,
+    summary: record.summary,
+    creatorName: creator?.displayName || 'Unknown',
+    url: jsonLdOrigin ? `${jsonLdOrigin}/evidence/${slug}` : null,
+  });
 
   return (
     <>
@@ -661,11 +679,21 @@ export default async function EvidencePage({ params }: PageProps) {
               borderRadius: '6px', backgroundColor: 'white',
               fontSize: '13px', lineHeight: 1.7, color: 'var(--text-secondary)',
             }}>
-              <div>
-                <strong style={{ color: 'var(--text-primary)' }}>Published</strong>
-                {' on '}
-                {record.createdAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-              </div>
+              {/* #256: the "Published on <date>" row that used to lead this
+                  list is gone. It rendered `created_at` — row-insert time,
+                  which for a record sealed first and published later is the
+                  SEAL time, not the publication date. Omitted rather than
+                  relabelled: every remaining row here is a signed lifecycle
+                  event resolved from the attestation chain, so a row sourced
+                  from an unsigned column of a different kind reads as the same
+                  claim without being one. Relabelling it "Created on" would
+                  stay technically true while a reader skimming a
+                  Published→Withdrawn sequence still takes the first date as the
+                  publication — the misread survives the wording fix (design
+                  principles 3 "no false precision" and 7 "three orthogonal
+                  axes"). "Sealed on" is ruled out separately by principle 9:
+                  the seal/publish split is implementation language. The
+                  record's date is still visible, unlabelled, in the byline. */}
               <div>
                 <strong style={{ color: 'var(--text-primary)' }}>Withdrawn</strong>
                 {' on '}

--- a/src/lib/evidence/page-metadata.test.ts
+++ b/src/lib/evidence/page-metadata.test.ts
@@ -1,0 +1,117 @@
+// Unit tests for the evidence detail page's machine-readable metadata
+// builders (#256, #258).
+//
+// The load-bearing assertions here are NEGATIVE: these blocks must not carry a
+// publication date, because no publication timestamp is stored. A defect of
+// that shape reads as a plain field on an object literal and would return
+// silently under any refactor, so it gets a named test rather than a comment.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildEvidenceJsonLd,
+  buildEvidenceCitationTags,
+} from './page-metadata.ts';
+
+const RECORD = {
+  title: 'NYC 311 noise complaints by borough, 2025',
+  summary:
+    'Counts of noise complaints per borough for calendar year 2025, from NYC Open Data 311 Service Requests (erm2-nwe9).',
+  creatorName: 'A. Analyst',
+  url: 'https://example.org/evidence/nyc-311-noise-by-borough-2025',
+};
+
+// --- schema.org JSON-LD ---------------------------------------------------
+
+test('buildEvidenceJsonLd: emits a schema.org Dataset with title, summary and creator', () => {
+  const jsonLd = buildEvidenceJsonLd(RECORD);
+
+  assert.equal(jsonLd['@context'], 'https://schema.org');
+  assert.equal(jsonLd['@type'], 'Dataset');
+  assert.equal(jsonLd.name, RECORD.title);
+  assert.equal(jsonLd.description, RECORD.summary);
+  assert.deepEqual(jsonLd.creator, { '@type': 'Person', name: 'A. Analyst' });
+});
+
+test('buildEvidenceJsonLd: asserts NO publication date (#256)', () => {
+  const jsonLd = buildEvidenceJsonLd(RECORD);
+
+  // The specific field search engines and citation tooling read to date a
+  // work. `evidence_records` stores no publication timestamp — only row-insert
+  // time, which for a sealed-then-published record is the SEAL time. Absent on
+  // purpose; see the no-publication-date note in page-metadata.ts.
+  assert.ok(
+    !('datePublished' in jsonLd),
+    'JSON-LD must not carry datePublished — no publication timestamp is stored',
+  );
+  // The ruling was omission, not substitution: `dateCreated` was considered
+  // and rejected, so its reappearance is also a regression.
+  assert.ok(
+    !('dateCreated' in jsonLd),
+    'JSON-LD must not substitute dateCreated for the omitted publication date',
+  );
+  // Belt and braces: no date-shaped key of any spelling reintroduces the claim.
+  const dateKeys = Object.keys(jsonLd).filter((k) => /date/i.test(k));
+  assert.deepEqual(dateKeys, [], 'JSON-LD must carry no date-bearing key');
+});
+
+test('buildEvidenceJsonLd: url omitted when the instance declared no origin (#258)', () => {
+  const withUrl = buildEvidenceJsonLd(RECORD);
+  assert.equal(withUrl.url, RECORD.url);
+
+  const withoutUrl = buildEvidenceJsonLd({ ...RECORD, url: null });
+  assert.ok(
+    !('url' in withoutUrl),
+    'url key must be absent, not null — never another deployment’s URL',
+  );
+  // Omitting the URL must not disturb anything else in the block.
+  assert.equal(withoutUrl.name, RECORD.title);
+  assert.equal(withoutUrl['@type'], 'Dataset');
+});
+
+// --- Highwire-Press citation tags -----------------------------------------
+
+test('buildEvidenceCitationTags: emits title, author and public url', () => {
+  const tags = buildEvidenceCitationTags(RECORD);
+
+  assert.equal(tags.citation_title, RECORD.title);
+  assert.equal(tags.citation_author, RECORD.creatorName);
+  assert.equal(tags.citation_public_url, RECORD.url);
+});
+
+test('buildEvidenceCitationTags: asserts NO citation_date (#256)', () => {
+  const tags = buildEvidenceCitationTags(RECORD);
+
+  // `citation_date` IS a publication-date assertion in the Highwire-Press
+  // vocabulary that Zotero and Google Scholar read. Same defect as
+  // `datePublished`, same fix.
+  assert.ok(
+    !('citation_date' in tags),
+    'citation tags must not carry citation_date — no publication timestamp is stored',
+  );
+  const dateKeys = Object.keys(tags).filter((k) => /date/i.test(k));
+  assert.deepEqual(dateKeys, [], 'citation tags must carry no date-bearing key');
+});
+
+test('buildEvidenceCitationTags: citation_public_url omitted when no origin (#258)', () => {
+  const tags = buildEvidenceCitationTags({ ...RECORD, url: null });
+
+  assert.ok(
+    !('citation_public_url' in tags),
+    'citation_public_url must be absent, not empty, when no origin is declared',
+  );
+  assert.equal(tags.citation_title, RECORD.title);
+  assert.equal(tags.citation_author, RECORD.creatorName);
+});
+
+// --- Shape guard ----------------------------------------------------------
+
+test('both builders emit only string-valued keys Next.js metadata accepts', () => {
+  // `other:` values must be string | number | Array<string|number>; the
+  // citation builder is the one whose output lands there directly.
+  for (const value of Object.values(buildEvidenceCitationTags(RECORD))) {
+    assert.equal(typeof value, 'string');
+  }
+});

--- a/src/lib/evidence/page-metadata.ts
+++ b/src/lib/evidence/page-metadata.ts
@@ -1,0 +1,96 @@
+// Machine-readable metadata for the evidence detail page: the schema.org
+// JSON-LD block and the Highwire-Press citation tags. Pure shape-builders,
+// extracted from `src/app/(app)/evidence/[slug]/page.tsx` so the SHAPE is
+// unit-testable — the page itself is a server component that reaches for the
+// database and `next/headers`, so nothing in it can be asserted directly.
+//
+// The reason this file exists at all is #256: what these two blocks OMIT is
+// load-bearing, and an omission with no test is one refactor away from being
+// "restored" as an oversight. See the no-publication-date note below.
+
+/**
+ * ## Why neither builder emits a publication date (#256)
+ *
+ * `evidence_records` stores no publication timestamp. The only two timestamps
+ * on the row are `created_at` (row insert, `defaultNow()`) and `updated_at`.
+ *
+ * A record may be sealed first and published later — a supported flow with its
+ * own endpoint, `POST /api/evidence/[slug]/publish`, which writes `visibility`
+ * and `updated_at` and nothing else. For such a record `created_at` is the SEAL
+ * time, strictly earlier than publication. And a record published atomically at
+ * creation is not distinguishable from a sealed-then-published one by anything
+ * on the row, so there is no subset of records for which `created_at` could be
+ * emitted as a publication date truthfully.
+ *
+ * `datePublished` and `citation_date` are the exact fields search engines,
+ * citation managers (Zotero), and scholarly indexes read to date a work.
+ * Emitting seal time there is a false claim in machine-readable form, on a
+ * project whose premise is independently verifiable publishing.
+ *
+ * So the field is absent, unconditionally and on purpose. This is the honest
+ * omission #258 established for URLs, applied to dates: no signal, no
+ * assertion — and it matches `docs/design-principles.md` Principle 3, "if we
+ * don't actually have a signal, don't show one."
+ *
+ * DO NOT restore it, and DO NOT substitute `dateCreated` — that decision was
+ * made deliberately, not missed. A real publication timestamp is tracked
+ * separately; the raw material for it already exists off-row as the signed
+ * `releasedAt` on the `attestation/publishes/v1` node. Wiring that in is the
+ * fix, not reaching for `created_at`.
+ */
+
+export interface EvidencePageMetadataInput {
+  /** The record's title. */
+  title: string;
+  /** Display name of the record's creator; caller supplies its own fallback. */
+  creatorName: string;
+  /**
+   * Canonical public URL for this record, or `null` when this instance has
+   * declared no origin (#258 — honest omission, never another deployment's
+   * URL). Null omits the URL-bearing key entirely.
+   */
+  url: string | null;
+}
+
+export interface EvidenceJsonLdInput extends EvidencePageMetadataInput {
+  /** The record's summary, used as the Dataset description. */
+  summary: string;
+}
+
+/**
+ * schema.org JSON-LD for one evidence record.
+ *
+ * Emitted unguarded on every non-sealed evidence page, so it is the
+ * highest-reach metadata surface the record has. Carries no date — see the
+ * no-publication-date note above.
+ */
+export function buildEvidenceJsonLd(
+  input: EvidenceJsonLdInput,
+): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: input.title,
+    description: input.summary,
+    creator: { '@type': 'Person', name: input.creatorName },
+    ...(input.url ? { url: input.url } : {}),
+  };
+}
+
+/**
+ * Highwire-Press citation tags for one evidence record, shaped for the
+ * `other:` block of a Next.js `Metadata` object.
+ *
+ * These are what Zotero and Google Scholar read. `citation_date` IS a
+ * publication-date assertion in that vocabulary, so it is absent for the same
+ * reason `datePublished` is — see the no-publication-date note above.
+ */
+export function buildEvidenceCitationTags(
+  input: EvidencePageMetadataInput,
+): Record<string, string> {
+  return {
+    citation_title: input.title,
+    citation_author: input.creatorName,
+    ...(input.url ? { citation_public_url: input.url } : {}),
+  };
+}


### PR DESCRIPTION
Closes #256. Phase P1 of the #220 pre-deployment hygiene sprint.

## The defect

The evidence detail page asserted a publication date it cannot know. `record.createdAt` is row-insert time (`evidence_records.created_at`, `defaultNow()`). For a record sealed first and published later — a supported flow with its own endpoint, `POST /api/evidence/[slug]/publish` — that value is the **seal** time, strictly earlier than publication. The publish route writes `visibility` and `updated_at` and nothing else.

Three sites made that false claim, two of them machine-readable.

## Premise checked before implementing

`evidence_records` carries no publication timestamp: `created_at`, `updated_at`, and the withdrawal/reinstatement pairs are the whole set. A record published atomically at creation is **not distinguishable** from a sealed-then-published one by anything on the row — `updated_at` moves for unrelated reasons, so it carries no signal.

So the ruling's "emit the field only where it is truthful" branch has no live subset: it collapses to unconditional omission. The omission is unguarded rather than conditional, and the code says why.

## Three sites lose the assertion

| Site | Reach | Disposition |
|---|---|---|
| schema.org JSON-LD `datePublished` | Emitted on **every** non-sealed evidence page, unguarded | Removed |
| `citation_date` (Highwire-Press tags) | Read by Zotero and Google Scholar | Removed |
| "Published on «date»" row, Status History | Withdrawn-record branch only | Omitted, not relabelled |

`citation_date` is **not named in #256** — it is the same defect at a second machine-readable site, found by re-measuring rather than trusting the issue's site list. In the Highwire vocabulary `citation_date` *is* a publication-date assertion.

The Status History row is omitted rather than relabelled because every other row there is a signed lifecycle event resolved from the attestation chain; a row sourced from an unsigned column of a different kind reads as the same claim without being one. "Created on" would stay technically true while a reader skimming a Published→Withdrawn sequence still takes the first date as the publication — the misread survives the wording fix. "Sealed on" is implementation language.

## Deliberately unchanged

The **byline date** keeps `created_at`. It is unlabelled — it names no field, so unlike the three above it asserts nothing a machine or citation manager reads as a publication date. It was examined and kept, and now carries a comment saying so. Honest caveat recorded on the deep-fix issue: a date beside an author name is conventionally read as a publication date by humans even unlabelled; its reach is far lower, which is why the ruling is defensible rather than obviously right.

No schema migration, no new column, no change to the publish route, no `dateCreated` substitution.

## Finding for the deep fix

A signed publication timestamp **already exists off-row** and this page already loads it and discards it: `attestation/publishes/v1` nodes carry `releasedAt`, covered by the signature, and `resolveLifecycle` selects all attestation rows but surfaces only withdrawn/reinstated. Two caveats for whoever wires it up: emission is best-effort on the publish-at-create path (failure is swallowed with a warning), and records predating the publication-pair feature have no such node — so `releasedAt` cannot be an unconditional substitute. The deep fix needs this same honest-omission shape.

## Tests

New seam `src/lib/evidence/page-metadata.ts` + 7 tests. Pure builders with zero imports, because the page is a server component reaching for the database and `next/headers` and could not be asserted directly. A seam, not a refactor — two functions, no restructuring.

The negative assertions were **mutation-checked**: reintroducing `datePublished` and `citation_date` fails exactly those two tests and nothing else. A regression test that cannot fail is theater, and negative assertions are where that hides.

## Verification

- `npm test` — 754 pass, 0 fail (7 new)
- `npm run lint` — 4 warnings, all pre-existing and unchanged
- `npm run typecheck` — clean
- `npx next build --webpack` — exit 0, `/evidence/[slug]` builds as before

**Scope of the claim:** type-checks, builds, and is unit-covered where a pure function can cover it. Not observed in a browser, and no record with a real seal/publish gap was rendered end-to-end. The Status History change renders only in the withdrawn branch and is a JSX deletion verified by build and by reading, not by observation.
