### PR TITLE
fix: the SSE error event carries a kind, not the raw error string (#154)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,6 @@ GITHUB_CLIENT_SECRET=
 # the S3_* set, the executor variables, OIDC_*, KV_*, SITE_BRAND_*, host
 # topology, rate-limit and token-budget knobs — is enumerated by the
 # preflight and explained tier by tier in docs/deploy.md.
+# SERVE_MARKETING=1   # Serve the marketing site on hosts matching neither APP_HOST nor
+#                     # MARKETING_HOST. Leave unset on an instance — unset withholds the
+#                     # reference deployment's marketing pages.

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -458,19 +458,23 @@ test('the sign-in gate and app-tier knobs are optional with coded fallbacks', ()
   assert.ok(!result.missingRecommended.some((r) => r.name === 'APP_TIER_RATE_LIMIT'));
 });
 
-test('the host-topology trio is optional with coded fallbacks (unset = single host, no withholding)', () => {
-  // All three reproduce today's behavior when unset — the middleware passes
-  // every request through — so none may ever fail or nag a run (the P3 seam
-  // convention, same shape as the sign-in gate above).
-  for (const name of ['APP_HOST', 'MARKETING_HOST', 'APP_ONLY']) {
+test('all four host-topology variables are optional with coded fallbacks (unset = the portable default)', () => {
+  // All four have coded defaults, so none may ever fail or nag a run (the P3
+  // seam convention, same shape as the sign-in gate above). What unset MEANS
+  // changed in #259 P3 — the default is now app-only rather than passthrough —
+  // but it still means a working instance, which is what this asserts.
+  // SERVE_MARKETING joins the loop here: it was enumerated in the spec module
+  // and exercised by the compose-env check, but sat outside this assertion.
+  const TOPOLOGY = ['APP_HOST', 'MARKETING_HOST', 'APP_ONLY', 'SERVE_MARKETING'];
+  for (const name of TOPOLOGY) {
     const entry = ENV_SPEC.find((s) => s.name === name);
     assert.ok(entry, `${name} is enumerated`);
     assert.equal(entry.tier, 'optional', `${name} is optional`);
     assert.equal(entry.hasFallback, true, `${name} has a coded fallback`);
   }
-  const result = evaluateEnv(envWithAllRequired()); // all three absent
+  const result = evaluateEnv(envWithAllRequired()); // all four absent
   assert.equal(result.ok, true);
-  for (const name of ['APP_HOST', 'MARKETING_HOST', 'APP_ONLY']) {
+  for (const name of TOPOLOGY) {
     assert.ok(!result.missingRequired.some((r) => r.name === name));
     assert.ok(!result.missingRecommended.some((r) => r.name === name));
   }

--- a/src/app/api/query-notebook/route.ts
+++ b/src/app/api/query-notebook/route.ts
@@ -30,6 +30,7 @@ import {
   type CompletionResult,
   type StreamCallbacks,
 } from '@/lib/openrouter-streaming';
+import { isStreamErrorKind, type StreamErrorCode } from '@/lib/streaming';
 import { TraceBuilder, hash as traceHash, CIVICAITOOLS_TRACE_CONFIG } from '@/lib/evidence/trace';
 import { getConfiguredKeyId } from '@/lib/evidence/signing';
 import {
@@ -72,7 +73,7 @@ type NotebookEvent =
       answer: string;
       duration_ms: number;
     }
-  | { type: 'error'; message: string };
+  | { type: 'error'; message: string; code?: StreamErrorCode };
 
 function encodeNotebookEvent(event: NotebookEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
@@ -254,7 +255,15 @@ export async function POST(request: NextRequest) {
       const message = err instanceof NotebookExecutionError
         ? `Notebook execution failed (exit ${err.exitCode ?? 'n/a'}): ${err.message}${err.stderr ? `\n${stderrTail(err.stderr)}` : ''}`
         : err instanceof Error ? err.message : 'Unknown error';
-      await emit({ type: 'error', message });
+      // Phase A attaches the classified kind to its rejection (#154). Guarded
+      // rather than forwarded blind: plenty of unrelated errors carry a `code`
+      // of their own (`ENOENT`, `ERR_*`), and only a real kind belongs on the
+      // wire — anything else would just fall through to prose matching anyway.
+      const rejectionCode = err !== null && typeof err === 'object' && 'code' in err
+        ? (err as { code?: unknown }).code
+        : undefined;
+      const code = isStreamErrorKind(rejectionCode) ? rejectionCode : undefined;
+      await emit({ type: 'error', message, ...(code ? { code } : {}) });
     } finally {
       trace.endRoot();
       await writer.close();
@@ -328,9 +337,13 @@ async function runPhaseA(args: {
         }
         void emit({ type: 'phase_a_answer', content: result.content });
       },
-      onError: (panel, message) => {
+      onError: (panel, message, code) => {
         if (panel !== 'withMcp') return;
-        reject(new Error(`Phase A failed: ${message}`));
+        // `message` is already reader-facing copy and `code` the classified
+        // kind (#154). Carry the kind on the rejection so the client renders
+        // the specific copy for it rather than re-deriving a kind from this
+        // prefixed prose, which would flatten several kinds to the generic one.
+        reject(Object.assign(new Error(`Phase A failed: ${message}`), { code }));
       },
     };
 

--- a/src/hooks/useNotebookStream.ts
+++ b/src/hooks/useNotebookStream.ts
@@ -220,7 +220,14 @@ export function useNotebookStream() {
           break;
         }
         case 'error': {
-          const message = friendlyStreamError((raw.message as string | undefined) || 'Notebook generation failed');
+          // Pass the carried kind alongside the text: since #154 the Phase A
+          // failure path puts a classified `code` on the event, and the message
+          // is already reader-facing copy. Without the code, prefixed copy
+          // would be re-classified from prose and flatten to the generic line.
+          const message = friendlyStreamError({
+            message: (raw.message as string | undefined) || 'Notebook generation failed',
+            code: raw.code,
+          });
           setState((prev) => ({
             ...prev,
             error: message,

--- a/src/lib/openrouter-streaming.test.ts
+++ b/src/lib/openrouter-streaming.test.ts
@@ -13,7 +13,7 @@ import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { queryWithoutMcpStreaming, queryWithMcpStreaming, type StreamCallbacks } from './openrouter-streaming.ts';
 import { _resetDefaultModelClientForTests } from './model-client.ts';
-import type { StreamErrorCode, PanelType } from './streaming.ts';
+import { streamErrorPayload, type StreamErrorCode, type PanelType } from './streaming.ts';
 
 const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
 
@@ -70,6 +70,10 @@ test('queryWithoutMcpStreaming: missing credential yields typed onError in bound
   assert.equal(errors.length, 1);
   assert.equal(errors[0].panel, 'withoutMcp');
   assert.equal(errors[0].code, 'model_not_configured');
+  // #154: the wire carries the sanitized payload, not `error.message`. The
+  // env-var name survives because the copy for this kind names it on purpose
+  // (#178) — the reader of that message is the operator who can fix it.
+  assert.equal(errors[0].message, streamErrorPayload('model_not_configured').message);
   assert.match(errors[0].message, /OPENROUTER_API_KEY/);
   assert.ok(elapsed < BOUNDED_MS, `bounded time: took ${elapsed}ms`);
 });
@@ -125,6 +129,11 @@ test('queryWithoutMcpStreaming: upstream 401 yields typed model_auth_rejected on
     assert.equal(errors.length, 1);
     assert.equal(errors[0].panel, 'withoutMcp');
     assert.equal(errors[0].code, 'model_auth_rejected');
+    // #154: the upstream body's text reached the SSE payload before this
+    // change; now only the classified kind and its reader-facing copy do. The
+    // raw error still goes to the server log.
+    assert.equal(errors[0].message, streamErrorPayload('model_auth_rejected').message);
+    assert.ok(!errors[0].message.includes('test fixture'), 'no upstream error text on the wire');
     assert.ok(elapsed < BOUNDED_MS, `bounded time: took ${elapsed}ms`);
   } finally {
     await new Promise((resolve) => server.close(resolve));

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -1,6 +1,6 @@
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
 import { getModelClient, classifyModelError } from './model-client.ts';
-import { formatToolProgress, formatToolResult, generateToolReason, describeToolFailureForLlm, type PanelType, type ProgressPhase, type StreamErrorCode } from './streaming.ts';
+import { formatToolProgress, formatToolResult, generateToolReason, describeToolFailureForLlm, classifyStreamError, streamErrorPayload, type PanelType, type ProgressPhase, type StreamErrorCode, type StreamErrorKind } from './streaming.ts';
 import type { TraceBuilder } from './evidence/trace.ts';
 import { hash as traceHash } from './evidence/trace.ts';
 import { deriveOperationType } from './mcp/operation-types.ts';
@@ -28,19 +28,37 @@ export interface StreamCallbacks {
   onProgress: (panel: PanelType, message: string, opts?: ProgressOpts) => void;
   onToken: (panel: PanelType, content: string) => void;
   onComplete: (panel: PanelType, result: CompletionResult) => void;
-  /** `code` is set for typed configuration failures (#178, #258 C4); undefined otherwise. */
+  /**
+   * `error` is reader-facing copy, never a raw error string, and `code` carries
+   * the classified kind for every failure — not just the typed configuration
+   * refusals of #178 and #258 C4 (#154). It stays optional because callers
+   * other than `reportStreamFailure` may still omit it.
+   */
   onError: (panel: PanelType, error: string, code?: StreamErrorCode) => void;
 }
 
 /**
  * Shared failure tail for both streaming query functions: classify the error,
  * log it server-side (previously this path was silent — the error only went to
- * the SSE callback), and forward message + typed code to the caller.
+ * the SSE callback), and forward a sanitized payload to the caller.
+ *
+ * #154: this used to forward `error.message`. Every render site maps that
+ * through `friendlyStreamError`, so nothing raw was ever displayed — but the
+ * raw string still travelled on the SSE `error` event, where MCP server names,
+ * status codes and timeout text were readable in devtools. Both streaming
+ * functions funnel their failures through here, so classifying ONCE at this
+ * single chokepoint is enough: the wire now carries reader-facing copy plus
+ * the classified kind, and the raw error goes only to the server log above.
+ *
+ * `classifyModelError` runs first because it classifies structurally (a
+ * `ModelConfigurationError` instance, a 401/403 status) where the text matcher
+ * could only guess from wording; `classifyStreamError` covers everything else.
  */
 function reportStreamFailure(panel: PanelType, error: unknown, callbacks: StreamCallbacks): void {
-  const code = classifyModelError(error) ?? undefined;
-  console.error(`[stream:${panel}] query failed${code ? ` (${code})` : ''}:`, error);
-  callbacks.onError(panel, error instanceof Error ? error.message : 'Unknown error', code);
+  const kind: StreamErrorKind = classifyModelError(error) ?? classifyStreamError(error);
+  console.error(`[stream:${panel}] query failed (${kind}):`, error);
+  const { message, code } = streamErrorPayload(kind);
+  callbacks.onError(panel, message, code);
 }
 
 export interface CompletionResult {

--- a/src/lib/streaming.test.ts
+++ b/src/lib/streaming.test.ts
@@ -8,7 +8,13 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyStreamError, friendlyStreamError, describeToolFailureForLlm } from './streaming.ts';
+import {
+  classifyStreamError,
+  friendlyStreamError,
+  describeToolFailureForLlm,
+  streamErrorPayload,
+  STREAM_ERROR_KINDS,
+} from './streaming.ts';
 
 // The actual raw strings produced across the streaming/error path, paired with
 // the kind each should classify to. Sources: mcp/client.ts, compare-stream
@@ -166,4 +172,100 @@ test('#258 C4: describeToolFailureForLlm handles the unconfigured kind without l
   assert.match(text, /Do not estimate, guess, or fabricate/);
   assert.match(text, /no live data source configured/i);
   assert.ok(!text.includes('SOCRATA_MCP_URL'), 'env-var names never reach the model-relayed answer');
+});
+
+// --- #154: the wire carries a typed kind, never raw infrastructure text -----
+//
+// The defect: `friendlyStreamError` maps errors to calm copy at the RENDER
+// site, so nothing raw was ever displayed — but the raw string (MCP server
+// names, status codes, timeout text) still travelled in the SSE `error` event
+// payload, readable in devtools. The fix classifies ONCE server-side and puts
+// the friendly copy plus the classified kind on the wire.
+//
+// The naive version of that fix is a trap, and these tests exist to keep it
+// shut. Sending the friendly copy with the OLD three-code branch would have
+// made the render side re-run `classifyStreamError` on the copy itself:
+// `mcp_not_configured`, `mcp_unavailable`, `connection` and `generic` survive
+// that second pass only by lexical accident (their copy happens to contain a
+// word a matcher looks for), and the other four — including the rate-limit
+// copy that tells a reader to sign in and both operator-actionable model-key
+// messages — would silently downgrade to "Something went wrong". So these
+// assertions are pinned on the CODE path: a future copy edit cannot break
+// them, because no assertion here depends on the wording of any message.
+
+test('#154: every StreamErrorKind round-trips server -> wire -> render into its own bucket', () => {
+  // Guard the "eight kinds" this phase enumerated: a ninth must be added to
+  // STREAM_ERROR_KINDS deliberately, and the loop below then covers it.
+  assert.equal(STREAM_ERROR_KINDS.length, 8, 'the eight classified kinds');
+
+  for (const kind of STREAM_ERROR_KINDS) {
+    // `streamErrorPayload` is the exact call the server chokepoint
+    // (`reportStreamFailure`) makes, so this is the real wire shape.
+    const payload = { type: 'error', panel: 'withMcp', ...streamErrorPayload(kind) };
+    assert.equal(payload.code, kind, `wire carries the kind: ${kind}`);
+    assert.equal(classifyStreamError(payload), kind, `round-trip: ${kind}`);
+    assert.equal(friendlyStreamError(payload), payload.message, `render copy is stable: ${kind}`);
+  }
+});
+
+test('#154: the round trip is decided by the carried code, not by the copy text', () => {
+  // Pair each kind's code with a DIFFERENT kind's copy. If classification ever
+  // fell back to reading the message for a payload that carries a kind, every
+  // one of these would land in the wrong bucket.
+  const kinds = [...STREAM_ERROR_KINDS];
+  for (let i = 0; i < kinds.length; i++) {
+    const kind = kinds[i];
+    const contradictoryProse = streamErrorPayload(kinds[(i + 1) % kinds.length]).message;
+    const payload = { type: 'error', message: contradictoryProse, code: kind };
+    assert.equal(classifyStreamError(payload), kind, `code wins over prose: ${kind}`);
+    assert.equal(
+      friendlyStreamError(payload),
+      streamErrorPayload(kind).message,
+      `copy follows the code, not the message: ${kind}`,
+    );
+  }
+});
+
+test('#154: no sanitized payload carries raw infrastructure text', () => {
+  // The env-var names in the three configuration-refusal messages are the
+  // deliberate exception (#178, #258 C4): the reader of those messages is the
+  // operator who can fix them, and their own tests above assert that naming as
+  // a feature. Everything below is text only a raw error would contain.
+  const RAW_ONLY = [
+    '45s',
+    '429',
+    '502',
+    '503',
+    '504',
+    'econnrefused',
+    'enotfound',
+    'fetch failed',
+    'jsonrpc',
+    'timed out',
+    'timeout',
+    'stack',
+    'undefined',
+  ];
+  for (const kind of STREAM_ERROR_KINDS) {
+    const { message } = streamErrorPayload(kind);
+    assert.ok(message.length > 0, `non-empty copy: ${kind}`);
+    const lower = message.toLowerCase();
+    for (const fragment of RAW_ONLY) {
+      assert.ok(!lower.includes(fragment), `copy for ${kind} leaks "${fragment}": ${message}`);
+    }
+  }
+});
+
+test('#154: rollout window — a client ignoring the code still renders calm copy', () => {
+  // During a deploy, a browser running the previous bundle receives the new
+  // payload and falls back to prose matching (its code branch knows only the
+  // three configuration refusals). That fallback may land in a different
+  // bucket — it is matching copy written for readers, not for matchers — but
+  // it must always produce one of the calm strings, never raw text. This is
+  // the defense-in-depth layer doing its remaining legitimate job.
+  const CALM = new Set(STREAM_ERROR_KINDS.map((kind) => streamErrorPayload(kind).message));
+  for (const kind of STREAM_ERROR_KINDS) {
+    const staleClientView = friendlyStreamError(streamErrorPayload(kind).message);
+    assert.ok(CALM.has(staleClientView), `stale-client copy for ${kind} is calm copy`);
+  }
 });

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -49,14 +49,19 @@ export interface CompleteEvent extends StreamEvent {
 export type ModelErrorCode = 'model_not_configured' | 'model_auth_rejected';
 
 /**
- * The full set of typed pre-flight configuration-refusal codes an `error`
- * event may carry. Widens `ModelErrorCode` with:
- * - `mcp_not_configured` — no MCP endpoint for the primary data source
- *   (`SOCRATA_MCP_URL` missing or empty; #258 C4). Like the model codes,
- *   detected on the request path before any upstream call — there is no
- *   coded fallback host to route through instead.
+ * The value set the `code` field of an `error` event may carry.
+ *
+ * It began as the three typed pre-flight configuration refusals
+ * (`model_not_configured`, `model_auth_rejected` from #178,
+ * `mcp_not_configured` from #258 C4). Since #154 it is the full
+ * `StreamErrorKind` set: the server classifies every streaming failure once
+ * and puts the resulting kind on the wire, which is what lets the `message`
+ * field carry reader-facing copy instead of raw error text. This is the app's
+ * own streaming wire and carries no protocol vocabulary, so widening the
+ * accepted value set renames nothing; every consumer already treats `code` as
+ * optional and unrecognized values fall through to message-shape matching.
  */
-export type StreamErrorCode = ModelErrorCode | 'mcp_not_configured';
+export type StreamErrorCode = StreamErrorKind;
 
 export interface ErrorEvent extends StreamEvent {
   type: 'error';
@@ -74,15 +79,28 @@ export interface ErrorEvent extends StreamEvent {
 // implementation jargon; no new trust/status vocabulary). They are the single
 // place error-to-copy mapping lives, consumed by every SSE-consuming hook.
 
-export type StreamErrorKind =
-  | 'rate_limit'
-  | 'model_not_configured'
-  | 'model_auth_rejected'
-  | 'mcp_not_configured'
-  | 'mcp_timeout'
-  | 'mcp_unavailable'
-  | 'connection'
-  | 'generic';
+/**
+ * The eight kinds every streaming failure classifies into. Single-sourced as
+ * an array rather than a bare union so the round-trip test can enumerate them
+ * (#154): a ninth kind is covered by that test the moment it is added here.
+ */
+export const STREAM_ERROR_KINDS = [
+  'rate_limit',
+  'model_not_configured',
+  'model_auth_rejected',
+  'mcp_not_configured',
+  'mcp_timeout',
+  'mcp_unavailable',
+  'connection',
+  'generic',
+] as const;
+
+export type StreamErrorKind = (typeof STREAM_ERROR_KINDS)[number];
+
+/** True for a value that is one of the eight kinds (an unknown code is not). */
+export function isStreamErrorKind(value: unknown): value is StreamErrorKind {
+  return typeof value === 'string' && (STREAM_ERROR_KINDS as readonly string[]).includes(value);
+}
 
 /** Pull a lowercased message string out of any error-ish input. */
 function errorMessageOf(input: unknown): string {
@@ -105,9 +123,12 @@ function errorMessageOf(input: unknown): string {
 export function classifyStreamError(input: unknown): StreamErrorKind {
   if (input !== null && typeof input === 'object' && 'code' in input) {
     const code = (input as { code?: unknown }).code;
-    if (code === 'model_not_configured' || code === 'model_auth_rejected' || code === 'mcp_not_configured') {
-      return code;
-    }
+    // Any kind, not just the three configuration-refusal codes this branch
+    // started with (#154). The server classifies once and carries the kind, so
+    // a payload that has one is never re-derived from its own prose — which
+    // would silently downgrade the kinds whose reader-facing copy was written
+    // for readers rather than for the matchers below.
+    if (isStreamErrorKind(code)) return code;
   }
 
   const status =
@@ -116,6 +137,18 @@ export function classifyStreamError(input: unknown): StreamErrorKind {
       : undefined;
   if (status === 429) return 'rate_limit';
 
+  // --- Fallback: matching the shape of the message text --------------------
+  // Secondary by design since #154, never the primary path for a payload that
+  // carries a kind — but still load-bearing, not vestigial. It runs for every
+  // input with no `code`: an `Error` thrown client-side, an `SSEError` built
+  // from a non-2xx JSON body, a raw error handed to `describeToolFailureForLlm`
+  // server-side, and — during a rollout — a browser still running the previous
+  // bundle, whose narrower code branch recognizes only the three configuration
+  // refusals and reads the message for the rest. That client renders calm copy
+  // in every case (it is now matching against reader-facing copy, not raw
+  // text); two of the eight kinds land on the generic message until it
+  // reloads.
+  // -------------------------------------------------------------------------
   const m = errorMessageOf(input).toLowerCase();
   if (!m) return 'generic';
 
@@ -177,6 +210,17 @@ const FRIENDLY_STREAM_COPY: Record<StreamErrorKind, string> = {
 /** Map any streaming error into calm, reader-facing copy. Never leaks raw text. */
 export function friendlyStreamError(input: unknown): string {
   return FRIENDLY_STREAM_COPY[classifyStreamError(input)];
+}
+
+/**
+ * Server-side: the sanitized `error`-event payload for an already-classified
+ * failure. The message is the reader-facing copy and the code is the kind, so
+ * the raw error text never leaves the server (#154) while the render side
+ * receives the kind as data instead of re-deriving it from prose. The raw
+ * error still goes to the server log, which is where an operator reads it.
+ */
+export function streamErrorPayload(kind: StreamErrorKind): { message: string; code: StreamErrorCode } {
+  return { message: FRIENDLY_STREAM_COPY[kind], code: kind };
 }
 
 /**


### PR DESCRIPTION
Closes #154. Phase P2 of the #220 pre-deployment hygiene sprint. Two independent riders plus one owner-run follow-up.

## Rider A — the SSE error event carries a kind, not the raw error string (#154)

`friendlyStreamError` maps errors to calm copy at the **render** site, so nothing raw was ever displayed. But the raw string — MCP server names, status codes, timeout text — still travelled in the SSE `error` payload, readable in devtools.

### The chartered fix-shape was wrong, and was corrected before tests were written to it

The charter said: sanitize the text server-side, keep `friendlyStreamError` as defense-in-depth. Implemented literally — send the friendly copy in place of `error.message` — the render side re-runs `classifyStreamError` **on that copy**. Measured against the real module rather than reasoned about, by running each kind's copy back through the classifier:

| kind | naive fix (copy, no code) | this PR (copy + code) |
|---|---|---|
| `rate_limit` | **generic** — copy says "request limit", matcher wants "rate limit" | `rate_limit` |
| `model_not_configured` | **generic** — copy says "no AI model … key" | `model_not_configured` |
| `model_auth_rejected` | **generic** — copy says "rejected this server's … key" | `model_auth_rejected` |
| `mcp_timeout` | **generic** — copy says "took too long to respond" | `mcp_timeout` |
| `mcp_not_configured` | survives | `mcp_not_configured` |
| `mcp_unavailable` | survives | `mcp_unavailable` |
| `connection` | survives | `connection` |
| `generic` | survives | `generic` |

**Four of eight would have silently downgraded to "Something went wrong"** — including the rate-limit copy that tells a reader to sign in and both operator-actionable model-key messages from #178. The four that survive do so by **lexical accident**: their copy happens to contain a word a matcher looks for. That is not a contract.

### What this does instead: carry typed data, stop re-deriving it from prose

1. **Classify once, server-side.** `reportStreamFailure` is a single chokepoint — both streaming functions funnel through it — so one place, not the two the issue predicted. `classifyModelError(error) ?? classifyStreamError(error)`; the model classifier stays first because it classifies *structurally* (error instance, 401/403 status) where the text matcher could only guess. The wire gets friendly copy plus the kind; the raw error goes to `console.error`, which is where an operator reads it.
2. **Widen the code branch** from three kinds to all eight, so the render side short-circuits on the carried kind.
3. **Prose matching stays as fallback only** — never the primary path for a payload carrying a kind.

The kinds are single-sourced as `STREAM_ERROR_KINDS`, so a ninth is covered by the round-trip test the moment it is added.

### Before / after, one payload

```
BEFORE
data: {"type":"error","panel":"withMcp","message":"MCP tool call \"get_data\" timed out after 45s — the data source may be slow or unresponsive. Try a simpler query."}

AFTER
data: {"type":"error","panel":"withMcp","message":"The live data source took too long to respond, so this query couldn't finish. Try again in a moment, or narrow the question (for example, add a date range).","code":"mcp_timeout"}
```

### Deploy-window behavior: 2 of 8, and it is designed

During a rollout a browser still running the previous bundle receives the new payload. Its narrower code branch recognizes the three configuration refusals, and three more kinds still match lexically — so **two kinds (`rate_limit`, `mcp_timeout`) land on the generic copy until it reloads.** Both are calm and leak-free. This is the fallback doing its remaining legitimate job, which is why it stays and is commented as such rather than left looking vestigial.

### Tests

Four new. The headline is the eight-kind round trip, **pinned on the code path**: a second test pairs each kind's code with a *different* kind's copy, so no assertion depends on any message's wording and a copy edit cannot silently break one. Plus a no-raw-text assertion over every payload, and a rollout-window test asserting a code-ignoring client still lands on calm copy. The two existing #178 tests now assert the emitted message *equals* the payload builder's output, tying the builder to the real chokepoint; the 401 case asserts the upstream body's text is absent from the wire.

### One change outside the literal contract

`/api/query-notebook` and `useNotebookStream` now forward the kind. That route consumes the same `onError` and wraps the message as `Phase A failed: …`, so **after this change its prefixed prose would have been re-classified and flattened to the generic line** — threading the kind repairs a regression this PR would otherwise cause, rather than adding scope. Guarded with `isStreamErrorKind`, because unrelated errors carry codes of their own (`ENOENT`, `ERR_*`).

### Deliberately unchanged

- **The friendly copy strings.** This changes how the kind travels, not what the reader is told.
- **The env-var naming in the three configuration-refusal messages** — kept by design (#178, #258 C4): the reader of those messages is the person who can fix them. The test pinning that naming still passes unmodified. A "strip all infrastructure detail" reading would have deleted a deliberate affordance.
- **The pre-flight refusals in `/api/compare-stream` and `/api/query-notebook`.** Examined and left: they already carry a typed code, and their text is that same operator-actionable naming — not server names, status codes, or stack text.
- **The notebook execution stderr tail** — a deliberate debugging surface; sanitizing it is a separate disclosure decision. (Noted in passing: the hook maps it through `friendlyStreamError` anyway, so it never renders — a pre-existing inconsistency, filed rather than untangled mid-phase.)

## Rider B — the preflight topology assertion covers all four variables

`scripts/preflight-env.test.mjs` asserted over a "trio" of topology variables while the spec module enumerates four. `SERVE_MARKETING` was added to the spec by #259 P3 but sat outside that phase's blast zone, so the assertion never caught up.

Both loops now cover all four, and the two arrays are collapsed into one named constant so they cannot drift apart again. The title's other stale claim — "unset = single host, no withholding" — also went: P3 replaced passthrough with the app-only default. Mutation-checked (renaming the new entry fails the test).

## Owner follow-up, riding this branch

`.env.example` gains the `SERVE_MARKETING` line recorded on #259. Committed by the owner directly — no agent in this sprint has touched any environment-config file, deliberately, and that boundary held.

## Verification

- `npm test` — 758 pass, 0 fail (4 new)
- `npm run lint` — 4 warnings, all pre-existing and unchanged
- `npm run typecheck` — clean
- `npx next build --webpack` — exit 0

**Scope of the claim:** type-checks, builds, and unit-covered. **Nothing here was observed in a browser.** The before/after payload was produced by calling the real `encodeSSE` with the old and new construction, not captured from devtools against a running server.
