### PR TITLE
refactor(css): rename the nyc-button/nyc-field classes to ui-* (#220 P4)

### DIFF
--- a/src/app/(app)/ask/AskSignInPanel.tsx
+++ b/src/app/(app)/ask/AskSignInPanel.tsx
@@ -125,7 +125,7 @@ export default function AskSignInPanel({
               <button
                 key={option.id}
                 onClick={() => signIn(option.id, { callbackUrl: '/ask' })}
-                className="nyc-button nyc-button-primary"
+                className="ui-button ui-button-primary"
                 style={{ padding: '10px 18px', fontSize: '14px' }}
               >
                 Sign in with {option.name}

--- a/src/app/(app)/auth/device/DeviceSignInPanel.tsx
+++ b/src/app/(app)/auth/device/DeviceSignInPanel.tsx
@@ -65,7 +65,7 @@ export default function DeviceSignInPanel({
               <button
                 key={option.id}
                 onClick={() => signIn(option.id, { callbackUrl })}
-                className="nyc-button nyc-button-primary"
+                className="ui-button ui-button-primary"
                 style={{ padding: '10px 18px', fontSize: '14px' }}
               >
                 Sign in with {option.name}

--- a/src/app/(marketing)/learn/page.tsx
+++ b/src/app/(marketing)/learn/page.tsx
@@ -177,7 +177,7 @@ export default function LearnPage() {
 
         <Link
           href="/explore"
-          className="nyc-button nyc-button-primary"
+          className="ui-button ui-button-primary"
           style={{
             display: 'inline-flex',
             alignItems: 'center',
@@ -735,7 +735,7 @@ cd socrata-mcp-server && npm install && npm run build`}</pre>
             href="https://github.com/npstorey/civic-ai-tools"
             target="_blank"
             rel="noopener noreferrer"
-            className="nyc-button nyc-button-primary"
+            className="ui-button ui-button-primary"
             style={{ textDecoration: 'none' }}
           >
             View on GitHub

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
               href="https://github.com/npstorey/civic-ai-tools"
               target="_blank"
               rel="noopener noreferrer"
-              className="nyc-button nyc-button-primary"
+              className="ui-button ui-button-primary"
               style={{
                 display: 'inline-flex',
                 alignItems: 'center',
@@ -75,7 +75,7 @@ export default function Home() {
             </a>
             <Link
               href="/learn#try-it"
-              className="nyc-button nyc-button-secondary"
+              className="ui-button ui-button-secondary"
               style={{ textDecoration: 'none', fontSize: '14px', padding: '10px 24px' }}
             >
               Learn how it works

--- a/src/app/(marketing)/project/page.tsx
+++ b/src/app/(marketing)/project/page.tsx
@@ -214,7 +214,7 @@ export default function ProjectPage() {
             href={EXPRESS_INTEREST_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="nyc-button nyc-button-primary"
+            className="ui-button ui-button-primary"
             style={{
               textDecoration: 'none',
               fontSize: '14px',

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -203,7 +203,6 @@ a:focus-visible {
 }
 
 /* NYC Design System Button Base */
-.nyc-button,
 .ui-button {
   display: inline-flex;
   align-items: center;
@@ -220,15 +219,12 @@ a:focus-visible {
   transition: all 0.15s ease;
 }
 
-.nyc-button:focus-visible,
 .ui-button:focus-visible {
   outline: 2px dashed var(--accent);
   outline-offset: 2px;
 }
 
 /* Primary Button */
-.nyc-button-primary,
-.nyc-button-primary:visited,
 .ui-button-primary,
 .ui-button-primary:visited {
   background-color: var(--accent);
@@ -236,55 +232,45 @@ a:focus-visible {
   border: none;
 }
 
-.nyc-button-primary:hover,
 .ui-button-primary:hover {
   background-color: var(--accent-hover);
   color: var(--white);
 }
 
-.nyc-button-primary:disabled,
 .ui-button-primary:disabled {
   background-color: var(--neutral-70);
   cursor: not-allowed;
 }
 
 /* Secondary Button */
-.nyc-button-secondary,
 .ui-button-secondary {
   background-color: var(--white);
   color: var(--accent);
   border: 1px solid var(--neutral-80);
 }
 
-.nyc-button-secondary:hover,
 .ui-button-secondary:hover {
   color: var(--accent-hover);
   border-color: var(--neutral-70);
 }
 
-.nyc-button-secondary:disabled,
 .ui-button-secondary:disabled {
   color: var(--neutral-70);
   cursor: not-allowed;
 }
 
 /* NYC Design System Form Fields */
-.nyc-field,
 .ui-field {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.nyc-field label,
 .ui-field label {
   font-weight: 500;
   color: var(--text-primary);
 }
 
-.nyc-field input,
-.nyc-field textarea,
-.nyc-field select,
 .ui-field input,
 .ui-field textarea,
 .ui-field select {
@@ -298,9 +284,6 @@ a:focus-visible {
   transition: all 0.15s ease;
 }
 
-.nyc-field input:focus-visible,
-.nyc-field textarea:focus-visible,
-.nyc-field select:focus-visible,
 .ui-field input:focus-visible,
 .ui-field textarea:focus-visible,
 .ui-field select:focus-visible {
@@ -310,9 +293,6 @@ a:focus-visible {
   background-color: var(--accent-light);
 }
 
-.nyc-field--error input,
-.nyc-field--error textarea,
-.nyc-field--error select,
 .ui-field--error input,
 .ui-field--error textarea,
 .ui-field--error select {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -203,7 +203,8 @@ a:focus-visible {
 }
 
 /* NYC Design System Button Base */
-.nyc-button {
+.nyc-button,
+.ui-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -219,61 +220,74 @@ a:focus-visible {
   transition: all 0.15s ease;
 }
 
-.nyc-button:focus-visible {
+.nyc-button:focus-visible,
+.ui-button:focus-visible {
   outline: 2px dashed var(--accent);
   outline-offset: 2px;
 }
 
 /* Primary Button */
 .nyc-button-primary,
-.nyc-button-primary:visited {
+.nyc-button-primary:visited,
+.ui-button-primary,
+.ui-button-primary:visited {
   background-color: var(--accent);
   color: var(--white);
   border: none;
 }
 
-.nyc-button-primary:hover {
+.nyc-button-primary:hover,
+.ui-button-primary:hover {
   background-color: var(--accent-hover);
   color: var(--white);
 }
 
-.nyc-button-primary:disabled {
+.nyc-button-primary:disabled,
+.ui-button-primary:disabled {
   background-color: var(--neutral-70);
   cursor: not-allowed;
 }
 
 /* Secondary Button */
-.nyc-button-secondary {
+.nyc-button-secondary,
+.ui-button-secondary {
   background-color: var(--white);
   color: var(--accent);
   border: 1px solid var(--neutral-80);
 }
 
-.nyc-button-secondary:hover {
+.nyc-button-secondary:hover,
+.ui-button-secondary:hover {
   color: var(--accent-hover);
   border-color: var(--neutral-70);
 }
 
-.nyc-button-secondary:disabled {
+.nyc-button-secondary:disabled,
+.ui-button-secondary:disabled {
   color: var(--neutral-70);
   cursor: not-allowed;
 }
 
 /* NYC Design System Form Fields */
-.nyc-field {
+.nyc-field,
+.ui-field {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.nyc-field label {
+.nyc-field label,
+.ui-field label {
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .nyc-field input,
 .nyc-field textarea,
-.nyc-field select {
+.nyc-field select,
+.ui-field input,
+.ui-field textarea,
+.ui-field select {
   padding: 12px 16px;
   font-size: 16px;
   font-family: inherit;
@@ -286,7 +300,10 @@ a:focus-visible {
 
 .nyc-field input:focus-visible,
 .nyc-field textarea:focus-visible,
-.nyc-field select:focus-visible {
+.nyc-field select:focus-visible,
+.ui-field input:focus-visible,
+.ui-field textarea:focus-visible,
+.ui-field select:focus-visible {
   outline: none;
   border-style: dashed;
   border-color: var(--accent);
@@ -295,7 +312,10 @@ a:focus-visible {
 
 .nyc-field--error input,
 .nyc-field--error textarea,
-.nyc-field--error select {
+.nyc-field--error select,
+.ui-field--error input,
+.ui-field--error textarea,
+.ui-field--error select {
   background-color: #FEE2E2;
   border-color: var(--error);
 }

--- a/src/app/ui-class-names.test.ts
+++ b/src/app/ui-class-names.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Guard: every `ui-*` class referenced from a className attribute resolves to
+ * a selector defined in globals.css.
+ *
+ * A missing class is silent in a way a missing token is not. A mistyped
+ * custom-property reference at least leaves a declaration in the cascade
+ * (dropped, but present); a className that matches no selector renders
+ * nothing extra at all -- no build error, no console warning, no failing
+ * test, just a control that looks like every other <button> until someone
+ * opens a browser. #220 P4 moved the button/field selectors off their old
+ * city-prefixed names to this ui- prefix for exactly this reason: same
+ * failure mode as the token rename this repo already got bitten by (see
+ * design-tokens.test.ts), louder consequence.
+ *
+ * Scope is deliberately the `ui-` prefix, not "every className in the repo".
+ * Tailwind utility classes (`flex`, `gap-2`, ...) are not defined in
+ * globals.css at all -- they are compiled from usage -- so a fully general
+ * "every className must resolve" check would either false-positive on every
+ * Tailwind class or require reimplementing Tailwind's own class scanner.
+ * `ui-` is this codebase's own low-level component-class namespace, chosen
+ * in #220 P4 specifically because it collides with nothing else (checked
+ * against this repo's CSS, the bpmn-js shipped assets, and Tailwind) --
+ * which makes it a clean, false-positive-free boundary for a test.
+ *
+ * The extraction is anchored on `className="..."` / `className='...'`
+ * string-literal attribute values, not "any `ui-` text anywhere in the
+ * file" -- `fontFamily: 'ui-monospace, ...'` (a CSS system-font keyword,
+ * used in several notebook-output components) would otherwise be a false
+ * positive on day one.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(import.meta.url);
+const APP_ROOT = path.dirname(HERE);
+const SRC_ROOT = path.dirname(APP_ROOT);
+const GLOBALS_CSS = path.join(APP_ROOT, 'globals.css');
+
+/**
+ * `ui-*` classes referenced in className attributes that are legitimately
+ * NOT selectors in globals.css (e.g. handled by a different stylesheet).
+ * One line of justification each -- see design-tokens.test.ts for why this
+ * is a named allowlist rather than a pattern exclusion.
+ */
+const DEFINED_ELSEWHERE: Record<string, string> = {};
+
+const SCANNED_EXTENSIONS = /\.(tsx|ts|jsx|js)$/;
+
+function sourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return SCANNED_EXTENSIONS.test(entry.name) ? [full] : [];
+  });
+}
+
+/** `className="a b c"` or `className='a b c'` -- the plain string-literal
+ *  form used everywhere in this codebase today. Dynamic forms (template
+ *  literals, clsx()) are not present as of #220 P4; if one is introduced,
+ *  this test will not see the classes inside it, same limitation
+ *  design-tokens.test.ts accepts for var(--c-${key}) construction. */
+const CLASSNAME_ATTR = /className=["']([^"']*)["']/g;
+
+/** Every class name that appears as a selector component in globals.css,
+ *  restricted to the ui- namespace this test governs. Comments removed
+ *  first so a commented-out rule does not count as a definition. Matches
+ *  `.ui-foo` wherever it appears in a selector (base, compound like
+ *  `.ui-field input`, or pseudo-class like `.ui-button:hover`) -- the
+ *  trailing [a-zA-Z0-9-]+ stops at `:` or whitespace, so pseudo-classes
+ *  are not folded into the class name. */
+function definedUiClasses(): Set<string> {
+  const css = fs.readFileSync(GLOBALS_CSS, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+  return new Set([...css.matchAll(/\.(ui-[a-zA-Z0-9-]+)/g)].map((m) => m[1]));
+}
+
+test('every ui-* className used in src/ is defined in globals.css', () => {
+  const defined = definedUiClasses();
+  const allowed = new Set(Object.keys(DEFINED_ELSEWHERE));
+
+  const missing: string[] = [];
+
+  for (const file of sourceFiles(SRC_ROOT)) {
+    const rel = path.relative(SRC_ROOT, file);
+    const contents = fs.readFileSync(file, 'utf8');
+
+    for (const match of contents.matchAll(CLASSNAME_ATTR)) {
+      const classList = match[1].split(/\s+/).filter(Boolean);
+      for (const cls of classList) {
+        if (!cls.startsWith('ui-')) continue;
+        if (defined.has(cls) || allowed.has(cls)) continue;
+        const line = contents.slice(0, match.index).split('\n').length;
+        missing.push(`${rel}:${line}  ${cls}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    [...new Set(missing)].sort(),
+    [],
+    'These ui-* classNames match no selector in src/app/globals.css. A ' +
+      'missing class renders the element completely unstyled with no build ' +
+      'or test failure to flag it -- either add the selector to globals.css, ' +
+      'fix the className typo, or add a justified DEFINED_ELSEWHERE entry to ' +
+      'this file if the class is legitimately styled elsewhere.',
+  );
+});
+
+test('every allowlist entry is still load-bearing', () => {
+  const defined = definedUiClasses();
+  const redundant = Object.keys(DEFINED_ELSEWHERE).filter((c) => defined.has(c));
+  assert.deepEqual(
+    redundant,
+    [],
+    'These classes are now defined in globals.css, so their DEFINED_ELSEWHERE ' +
+      'entries are dead. Remove them.',
+  );
+});

--- a/src/components/DirectoryClient.tsx
+++ b/src/components/DirectoryClient.tsx
@@ -365,7 +365,7 @@ export default function DirectoryClient({ servers, portalCounts }: { servers: Mc
           href={SUGGEST_SERVER_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="nyc-button nyc-button-secondary"
+          className="ui-button ui-button-secondary"
           style={{ fontSize: '14px', padding: '8px 16px', textDecoration: 'none', whiteSpace: 'nowrap', flexShrink: 0 }}
         >
           Suggest a Server
@@ -566,7 +566,7 @@ export default function DirectoryClient({ servers, portalCounts }: { servers: Mc
           </p>
           <button
             onClick={clearFilters}
-            className="nyc-button nyc-button-secondary"
+            className="ui-button ui-button-secondary"
             style={{ fontSize: '14px', padding: '8px 16px' }}
           >
             Clear all filters

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -450,7 +450,7 @@ export default function Header({
                inactive label is hidden but keeps contributing its width. */
             <a
               href={crossHostSignedIn ? sessionProbe.openAppHref : signInHref}
-              className="nyc-button nyc-button-primary"
+              className="ui-button ui-button-primary"
               style={{
                 padding: '8px 16px',
                 fontSize: '14px',
@@ -486,7 +486,7 @@ export default function Header({
                providers the instance actually configured. */
             <a
               href={signInHref}
-              className="nyc-button nyc-button-primary"
+              className="ui-button ui-button-primary"
               style={{ padding: '8px 16px', fontSize: '14px', textDecoration: 'none' }}
             >
               Sign in
@@ -494,7 +494,7 @@ export default function Header({
           ) : signInAffordance.kind === 'provider' ? (
             <button
               onClick={() => signIn(signInAffordance.option.id)}
-              className="nyc-button nyc-button-primary"
+              className="ui-button ui-button-primary"
               style={{ padding: '8px 16px', fontSize: '14px' }}
             >
               Sign in with {signInAffordance.option.name}
@@ -502,7 +502,7 @@ export default function Header({
           ) : signInAffordance.kind === 'panel' ? (
             <a
               href={signInAffordance.href}
-              className="nyc-button nyc-button-primary"
+              className="ui-button ui-button-primary"
               style={{ padding: '8px 16px', fontSize: '14px', textDecoration: 'none' }}
             >
               Sign in

--- a/src/components/PortalDirectoryClient.tsx
+++ b/src/components/PortalDirectoryClient.tsx
@@ -606,7 +606,7 @@ export default function PortalDirectoryClient({
           </p>
           <button
             onClick={clearFilters}
-            className="nyc-button nyc-button-secondary"
+            className="ui-button ui-button-secondary"
             style={{ fontSize: '14px', padding: '8px 16px' }}
           >
             Clear all filters

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -188,7 +188,7 @@ export default function QueryForm({
   return (
     <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
       {/* Chat-style textarea with inline send button */}
-      <div className="nyc-field" style={{ position: 'relative' }}>
+      <div className="ui-field" style={{ position: 'relative' }}>
         <textarea
           id="query"
           ref={textareaRef}
@@ -402,7 +402,7 @@ export default function QueryForm({
                      loading state: the destination decides server-side. */
                   <a
                     href={signInHref}
-                    className="nyc-button nyc-button-primary"
+                    className="ui-button ui-button-primary"
                     style={{ fontSize: '13px', padding: '6px 14px', textDecoration: 'none' }}
                   >
                     Sign in
@@ -412,7 +412,7 @@ export default function QueryForm({
                   type="button"
                   onClick={() => signIn(signInAffordance.option.id)}
                   disabled={authStatus === 'loading'}
-                  className="nyc-button nyc-button-primary"
+                  className="ui-button ui-button-primary"
                   style={{
                     fontSize: '13px',
                     padding: '6px 14px',
@@ -425,7 +425,7 @@ export default function QueryForm({
                   /* More than one provider: the panel that can list them. */
                   <a
                     href={signInAffordance.href}
-                    className="nyc-button nyc-button-primary"
+                    className="ui-button ui-button-primary"
                     style={{ fontSize: '13px', padding: '6px 14px', textDecoration: 'none' }}
                   >
                     Sign in
@@ -480,7 +480,7 @@ export default function QueryForm({
 
           <div className="form-controls-row">
               {/* Model dropdown */}
-              <div className="nyc-field" ref={modelDropdownRef} style={{ position: 'relative' }}>
+              <div className="ui-field" ref={modelDropdownRef} style={{ position: 'relative' }}>
                 <label style={{ fontSize: '13px', color: 'var(--text-muted)', fontWeight: 400 }}>Model</label>
                 <button
                   type="button"
@@ -554,7 +554,7 @@ export default function QueryForm({
               </div>
 
               {/* Portal dropdown */}
-              <div className="nyc-field" ref={portalDropdownRef} style={{ position: 'relative' }}>
+              <div className="ui-field" ref={portalDropdownRef} style={{ position: 'relative' }}>
                 <label style={{ fontSize: '13px', color: 'var(--text-muted)', fontWeight: 400 }}>Data portal</label>
                 <button
                   type="button"

--- a/src/components/explore/TraceControls.tsx
+++ b/src/components/explore/TraceControls.tsx
@@ -200,7 +200,7 @@ export default function TraceControls({
           <div className="playback-bar" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             <button
               onClick={replayState.isPlaying ? onPause : onPlay}
-              className="nyc-button nyc-button-secondary"
+              className="ui-button ui-button-secondary"
               style={{ padding: '6px 16px', fontSize: '13px', minWidth: '70px' }}
             >
               {replayState.isPlaying ? 'Pause' : replayState.isComplete ? 'Replay' : 'Play'}
@@ -285,7 +285,7 @@ export default function TraceControls({
               <button
                 type="submit"
                 disabled={!liveQuery.trim()}
-                className="nyc-button nyc-button-primary"
+                className="ui-button ui-button-primary"
                 style={{
                   padding: '8px 20px',
                   fontSize: '13px',
@@ -432,7 +432,7 @@ export default function TraceControls({
               </span>
               <button
                 onClick={onLiveReplay}
-                className="nyc-button nyc-button-secondary"
+                className="ui-button ui-button-secondary"
                 style={{ padding: '6px 16px', fontSize: '13px' }}
               >
                 Replay
@@ -463,7 +463,7 @@ export default function TraceControls({
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
               <button
                 onClick={replayState.isPlaying ? onPause : onLiveReplay}
-                className="nyc-button nyc-button-secondary"
+                className="ui-button ui-button-secondary"
                 style={{ padding: '6px 16px', fontSize: '13px', minWidth: '70px' }}
               >
                 {replayState.isPlaying ? 'Pause' : replayState.isComplete ? 'Replay' : 'Play'}

--- a/src/components/home/PositioningBand.tsx
+++ b/src/components/home/PositioningBand.tsx
@@ -298,7 +298,7 @@ export default function PositioningBand() {
             href={EXPRESS_INTEREST_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="nyc-button nyc-button-primary"
+            className="ui-button ui-button-primary"
             style={{
               textDecoration: 'none',
               fontSize: '14px',

--- a/src/components/notebook/NotebookOutput.tsx
+++ b/src/components/notebook/NotebookOutput.tsx
@@ -97,7 +97,7 @@ export default function NotebookOutput({ state, prompt, model, portal, onRetry }
             <button
               type="button"
               onClick={onRetry}
-              className="nyc-button nyc-button-secondary"
+              className="ui-button ui-button-secondary"
               style={{ alignSelf: 'flex-start', fontSize: '13px', padding: '6px 14px' }}
             >
               Retry


### PR DESCRIPTION
Phase P4 of #220. P3 moved every CSS custom property off the `--nyc-*` names; the **class names** still carried it. **A rename — not one rendered style changes.**

```
.nyc-button            ->  .ui-button
.nyc-button-primary    ->  .ui-button-primary
.nyc-button-secondary  ->  .ui-button-secondary
.nyc-field             ->  .ui-field
.nyc-field--error      ->  .ui-field--error
```

## Why this phase was more dangerous than it looks

A missed **token** reference still resolved, through P3's alias layer. A missed **class** reference does not — the element silently loses its styling, with no build error, no failing test, no type error. It is invisible in CI and obvious in a browser.

So the migration used a **dual-selector expand → flip → retire**, in three separate commits so the window is visible opening and closing:

1. **Expand** — all 13 rule blocks carry both selectors, so both class names style identically and a missed usage still renders.
2. **Flip** — 49 occurrences across 12 files move to `ui-*`.
3. **Retire** — the `.nyc-*` selectors drop, only after the zero-usages grep passes.

Unlike P3's token aliases, which are retained deliberately as a compatibility surface for code outside this repo, these dual selectors were pure migration scaffold and are gone within the phase.

## The `ui-` prefix

Bare `.button` / `.field` were checked against this repo's CSS, the bpmn-js shipped assets, and Tailwind, and collide with none of them today — but they are generic enough that a future dependency could. Two characters removes that permanently, and the prefix is neutral: no city, no design system, no product name.

## Counting

`grep -o '\bnyc-button\b'` returns 55, which is wrong: a hyphen is a word boundary, so it double-counts matches inside `nyc-button-primary` and `nyc-button-secondary`. Isolating true bare tokens gives 25. Full census, **69 across 13 files**:

| class | count |
|---|---|
| `nyc-button` (bare) | 25 |
| `nyc-button-primary` | 19 |
| `nyc-button-secondary` | 11 |
| `nyc-field` (bare) | 11 |
| `nyc-field--error` | 3 — all in `globals.css`, **zero usage sites** |

Nothing outside `src/`: no hits in `public/`, and the self-contained talks deck carries its own styles and uses none of these. One historical mention in `sprints/completed/sprint-003-polish-audit.md` is left untouched, per the same precedent P3 set for dated records.

All usages turned out to be plain string literals — no template literals, no `clsx()`, no conditional joins — so the naive rename form was never at risk of mangling one. That was checked rather than assumed.

## Acceptance

1. **Zero `nyc-button` / `nyc-field` strings in `src/`.** Pass.
2. **Selector-set equivalence.** The net `globals.css` diff is 20 removed / 20 added, and **every changed line is selector-shaped — not one declaration was touched.** Verified two ways: by a script parsing both revisions into selector/body pairs and asserting byte-identical bodies, and by asserting no changed line is declaration-shaped.
3. **`src/app/ui-class-names.test.ts`** — a permanent guard, mutation-verified (a typo'd `ui-button-typo` className fails it; reverting passes). Scoped to the `ui-` prefix rather than all class names, because Tailwind utilities are compiled from usage rather than defined in `globals.css` and a general check would false-positive constantly. The prefix was chosen this phase precisely because it collides with nothing, which makes it a clean boundary.
4. **Owner browser pass** — the gate's, focused on controls, since that is exactly what a missed class would strip.

Untouched and verified: the 15 `--nyc-*` custom-property aliases (P5's ruling), the "NYC Design System" prose comments (P5), and every `EVIDENCE_*` identifier.

## One ruling worth recording

`.nyc-field--error` was **dead** — defined, used nowhere — and was renamed rather than dropped. That is the opposite of what P3 did with `--nyc-gray-30`/`-40`, which were dropped on the principle that renaming a dead token launders debt under a cleaner name.

The cases differ, and the difference is why this one stays. Those greys were **superseded** palette values, replaced when `--text-muted` moved off `--nyc-gray-40` for a WCAG AA contrast failure — dead because something took their place. `.ui-field--error` is a component **state affordance** that exists in the design layer with no current consumer: a usage gap, not debt. Dropping it would remove the only styling the codebase has for an invalid form field.

Recorded because the inconsistency is real on its face and a later reader deserves the reasoning rather than having to reconstruct it.

## Verification

- `npm test` — 762 pass, 0 fail
- `npm run lint` — 0 errors, 4 pre-existing warnings unchanged
- `npm run typecheck` — clean
- `npx next build --webpack` — succeeds, all routes compile

**Scope of the claim:** builds, tests, and greps clean, and the CSS is provably selector-only. **Nothing was opened in a browser** — and for this phase specifically, that gap is the entire residual risk, which is why the browser pass is a gate condition rather than a courtesy.
