### PR TITLE
fix: keep notebook execution stderr off the wire, add a correlation id (#271)

### DIFF
--- a/src/app/api/query-notebook/route.ts
+++ b/src/app/api/query-notebook/route.ts
@@ -18,6 +18,7 @@
  */
 import { NextRequest } from 'next/server';
 import { headers } from 'next/headers';
+import { randomUUID } from 'node:crypto';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
@@ -30,7 +31,7 @@ import {
   type CompletionResult,
   type StreamCallbacks,
 } from '@/lib/openrouter-streaming';
-import { isStreamErrorKind, type StreamErrorCode } from '@/lib/streaming';
+import { isStreamErrorKind, notebookExecutionErrorMessage, type StreamErrorCode } from '@/lib/streaming';
 import { TraceBuilder, hash as traceHash, CIVICAITOOLS_TRACE_CONFIG } from '@/lib/evidence/trace';
 import { getConfiguredKeyId } from '@/lib/evidence/signing';
 import {
@@ -73,7 +74,12 @@ type NotebookEvent =
       answer: string;
       duration_ms: number;
     }
-  | { type: 'error'; message: string; code?: StreamErrorCode };
+  // `correlationId` + `exitCode` are set only for `code: 'notebook_execution'`
+  // (#271): they let the reader trace a failure to its full-stderr server log
+  // line without the wire ever carrying that stderr. See
+  // `notebookExecutionErrorMessage()` in lib/streaming.ts, which builds
+  // `message` from exactly these two values and nothing else.
+  | { type: 'error'; message: string; code?: StreamErrorCode; correlationId?: string; exitCode?: number };
 
 function encodeNotebookEvent(event: NotebookEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
@@ -228,42 +234,48 @@ export async function POST(request: NextRequest) {
         duration_ms: Date.now() - pipelineStart,
       });
     } catch (err) {
-      // Log full stderr server-side (Vercel function logs) so the actual
-      // preprocess_cell exception is recoverable for debugging — the SSE
-      // payload only carries a tail of the traceback to keep the UI sane.
       if (err instanceof NotebookExecutionError) {
+        // #271 disclosure ruling: the stderr tail is not for the reader. It
+        // used to be flattened into the wire `message` and then discarded at
+        // render (friendlyStreamError never showed it) — exposed on the wire
+        // while unavailable to the reader it was collected for. Now it stays
+        // server-side only, logged here in FULL (not just a tail — the log
+        // has no wire-size constraint, so this only ever captures at least as
+        // much as the old `stderrTail` bound did), tagged with a correlation
+        // id the reader *does* see, so a reported failure is traceable back
+        // to this exact log line. Prefix + shape are stable for grepping:
+        // `[query-notebook] NotebookExecutionError` with a `correlationId`.
+        const correlationId = `nb-${randomUUID().slice(0, 8)}`;
         console.error('[query-notebook] NotebookExecutionError', {
+          correlationId,
           exitCode: err.exitCode,
           message: err.message,
           stderr: err.stderr,
         });
-      } else if (err instanceof Error) {
-        console.error('[query-notebook] error', { message: err.message, stack: err.stack });
+        await emit({
+          type: 'error',
+          message: notebookExecutionErrorMessage(err.exitCode, correlationId),
+          code: 'notebook_execution',
+          correlationId,
+          exitCode: err.exitCode,
+        });
       } else {
-        console.error('[query-notebook] unknown error', err);
+        if (err instanceof Error) {
+          console.error('[query-notebook] error', { message: err.message, stack: err.stack });
+        } else {
+          console.error('[query-notebook] unknown error', err);
+        }
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        // Phase A attaches the classified kind to its rejection (#154). Guarded
+        // rather than forwarded blind: plenty of unrelated errors carry a `code`
+        // of their own (`ENOENT`, `ERR_*`), and only a real kind belongs on the
+        // wire — anything else would just fall through to prose matching anyway.
+        const rejectionCode = err !== null && typeof err === 'object' && 'code' in err
+          ? (err as { code?: unknown }).code
+          : undefined;
+        const code = isStreamErrorKind(rejectionCode) ? rejectionCode : undefined;
+        await emit({ type: 'error', message, ...(code ? { code } : {}) });
       }
-
-      // The Python exception nbconvert raises lives at the TAIL of stderr
-      // (the cell traceback + `<exception type>: <message>` is the last
-      // thing printed). Slice the last 8000 chars so the user sees the
-      // smoking gun rather than the warmup boilerplate.
-      const STDERR_TAIL_CHARS = 8000;
-      const stderrTail = (s: string): string => {
-        if (s.length <= STDERR_TAIL_CHARS) return s;
-        return `…(stderr truncated; full output in server logs)…\n${s.slice(-STDERR_TAIL_CHARS)}`;
-      };
-      const message = err instanceof NotebookExecutionError
-        ? `Notebook execution failed (exit ${err.exitCode ?? 'n/a'}): ${err.message}${err.stderr ? `\n${stderrTail(err.stderr)}` : ''}`
-        : err instanceof Error ? err.message : 'Unknown error';
-      // Phase A attaches the classified kind to its rejection (#154). Guarded
-      // rather than forwarded blind: plenty of unrelated errors carry a `code`
-      // of their own (`ENOENT`, `ERR_*`), and only a real kind belongs on the
-      // wire — anything else would just fall through to prose matching anyway.
-      const rejectionCode = err !== null && typeof err === 'object' && 'code' in err
-        ? (err as { code?: unknown }).code
-        : undefined;
-      const code = isStreamErrorKind(rejectionCode) ? rejectionCode : undefined;
-      await emit({ type: 'error', message, ...(code ? { code } : {}) });
     } finally {
       trace.endRoot();
       await writer.close();

--- a/src/hooks/useNotebookStream.ts
+++ b/src/hooks/useNotebookStream.ts
@@ -15,7 +15,7 @@
  */
 import { useCallback, useRef, useState } from 'react';
 import { connectSSE } from '@/lib/sse-client';
-import { friendlyStreamError } from '@/lib/streaming';
+import { friendlyStreamError, notebookExecutionErrorMessage } from '@/lib/streaming';
 import type { Notebook } from '@/lib/notebook-author';
 import type { NotebookPhase } from '@/components/notebook/NotebookProgress';
 
@@ -220,14 +220,24 @@ export function useNotebookStream() {
           break;
         }
         case 'error': {
-          // Pass the carried kind alongside the text: since #154 the Phase A
-          // failure path puts a classified `code` on the event, and the message
-          // is already reader-facing copy. Without the code, prefixed copy
-          // would be re-classified from prose and flatten to the generic line.
-          const message = friendlyStreamError({
-            message: (raw.message as string | undefined) || 'Notebook generation failed',
-            code: raw.code,
-          });
+          const code = raw.code as string | undefined;
+          const correlationId = raw.correlationId as string | undefined;
+          // #271: a notebook execution failure is rebuilt CLIENT-SIDE from
+          // the typed `correlationId` + `exitCode` fields only — never from
+          // `raw.message` — so the reader-facing copy can never carry raw
+          // stderr no matter what the server happened to put in `message`.
+          // Falls back to the generic friendly copy if a correlation id
+          // wasn't sent (a stale server, or this event predating #271).
+          const message = code === 'notebook_execution' && correlationId
+            ? notebookExecutionErrorMessage(raw.exitCode as number | undefined, correlationId)
+            // Pass the carried kind alongside the text: since #154 the Phase A
+            // failure path puts a classified `code` on the event, and the message
+            // is already reader-facing copy. Without the code, prefixed copy
+            // would be re-classified from prose and flatten to the generic line.
+            : friendlyStreamError({
+                message: (raw.message as string | undefined) || 'Notebook generation failed',
+                code: raw.code,
+              });
           setState((prev) => ({
             ...prev,
             error: message,

--- a/src/lib/streaming.test.ts
+++ b/src/lib/streaming.test.ts
@@ -13,6 +13,7 @@ import {
   friendlyStreamError,
   describeToolFailureForLlm,
   streamErrorPayload,
+  notebookExecutionErrorMessage,
   STREAM_ERROR_KINDS,
 } from './streaming.ts';
 
@@ -194,9 +195,10 @@ test('#258 C4: describeToolFailureForLlm handles the unconfigured kind without l
 // them, because no assertion here depends on the wording of any message.
 
 test('#154: every StreamErrorKind round-trips server -> wire -> render into its own bucket', () => {
-  // Guard the "eight kinds" this phase enumerated: a ninth must be added to
-  // STREAM_ERROR_KINDS deliberately, and the loop below then covers it.
-  assert.equal(STREAM_ERROR_KINDS.length, 8, 'the eight classified kinds');
+  // Guard the "nine kinds" this phase (plus #271's notebook_execution)
+  // enumerated: a tenth must be added to STREAM_ERROR_KINDS deliberately, and
+  // the loop below then covers it.
+  assert.equal(STREAM_ERROR_KINDS.length, 9, 'the nine classified kinds');
 
   for (const kind of STREAM_ERROR_KINDS) {
     // `streamErrorPayload` is the exact call the server chokepoint
@@ -268,4 +270,64 @@ test('#154: rollout window — a client ignoring the code still renders calm cop
     const staleClientView = friendlyStreamError(streamErrorPayload(kind).message);
     assert.ok(CALM.has(staleClientView), `stale-client copy for ${kind} is calm copy`);
   }
+});
+
+// --- #271: a notebook execution failure carries a correlation id, not stderr ---
+//
+// The defect: `/api/query-notebook` embedded a bounded tail of the sandbox's
+// raw stderr into the wire `message`, and `useNotebookStream` then discarded
+// it anyway via `friendlyStreamError` in favour of fixed copy — so the raw
+// text was BOTH exposed on the wire (devtools-readable, the #154 exposure)
+// AND unavailable to the reader it was collected for. The ruling: the
+// stderr tail is not for the reader. It now stays server-side, logged in
+// full (route.ts's catch block); the reader gets the exit code plus a
+// correlation id that ties a report back to that exact log line.
+
+test('#271: notebookExecutionErrorMessage carries the exit code and correlation id', () => {
+  const message = notebookExecutionErrorMessage(1, 'nb-a1b2c3d4');
+  assert.match(message, /exit 1/);
+  assert.match(message, /nb-a1b2c3d4/);
+});
+
+test('#271: notebookExecutionErrorMessage falls back to "n/a" for a missing exit code', () => {
+  const message = notebookExecutionErrorMessage(undefined, 'nb-deadbeef');
+  assert.match(message, /exit n\/a/);
+  assert.match(message, /nb-deadbeef/);
+});
+
+test('#271: notebookExecutionErrorMessage cannot carry stderr content — it takes no stderr parameter', () => {
+  // The function's signature only accepts (exitCode, correlationId): there is
+  // no stderr parameter for a raw traceback to ride in on. This checks a
+  // representative call for the raw fragments a real nbconvert traceback (the
+  // Python exception text `stderrTail` used to slice out) would contain.
+  const message = notebookExecutionErrorMessage(1, 'nb-a1b2c3d4');
+  const RAW_FRAGMENTS = ['traceback', 'nameerror', 'preprocess_cell', 'file "', 'nbconvert', 'stderr'];
+  const lower = message.toLowerCase();
+  for (const frag of RAW_FRAGMENTS) {
+    assert.ok(!lower.includes(frag), `message leaks "${frag}": ${message}`);
+  }
+});
+
+test('#271: notebook_execution is part of the classified-kind round trip', () => {
+  const payload = streamErrorPayload('notebook_execution');
+  assert.equal(payload.code, 'notebook_execution');
+  assert.equal(classifyStreamError(payload), 'notebook_execution');
+  assert.equal(friendlyStreamError(payload), payload.message);
+});
+
+test('#271: friendlyStreamError alone collapses a notebook_execution payload to generic copy — why the client rebuilds it from typed fields', () => {
+  // This is the exact trap the naive fix would fall into: routing the
+  // per-failure message through friendlyStreamError() the same way every
+  // other kind does silently drops the correlation id, because
+  // FRIENDLY_STREAM_COPY maps a kind to one fixed string. useNotebookStream's
+  // `error` case special-cases `code === 'notebook_execution'` precisely to
+  // avoid this — it calls notebookExecutionErrorMessage() with the typed
+  // `correlationId` / `exitCode` fields instead of trusting `message`.
+  const perFailureMessage = notebookExecutionErrorMessage(2, 'nb-12345678');
+  const collapsed = friendlyStreamError({ message: perFailureMessage, code: 'notebook_execution' });
+  assert.equal(collapsed, streamErrorPayload('notebook_execution').message);
+  assert.ok(
+    !collapsed.includes('nb-12345678'),
+    'friendlyStreamError alone drops the correlation id — confirms the client must rebuild it from typed fields',
+  );
 });

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -80,9 +80,13 @@ export interface ErrorEvent extends StreamEvent {
 // place error-to-copy mapping lives, consumed by every SSE-consuming hook.
 
 /**
- * The eight kinds every streaming failure classifies into. Single-sourced as
+ * The nine kinds every streaming failure classifies into. Single-sourced as
  * an array rather than a bare union so the round-trip test can enumerate them
- * (#154): a ninth kind is covered by that test the moment it is added here.
+ * (#154): a tenth kind is covered by that test the moment it is added here.
+ *
+ * `notebook_execution` (#271) is set explicitly by the server — never derived
+ * from message-shape matching below — because its reader-facing copy carries
+ * a per-failure correlation id and exit code that no static string can hold.
  */
 export const STREAM_ERROR_KINDS = [
   'rate_limit',
@@ -92,6 +96,7 @@ export const STREAM_ERROR_KINDS = [
   'mcp_timeout',
   'mcp_unavailable',
   'connection',
+  'notebook_execution',
   'generic',
 ] as const;
 
@@ -204,6 +209,12 @@ const FRIENDLY_STREAM_COPY: Record<StreamErrorKind, string> = {
   mcp_unavailable:
     'The live data source is temporarily unavailable, so this query couldn’t be completed. Please try again shortly.',
   connection: 'The connection was interrupted before the response finished. Please try again.',
+  // Static fallback only — used when a wire payload carries this kind's code
+  // without the correlation id (a stale client, or the rollout-window /
+  // message-shape fallback tested below). The normal path builds copy with
+  // `notebookExecutionErrorMessage()` instead, so a reader can actually trace
+  // the failure back to its server log line (#271).
+  notebook_execution: 'The notebook could not finish running. Please try again.',
   generic: 'Something went wrong while running this query. Please try again in a moment.',
 };
 
@@ -221,6 +232,27 @@ export function friendlyStreamError(input: unknown): string {
  */
 export function streamErrorPayload(kind: StreamErrorKind): { message: string; code: StreamErrorCode } {
   return { message: FRIENDLY_STREAM_COPY[kind], code: kind };
+}
+
+/**
+ * Reader-facing copy for a notebook execution failure (#271). The disclosure
+ * ruling: the sandbox's stderr is a debugging surface, not a reader surface —
+ * it is logged server-side in full (see `route.ts`'s catch block) but never
+ * put on the wire. What the reader gets instead is the exit code (already
+ * plain, non-sensitive) and a correlation id that ties their report back to
+ * that server log line.
+ *
+ * Deliberately takes only these two typed, non-sensitive values as
+ * parameters — never a free-text message or the stderr itself — so the copy
+ * can never carry raw infrastructure text by construction, not just by
+ * convention.
+ */
+export function notebookExecutionErrorMessage(
+  exitCode: number | undefined,
+  correlationId: string,
+): string {
+  const exit = typeof exitCode === 'number' ? exitCode : 'n/a';
+  return `Notebook execution failed (exit ${exit}). Reference: ${correlationId}. Try again, or include this reference if you report the problem.`;
 }
 
 /**


### PR DESCRIPTION
## What

Resolves #271's worst-of-both state per the owner's G0-2 disclosure ruling on the Wave N1 sprint (anchor #179): **notebook-execution stderr is not for the reader.** The stderr tail no longer travels on the SSE wire at all; the reader gets copy that is actually useful for reporting; the debugging surface moves entirely server-side.

- **Wire, before:** `Notebook execution failed (exit 1): <err.message>` + an 8000-char raw stderr tail — devtools-readable (the #154 exposure class) yet discarded at render by `friendlyStreamError`, so no one it was collected for ever saw it.
- **Wire, after:** a typed event — `code: 'notebook_execution'`, `correlationId`, `exitCode` — with copy built by the new `notebookExecutionErrorMessage()`: *"Notebook execution failed (exit 1). Reference: nb-a1b2c3d4. Try again, or include this reference if you report the problem."*
- **Server log:** the existing greppable `[query-notebook] NotebookExecutionError` line now carries the correlation id alongside what it already logged — full untruncated stderr, exit code, message. Nothing narrowed; the log was already a superset of the old wire tail.

The disclosure guarantee is structural, not conventional: `notebookExecutionErrorMessage(exitCode, correlationId)` has no parameter that could carry stderr, the kind is set explicitly by the server rather than derived from message text, and the hook rebuilds copy from the typed fields — never from `raw.message`. `notebook_execution` joins `STREAM_ERROR_KINDS` as the ninth kind (pin test updated), keeping the #154 posture: the event carries a kind, raw infrastructure text stays out of the browser.

## Premise check (rider)

All three of the issue's claims verified against the live tree before implementation. The suite pinned nothing about these paths (zero references to `stderrTail`, `NotebookExecutionError`, or `query-notebook` in any test), so no existing assertion blessed the old behavior.

## Tests

Five added in `src/lib/streaming.test.ts`: correlation id + exit code in copy; `n/a` fallback; structural proof no stderr fragment (real traceback strings) can reach the copy; kind round-trip through `streamErrorPayload`/`classifyStreamError`/`friendlyStreamError`; and a trap test documenting that plain `friendlyStreamError` alone drops the correlation id — which is exactly why the hook special-cases this kind. Route/hook surfaces have no test harness in this repo (no jsdom, no route-handler tests anywhere); the guarantee lives in the pure logic that is tested.

## Verification (sandbox-local; CI is the authoritative gate)

Tests 770/770 (was 765 on main; +5 = the new tests); lint 0 errors (4 pre-existing warnings, untouched files); typecheck clean; `next build --webpack` green with `/api/query-notebook` building as a dynamic route.

Sprint: Wave N1 P3 · anchor #179 · closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
