### PR TITLE
chore(build): ship the app in the standalone image, not the repository (#179)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,27 @@ coverage
 *.tsbuildinfo
 npm-debug.log*
 .DS_Store
+
+# Repository material, not application material (#179). Standalone tracing
+# copies from the project directory, so the surest way to keep something out
+# of the runtime image is to keep it out of the build context. next.config.ts
+# excludes these from the traced output as well — belt and braces, because
+# only one of the two layers survives a change of build method.
+docs
+sprints
+CLAUDE.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+README.md
+
+# Untracked local scratch (gitignored). A build host is not guaranteed clean,
+# and whatever is lying here would otherwise be copied into the image.
+temp
+
+# The build stage runs exactly one repository script — the standalone asset
+# check chained into `npm run build:standalone`. Admitting only that one keeps
+# the built stages from doubling as a place to run the rest of the repo's
+# tooling. A new build-time script must be added here explicitly; forgetting
+# fails the build loudly rather than silently enlarging the image.
+scripts/*
+!scripts/check-standalone-assets.mjs

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,11 +29,83 @@ const nextConfig: NextConfig = {
   // notebook-author module to embed inline in cell-3 of executed notebooks.
   // Next.js automatic file tracing does not always pick up non-JS files, so
   // we tell it explicitly to bundle them with the executed-notebook route.
+  //
+  // KEY FORMAT — this is easy to get wrong and fails silently. Next matches
+  // each key with `picomatch(key, { contains: true })` against the NORMALIZED
+  // ROUTE (`normalizeAppPath('app/api/query-notebook/route')` →
+  // '/app/api/query-notebook'), not against a source path. A key written as a
+  // file path ('src/app/api/query-notebook/route') therefore matches nothing,
+  // the include is dropped, and the build still succeeds — which is exactly
+  // the trapdoor `scripts/check-standalone-assets.mjs` exists to catch.
   outputFileTracingIncludes: {
-    'src/app/api/query-notebook/route': [
+    '/api/query-notebook': [
       './src/lib/notebook-author/helpers/*.py',
     ],
   },
+
+  // Standalone tracing errs toward copying the project directory, so the
+  // runtime image ends up carrying the REPOSITORY rather than the
+  // application (#179). These excludes trim it back to what serves traffic.
+  //
+  // Scoped to standalone on purpose: excludes rewrite the per-route
+  // .nft.json traces, which the hosted (Vercel) builder also consumes to
+  // assemble its functions. Leaving them off unless BUILD_STANDALONE=1 keeps
+  // the promise made at the top of this file — with the flag unset, the
+  // hosted build is the build this repo has always produced.
+  //
+  // Excludes are applied AFTER includes are merged, so nothing here may
+  // match the helper .py files above. Every pattern below is extension- or
+  // directory-scoped away from them.
+  ...(standalone
+    ? {
+        outputFileTracingExcludes: {
+          // '**' matches every route: these are not per-route concerns.
+          '**': [
+            // Documentation and process material.
+            'docs/**',
+            'sprints/**',
+            '*.md',
+            // Build/dev tooling. The server runs none of it; keeping it out
+            // is also what stops a built image from being a place to run
+            // repository scripts.
+            'scripts/**',
+            'drizzle/**',
+            'drizzle.config.ts',
+            'eslint.config.mjs',
+            'postcss.config.mjs',
+            'tsconfig.json',
+            'package-lock.json',
+            '*.tsbuildinfo',
+            // Container / CI definitions describe how to build and deploy
+            // the image; the image itself has no use for them.
+            'Dockerfile',
+            'docker-compose.yml',
+            'docker/**',
+            '.github/**',
+            // Untracked local scratch (gitignored). Nothing guarantees a
+            // build host is clean, and an operator's scratch directory must
+            // never become part of a published image.
+            'temp/**',
+            // TypeScript/React/CSS sources are compiled into
+            // .next/server chunks; nothing loads them from disk at runtime.
+            // (Tracing lists them because driver seams use dynamic imports
+            // written with explicit .ts specifiers — e.g.
+            // `await import('./s3.ts')` in src/lib/storage/index.ts — but
+            // the compiled chunk is what actually runs.)
+            'src/**/*.ts',
+            'src/**/*.tsx',
+            'src/**/*.css',
+            // Font sources are emitted into .next/static at build time and
+            // served from there.
+            'src/fonts/**',
+            // Talk decks are read only by generateStaticParams at build
+            // time; the route is force-static with dynamicParams = false, so
+            // the standalone server never touches _decks/.
+            'src/app/**/_decks/**',
+          ],
+        },
+      }
+    : {}),
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Premise correction first (the load-bearing find)

The `outputFileTracingIncludes` key protecting the runtime-read Python helpers was **inert on main**. Next matches include keys with `picomatch(key, {contains: true})` against the *normalized route* (`/app/api/query-notebook` → matched by `/api/query-notebook`), not a source path — so the existing key `'src/app/api/query-notebook/route'` matched nothing, silently. The helpers survived only because Turbopack's tracing over-copies the project tree; a `BUILD_STANDALONE=1 next build --webpack` on main ships **zero** helpers and fails `check:standalone` outright (verified with Next's own matching functions and a live build). Slimming without fixing the key first would have armed exactly the silent failure #179 warned about. The key is corrected in this PR, with the trap documented at the declaration site.

## The slimming — two layers, each at the right level

- **`next.config.ts`**: `outputFileTracingExcludes`, scoped to `BUILD_STANDALONE=1` only, trimming docs/, sprints/, scripts/, drizzle/, CI/container definitions, gitignored `temp/` scratch, and compiled-away `src/**/*.{ts,tsx,css}` sources out of the trace. Excludes are applied after includes merge, and every pattern is extension- or directory-scoped away from the `.py` helpers.
- **`.dockerignore`**: keeps the same material out of the build context (admitting exactly one repo script, `check-standalone-assets.mjs`, which the standalone build chains). Survives a change of build method; the tracing config serves non-Docker standalone consumers.

No Dockerfile change — its COPY lines were already correct; the bloat entered through tracing, not COPY.

## Result

391 files removed from `.next/standalone`, 0 added. Like-for-like on a clean checkout: **66.9 MB → 61.8 MB (−7.6%)**. The local measurement showed a larger delta (95.6 MB → 69.5 MB) because the build host carried 12.6 MiB of gitignored `temp/` scratch — excluding that class is a hardening win (operator scratch can never reach a published image), not a size claim. Surviving `src/` is 5 files: `favicon.ico`, one statically-imported JSON, and the three Python helpers — byte-identical, verified by `check:standalone` green **in the same `npm run build:standalone` run that produced the slimmed output** (sandbox-local, Turbopack — the builder the Dockerfile actually runs).

Safety evidence for excluding TS sources: the dynamic `await import('./s3.ts')` driver-seam imports are compiled into `.next/server/chunks/*` (confirmed `createS3Driver` present); the only remaining references to the `.ts` paths are `.nft.json` metadata.

## Vercel (hosted) path: provably unaffected

With `BUILD_STANDALONE` unset, `outputFileTracingExcludes` is absent from the config object entirely — the hosted build cannot see it. The include-key fix is purely additive on that path (588 → 591 traced entries; the 3 additions are duplicates of already-present helper paths — Turbopack was already tracing them, so this is *not* a claim that production was broken). Both configs built clean on the plain path.

## Owner-run verification at the merge gate (Docker daemon unavailable in the agent sandbox — measured, not assumed)

```bash
cd /Users/npstorey/code/civic-ai-tools-website
git checkout main && docker build -t civic-app:before .
git checkout chore/179-slim-standalone && docker build -t civic-app:after .
docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' | grep civic-app
docker run --rm --entrypoint sh civic-app:after -c 'ls -l src/lib/notebook-author/helpers/'
docker run --rm --entrypoint sh civic-app:after -c 'ls; echo ---; ls docs sprints scripts 2>&1'
```

Expected: `after` smaller; three `.py` files listed; `docs`/`sprints`/`scripts` absent. A successful `docker build` is itself the assets check passing in-build (`RUN npm run build:standalone` chains it).

Local verification (sandbox): tests 770/770, lint 0 errors, typecheck clean, `npm run build` (hosted path) exit 0 with no standalone emitted.

Sprint: Wave N1 P4 · anchor #179 (this PR implements the anchor issue's own body). No closing keyword here on purpose: #179 doubles as the sprint anchor and carries the ledger, so it is closed manually at sprint close-out, not by this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
