### PR TITLE
ci: standalone-build nets — empirical CI leg + tracing-key validity test (#282)

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,0 +1,61 @@
+name: Standalone
+
+# The empirical net for the standalone build (wave N5 P1, anchor #282).
+#
+# `npm run build:standalone` (BUILD_STANDALONE=1 next build, then
+# scripts/check-standalone-assets.mjs) otherwise runs only inside
+# `docker build` — which no workflow performs — so a change that breaks
+# standalone tracing of the runtime-read helper files would first surface in
+# an operator's image build. This leg runs the same command directly, on the
+# paths that can break it.
+#
+# Credential-free by construction, same charter as ci.yml: zero `secrets.`
+# references, no `env:` blocks of placeholder credentials, first-party
+# actions only. The standalone build needing no secret is part of the same
+# tested invariant.
+#
+# NOT a required check, on purpose: a required check backed by a
+# paths-filtered workflow never reports on non-matching PRs and would block
+# every one of them forever. If this is ever promoted to required, the shape
+# must change to an always-run job that early-exits green on non-matching
+# changes — do not just add the current check name to the ruleset.
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'next.config.*'
+      - 'scripts/**'
+      - 'src/lib/notebook-author/helpers/**'
+      - '.github/workflows/standalone.yml'
+
+permissions:
+  contents: read
+
+# Superseded runs on the same ref are pointless spend — cancel them.
+concurrency:
+  group: standalone-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-standalone:
+    name: standalone build + asset check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Same Node source of truth as ci.yml: .nvmrc pins 22, matching
+      # package.json engines and the container base image.
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install
+        run: npm ci
+
+      # BUILD_STANDALONE=1 next build, then the runtime-read asset check.
+      # The check is the point: standalone file tracing can drop node:fs-read
+      # files silently, and a successful build that ships without them fails
+      # only later, in front of a user (#179 P4).
+      - name: Build standalone + check runtime-read assets
+        run: npm run build:standalone

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,13 +339,17 @@ CSS keyframes (`blink`, `spin`, `pulse`) and component-specific styles use style
 
 ## Known Tech Debt
 
-### `next build` cannot run in a sandboxed agent session
+### `next build` in a sandboxed agent session: re-measure in your environment
 
-The default (Turbopack) builder cannot complete inside a Claude Code sandbox on
-any branch: its PostCSS worker pool binds a TCP port, and the sandbox denies
-port binding (`Operation not permitted`) — the same restriction behind the
-`listen EPERM` failures in `openrouter-streaming.test.ts`. Agents should build
-with `next build --webpack`, and treat CI's `build` check as the real gate.
+Whether the default (Turbopack) builder completes inside a Claude Code sandbox
+is environment-dependent, not absolute. Its PostCSS worker pool binds a TCP
+port, and a sandbox that denies port binding (`Operation not permitted`) kills
+the build — the same restriction behind the `listen EPERM` failures in
+`openrouter-streaming.test.ts` — but measured 2026-08-19, Turbopack built
+repeatedly (exit 0) in a sandboxed agent session. Re-measure in your
+environment (`npm run build`); if port binding is denied there, `next build
+--webpack` completes without the worker pool. Either way, treat CI's `build`
+check as the real gate.
 
 Note for anyone diagnosing a build failure here: this is **not** a network
 problem. Google Fonts was blamed for it for two days; the sandbox reaches

--- a/src/lib/notebook-author/helpers/standalone-tracing-keys.test.ts
+++ b/src/lib/notebook-author/helpers/standalone-tracing-keys.test.ts
@@ -1,0 +1,196 @@
+// Route-key validity for next.config.ts file tracing (wave N5 P1).
+//
+// Sibling to standalone-tracing.test.ts, which pins the *value* side of the
+// `outputFileTracingIncludes` declaration (the helpers glob). This file pins
+// the *key* side: every key in `outputFileTracingIncludes` AND
+// `outputFileTracingExcludes` must match at least one route that actually
+// exists, under the matching semantics of the installed Next.
+//
+// Why: during #179 P4 the key was written as 'src/app/api/query-notebook/route'
+// — a source path. Next never matches keys against source paths, so the key
+// was silently inert: the build succeeded, the include was dropped, and the
+// only symptom was a runtime 500 in a standalone deployment. A key is config
+// that LOOKS declarative but is really a pattern matched against generated
+// route strings; nothing in the build validates it.
+//
+// The installed Next (16.3.0) consumes these keys in two places:
+//
+//   1. Webpack builds — next/dist/build/collect-build-traces.js
+//      ("apply-include-excludes" span): each key is compiled with
+//      `picomatch(key, { dot: true, contains: true })` and tested against
+//      `normalizeAppPath(entryName)` for app routes (normalizePagePath for
+//      pages/). entryName is like 'app/api/query-notebook/route', and
+//      normalizeAppPath KEEPS the leading 'app' segment while stripping
+//      route groups and the trailing 'page'/'route' segment, so the string
+//      matched is '/app/api/query-notebook'. Includes and excludes use the
+//      same route string. (Static pages and edge routes are skipped there,
+//      so "matches a route" is necessary, not sufficient.)
+//
+//   2. Turbopack builds (this repo's default builder) — the matching lives in
+//      the native binary; its source is crates/next-api/src/nft.rs at the
+//      installed version's tag (v16.3.0). Keys are compiled with
+//      `Glob::new(key, GlobOptions { contains: true, .. })` and tested against
+//      a DIFFERENT string shape: `app{originalName}` for includes (e.g.
+//      'app/api/query-notebook/route' — groups and the trailing segment are
+//      NOT stripped) and `/app{originalName}` for excludes (tracing_exclude_glob
+//      prefixes '/'). turbo-tasks-fs Glob is not callable from Node; for the
+//      keys this config uses (literal paths and '**') its contains-mode
+//      matching agrees with picomatch's, which is what this test uses for
+//      those shapes too.
+//
+// A key is only trustworthy if it matches under BOTH consumers, so each key
+// is asserted against the webpack-normalized shape and the Turbopack shape.
+//
+// The route inventory is DERIVED by walking src/app for page/route entry
+// files — never hardcoded — so renaming or deleting a route cannot leave
+// this test asserting against a stale inventory.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HELPERS_DIR, '../../../..');
+const APP_DIR = path.join(REPO_ROOT, 'src', 'app');
+
+// ---------------------------------------------------------------------------
+// Next's own matcher and normalizer — the exact modules its webpack-path
+// build code requires in collect-build-traces.js, not lookalikes.
+// ---------------------------------------------------------------------------
+const requireFromHere = createRequire(import.meta.url);
+
+type Matcher = (candidate: string) => boolean;
+type Picomatch = (pattern: string, options: { dot: boolean; contains: boolean }) => Matcher;
+
+const picomatch = requireFromHere('next/dist/compiled/picomatch') as Picomatch;
+const { normalizeAppPath } = requireFromHere(
+  'next/dist/shared/lib/router/utils/app-paths',
+) as { normalizeAppPath: (route: string) => string };
+
+/** Compile a tracing key the way both consumers do: contains-mode glob. */
+function keyMatcher(key: string): Matcher {
+  return picomatch(key, { dot: true, contains: true });
+}
+
+// ---------------------------------------------------------------------------
+// Route inventory, derived from the filesystem.
+// ---------------------------------------------------------------------------
+
+/** Recursively collect app-router entry files (page.* / route.*). */
+function collectEntryFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      // Underscore-prefixed folders are private (not routable) in the App
+      // Router — e.g. src/app/(marketing)/talks/_decks.
+      if (entry.name.startsWith('_')) continue;
+      found.push(...collectEntryFiles(path.join(dir, entry.name)));
+    } else if (/^(page|route)\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      found.push(path.join(dir, entry.name));
+    }
+  }
+  return found;
+}
+
+/**
+ * Entry names in the shape Next generates them: 'app/' + app-dir-relative
+ * path without the extension, posix separators — e.g.
+ * 'app/api/query-notebook/route', 'app/(marketing)/page'. This repo has no
+ * pages/ directory, so the app router is the whole inventory.
+ */
+function deriveEntryNames(): string[] {
+  return collectEntryFiles(APP_DIR).map((file) => {
+    const rel = path.relative(APP_DIR, file).split(path.sep).join('/');
+    return `app/${rel.replace(/\.(ts|tsx|js|jsx)$/, '')}`;
+  });
+}
+
+const entryNames = deriveEntryNames();
+
+// The three route-string shapes the installed Next matches keys against.
+const webpackRoutes = entryNames.map((name) => normalizeAppPath(name)); // '/app/api/query-notebook'
+const turbopackIncludeNames = entryNames; // 'app/api/query-notebook/route'
+const turbopackExcludeRoutes = entryNames.map((name) => `/${name}`); // '/app/api/query-notebook/route'
+
+/** Assert one tracing key matches at least one derived route in every shape-set. */
+function assertKeyMatchesSomeRoute(
+  key: string,
+  configField: string,
+  shapeSets: Array<{ label: string; routes: string[] }>,
+): void {
+  const isMatch = keyMatcher(key);
+  for (const { label, routes } of shapeSets) {
+    assert.ok(
+      routes.some((route) => isMatch(route)),
+      `${configField} key '${key}' matches no actual route under the ${label} ` +
+        `semantics of the installed Next — it would be silently inert there ` +
+        `(the #179 P4 trapdoor). Derived route strings checked: ${JSON.stringify(routes)}`,
+    );
+  }
+}
+
+// Load the real config with the standalone flag set, so the
+// standalone-gated `outputFileTracingExcludes` block is present. The env
+// write is process-local; node --test runs each test file in its own child
+// process, so nothing leaks into other test files.
+process.env.BUILD_STANDALONE = '1';
+const configPromise = import('../../../../next.config.ts');
+
+test('route inventory is derived and non-empty', () => {
+  assert.ok(entryNames.length > 0, `no page/route entry files found under ${APP_DIR}`);
+  for (const route of webpackRoutes) {
+    // Shape invariant of the derivation: normalizeAppPath keeps the 'app'
+    // segment, so every derived route string starts with '/app'. A failure
+    // here means the walker or the normalizer is being fed the wrong thing.
+    assert.match(route, /^\/app(\/|$)/, `unexpected normalized route shape: ${route}`);
+  }
+});
+
+test('every outputFileTracingIncludes key matches at least one actual route', async () => {
+  const { default: nextConfig } = await configPromise;
+  const includes = nextConfig.outputFileTracingIncludes ?? {};
+  const keys = Object.keys(includes);
+  assert.ok(keys.length > 0, 'outputFileTracingIncludes vanished from next.config.ts — nothing left to validate');
+  for (const key of keys) {
+    assertKeyMatchesSomeRoute(key, 'outputFileTracingIncludes', [
+      { label: 'webpack (normalized route)', routes: webpackRoutes },
+      { label: 'Turbopack (app{originalName})', routes: turbopackIncludeNames },
+    ]);
+  }
+});
+
+test('every outputFileTracingExcludes key matches at least one actual route', async () => {
+  const { default: nextConfig } = await configPromise;
+  const excludes = nextConfig.outputFileTracingExcludes ?? {};
+  const keys = Object.keys(excludes);
+  assert.ok(
+    keys.length > 0,
+    'outputFileTracingExcludes is absent even with BUILD_STANDALONE=1 — the standalone trim (#179/#281) is gone',
+  );
+  for (const key of keys) {
+    assertKeyMatchesSomeRoute(key, 'outputFileTracingExcludes', [
+      { label: 'webpack (normalized route)', routes: webpackRoutes },
+      { label: 'Turbopack (/app{originalName})', routes: turbopackExcludeRoutes },
+    ]);
+  }
+});
+
+test('negative control: the pre-#281 source-path key form matches nothing', () => {
+  // Pins the matcher itself. If the matching here were wired so loosely that
+  // any key passes, this is the assertion that would catch it: the exact key
+  // shape that caused the #179 P4 incident must fail against every shape-set.
+  const inertKey = 'src/app/api/query-notebook/route';
+  const isMatch = keyMatcher(inertKey);
+  for (const routes of [webpackRoutes, turbopackIncludeNames, turbopackExcludeRoutes]) {
+    assert.equal(
+      routes.some((route) => isMatch(route)),
+      false,
+      `source-path key '${inertKey}' unexpectedly matched a route — the matcher no longer mirrors Next's semantics`,
+    );
+  }
+});


### PR DESCRIPTION
## What this is (Wave N5 P1 — anchor #282)

Both standalone-build nets from #282 in one PR, plus the chartered CLAUDE.md rider.

**Empirical net** — `.github/workflows/standalone.yml`: a paths-filtered `pull_request` job running `npm run build:standalone` (which chains `check:standalone`) on the paths that can break it (`Dockerfile`, `next.config.*`, `scripts/**`, `src/lib/notebook-author/helpers/**`, and the workflow file itself). Until now that check ran only inside `docker build`, which no workflow performs — a guard that only runs inside a build no CI performs guards nothing. Credential-free by construction, same charter as ci.yml (zero `secrets.` references, first-party actions only). Deliberately **not** a required check: a required check backed by a paths-filtered workflow never reports on non-matching PRs and would block every one of them forever; if it is ever promoted, the shape must change to an always-run job that early-exits green (warning comment in the workflow).

**Static net** — `src/lib/notebook-author/helpers/standalone-tracing-keys.test.ts`: every `outputFileTracingIncludes` / `outputFileTracingExcludes` key must match at least one actual route under the installed Next's own matching semantics (its bundled picomatch, `{ dot: true, contains: true }`), with the route inventory derived by walking `src/app` — never hardcoded. A negative control pins the matcher: the exact pre-#281 inert key form must match nothing.

**Premise correction (measured against installed Next 16.3.0):** the charter described key matching against "normalized routes" — true of the **webpack** path only (`collect-build-traces.js`, matching `/app/api/query-notebook`). The **Turbopack** path (this repo's default builder; `crates/next-api/src/nft.rs` at the v16.3.0 tag) matches includes-keys against `app{originalName}` (`app/api/query-notebook/route`, groups and trailing segment kept) and excludes-keys against `/app{originalName}`. The test therefore asserts every key under **both** consumers' shapes.

**Rider** — CLAUDE.md's "sandboxed `next build`" note is corrected to environment-dependent, "re-measure in your environment; treat CI as the gate" phrasing (measured 2026-08-19: Turbopack built repeatedly, exit 0, in a sandboxed agent session — the port-binding restriction is real where port binding is denied, not absolute).

## Demonstrate-the-net-is-live

A companion draft PR (clearly labeled, never merges) carries the **measured minimal breakage set** that fails both nets. Measured correction to the charter's single-broken-key hypothesis: an inert include key alone fails only the static net — under Turbopack the helpers still ship because the loader's `node:fs` read is statically traced — so the empirical net additionally needs an exclude stripping the helpers. Red run IDs are recorded on the #282 gate record.

## Evidence (measured in a macOS sandboxed agent session, Node v22.23.1; CI is the cross-environment gate)

- `npm test`: 774 pass / 0 fail (counting `node:test` blocks; 770 at baseline `df547b3`, 4 new)
- demo branch `npm test`: 773 pass / 1 fail — the new includes-key test, by design
- `npm run lint` exit 0 (4 pre-existing warnings, all in files this PR does not touch); `npm run typecheck` exit 0
- `npm run build:standalone` exit 0 on this branch (`[standalone-assets] OK — 3 runtime-read asset(s) present and byte-identical`); exit 1 on the demo branch (all three `.py` helpers missing)

Closes #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLEVoy9CnMF6vPYfKqC9no
