### PR TITLE
DEMO — deliberate failure, never merge: net-is-live demonstration for #282

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -38,7 +38,11 @@ const nextConfig: NextConfig = {
   // the include is dropped, and the build still succeeds — which is exactly
   // the trapdoor `scripts/check-standalone-assets.mjs` exists to catch.
   outputFileTracingIncludes: {
-    '/api/query-notebook': [
+    // DEMO breakage 1 of 2 (never merge): the pre-#281 source-path key form.
+    // Next matches keys against generated route strings, never source paths,
+    // so this key matches nothing and the include is silently dropped.
+    // The static net (standalone-tracing-keys.test.ts) must go red on this.
+    'src/app/api/query-notebook/route': [
       './src/lib/notebook-author/helpers/*.py',
     ],
   },
@@ -61,6 +65,15 @@ const nextConfig: NextConfig = {
         outputFileTracingExcludes: {
           // '**' matches every route: these are not per-route concerns.
           '**': [
+            // DEMO breakage 2 of 2 (never merge): strips the runtime-read
+            // helpers from the traced modules. Measured 2026-08-19 under
+            // Turbopack 16.3.0: breakage 1 alone does NOT fail the build —
+            // the helpers still ship as traced modules (the loader's node:fs
+            // read is statically traced), so the empirical net only fires
+            // when this exclude removes them AND the inert key above fails
+            // to re-add them. Together they make `npm run check:standalone`
+            // exit 1.
+            'src/lib/notebook-author/helpers/**',
             // Documentation and process material.
             'docs/**',
             'sprints/**',


### PR DESCRIPTION
## ⚠️ DEMO — deliberate failure. Never merge.

Net-is-live demonstration for #282 (Wave N5 P1). This draft PR exists solely to show, on GitHub, that both new standalone nets actually fire. It is not a regression — the breakage is deliberate and labeled in every hunk.

1. **Static net red:** the `outputFileTracingIncludes` key is rewritten to the pre-#281 source-path form (`src/app/api/query-notebook/route`) → `standalone-tracing-keys.test.ts` fails inside the required `build / test / lint / typecheck` job.
2. **Empirical net red:** an exclude strips the runtime-read helpers under the `'**'` key → the `Standalone` workflow's `npm run build:standalone` fails at `check:standalone` (all three `.py` files missing).

The two breakages are the **measured minimal set**: under Turbopack 16.3.0 the inert key alone does not fail the empirical net (the loader's `node:fs` read is statically traced), which corrects the charter's single-broken-key hypothesis.

Lifecycle: opened as draft → both red runs captured on the #282 gate record → closed unmerged → branch deleted. Do not review, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLEVoy9CnMF6vPYfKqC9no
