### PR TITLE
fix: route a shape-invalid /api/models response through the form's error state (#283)

### DIFF
--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -13,19 +13,25 @@ import {
   resolveEffectiveMode,
   type QueryMode,
 } from '@/lib/query-presentation';
+import { parseModelsResponse, type Model } from '@/lib/model-list';
 import RateLimitBanner from './RateLimitBanner';
-
-interface Model {
-  id: string;
-  name: string;
-  tag?: string;
-  provider: string;
-  description?: string;
-}
 
 // Re-exported for existing importers; the type itself lives in
 // src/lib/query-presentation.ts alongside the derivations that use it.
 export type { QueryMode };
+
+/**
+ * Reader-facing copy for a `/api/models` load failure (#283) — covers both a
+ * failed fetch/JSON parse and a 200 response whose body doesn't carry a
+ * usable `models` array. Both are the same class of failure to the reader
+ * (the model list didn't load), so both route through this one message
+ * rather than a raw error or a silent render crash. The default model still
+ * works, so this discloses a degraded state rather than a blocking one — see
+ * docs/design-principles.md Principle 3 and its corollary (a list that failed
+ * to load is not a bad selection; don't mark the picker invalid).
+ */
+const MODELS_LOAD_ERROR =
+  "Couldn't load the list of AI models, so only the default model is available right now. Refresh the page to try again.";
 
 /**
  * Sticky-per-session mode persistence (§10 Q7), on the shared
@@ -107,6 +113,7 @@ export default function QueryForm({
   const signInAffordance = resolveSignInAffordance(useSignInOptions());
   const [mode, updateMode] = useStoredMode(isAuthenticated, defaultMode);
   const [models, setModels] = useState<Model[]>([]);
+  const [modelsError, setModelsError] = useState(false);
   const [modelOpen, setModelOpen] = useState(false);
   const [portalOpen, setPortalOpen] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -130,9 +137,22 @@ export default function QueryForm({
       try {
         const res = await fetch('/api/models');
         const data = await res.json();
-        if (isMounted) setModels(data.models);
+        const parsed = parseModelsResponse(data);
+        if (!isMounted) return;
+        if (parsed === null) {
+          // Same failure class as the catch below (#283): a 200 response
+          // whose body doesn't carry a usable `models` array. Routed through
+          // the same reader-facing state rather than left to crash at
+          // render (`models.find(...)` on an undefined `models`).
+          console.error('Failed to fetch models: response missing a `models` array');
+          setModelsError(true);
+          return;
+        }
+        setModels(parsed);
+        setModelsError(false);
       } catch (error) {
         console.error('Failed to fetch models:', error);
+        if (isMounted) setModelsError(true);
       }
     };
     fetchModels();
@@ -306,6 +326,21 @@ export default function QueryForm({
         </button>
         {queryCount > 0 && <RateLimitBanner refreshTrigger={queryCount} />}
       </div>
+
+      {/* Model-list load failure (#283): disclosed, not painted onto the
+          model picker as an invalid field — the picker didn't fail, the
+          background fetch did (see docs/design-principles.md's corollary).
+          Always visible, not gated behind Advanced options, since that's
+          where "visible" cashes out for a background failure the reader
+          never asked to see. */}
+      {modelsError && (
+        <div
+          role="status"
+          style={{ fontSize: '13px', color: 'var(--caution)', textAlign: 'center' }}
+        >
+          {MODELS_LOAD_ERROR}
+        </div>
+      )}
 
       {/* Advanced options expanded section */}
       {advancedOpen && (

--- a/src/lib/model-list.test.ts
+++ b/src/lib/model-list.test.ts
@@ -1,0 +1,45 @@
+// Tests for the /api/models response-shape guard (#283).
+//
+// The defect: QueryForm's fetch effect did `setModels(data.models)` inside
+// its try block with nothing checking the shape. A 200 response missing the
+// `models` key (or shipping a non-array in its place) would set `models` to
+// `undefined`, and the render path's `models.find(...)` would throw. This
+// guard turns that into a `null` the caller can route through the same
+// reader-facing failure path as a network/JSON error, instead of crashing.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseModelsResponse } from './model-list.ts';
+
+test('parseModelsResponse: a well-formed body returns the models array', () => {
+  const models = [
+    { id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'openai' },
+    { id: 'anthropic/claude-sonnet-4-6', name: 'Claude Sonnet 4.6', provider: 'anthropic' },
+  ];
+  assert.deepEqual(parseModelsResponse({ models }), models);
+});
+
+test('parseModelsResponse: an empty models array is valid (not an error)', () => {
+  assert.deepEqual(parseModelsResponse({ models: [] }), []);
+});
+
+test('parseModelsResponse: a 200 body missing the `models` key is null, not undefined', () => {
+  // The literal shape #283 describes: /api/models responds 200 with a body
+  // that has no `models` key at all.
+  assert.equal(parseModelsResponse({}), null);
+});
+
+test('parseModelsResponse: a non-array `models` value is null', () => {
+  assert.equal(parseModelsResponse({ models: 'openai/gpt-4o' }), null);
+  assert.equal(parseModelsResponse({ models: null }), null);
+  assert.equal(parseModelsResponse({ models: { id: 'openai/gpt-4o' } }), null);
+});
+
+test('parseModelsResponse: a non-object body is null', () => {
+  assert.equal(parseModelsResponse(null), null);
+  assert.equal(parseModelsResponse(undefined), null);
+  assert.equal(parseModelsResponse('not json'), null);
+  assert.equal(parseModelsResponse(42), null);
+});

--- a/src/lib/model-list.ts
+++ b/src/lib/model-list.ts
@@ -1,0 +1,36 @@
+/**
+ * The `/api/models` response shape and its validation, used by QueryForm's
+ * model-picker fetch.
+ *
+ * Extracted out of QueryForm.tsx — a client component with JSX, which
+ * node:test's `--experimental-strip-types` runner cannot parse — so the
+ * response-shape guard can be unit-tested directly (#283).
+ *
+ * The defect this guards: `/api/models` always returns `{ models: [...] }`
+ * today, but nothing enforced that shape at the call site. A 200 response
+ * missing the `models` key would set `models` to `undefined`, and the render
+ * path's `models.find(...)` would throw. `parseModelsResponse` turns a
+ * malformed body into `null` instead, so the caller can route it through the
+ * same failure path as a network/JSON error rather than crash at render.
+ */
+
+export interface Model {
+  id: string;
+  name: string;
+  tag?: string;
+  provider: string;
+  description?: string;
+}
+
+/**
+ * Validate a decoded `/api/models` JSON body into a `Model[]`, or `null` if
+ * the body doesn't carry a usable `models` array. Only checks that `models`
+ * is present and is an array — it does not deep-validate individual entries,
+ * since a malformed entry degrades gracefully at the render sites that read
+ * it (`.find`, `.map`) rather than throwing.
+ */
+export function parseModelsResponse(data: unknown): Model[] | null {
+  if (data === null || typeof data !== 'object') return null;
+  const models = (data as { models?: unknown }).models;
+  return Array.isArray(models) ? (models as Model[]) : null;
+}


### PR DESCRIPTION
## What this is (Wave N5 P2 — #283, anchor #282)

`QueryForm.tsx` set `setModels(data.models)` inside its fetch `try`, with the `catch` covering only fetch/JSON failures. A 200 response from `/api/models` without a `models` key would set the state to `undefined` and `models.find(...)` would throw a `TypeError` at the next render — a crash where the reader needs actionable copy. Latent today (the route unconditionally returns the key; left untouched), but the failure mode was wrong.

## Premise correction (measured)

The issue's disposition assumed a "form-level error path" existed to route through. It does not: the existing `catch` only wrote to `console.error` — nothing reached the reader for a failed fetch either. Since the issue defines a malformed 200 and a failed fetch as one failure class, both now route through one new `modelsError` state.

## Fix shape

- `src/lib/model-list.ts` (new): the `Model` interface (moved from `QueryForm.tsx`, its only user) plus `parseModelsResponse(data: unknown): Model[] | null` — the array when the body carries a usable `models` array, `null` otherwise (missing key, non-object body, non-array value).
- `src/components/QueryForm.tsx`: the fetch effect parses through that guard; `null` and the `catch` both set `modelsError`, rendered as an always-visible `role="status"` notice (not gated behind the collapsed Advanced panel) in `var(--caution)` — deliberately **not** painted onto the model picker as an invalid field, per `docs/design-principles.md`'s corollary: a list that failed to load is not a bad selection.
- `src/lib/model-list.test.ts` (new): 5 unit tests — well-formed body, empty array (valid), missing key, non-array `models`, non-object body.

Reader-facing copy (verbatim): *"Couldn't load the list of AI models, so only the default model is available right now. Refresh the page to try again."* — accurate about the degraded state (the `model` state defaults to a working model id, so submitting still works), plain language, no infrastructure detail.

## Net-is-live

The guard replaced with the pre-change inline equivalent (`return data?.models`) makes 3 of the 5 new tests fail, including the literal #283 defect: `not ok 3 — parseModelsResponse: a 200 body missing the 'models' key is null, not undefined` (`+ actual: undefined / - expected: null`). Restored implementation re-verified green.

## Evidence (measured in a macOS sandboxed agent session; CI is the cross-environment gate)

- `npm test`: 779 pass / 0 fail (individual `node:test` blocks; 774 at baseline `91d4950`, +5 new)
- `npm run lint`: exit 0 — 0 errors, 4 pre-existing warnings in untouched files; `npm run typecheck`: clean
- `npm run build -- --webpack`: exit 0, all routes generated
- No collision-boundary paths touched (verified via `git diff --name-only` against the exclusion list); the paths-filtered `Standalone` workflow does not fire on this PR (none of its paths are touched)

## On the record

Issue #30's endpoint-generic provider layer later rebuilds exactly this path structurally; this phase buys correct behavior in the meantime, cheaply.

Closes #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLEVoy9CnMF6vPYfKqC9no
