### PR TITLE
expand: /records segments + PUBLISHER_* env + records:publish scope, all aliasing old names (civic#160 P3)

### DIFF
--- a/scripts/check-compose-env.mjs
+++ b/scripts/check-compose-env.mjs
@@ -23,7 +23,13 @@
  *      its `build.args`; one read at both must appear in both (see `readBy`
  *      in ENV_SPEC). Not-applicable variables (a driver this profile does not
  *      select) and `external-tool` variables are excluded — an instance must
- *      not be asked to deliver what it will never read.
+ *      not be asked to deliver what it will never read. Coverage is satisfied
+ *      by EITHER accepted name for the publisher-identity set: since the
+ *      2026-08-19 vocabulary settlement each of those has a canonical
+ *      `PUBLISHER_*` spelling and a prior-era `EVIDENCE_*` one, and the app
+ *      reads both (Appendix J; civic-ai-tools#160). The compose file names the
+ *      prior-era spellings today; a NOTE lists them, because that list is
+ *      exactly the work the flip phase has to do here.
  *   2. FORM — an `environment` entry written `${NAME:-}` is rejected. That
  *      form does NOT pass a variable through: it always sets the variable, to
  *      the empty string when the caller's environment has none. Empty is not
@@ -33,8 +39,9 @@
  *      and the host-topology trio all carry meaning in their absence too. Bare
  *      `NAME:` is the form that leaves an unset variable unset.
  *   3. DRIFT, the other way — a variable in the app service's `environment`
- *      that ENV_SPEC does not declare. Either the app stopped reading it, or
- *      the inventory is stale; both are worth knowing.
+ *      that ENV_SPEC does not declare under EITHER of its accepted names.
+ *      Either the app stopped reading it, or the inventory is stale; both are
+ *      worth knowing.
  *
  * It reads NO values from the environment and prints none: it compares two
  * checked-in files. Exit 0 clean, 1 on any failure.
@@ -206,6 +213,13 @@ export function checkComposeEnvCoverage(composeText, spec = ENV_SPEC, service = 
   const missingBuildArg = [];
   const emptyDefaultForm = [];
   const runtimeInert = [];
+  const priorEraNamesInUse = [];
+
+  /** Every name a spec entry answers to — canonical first. */
+  const acceptedNames = (entry) =>
+    typeof entry.priorEraName === 'string' ? [entry.name, entry.priorEraName] : [entry.name];
+  /** Whether ANY accepted name of `entry` appears in `map`. */
+  const covered = (map, entry) => acceptedNames(entry).some((n) => map.has(n));
 
   for (const entry of applicable) {
     const readBy = entry.readBy ?? 'runtime';
@@ -214,16 +228,21 @@ export function checkComposeEnvCoverage(composeText, spec = ENV_SPEC, service = 
     const needsRuntime = readBy === 'runtime' || readBy === 'build-and-runtime';
     const needsBuildArg = readBy === 'build' || readBy === 'build-and-runtime';
 
-    if (needsRuntime && coverageProvable && !environment.has(entry.name)) {
+    if (needsRuntime && coverageProvable && !covered(environment, entry)) {
       missingRuntime.push(entry);
     }
-    if (needsBuildArg && !buildArgs.has(entry.name)) {
+    if (needsBuildArg && !covered(buildArgs, entry)) {
       missingBuildArg.push(entry);
     }
     // A build-only value in `environment` reads as though setting it at run
     // time would do something. It cannot: the value is already inlined.
-    if (readBy === 'build' && environment.has(entry.name)) {
+    if (readBy === 'build' && covered(environment, entry)) {
       runtimeInert.push(entry);
+    }
+    // Delivered under the retiring spelling — reported, never failed. The
+    // compose file is the flip phase's surface, not this phase's.
+    if (typeof entry.priorEraName === 'string' && environment.has(entry.priorEraName)) {
+      priorEraNamesInUse.push(entry);
     }
   }
 
@@ -231,7 +250,9 @@ export function checkComposeEnvCoverage(composeText, spec = ENV_SPEC, service = 
     if (typeof value === 'string' && EMPTY_DEFAULT_FORM.test(value)) emptyDefaultForm.push(name);
   }
 
-  const declared = new Set(spec.map((s) => s.name));
+  // Both accepted names count as declared: the compose file naming the
+  // prior-era spelling is the CURRENT state of that file, not inventory drift.
+  const declared = new Set(spec.flatMap(acceptedNames));
   const notApplicableNames = new Set(notApplicable.map((s) => s.name));
   const undeclared = [...environment.keys()].filter((n) => !declared.has(n));
   // Present but inert under this profile: not a failure (an operator may be
@@ -254,6 +275,7 @@ export function checkComposeEnvCoverage(composeText, spec = ENV_SPEC, service = 
     missingBuildArg,
     emptyDefaultForm,
     runtimeInert,
+    priorEraNamesInUse,
     undeclared,
     inapplicablePresent,
     counts: { environment: environment.size, buildArgs: buildArgs.size, applicable: applicable.length },
@@ -312,6 +334,17 @@ export function renderComposeReport(result, service = APP_SERVICE) {
     lines.push(`  FAIL: ${result.undeclared.length} variable(s) passed to the container that ENV_SPEC does not`);
     lines.push('        declare — either the app stopped reading them, or the inventory is stale:');
     for (const n of result.undeclared) lines.push(`          - ${n}`);
+    lines.push('');
+  }
+  if (result.priorEraNamesInUse && result.priorEraNamesInUse.length > 0) {
+    lines.push(
+      `  NOTE: ${result.priorEraNamesInUse.length} variable(s) passed through under a prior-era`,
+    );
+    lines.push('        name. Both spellings reach the app, so this is not a failure — it is');
+    lines.push('        the inventory of what the vocabulary flip has to rename here:');
+    for (const e of result.priorEraNamesInUse) {
+      lines.push(`          - ${e.priorEraName} → ${e.name}`);
+    }
     lines.push('');
   }
   if (result.inapplicablePresent.length > 0) {

--- a/scripts/generate-signing-key.test.mjs
+++ b/scripts/generate-signing-key.test.mjs
@@ -1,7 +1,7 @@
 // Tests for scripts/generate-signing-key.ts (#258 E2).
 //
 // The script must never print the private key to stdout — it writes
-// EVIDENCE_SIGNING_KEY=... to a local, git-ignored, 0600-permission file
+// PUBLISHER_SIGNING_KEY=... to a local, git-ignored, 0600-permission file
 // instead. Spawned as a CHILD PROCESS in a throwaway temp directory, exactly
 // the command an operator runs — the same idiom
 // src/lib/evidence/instance-rehearsal.test.ts uses for
@@ -39,14 +39,23 @@ test('never prints the private key to stdout; writes it to a 0600 local file ins
     );
 
     // --- stdout carries guidance but no private-key material --------------
-    // Mentioning the variable NAME (e.g. "copy the EVIDENCE_SIGNING_KEY
+    // Mentioning the variable NAME (e.g. "copy the PUBLISHER_SIGNING_KEY
     // line") is fine; an actual assignment — the name followed by `=` and a
-    // base64-looking value — is the thing that must never appear.
+    // base64-looking value — is the thing that must never appear. Checked
+    // under BOTH accepted spellings (civic-ai-tools#160 P3): the secret is the
+    // same secret whichever name introduces it, so the leak guard must not
+    // have a hole the rename could walk through.
+    assert.doesNotMatch(result.stdout, /PUBLISHER_SIGNING_KEY=[A-Za-z0-9+/]/);
     assert.doesNotMatch(result.stdout, /EVIDENCE_SIGNING_KEY=[A-Za-z0-9+/]/);
     assert.match(result.stdout, /Public key/i);
-    assert.match(result.stdout, /EVIDENCE_KEY_ID/);
+    assert.match(result.stdout, /PUBLISHER_KEY_ID/);
     assert.match(result.stdout, /signing_key_id_missing/);
     assert.match(result.stdout, /docs\/instance-setup\.md/);
+    // A writer has to pick one name; it picks the canonical one and NAMES the
+    // prior-era spelling so an operator meeting it in a deployment guide
+    // recognizes it rather than assuming one of the two is wrong.
+    assert.match(result.stdout, /EVIDENCE_\*/);
+    assert.match(result.stdout, /docker-compose/);
 
     // --- the private key landed in the file, not the terminal -------------
     const keyFilePath = path.join(tmpDir, KEY_FILE_NAME);
@@ -61,13 +70,23 @@ test('never prints the private key to stdout; writes it to a 0600 local file ins
     );
 
     const fileContents = fs.readFileSync(keyFilePath, 'utf-8');
-    assert.match(fileContents, /^EVIDENCE_SIGNING_KEY=[A-Za-z0-9+/=]+$/m);
-    assert.match(fileContents, /^EVIDENCE_PUBLIC_KEY=[A-Za-z0-9+/=]+$/m);
+    assert.match(fileContents, /^PUBLISHER_SIGNING_KEY=[A-Za-z0-9+/=]+$/m);
+    assert.match(fileContents, /^PUBLISHER_PUBLIC_KEY=[A-Za-z0-9+/=]+$/m);
+    // EXACTLY ONE private-key line. The obvious way to be helpful during a
+    // rename is to write the secret under both names; that doubles the
+    // material a leak, a stale backup, or a scrollback has to expose, and no
+    // naming convenience is worth it. The reader accepts both names, so one
+    // line is enough.
+    assert.equal(
+      fileContents.match(/^[A-Z_]*SIGNING_KEY=/gm)?.length,
+      1,
+      'the key file must carry the private key exactly once',
+    );
 
     // The public key printed to stdout must be the SAME keypair as the file
     // — only the private half is withheld from stdout, not a different key.
-    const pubMatch = fileContents.match(/^EVIDENCE_PUBLIC_KEY=([A-Za-z0-9+/=]+)$/m);
-    assert.ok(pubMatch, 'file did not contain EVIDENCE_PUBLIC_KEY');
+    const pubMatch = fileContents.match(/^PUBLISHER_PUBLIC_KEY=([A-Za-z0-9+/=]+)$/m);
+    assert.ok(pubMatch, 'file did not contain PUBLISHER_PUBLIC_KEY');
     assert.ok(
       result.stdout.includes(pubMatch[1]),
       'stdout did not echo the same public key written to the file',

--- a/scripts/generate-signing-key.ts
+++ b/scripts/generate-signing-key.ts
@@ -1,14 +1,36 @@
 /**
- * Generate an Ed25519 signing keypair for evidence packages.
+ * Generate an Ed25519 signing keypair for record packages.
  *
  * Usage: node --experimental-strip-types scripts/generate-signing-key.ts
+ *
+ * WHICH NAMES THIS WRITES, and why a writer needs a rule of its own. Everything
+ * that READS these variables accepts two spellings since the 2026-08-19
+ * vocabulary settlement (Appendix J of the Typed Standards specification;
+ * civic-ai-tools#160): the canonical `PUBLISHER_*` first, the prior-era
+ * `EVIDENCE_*` as a fallback. A writer cannot be "both" — it has to pick one
+ * name to put in a file. It writes the CANONICAL one, because the file it
+ * produces is what an operator copies into a secret manager and keeps for
+ * years, and because emitting the retiring name would manufacture new work for
+ * the flip. The prior-era spelling is named in the output so an operator who
+ * meets it in a deployment guide recognizes it.
+ *
+ * ONE CAVEAT WORTH STATING, because it is the case where the canonical name
+ * does NOT reach the app: the bundled `docker-compose.yml` passes variables
+ * through by explicit name, and its `environment:` map still lists the
+ * prior-era spellings. On that deployment path — and only there — supply the
+ * key under `EVIDENCE_SIGNING_KEY` until the compose file flips. Every other
+ * path (a hosting platform's environment, a shell, a systemd unit) delivers
+ * whatever name you set, and the app honors both.
  *
  * SECRET HYGIENE (#258 E2): this script never prints the private key to
  * stdout, logs, or anywhere else it could be scraped from a terminal
  * scrollback or a Claude Code session transcript. It writes
- * `EVIDENCE_SIGNING_KEY=<base64 DER PKCS8>` to a local file, created with
+ * `PUBLISHER_SIGNING_KEY=<base64 DER PKCS8>` to a local file, created with
  * 0600 permissions, in the current working directory. Copy that line into
  * your secret manager (docs/instance-setup.md §1), then delete the file.
+ * ONE private-key line only: writing the same secret twice under two names
+ * would double the surface a leak has to cover, which no naming convenience
+ * is worth.
  *
  * The output filename is deliberately NOT `.env*`-shaped: an `.env*`-fenced
  * agent-session hook would hang on a matching path. It is also listed in
@@ -20,13 +42,13 @@
  *
  * A keypair alone does not make an instance a signing publisher. Two more
  * things are required and NEITHER has a default:
- *   - `EVIDENCE_KEY_ID` — the kid naming this key's entry in your trust
+ *   - `PUBLISHER_KEY_ID` — the kid naming this key's entry in your trust
  *     registry. With the key set but no kid, the instance refuses to seal
  *     or publish (`signing_key_id_missing`) rather than emit a kid it was
  *     never given.
- *   - The instance-identity set (`EVIDENCE_SITE_ORIGIN`,
- *     `EVIDENCE_SIGNER_BINDING_TIER`/`_IDENTIFIER`/`_DISPLAY_NAME`,
- *     `EVIDENCE_PLATFORM_AGENT_TITLE`) — with the signing pair set but any
+ *   - The instance-identity set (`PUBLISHER_SITE_ORIGIN`,
+ *     `PUBLISHER_SIGNER_BINDING_TIER`/`_IDENTIFIER`/`_DISPLAY_NAME`,
+ *     `PUBLISHER_PLATFORM_AGENT_TITLE`) — with the signing pair set but any
  *     of these absent, every seal/publish attempt refuses
  *     (`instance_identity_missing`).
  *
@@ -38,6 +60,14 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+// The canonical names come from the same census the readers use, so the
+// writer cannot drift from them. Relative and extension-bearing: this script
+// runs under `node --experimental-strip-types`, which resolves neither the
+// `@/` alias nor extensionless specifiers.
+import {
+  canonicalEnvName,
+  priorEraEnvName,
+} from '../src/lib/publisher-env.ts';
 
 /** Deliberately not `.env*`-shaped — see the header comment. */
 export const KEY_FILE_NAME = 'signing-key.local.txt';
@@ -51,25 +81,30 @@ function main(): void {
   const pubB64 = pubDer.toString('base64');
 
   const keyFilePath = path.join(process.cwd(), KEY_FILE_NAME);
+  const signingKeyVar = canonicalEnvName('SIGNING_KEY');
+  const publicKeyVar = canonicalEnvName('PUBLIC_KEY');
   const fileContents =
-    `# Ed25519 evidence signing key — generated ${new Date().toISOString()}\n` +
-    `# SENSITIVE — the EVIDENCE_SIGNING_KEY line below is a private key.\n` +
+    `# Ed25519 record signing key — generated ${new Date().toISOString()}\n` +
+    `# SENSITIVE — the ${signingKeyVar} line below is a private key.\n` +
     `# Copy it into your secret manager (docs/instance-setup.md §1), then\n` +
     `# delete this file. It is listed in .gitignore, but confirm before\n` +
     `# pushing — a pre-push scan is not a substitute for deleting it.\n` +
-    `EVIDENCE_SIGNING_KEY=${privB64}\n` +
-    `EVIDENCE_PUBLIC_KEY=${pubB64}\n`;
+    `# The prior-era names ${priorEraEnvName('SIGNING_KEY')} /\n` +
+    `# ${priorEraEnvName('PUBLIC_KEY')} are still read, so an environment\n` +
+    `# already using them keeps working; rename when convenient.\n` +
+    `${signingKeyVar}=${privB64}\n` +
+    `${publicKeyVar}=${pubB64}\n`;
 
   // `mode` at creation is still subject to umask; chmod afterward guarantees
   // 0600 regardless of the caller's umask setting.
   fs.writeFileSync(keyFilePath, fileContents, { mode: 0o600 });
   fs.chmodSync(keyFilePath, 0o600);
 
-  console.log('=== Evidence Package Signing Keypair (Ed25519) ===\n');
+  console.log('=== Record Package Signing Keypair (Ed25519) ===\n');
   console.log(`Private key written to: ${keyFilePath}`);
   console.log('File permissions: 0600 (owner read/write only).');
   console.log(
-    'Not printed here, not logged: copy the EVIDENCE_SIGNING_KEY line from',
+    `Not printed here, not logged: copy the ${signingKeyVar} line from`,
   );
   console.log('that file into your secret manager, then delete the file.\n');
   console.log('Public key (safe to share — embedded in every package this key signs):');
@@ -79,12 +114,18 @@ function main(): void {
   console.log('Next (docs/instance-setup.md):');
   console.log('  1. Pick a kid, e.g. platform:evidence-2026-08 (§2).');
   console.log("  2. Publish a trust-registry entry for this public key under that kid (§3).");
-  console.log('  3. Set EVIDENCE_KEY_ID to that kid — no default. With EVIDENCE_SIGNING_KEY');
-  console.log('     set but EVIDENCE_KEY_ID unset, this instance refuses to seal or publish');
-  console.log('     (signing_key_id_missing).');
-  console.log('  4. Set the instance-identity set too — EVIDENCE_SITE_ORIGIN,');
-  console.log('     EVIDENCE_SIGNER_BINDING_TIER/_IDENTIFIER/_DISPLAY_NAME, and');
-  console.log('     EVIDENCE_PLATFORM_AGENT_TITLE — also no default (§4).');
+  console.log(`  3. Set ${canonicalEnvName('KEY_ID')} to that kid — no default. With`);
+  console.log(`     ${signingKeyVar} set but the key id unset, this instance refuses to`);
+  console.log('     seal or publish (signing_key_id_missing).');
+  console.log(`  4. Set the instance-identity set too — ${canonicalEnvName('SITE_ORIGIN')},`);
+  console.log('     PUBLISHER_SIGNER_BINDING_TIER/_IDENTIFIER/_DISPLAY_NAME, and');
+  console.log(`     ${canonicalEnvName('PLATFORM_AGENT_TITLE')} — also no default (§4).`);
+  console.log('');
+  console.log('Prior-era names: every variable above also answers to its EVIDENCE_*');
+  console.log('spelling (EVIDENCE_KEY_ID, EVIDENCE_SITE_ORIGIN, and so on) — both work,');
+  console.log('and the PUBLISHER_* form is the one to set from here on. The bundled');
+  console.log('docker-compose.yml still passes through the EVIDENCE_* names only, so on');
+  console.log('that deployment path use those until it flips.');
 }
 
 // Run main() only when invoked as a script, not when imported (the test

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -6,7 +6,7 @@
  * instance of civic-ai-tools-website needs to run, and prints a grouped
  * pass/fail table. Several of these vars fail silently or with a generic
  * error when absent (DATABASE_URL, the storage credentials,
- * EVIDENCE_SIGNING_KEY, the MCP endpoints, the model key), so a one-shot
+ * PUBLISHER_SIGNING_KEY, the MCP endpoints, the model key), so a one-shot
  * "is everything wired?" check removes that failure mode.
  *
  * INSTANCE-AWARE: an instance is not one fixed deployment shape. The three
@@ -108,6 +108,19 @@ export const DRIVER_SEAMS = {
  *     script or an eval harness); enumerated here for completeness only, and
  *     never something a deployment must deliver to the container.
  *
+ * TWO ACCEPTED NAMES for the publisher-identity set:
+ *   - `priorEraName: 'EVIDENCE_X'` — the entry's `name` is the CANONICAL
+ *     `PUBLISHER_X` spelling introduced by the 2026-08-19 vocabulary
+ *     settlement (Appendix J of the Typed Standards specification;
+ *     civic-ai-tools#160), and the prior-era spelling is still read by the
+ *     app. Presence is satisfied by EITHER name; the report shows the one that
+ *     answered and warns when it was the prior-era one. The precedence rule
+ *     mirrors `src/lib/publisher-env.ts` exactly — the CANONICAL name wins
+ *     whenever it is DEFINED, empty string included, because empty is a value
+ *     in this set (`TRUST_REGISTRY_LEGACY_URL=''` omits a URL from signed
+ *     output) and a preflight that disagreed with the app's own resolver would
+ *     pass a configuration the app then refuses.
+ *
  * A third conditional field expresses ALTERNATIVES rather than drivers — the
  * case where two variable sets satisfy the same need and an instance picks
  * one:
@@ -195,8 +208,8 @@ export const ENV_SPEC = [
   // with another deployment's registry entry (misattribution + unverifiable
   // evidence). Both halves are hard requirements of a signing instance, and
   // the SIGNING_PAIR group below adds the all-or-nothing semantics on top.
-  { name: 'EVIDENCE_SIGNING_KEY', tier: 'required', purpose: 'Ed25519 private key — signs evidence packages' },
-  { name: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry; no coded default' },
+  { name: 'PUBLISHER_SIGNING_KEY', priorEraName: 'EVIDENCE_SIGNING_KEY', tier: 'required', purpose: 'Ed25519 private key — signs evidence packages' },
+  { name: 'PUBLISHER_KEY_ID', priorEraName: 'EVIDENCE_KEY_ID', tier: 'required', purpose: 'Active signing key id (kid) — must match the trust registry; no coded default' },
 
   // --- Sign-in path (the rate-limit headroom option; OAuth) ---
   { name: 'NEXTAUTH_SECRET', tier: 'required', purpose: 'NextAuth session encryption' },
@@ -269,21 +282,21 @@ export const ENV_SPEC = [
   //     the "Evidence signing" group below carries the relationship. The
   //     remaining five are per-item overrides that DERIVE from the origin
   //     (host, registry URLs, agent URL) or the host (agent id). ---
-  { name: 'EVIDENCE_SITE_ORIGIN', tier: 'required', purpose: 'Instance origin — required to sign; registry URLs, platform-agent URL, notebook/bundle attribution links derive from it' },
-  { name: 'EVIDENCE_SIGNER_BINDING_TIER', tier: 'required', purpose: 'Envelope signer claim: bindingTier — required to sign; must match the registry entry (check #14)' },
-  { name: 'EVIDENCE_SIGNER_IDENTIFIER', tier: 'required', purpose: 'Envelope signer claim: identifier — required to sign; must match the registry entry (check #14)' },
-  { name: 'EVIDENCE_SIGNER_DISPLAY_NAME', tier: 'required', purpose: 'Envelope signer claim: displayName — required to sign; must match the registry entry (check #14)' },
-  { name: 'EVIDENCE_PLATFORM_AGENT_TITLE', tier: 'required', purpose: 'PROV platform-agent title + notebook attribution display name — required to sign' },
-  { name: 'EVIDENCE_PUBLICATION_HOST', tier: 'optional', purpose: 'Host label override on publishes-attestations, datHere environment.host, notebook/skill-text host mentions (derives from the origin)', hasFallback: true },
-  { name: 'EVIDENCE_TRUST_REGISTRY_CANONICAL_URL', tier: 'optional', purpose: 'Sidecar trustRegistryUrl override (defaults to origin + well-known path)', hasFallback: true },
-  { name: 'EVIDENCE_TRUST_REGISTRY_LEGACY_URL', tier: 'optional', purpose: 'Sidecar trustRegistryUrlLegacy override (empty string omits it; defaults to origin + legacy path)', hasFallback: true },
-  { name: 'EVIDENCE_PLATFORM_AGENT_ID', tier: 'optional', purpose: 'PROV platform-agent id inside the signed provenance graph (derives from the publication host)', hasFallback: true },
-  { name: 'EVIDENCE_PLATFORM_AGENT_URL', tier: 'optional', purpose: 'PROV platform-agent URL (defaults to EVIDENCE_SITE_ORIGIN)', hasFallback: true },
+  { name: 'PUBLISHER_SITE_ORIGIN', priorEraName: 'EVIDENCE_SITE_ORIGIN', tier: 'required', purpose: 'Instance origin — required to sign; registry URLs, platform-agent URL, notebook/bundle attribution links derive from it' },
+  { name: 'PUBLISHER_SIGNER_BINDING_TIER', priorEraName: 'EVIDENCE_SIGNER_BINDING_TIER', tier: 'required', purpose: 'Envelope signer claim: bindingTier — required to sign; must match the registry entry (check #14)' },
+  { name: 'PUBLISHER_SIGNER_IDENTIFIER', priorEraName: 'EVIDENCE_SIGNER_IDENTIFIER', tier: 'required', purpose: 'Envelope signer claim: identifier — required to sign; must match the registry entry (check #14)' },
+  { name: 'PUBLISHER_SIGNER_DISPLAY_NAME', priorEraName: 'EVIDENCE_SIGNER_DISPLAY_NAME', tier: 'required', purpose: 'Envelope signer claim: displayName — required to sign; must match the registry entry (check #14)' },
+  { name: 'PUBLISHER_PLATFORM_AGENT_TITLE', priorEraName: 'EVIDENCE_PLATFORM_AGENT_TITLE', tier: 'required', purpose: 'PROV platform-agent title + notebook attribution display name — required to sign' },
+  { name: 'PUBLISHER_PUBLICATION_HOST', priorEraName: 'EVIDENCE_PUBLICATION_HOST', tier: 'optional', purpose: 'Host label override on publishes-attestations, datHere environment.host, notebook/skill-text host mentions (derives from the origin)', hasFallback: true },
+  { name: 'PUBLISHER_TRUST_REGISTRY_CANONICAL_URL', priorEraName: 'EVIDENCE_TRUST_REGISTRY_CANONICAL_URL', tier: 'optional', purpose: 'Sidecar trustRegistryUrl override (defaults to origin + well-known path)', hasFallback: true },
+  { name: 'PUBLISHER_TRUST_REGISTRY_LEGACY_URL', priorEraName: 'EVIDENCE_TRUST_REGISTRY_LEGACY_URL', tier: 'optional', purpose: 'Sidecar trustRegistryUrlLegacy override (empty string omits it; defaults to origin + legacy path)', hasFallback: true },
+  { name: 'PUBLISHER_PLATFORM_AGENT_ID', priorEraName: 'EVIDENCE_PLATFORM_AGENT_ID', tier: 'optional', purpose: 'PROV platform-agent id inside the signed provenance graph (derives from the publication host)', hasFallback: true },
+  { name: 'PUBLISHER_PLATFORM_AGENT_URL', priorEraName: 'EVIDENCE_PLATFORM_AGENT_URL', tier: 'optional', purpose: 'PROV platform-agent URL (defaults to PUBLISHER_SITE_ORIGIN)', hasFallback: true },
 
   // --- Instance branding (#217: chrome-only theming seam; src/lib/brand-config.ts).
   //     All optional with coded defaults: unset, the demo chrome renders
   //     byte-identically. Chrome only — nothing here is emitted inside signed
-  //     evidence (that is the EVIDENCE_* identity set above), so these can
+  //     evidence (that is the PUBLISHER_* identity set above), so these can
   //     never invalidate a package or a registry cross-check. ---
   { name: 'SITE_BRAND_NAME', readBy: 'build-and-runtime', tier: 'optional', purpose: 'Instance display name — header wordmark, page titles, citation labels (default "Civic AI Tools")', hasFallback: true },
   { name: 'SITE_BRAND_ACCENT', readBy: 'build-and-runtime', tier: 'optional', purpose: 'Accent color (#rgb/#rrggbb) — overrides the accent tokens site-wide; unset or invalid = stylesheet default', hasFallback: true },
@@ -300,7 +313,15 @@ export const ENV_SPEC = [
   { name: 'ROADMAP_GITHUB_URL', readBy: 'build-and-runtime', tier: 'optional', purpose: '/roadmap "view source" link and byline label (unset: derived from ROADMAP_RAW_URL)', hasFallback: true },
 
   // --- Optional / feature / ops ---
-  { name: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },
+  { name: 'PUBLISHER_TRUST_REGISTRY_URL', priorEraName: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },
+  // WRITTEN, NEVER READ — the fourteenth variable of the settlement's Group A,
+  // and the one this inventory used to miss precisely because the inventory
+  // was derived from `process.env.*` reads. scripts/generate-signing-key.ts
+  // emits it beside the private key so an operator has the public half to
+  // publish in their trust registry; no app code loads it. Listed as
+  // `external-tool` so it is enumerated for completeness without a deployment
+  // ever being asked to deliver it to the container.
+  { name: 'PUBLISHER_PUBLIC_KEY', priorEraName: 'EVIDENCE_PUBLIC_KEY', readBy: 'external-tool', tier: 'optional', purpose: 'Public half of the signing keypair — written by scripts/generate-signing-key.ts for the trust-registry entry; never read by the app', hasFallback: true },
   { name: 'CIVICAITOOLS_SESSION_TOKEN', readBy: 'external-tool', tier: 'optional', purpose: 'publish-evidence skill (Claude Code) auth' },
   { name: 'CRON_SECRET', tier: 'optional', purpose: 'Cron endpoint auth (blob-gc, portal refresh)' },
   { name: 'NEXT_PUBLIC_GA_MEASUREMENT_ID', readBy: 'build', tier: 'optional', purpose: 'Google Analytics 4' },
@@ -378,13 +399,13 @@ export const ENV_GROUPS = [
   {
     name: 'Evidence signing',
     members: [
-      'EVIDENCE_SIGNING_KEY',
-      'EVIDENCE_KEY_ID',
-      'EVIDENCE_SITE_ORIGIN',
-      'EVIDENCE_SIGNER_BINDING_TIER',
-      'EVIDENCE_SIGNER_IDENTIFIER',
-      'EVIDENCE_SIGNER_DISPLAY_NAME',
-      'EVIDENCE_PLATFORM_AGENT_TITLE',
+      'PUBLISHER_SIGNING_KEY',
+      'PUBLISHER_KEY_ID',
+      'PUBLISHER_SITE_ORIGIN',
+      'PUBLISHER_SIGNER_BINDING_TIER',
+      'PUBLISHER_SIGNER_IDENTIFIER',
+      'PUBLISHER_SIGNER_DISPLAY_NAME',
+      'PUBLISHER_PLATFORM_AGENT_TITLE',
     ],
     // src/lib/evidence/unsigned-tier.ts: `isSigningConfigured` requires BOTH
     // custody halves (key + declared kid), and as of #258 the seal/commit
@@ -398,7 +419,7 @@ export const ENV_GROUPS = [
     // `instance_identity_missing`) and the banner shows — but preflight is
     // where the operator sees the RELATIONSHIP before a deploy.
     feature: 'evidence seal/publish stays gated off — the instance cannot sign',
-    note: 'Key, key id, and the instance-identity set travel together: a key without a declared kid refuses rather than emit a kid it never declared, and a signing pair without EVIDENCE_SITE_ORIGIN, the EVIDENCE_SIGNER_* triple, and EVIDENCE_PLATFORM_AGENT_TITLE refuses rather than sign under an identity this instance never configured (docs/instance-setup.md).',
+    note: 'Key, key id, and the instance-identity set travel together: a key without a declared kid refuses rather than emit a kid it never declared, and a signing pair without PUBLISHER_SITE_ORIGIN, the PUBLISHER_SIGNER_* triple, and PUBLISHER_PLATFORM_AGENT_TITLE refuses rather than sign under an identity this instance never configured (docs/instance-setup.md). Each of those also answers to its prior-era EVIDENCE_* spelling.',
   },
   {
     name: 'Durable rate limiting',
@@ -461,6 +482,44 @@ function allPresent(names, env) {
   return names.every((name) => isPresent(env[name]));
 }
 
+/** ENV_SPEC indexed by canonical name, so a group member resolves to its
+ *  entry (and therefore to its two-name rule) rather than to a bare lookup. */
+function specIndex(spec) {
+  const byName = new Map();
+  for (const s of spec) byName.set(s.name, s);
+  return byName;
+}
+
+/**
+ * Resolve ONE spec entry against `env`, honoring the two accepted names.
+ *
+ * Mirrors `src/lib/publisher-env.ts` deliberately and exactly: the canonical
+ * name wins whenever it is DEFINED — empty string included — and only an
+ * entirely unset canonical name falls through to the prior-era spelling. A
+ * preflight that resolved differently from the app's own reader would pass a
+ * configuration the app then refuses, which is worse than no preflight.
+ *
+ * Returns the name that ANSWERED (the canonical one when neither did), the raw
+ * value for the presence test, and whether the prior-era name supplied it.
+ * Nothing is echoed: the raw value is consumed by `isPresent` alone.
+ *
+ * @param {{ name: string, priorEraName?: string }} entry
+ * @param {Record<string, string | undefined>} env
+ */
+export function resolveEnvName(entry, env) {
+  const canonical = env[entry.name];
+  if (typeof canonical === 'string') {
+    return { name: entry.name, raw: canonical, viaPriorEra: false };
+  }
+  if (typeof entry.priorEraName === 'string') {
+    const priorEra = env[entry.priorEraName];
+    if (typeof priorEra === 'string') {
+      return { name: entry.priorEraName, raw: priorEra, viaPriorEra: true };
+    }
+  }
+  return { name: entry.name, raw: undefined, viaPriorEra: false };
+}
+
 /**
  * Detect partially set all-or-nothing groups (#195). A group whose
  * `onlyWhen` condition the resolved drivers do not meet is skipped entirely
@@ -473,11 +532,17 @@ function allPresent(names, env) {
  * @param {typeof ENV_GROUPS} [groups]
  * @returns {{ name: string, feature: string, note?: string, total: number, present: string[], missing: string[] }[]}
  */
-export function evaluateGroups(env, drivers, groups = ENV_GROUPS) {
+export function evaluateGroups(env, drivers, groups = ENV_GROUPS, spec = ENV_SPEC) {
+  const byName = specIndex(spec);
+  // A member counts as present under EITHER of its accepted names; a member
+  // that is MISSING is named canonically, because the warning tells an
+  // operator what to set and the prior-era spelling is the one being retired.
+  const memberPresent = (name) =>
+    isPresent(resolveEnvName(byName.get(name) ?? { name }, env).raw);
   const partial = [];
   for (const g of groups) {
     if (g.onlyWhen && !conditionMet(g.onlyWhen, drivers)) continue;
-    const present = g.members.filter((name) => isPresent(env[name]));
+    const present = g.members.filter(memberPresent);
     if (present.length === 0 || present.length === g.members.length) continue;
     partial.push({
       name: g.name,
@@ -485,7 +550,7 @@ export function evaluateGroups(env, drivers, groups = ENV_GROUPS) {
       note: g.note,
       total: g.members.length,
       present,
-      missing: g.members.filter((name) => !isPresent(env[name])),
+      missing: g.members.filter((name) => !memberPresent(name)),
     });
   }
   return partial;
@@ -542,13 +607,18 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
   const { applicable, notApplicable } = resolveSpec(drivers, spec, env);
 
   const rows = applicable.map((s) => {
-    const present = isPresent(env[s.name]);
+    const resolved = resolveEnvName(s, env);
     return {
-      name: s.name,
+      // The name that ANSWERED — so an instance still on the prior-era
+      // spelling sees the variable it actually set, not one it did not.
+      name: resolved.name,
+      // The name to set from here on; drives the deprecation notice below.
+      canonicalName: s.name,
+      viaPriorEra: resolved.viaPriorEra,
       tier: s.tier,
       purpose: s.purpose,
       hasFallback: Boolean(s.hasFallback),
-      present,
+      present: isPresent(resolved.raw),
     };
   });
 
@@ -560,7 +630,11 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
   const missingRequired = rows.filter((r) => r.tier === 'required' && !r.present && !r.hasFallback);
   const requiredOnFallback = rows.filter((r) => r.tier === 'required' && !r.present && r.hasFallback);
   const missingRecommended = rows.filter((r) => r.tier === 'recommended' && !r.present);
-  const partialGroups = evaluateGroups(env, drivers);
+  const partialGroups = evaluateGroups(env, drivers, ENV_GROUPS, spec);
+  // Variables supplied under a prior-era name. Warn-only and never a failure:
+  // both spellings work, and the expand half of the settlement exists exactly
+  // so that an instance mid-rename is a working instance.
+  const deprecatedNames = rows.filter((r) => r.viaPriorEra);
 
   return {
     rows,
@@ -571,6 +645,7 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
     // a partial group never flips `ok` — each member's own tier already
     // governs pass/fail, and the group adds the set semantics on top.
     partialGroups,
+    deprecatedNames,
     // Profile context. `notApplicable` is deliberately NOT rendered as rows:
     // an instance must not be told about variables its profile never reads.
     profile: { drivers, isDefault },
@@ -649,6 +724,22 @@ export function renderReport(result) {
       lines.push(`            - ${g.name}: ${g.present.length} of ${g.total} present; off until all ${g.total} are set. Missing: ${g.missing.join(', ')}`);
       lines.push(`              (while partial: ${g.feature})`);
       if (g.note) lines.push(`              Note: ${g.note}`);
+    }
+  }
+  // Prior-era variable names still in use (civic-ai-tools#160 P3). A NOTE,
+  // not a WARN and never a failure: the value reached the app, the instance
+  // works, and the rename is the operator's to schedule. It is reported at all
+  // because the alternative — silence — leaves an operator to discover the new
+  // names from a release note, and because this list is exactly the work the
+  // eventual removal will require.
+  if (result.deprecatedNames && result.deprecatedNames.length > 0) {
+    lines.push(
+      `  NOTE: ${result.deprecatedNames.length} variable(s) supplied under a prior-era name.`,
+    );
+    lines.push('        Both spellings work today; the prior-era one is removed at a future');
+    lines.push('        major version (2026-08-19 vocabulary settlement):');
+    for (const r of result.deprecatedNames) {
+      lines.push(`            - ${r.name} → rename to ${r.canonicalName}`);
     }
   }
   if (result.requiredOnFallback && result.requiredOnFallback.length > 0) {

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -321,7 +321,7 @@ export const ENV_SPEC = [
   // publish in their trust registry; no app code loads it. Listed as
   // `external-tool` so it is enumerated for completeness without a deployment
   // ever being asked to deliver it to the container.
-  { name: 'PUBLISHER_PUBLIC_KEY', priorEraName: 'EVIDENCE_PUBLIC_KEY', readBy: 'external-tool', tier: 'optional', purpose: 'Public half of the signing keypair — written by scripts/generate-signing-key.ts for the trust-registry entry; never read by the app', hasFallback: true },
+  { name: 'PUBLISHER_PUBLIC_KEY', priorEraName: 'EVIDENCE_PUBLIC_KEY', readBy: 'external-tool', tier: 'optional', purpose: 'Public half of the signing keypair — written by scripts/generate-signing-key.ts for the trust-registry entry; never read by the app' },
   { name: 'CIVICAITOOLS_SESSION_TOKEN', readBy: 'external-tool', tier: 'optional', purpose: 'publish-evidence skill (Claude Code) auth' },
   { name: 'CRON_SECRET', tier: 'optional', purpose: 'Cron endpoint auth (blob-gc, portal refresh)' },
   { name: 'NEXT_PUBLIC_GA_MEASUREMENT_ID', readBy: 'build', tier: 'optional', purpose: 'Google Analytics 4' },

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -12,6 +12,7 @@ import {
   evaluateGroups,
   renderReport,
   resolveDrivers,
+  resolveEnvName,
   resolveSpec,
   ENV_SPEC,
   ENV_GROUPS,
@@ -46,12 +47,12 @@ test('ok=false and the missing required var is reported when one is absent', () 
 test('empty string and whitespace-only count as absent (not present)', () => {
   const env = envWithAllRequired();
   // Two required vars with NO coded fallback, so they count as hard misses.
-  env.EVIDENCE_SIGNING_KEY = '';
+  env.PUBLISHER_SIGNING_KEY = '';
   env.NEXTAUTH_SECRET = '   ';
   const result = evaluateEnv(env);
   assert.equal(result.ok, false);
   const names = result.missingRequired.map((r) => r.name).sort();
-  assert.deepEqual(names, ['EVIDENCE_SIGNING_KEY', 'NEXTAUTH_SECRET']);
+  assert.deepEqual(names, ['NEXTAUTH_SECRET', 'PUBLISHER_SIGNING_KEY']);
 });
 
 test('a required var with a coded fallback is soft when absent (fallbk, run still passes)', () => {
@@ -91,21 +92,113 @@ test('#258 C5: NEXT_PUBLIC_SOCRATA_MCP_URL is no longer part of the environment 
   assert.ok(!ENV_SPEC.some((s) => s.name === 'NEXT_PUBLIC_SOCRATA_MCP_URL'));
 });
 
-test('EVIDENCE_KEY_ID has NO coded fallback: absent, it is a hard miss that fails the run', () => {
+test('the signing key id has NO coded fallback: absent, it is a hard miss that fails the run', () => {
   // The kid used to carry `hasFallback: true`, pointing at a hardcoded
   // default in signing.ts that substituted the reference deployment's kid.
   // That default is gone — an instance emits the kid it declared or none —
   // so an absent kid is a real miss, not a soft note.
-  const entry = ENV_SPEC.find((s) => s.name === 'EVIDENCE_KEY_ID');
+  const entry = ENV_SPEC.find((s) => s.name === 'PUBLISHER_KEY_ID');
   assert.equal(entry.tier, 'required');
-  assert.ok(!entry.hasFallback, 'EVIDENCE_KEY_ID must not claim a coded fallback');
+  assert.ok(!entry.hasFallback, 'the key id must not claim a coded fallback');
 
   const env = envWithAllRequired();
-  delete env.EVIDENCE_KEY_ID;
+  delete env.PUBLISHER_KEY_ID;
   const result = evaluateEnv(env);
   assert.equal(result.ok, false);
-  assert.deepEqual(result.missingRequired.map((r) => r.name), ['EVIDENCE_KEY_ID']);
-  assert.ok(!result.requiredOnFallback.some((r) => r.name === 'EVIDENCE_KEY_ID'));
+  assert.deepEqual(result.missingRequired.map((r) => r.name), ['PUBLISHER_KEY_ID']);
+  assert.ok(!result.requiredOnFallback.some((r) => r.name === 'PUBLISHER_KEY_ID'));
+
+  // ...and the prior-era spelling satisfies it, because the app still reads
+  // that name (civic-ai-tools#160 P3). An instance that has not renamed
+  // anything must not be told it is unconfigured.
+  env[entry.priorEraName] = 'present';
+  const viaPriorEra = evaluateEnv(env);
+  assert.equal(viaPriorEra.ok, true);
+  assert.ok(!viaPriorEra.missingRequired.some((r) => r.canonicalName === 'PUBLISHER_KEY_ID'));
+});
+
+// --- The two-name expand (civic-ai-tools#160 P3) ------------------------------
+//
+// Group A of the 2026-08-19 vocabulary settlement moves the publisher-identity
+// set from `EVIDENCE_*` to `PUBLISHER_*`. Everything that READS these accepts
+// both names; this preflight has to agree with the readers exactly, or it
+// passes configurations the app refuses (and refuses ones the app accepts).
+
+test('two-name expand: either spelling satisfies presence, and the report names the one found', () => {
+  const env = {};
+  for (const entry of ENV_SPEC.filter((e) => e.tier === 'required')) {
+    // Deliberately the PRIOR-ERA spelling wherever there is one — the state
+    // every existing instance is in on the day this ships.
+    env[entry.priorEraName ?? entry.name] = 'present';
+  }
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, true, 'an entirely prior-era instance still passes');
+
+  // The row reports the name that ANSWERED, so an operator sees what they set.
+  const keyIdRow = result.rows.find((r) => r.canonicalName === 'PUBLISHER_KEY_ID');
+  assert.equal(keyIdRow.present, true);
+  assert.equal(keyIdRow.name, 'EVIDENCE_KEY_ID');
+  assert.equal(keyIdRow.viaPriorEra, true);
+
+  // And the deprecation notice lists every one of them, with its successor.
+  assert.ok(result.deprecatedNames.length > 0);
+  assert.ok(
+    result.deprecatedNames.every((r) => r.name.startsWith('EVIDENCE_')),
+    'only prior-era names are listed as deprecated',
+  );
+  const report = renderReport(result);
+  assert.match(report, /EVIDENCE_KEY_ID → rename to PUBLISHER_KEY_ID/);
+  assert.match(report, /removed at a future/);
+  // A NOTE, never a failure: the value reached the app.
+  assert.ok(!report.includes('RESULT: FAIL'));
+});
+
+test('two-name expand: the canonical name wins whenever it is DEFINED, empty included', () => {
+  // The precedence rule is `defined`, not `truthy`, and it must match
+  // src/lib/publisher-env.ts exactly. Empty is a VALUE in this set —
+  // TRUST_REGISTRY_LEGACY_URL='' omits a URL from signed output — so a
+  // preflight that fell through on empty would report PASS for a
+  // configuration the app treats as unset.
+  const entry = ENV_SPEC.find((s) => s.name === 'PUBLISHER_SITE_ORIGIN');
+  assert.equal(
+    resolveEnvName(entry, { PUBLISHER_SITE_ORIGIN: 'a', EVIDENCE_SITE_ORIGIN: 'b' }).name,
+    'PUBLISHER_SITE_ORIGIN',
+  );
+  const shadowed = resolveEnvName(entry, {
+    PUBLISHER_SITE_ORIGIN: '',
+    EVIDENCE_SITE_ORIGIN: 'https://prior-era.example.org',
+  });
+  assert.equal(shadowed.name, 'PUBLISHER_SITE_ORIGIN');
+  assert.equal(shadowed.raw, '');
+  assert.equal(shadowed.viaPriorEra, false);
+
+  const env = envWithAllRequired();
+  env.PUBLISHER_SITE_ORIGIN = '';
+  env.EVIDENCE_SITE_ORIGIN = 'https://prior-era.example.org';
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false, 'an emptied canonical name is a miss, not a fall-through');
+  assert.deepEqual(result.missingRequired.map((r) => r.name), ['PUBLISHER_SITE_ORIGIN']);
+});
+
+test('two-name expand: every publisher variable in the census is declared with both names', () => {
+  // The census is Appendix J's environment row: fourteen variables. This
+  // inventory used to hold thirteen — PUBLIC_KEY is written by the keygen
+  // script and never read, so an inventory derived from `process.env.*` reads
+  // could not see it. Pinned at fourteen so the gap cannot reopen.
+  const publisherEntries = ENV_SPEC.filter((s) => s.name.startsWith('PUBLISHER_'));
+  assert.equal(publisherEntries.length, 14, 'the settlement names fourteen variables');
+  for (const entry of publisherEntries) {
+    assert.equal(
+      entry.priorEraName,
+      entry.name.replace(/^PUBLISHER_/, 'EVIDENCE_'),
+      `${entry.name} must declare its prior-era spelling`,
+    );
+  }
+  // Nothing is left behind under the old prefix.
+  assert.deepEqual(
+    ENV_SPEC.filter((s) => s.name.startsWith('EVIDENCE_')).map((s) => s.name),
+    [],
+  );
 });
 
 test('missing recommended variables do not fail the run', () => {
@@ -611,18 +704,18 @@ test('a partially-set signing group warns, naming the missing members and the mi
   // also carries the instance-identity set, which the seal/commit gate
   // requires alongside the pair (key + kid + identity travel together).
   const env = envWithAllRequired();
-  delete env.EVIDENCE_KEY_ID; // key + identity set, kid absent — a defect state
+  delete env.PUBLISHER_KEY_ID; // key + identity set, kid absent — a defect state
   const result = evaluateEnv(env);
 
   const partial = result.partialGroups.find((g) => g.name === 'Evidence signing');
   assert.ok(partial, 'the partially-set signing group is reported as partial');
   assert.equal(partial.total, 7);
-  assert.ok(partial.present.includes('EVIDENCE_SIGNING_KEY'));
-  assert.ok(partial.present.includes('EVIDENCE_SITE_ORIGIN'));
-  assert.deepEqual(partial.missing, ['EVIDENCE_KEY_ID']);
+  assert.ok(partial.present.includes('PUBLISHER_SIGNING_KEY'));
+  assert.ok(partial.present.includes('PUBLISHER_SITE_ORIGIN'));
+  assert.deepEqual(partial.missing, ['PUBLISHER_KEY_ID']);
 
   const report = renderReport(result);
-  assert.match(report, /Evidence signing: 6 of 7 present; off until all 7 are set\. Missing: EVIDENCE_KEY_ID/);
+  assert.match(report, /Evidence signing: 6 of 7 present; off until all 7 are set\. Missing: PUBLISHER_KEY_ID/);
   assert.match(report, /cannot sign/);
   assert.match(report, /travel together/);
   // Unlike the other groups, this one ALSO fails the run — every member is
@@ -632,11 +725,11 @@ test('a partially-set signing group warns, naming the missing members and the mi
 
 test('#258: the identity members of the signing group are required-tier with no coded fallback', () => {
   const IDENTITY_MEMBERS = [
-    'EVIDENCE_SITE_ORIGIN',
-    'EVIDENCE_SIGNER_BINDING_TIER',
-    'EVIDENCE_SIGNER_IDENTIFIER',
-    'EVIDENCE_SIGNER_DISPLAY_NAME',
-    'EVIDENCE_PLATFORM_AGENT_TITLE',
+    'PUBLISHER_SITE_ORIGIN',
+    'PUBLISHER_SIGNER_BINDING_TIER',
+    'PUBLISHER_SIGNER_IDENTIFIER',
+    'PUBLISHER_SIGNER_DISPLAY_NAME',
+    'PUBLISHER_PLATFORM_AGENT_TITLE',
   ];
   const group = ENV_GROUPS.find((g) => g.name === 'Evidence signing');
   for (const name of IDENTITY_MEMBERS) {
@@ -658,11 +751,11 @@ test('#258: the identity members of the signing group are required-tier with no 
   // The DERIVED identity overrides stay optional-with-fallback: derivation
   // from an operator-set origin is real config, not a reference default.
   for (const name of [
-    'EVIDENCE_PUBLICATION_HOST',
-    'EVIDENCE_TRUST_REGISTRY_CANONICAL_URL',
-    'EVIDENCE_TRUST_REGISTRY_LEGACY_URL',
-    'EVIDENCE_PLATFORM_AGENT_ID',
-    'EVIDENCE_PLATFORM_AGENT_URL',
+    'PUBLISHER_PUBLICATION_HOST',
+    'PUBLISHER_TRUST_REGISTRY_CANONICAL_URL',
+    'PUBLISHER_TRUST_REGISTRY_LEGACY_URL',
+    'PUBLISHER_PLATFORM_AGENT_ID',
+    'PUBLISHER_PLATFORM_AGENT_URL',
   ]) {
     const entry = ENV_SPEC.find((s) => s.name === name);
     assert.equal(entry.tier, 'optional', `${name} stays an optional override`);

--- a/scripts/rehearse-instance-identity.ts
+++ b/scripts/rehearse-instance-identity.ts
@@ -6,16 +6,25 @@
  * With ZERO code edits, configuration only, this script:
  *
  *   1. generates an EPHEMERAL Ed25519 keypair in-process (never the real
- *      `EVIDENCE_SIGNING_KEY`; nothing is read from or written to any
+ *      signing key; nothing is read from or written to any
  *      secret store — the keypair lives and dies with this run);
  *   2. builds a local trust-registry JSON from the docs/instance-setup.md §3
  *      template, carrying the ephemeral PUBLIC key under a rehearsal kid;
  *   3. runs the app's produce path under a fully alternate identity
- *      (`EVIDENCE_SITE_ORIGIN` / `EVIDENCE_PUBLICATION_HOST` /
- *      `EVIDENCE_SIGNER_*` / registry URLs pointed at the local registry);
+ *      (`PUBLISHER_SITE_ORIGIN` / `PUBLISHER_PUBLICATION_HOST` /
+ *      `PUBLISHER_SIGNER_*` / registry URLs pointed at the local registry);
  *   4. verifies the emitted package OFFLINE (verify-core §9.2 checks) against
  *      that local registry, resolved from the sidecar's own
  *      `trustRegistryUrl` — the same bootstrap a third-party verifier uses.
+ *
+ * WHICH SPELLING IT REHEARSES, and why that matters (civic-ai-tools#160 P3).
+ * Since the 2026-08-19 vocabulary settlement every one of these variables has
+ * two accepted names — canonical `PUBLISHER_*`, prior-era `EVIDENCE_*`. This
+ * rehearsal drives the CANONICAL ones, and explicitly UNSETS each prior-era
+ * twin before it starts, so a PASS is proof that the canonical names carry the
+ * whole produce path on their own rather than proof that something in the
+ * ambient environment answered. (The prior-era leg has its own coverage: the
+ * reference-identity fixture in the unit suite is entirely prior-era.)
  *
  * PASS means: the emitted package carries the alternate identity throughout
  * (envelope signer, sidecar registry URLs, environment-extension host, PROV
@@ -38,6 +47,12 @@ import os from 'node:os';
 import path from 'node:path';
 import assert from 'node:assert/strict';
 import { pathToFileURL, fileURLToPath } from 'node:url';
+// The publisher-variable census, so the prior-era names this rehearsal clears
+// cannot drift from the names the readers accept.
+import {
+  PUBLISHER_ENV_SUFFIXES,
+  priorEraEnvName,
+} from '../src/lib/publisher-env.ts';
 
 // --- The alternate identity (pure config; every value is synthetic) --------
 
@@ -100,17 +115,23 @@ async function main(): Promise<void> {
   log(`[2/6] local trust registry written from the instance-setup template`);
 
   // --- 3. Alternate identity via CONFIG ONLY (the ADR-0020 claim) ---------
-  process.env.EVIDENCE_SIGNING_KEY = privB64;
-  process.env.EVIDENCE_KEY_ID = REHEARSAL_KID;
-  process.env.EVIDENCE_SITE_ORIGIN = REHEARSAL_ORIGIN;
-  process.env.EVIDENCE_PUBLICATION_HOST = REHEARSAL_HOST;
-  process.env.EVIDENCE_SIGNER_BINDING_TIER = REHEARSAL_SIGNER.bindingTier;
-  process.env.EVIDENCE_SIGNER_IDENTIFIER = REHEARSAL_SIGNER.identifier;
-  process.env.EVIDENCE_SIGNER_DISPLAY_NAME = REHEARSAL_SIGNER.displayName;
-  process.env.EVIDENCE_TRUST_REGISTRY_CANONICAL_URL = registryUrl;
-  process.env.EVIDENCE_TRUST_REGISTRY_LEGACY_URL = ''; // omit — no legacy client base
-  process.env.EVIDENCE_PLATFORM_AGENT_ID = REHEARSAL_AGENT_ID;
-  process.env.EVIDENCE_PLATFORM_AGENT_TITLE = REHEARSAL_SIGNER.displayName;
+  // Every prior-era twin is cleared first. Without this the rehearsal could
+  // pass on a machine where the operator's shell already exports the old
+  // names — a green that says nothing about the canonical ones.
+  for (const suffix of PUBLISHER_ENV_SUFFIXES) {
+    delete process.env[priorEraEnvName(suffix)];
+  }
+  process.env.PUBLISHER_SIGNING_KEY = privB64;
+  process.env.PUBLISHER_KEY_ID = REHEARSAL_KID;
+  process.env.PUBLISHER_SITE_ORIGIN = REHEARSAL_ORIGIN;
+  process.env.PUBLISHER_PUBLICATION_HOST = REHEARSAL_HOST;
+  process.env.PUBLISHER_SIGNER_BINDING_TIER = REHEARSAL_SIGNER.bindingTier;
+  process.env.PUBLISHER_SIGNER_IDENTIFIER = REHEARSAL_SIGNER.identifier;
+  process.env.PUBLISHER_SIGNER_DISPLAY_NAME = REHEARSAL_SIGNER.displayName;
+  process.env.PUBLISHER_TRUST_REGISTRY_CANONICAL_URL = registryUrl;
+  process.env.PUBLISHER_TRUST_REGISTRY_LEGACY_URL = ''; // omit — no legacy client base
+  process.env.PUBLISHER_PLATFORM_AGENT_ID = REHEARSAL_AGENT_ID;
+  process.env.PUBLISHER_PLATFORM_AGENT_TITLE = REHEARSAL_SIGNER.displayName;
 
   // App modules are imported AFTER the environment is set (config getters
   // read at call time; the late import simply removes any load-order doubt).

--- a/src/app/(app)/records/[slug]/page.tsx
+++ b/src/app/(app)/records/[slug]/page.tsx
@@ -1,0 +1,16 @@
+// `/records/[slug]` — the settlement-era address of a published record's
+// detail page (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/evidence/[slug]` is a PERMANENT alias, not a
+// deprecation window: every share link, citation and OG card already published
+// carries the prior-era form and must keep resolving forever.
+//
+// The page is defined ONCE, at the prior-era path, and re-exported here — the
+// direction is measured in `src/app/api/records/segment-alias.test.ts`.
+//
+// `generateMetadata` comes across with it, which means this address emits the
+// PRIOR-ERA canonical/OG/citation URL (`…/evidence/<slug>`) for now. That is
+// deliberate for this phase: the new segments SERVE, and nothing advertises
+// them until the cutover phase flips what the site emits. No route-segment
+// config to mirror here — neither address declares any, so both render on
+// demand for the same reason (a dynamic segment with no `generateStaticParams`).
+export { default, generateMetadata } from '@/app/(app)/evidence/[slug]/page';

--- a/src/app/(app)/records/page.tsx
+++ b/src/app/(app)/records/page.tsx
@@ -1,0 +1,21 @@
+// `/records` — the settlement-era address of the published-record index
+// (Appendix J of the Typed Standards specification; civic-ai-tools#160).
+// `/evidence` is a PERMANENT alias, not a deprecation window: published links
+// carry the prior-era form and must keep resolving forever.
+//
+// The page is defined ONCE, at the prior-era path, and re-exported here — the
+// direction is measured in `src/app/api/records/segment-alias.test.ts`. Both
+// addresses therefore render the same tree, with the same metadata, under the
+// same `(app)` layout; nothing here advertises the new address, which is the
+// cutover phase's job.
+export { default, metadata } from '@/app/(app)/evidence/page';
+
+// DECLARED, NOT RE-EXPORTED, and the distinction is load-bearing. Next reads
+// route-segment config by parsing THIS file's source (`getPageStaticInfo`),
+// which sees initialized `export const` declarations and not re-export
+// bindings. `export { dynamic } from …` would be invisible to it, and this
+// address would prerender at build while `/evidence` kept rendering per
+// request — two addresses for one page, silently disagreeing. The literal
+// below is the mirror of the one in the page this file re-exports, and the
+// alias test pins the pair so they cannot drift apart.
+export const dynamic = 'force-dynamic';

--- a/src/app/api/auth/device/code/route.ts
+++ b/src/app/api/auth/device/code/route.ts
@@ -10,6 +10,11 @@ import {
   generateUserCode,
   getBaseUrl,
 } from '@/lib/device-flow';
+import {
+  ACCEPTED_PUBLISH_SCOPES,
+  isAcceptedMintScope,
+  resolveMintScope,
+} from '@/lib/publish-scope';
 
 /**
  * Device authorization grant start (RFC 8628 §3.1).
@@ -18,6 +23,17 @@ import {
  * user_code, and the verification URL to display to the user. The
  * client then polls /api/auth/device/token with the device_code until
  * the user approves the flow in a browser.
+ *
+ * SCOPE, under two names (civic-ai-tools#160 P3). The 2026-08-19 vocabulary
+ * settlement renames the publish scope `evidence:publish` → `records:publish`
+ * as an alias-and-deprecate: BOTH are accepted here, an omitted scope now
+ * takes the canonical `records:publish`, and an explicitly requested scope is
+ * granted VERBATIM. Verbatim matters — this endpoint and the token endpoint
+ * echo the granted scope back, and RFC 8628 clients compare that against what
+ * they asked for. Silently upgrading a client's string would fail that
+ * comparison for a client that did nothing wrong. Enforcement treats the two
+ * as one authorization (`hasPublishScope`), so which string a token ends up
+ * carrying never changes what it can do.
  */
 
 interface DeviceCodeRequest {
@@ -25,7 +41,7 @@ interface DeviceCodeRequest {
   scope?: string;
 }
 
-const ALLOWED_SCOPES = new Set(['evidence:publish']);
+const ALLOWED_SCOPES = new Set(ACCEPTED_PUBLISH_SCOPES);
 const MAX_NAME_LENGTH = 80;
 const MAX_USER_CODE_COLLISION_RETRIES = 5;
 
@@ -37,10 +53,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
 
-  const scope = (body.scope ?? 'evidence:publish').trim();
-  if (!ALLOWED_SCOPES.has(scope)) {
+  const scope = resolveMintScope(body.scope);
+  if (!isAcceptedMintScope(scope)) {
     return NextResponse.json(
-      { error: 'invalid_scope', error_description: `Unknown scope: ${scope}` },
+      {
+        error: 'invalid_scope',
+        error_description:
+          `Unknown scope: ${scope}. Accepted: ${[...ALLOWED_SCOPES].join(', ')}`,
+      },
       { status: 400 },
     );
   }

--- a/src/app/api/blob/upload-token/route.ts
+++ b/src/app/api/blob/upload-token/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { grantClientUpload } from '@/lib/storage';
-import { resolveRequestUser, hasScope } from '@/lib/api-auth';
+import { resolveRequestUser, hasPublishScope } from '@/lib/api-auth';
+import { MISSING_PUBLISH_SCOPE_ERROR } from '@/lib/publish-scope';
 
 /**
  * Client-upload grant endpoint for evidence blob references
@@ -67,8 +68,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         if (!auth) {
           throw new Error('Authentication required');
         }
-        if (!hasScope(auth, 'evidence:publish')) {
-          throw new Error('Token missing required scope: evidence:publish');
+        // Either accepted spelling authorizes — see the note at
+        // POST /api/evidence. This route gates the blob store that the
+        // publish path writes through, so a disagreement with the two
+        // publish routes would let a token start a publish it cannot finish.
+        if (!hasPublishScope(auth)) {
+          throw new Error(MISSING_PUBLISH_SCOPE_ERROR);
         }
 
         // Pathname validation: lock uploads to `evidence-refs/<sha256>[.ext]`.

--- a/src/app/api/evidence/[slug]/publish/route.ts
+++ b/src/app/api/evidence/[slug]/publish/route.ts
@@ -6,7 +6,8 @@ import { getPackage, putPackage, deletePackageBlob } from '@/lib/storage';
 import { emitPublicationPair } from '@/lib/evidence/publication';
 import { resolveLifecycle } from '@/lib/evidence/lifecycle';
 import type { EvidencePackage } from '@/lib/evidence/packager';
-import { resolveRequestUser, hasScope } from '@/lib/api-auth';
+import { resolveRequestUser, hasPublishScope } from '@/lib/api-auth';
+import { MISSING_PUBLISH_SCOPE_ERROR } from '@/lib/publish-scope';
 import {
   runAdversarialEval,
   emitEvaluationAttestation,
@@ -70,9 +71,10 @@ export async function POST(
   if (!auth) {
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
   }
-  if (!hasScope(auth, 'evidence:publish')) {
+  // Either accepted spelling authorizes — see the note at POST /api/evidence.
+  if (!hasPublishScope(auth)) {
     return NextResponse.json(
-      { error: 'Token missing required scope: evidence:publish' },
+      { error: MISSING_PUBLISH_SCOPE_ERROR },
       { status: 403 },
     );
   }

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -8,7 +8,8 @@ import { hash } from '@/lib/evidence/trace';
 import { signPackage, getRfc3161Timestamp, publishToRekor, getActiveSigner, type SignerIdentity } from '@/lib/evidence/signing';
 import { captureVocabForProfile } from '@/lib/evidence/profiles';
 import { type BlobRef } from '@/lib/evidence/blob-ref';
-import { resolveRequestUser, hasScope } from '@/lib/api-auth';
+import { resolveRequestUser, hasPublishScope } from '@/lib/api-auth';
+import { MISSING_PUBLISH_SCOPE_ERROR } from '@/lib/publish-scope';
 import { emitPublicationPair } from '@/lib/evidence/publication';
 import { evaluateSealCommitGate } from '@/lib/evidence/unsigned-tier';
 import {
@@ -134,9 +135,12 @@ export async function POST(request: NextRequest) {
     if (!auth) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
-    if (!hasScope(auth, 'evidence:publish')) {
+    // Either accepted spelling of the publish scope authorizes here — live
+    // tokens minted before the 2026-08-19 vocabulary settlement carry the
+    // prior-era one (civic-ai-tools#160 P3).
+    if (!hasPublishScope(auth)) {
       return NextResponse.json(
-        { error: 'Token missing required scope: evidence:publish' },
+        { error: MISSING_PUBLISH_SCOPE_ERROR },
         { status: 403 },
       );
     }

--- a/src/app/api/records/[slug]/attestations/route.ts
+++ b/src/app/api/records/[slug]/attestations/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/attestations` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET, POST } from '@/app/api/evidence/[slug]/attestations/route';

--- a/src/app/api/records/[slug]/bundle/route.ts
+++ b/src/app/api/records/[slug]/bundle/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/bundle` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET } from '@/app/api/evidence/[slug]/bundle/route';

--- a/src/app/api/records/[slug]/commitment/route.ts
+++ b/src/app/api/records/[slug]/commitment/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/commitment` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET, OPTIONS } from '@/app/api/evidence/[slug]/commitment/route';

--- a/src/app/api/records/[slug]/evaluate/route.ts
+++ b/src/app/api/records/[slug]/evaluate/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/evaluate` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { POST } from '@/app/api/evidence/[slug]/evaluate/route';

--- a/src/app/api/records/[slug]/package/route.ts
+++ b/src/app/api/records/[slug]/package/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/package` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET } from '@/app/api/evidence/[slug]/package/route';

--- a/src/app/api/records/[slug]/publish/route.ts
+++ b/src/app/api/records/[slug]/publish/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/publish` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { POST } from '@/app/api/evidence/[slug]/publish/route';

--- a/src/app/api/records/[slug]/reinstate/route.ts
+++ b/src/app/api/records/[slug]/reinstate/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/reinstate` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { POST } from '@/app/api/evidence/[slug]/reinstate/route';

--- a/src/app/api/records/[slug]/replay/route.ts
+++ b/src/app/api/records/[slug]/replay/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/replay` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { POST } from '@/app/api/evidence/[slug]/replay/route';

--- a/src/app/api/records/[slug]/route.ts
+++ b/src/app/api/records/[slug]/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET } from '@/app/api/evidence/[slug]/route';

--- a/src/app/api/records/[slug]/verify/route.ts
+++ b/src/app/api/records/[slug]/verify/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/verify` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET } from '@/app/api/evidence/[slug]/verify/route';

--- a/src/app/api/records/[slug]/withdraw/route.ts
+++ b/src/app/api/records/[slug]/withdraw/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/[slug]/withdraw` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { POST } from '@/app/api/evidence/[slug]/withdraw/route';

--- a/src/app/api/records/generate-summary/route.ts
+++ b/src/app/api/records/generate-summary/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/generate-summary` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { POST } from '@/app/api/evidence/generate-summary/route';

--- a/src/app/api/records/list/route.ts
+++ b/src/app/api/records/list/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/list` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET } from '@/app/api/evidence/list/route';

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { POST } from '@/app/api/evidence/route';

--- a/src/app/api/records/segment-alias.test.ts
+++ b/src/app/api/records/segment-alias.test.ts
@@ -1,0 +1,292 @@
+// Drift guard for the record/evidence segment pair (civic-ai-tools#160 P3).
+//
+// WHAT THE SETTLEMENT ASKS FOR. Appendix J of the Typed Standards
+// specification retires "evidence" from the artifact and infrastructure brand
+// and names `/api/records/*` and `/records/*` the canonical segments, with
+// `/api/evidence/*` and `/evidence/*` served as PERMANENT aliases — migration
+// class `alias-permanent`, explicitly not a deprecation window, because
+// published links carry the prior-era form and nothing already published may
+// stop resolving.
+//
+// WHICH DIRECTION THE ALIASING RUNS, AND WHY IT WAS MEASURED RATHER THAN
+// ASSUMED. Two shapes were available: move the seventeen handlers and two
+// pages to the `records/` paths and leave re-export shims at the `evidence/`
+// paths, or leave the implementations where they are and add the shims at the
+// `records/` paths. Both single-source the handlers and both produce an
+// honest diff (git detects the renames either way), so those two criteria did
+// not decide it. Three measurements did:
+//
+//   1. WHERE THE RISK LANDS. This phase's hard constraint is that production
+//      behavior on the EXISTING names must not change. Leaving the
+//      implementations in place makes that structural rather than asserted:
+//      the live route and page files are byte-identical, so no property of the
+//      re-export mechanism can reach them. Under the inverse, all seventeen
+//      live paths — the ones with links in the wild — would newly depend on a
+//      mechanism this repo cannot execute locally (below), and the new,
+//      unadvertised segment would be the safe one. That is the wrong way
+//      round.
+//   2. A MEASURED ASYMMETRY, not a general worry. Next reads route-segment
+//      config by parsing each route file's own source (`getPageStaticInfo`),
+//      which sees initialized `export const` declarations and not re-export
+//      bindings. `src/app/(app)/evidence/page.tsx` declares
+//      `dynamic = 'force-dynamic'`; a shim standing in front of it must
+//      re-declare that literal, and a future editor who forgets silently turns
+//      a per-request page into a prerendered one. Whichever file is the shim
+//      carries that hazard — so it should be the address with no published
+//      links behind it. (The `dynamic` mirror is asserted below, so the hazard
+//      is guarded wherever it sits.)
+//   3. NOTHING ELSE POINTS AT THE PATHS. Nothing in the build tooling
+//      addresses these files by path — `next.config.ts`'s
+//      `outputFileTracingIncludes` names `/api/query-notebook` only, and the
+//      standalone-asset checker names no route directory — so the move was
+//      never forced by the build either.
+//
+// The consequence to keep in view: the implementation currently sits at the
+// PRIOR-ERA path while the CANONICAL name is `records`. That inversion is
+// deliberate for the expand phase and is a follow-up for whoever flips what
+// the site emits; it is invisible from outside, because which file holds the
+// body never crosses a public surface.
+//
+// WHAT THIS FILE CAN AND CANNOT PROVE. It reads source text. It can prove
+// that both segments exist, that they are paired one-for-one in both
+// directions, that the alias side re-exports rather than reimplements, that
+// the exported HTTP methods agree, and that the page-level route-segment
+// config is mirrored. It CANNOT prove that a request to either address
+// reaches a handler: this repo has no route-handler harness (`npm test` is
+// `node --test` over modules that resolve neither the `@/` alias nor Next's
+// request plumbing), so handler dispatch is proven by `next build` registering
+// both route entries and, authoritatively, by CI and the preview deployment.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+/** `src/app` — this file lives at `src/app/api/records/`. */
+const APP_DIR = path.resolve(HERE, '..', '..');
+const REPO_SRC = path.resolve(APP_DIR, '..');
+
+/** The two segment families, prior-era first. */
+const API_PRIOR = path.join(APP_DIR, 'api', 'evidence');
+const API_SETTLEMENT = path.join(APP_DIR, 'api', 'records');
+const PAGES_PRIOR = path.join(APP_DIR, '(app)', 'evidence');
+const PAGES_SETTLEMENT = path.join(APP_DIR, '(app)', 'records');
+
+/** Repo-relative path, for assertion messages that read cold. */
+function rel(abs: string): string {
+  return path.relative(path.resolve(REPO_SRC, '..'), abs);
+}
+
+/**
+ * Every routable file under `dir`, keyed by its path RELATIVE to `dir` — so
+ * `[slug]/commitment/route.ts` is the key on both sides of a pair and the two
+ * trees compare as sets.
+ */
+function routeFiles(dir: string, filename: RegExp): string[] {
+  return readdirSync(dir, { withFileTypes: true, recursive: true })
+    .filter((e) => e.isFile() && filename.test(e.name))
+    .map((e) => path.relative(dir, path.join(e.parentPath, e.name)))
+    .sort();
+}
+
+const ROUTE_FILE = /^route\.ts$/;
+const PAGE_FILE = /^page\.tsx$/;
+
+const API_PRIOR_FILES = routeFiles(API_PRIOR, ROUTE_FILE);
+const API_SETTLEMENT_FILES = routeFiles(API_SETTLEMENT, ROUTE_FILE);
+const PAGE_PRIOR_FILES = routeFiles(PAGES_PRIOR, PAGE_FILE);
+const PAGE_SETTLEMENT_FILES = routeFiles(PAGES_SETTLEMENT, PAGE_FILE);
+
+/** HTTP methods a route file DEFINES (`export async function GET(`). */
+function definedMethods(source: string): string[] {
+  return [...source.matchAll(/^export\s+(?:async\s+)?function\s+([A-Z]+)\s*\(/gm)]
+    .map((m) => m[1])
+    .sort();
+}
+
+/** Names a file RE-EXPORTS, with the specifier they come from. */
+function reExports(source: string): { names: string[]; from: string }[] {
+  return [...source.matchAll(/^export\s*\{([^}]*)\}\s*from\s*'([^']+)';/gm)].map((m) => ({
+    names: m[1]
+      .split(',')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0)
+      .sort(),
+    from: m[2],
+  }));
+}
+
+// --- Sanity: the walker found something ---------------------------------------
+//
+// Every assertion below compares two lists. Two empty lists compare equal, so
+// without this the whole file could pass while describing nothing.
+
+test('the segment walker finds both families', () => {
+  assert.ok(
+    API_PRIOR_FILES.length > 0,
+    `Found no route.ts files under ${rel(API_PRIOR)}. Either the family moved or\n` +
+      `this walker is broken — every pairing assertion below passes vacuously when\n` +
+      `this happens, so fix it here rather than trusting the greens.`,
+  );
+  assert.ok(PAGE_PRIOR_FILES.length > 0, `Found no page.tsx under ${rel(PAGES_PRIOR)} — see above.`);
+});
+
+// --- The pairing guard, both directions ---------------------------------------
+
+test('every /api/evidence route has a /api/records twin, and vice versa', () => {
+  assert.deepEqual(
+    API_SETTLEMENT_FILES,
+    API_PRIOR_FILES,
+    `The two API segment families have drifted apart.\n` +
+      `\n` +
+      `  ${rel(API_PRIOR)}:      ${API_PRIOR_FILES.length} route file(s)\n` +
+      `  ${rel(API_SETTLEMENT)}: ${API_SETTLEMENT_FILES.length} route file(s)\n` +
+      `\n` +
+      `FIX: whichever side is missing an entry, add it. A NEW endpoint needs a\n` +
+      `file in both trees — the implementation at the evidence/ path and a\n` +
+      `re-export at the records/ path (see this file's header for why that\n` +
+      `direction). A RETIRED endpoint has to be removed from both.\n` +
+      `\n` +
+      `WHY THIS IS NOT BOOKKEEPING: the settlement (Appendix J) promises that\n` +
+      `both segments serve the same API forever. A one-sided endpoint breaks\n` +
+      `that promise silently — the missing address just 404s, and nothing in\n` +
+      `the response says an alias was supposed to exist.`,
+  );
+});
+
+test('every /evidence page has a /records twin, and vice versa', () => {
+  assert.deepEqual(
+    PAGE_SETTLEMENT_FILES,
+    PAGE_PRIOR_FILES,
+    `The two page segment families have drifted apart:\n` +
+      `  ${rel(PAGES_PRIOR)}:      ${PAGE_PRIOR_FILES.join(', ') || '(none)'}\n` +
+      `  ${rel(PAGES_SETTLEMENT)}: ${PAGE_SETTLEMENT_FILES.join(', ') || '(none)'}\n` +
+      `\n` +
+      `FIX: add the missing page on whichever side lacks it. See the API twin\n` +
+      `test above for the reasoning; it applies identically here.`,
+  );
+});
+
+// --- The single-sourcing guard ------------------------------------------------
+
+test('every /api/records route re-exports its twin and implements nothing', () => {
+  for (const file of API_SETTLEMENT_FILES) {
+    const aliasPath = path.join(API_SETTLEMENT, file);
+    const source = readFileSync(aliasPath, 'utf8');
+    const exports = reExports(source);
+
+    assert.equal(
+      exports.length,
+      1,
+      `${rel(aliasPath)} should carry exactly one \`export { … } from '…';\` line\n` +
+        `(found ${exports.length}). The settlement-era segment is an ALIAS: it names\n` +
+        `the handlers its twin defines and adds nothing of its own.`,
+    );
+    assert.deepEqual(
+      definedMethods(source),
+      [],
+      `${rel(aliasPath)} DEFINES a handler of its own.\n` +
+        `\n` +
+        `FIX: move the implementation to the twin under ${rel(API_PRIOR)} and\n` +
+        `re-export it here.\n` +
+        `\n` +
+        `WHY: two addresses serving two copies of one endpoint is the failure this\n` +
+        `alias layer exists to prevent. The copies drift, one of them gets the\n` +
+        `bug fix, and which address a caller used decides which behavior it got.`,
+    );
+
+    const expectedSpecifier = `@/app/api/evidence/${file.replace(/\.ts$/, '')}`;
+    assert.equal(
+      exports[0].from,
+      expectedSpecifier,
+      `${rel(aliasPath)} re-exports from '${exports[0].from}' but its twin is\n` +
+        `'${expectedSpecifier}'. An alias that points at the wrong endpoint serves\n` +
+        `the wrong endpoint — silently, with a 200.`,
+    );
+
+    const twin = readFileSync(path.join(API_PRIOR, file), 'utf8');
+    assert.deepEqual(
+      exports[0].names,
+      definedMethods(twin),
+      `${rel(aliasPath)} re-exports [${exports[0].names.join(', ')}] but its twin\n` +
+        `defines [${definedMethods(twin).join(', ')}].\n` +
+        `\n` +
+        `FIX: name every method the twin defines, and only those.\n` +
+        `\n` +
+        `WHY: an unnamed method does not 500 on the alias address — it 405s, as\n` +
+        `though the endpoint did not support it. A caller reading the docs for\n` +
+        `the canonical segment gets "Method Not Allowed" for a method that\n` +
+        `demonstrably works one path over.`,
+    );
+  }
+});
+
+test('both /records pages re-export their twins and implement nothing', () => {
+  for (const file of PAGE_SETTLEMENT_FILES) {
+    const aliasPath = path.join(PAGES_SETTLEMENT, file);
+    const source = readFileSync(aliasPath, 'utf8');
+    const exports = reExports(source);
+
+    assert.equal(
+      exports.length,
+      1,
+      `${rel(aliasPath)} should carry exactly one \`export { … } from '…';\` line ` +
+        `(found ${exports.length}).`,
+    );
+    const expectedSpecifier = `@/app/(app)/evidence/${file.replace(/\.tsx$/, '')}`;
+    assert.equal(
+      exports[0].from,
+      expectedSpecifier,
+      `${rel(aliasPath)} re-exports from '${exports[0].from}', not from its twin ` +
+        `'${expectedSpecifier}'.`,
+    );
+    assert.ok(
+      exports[0].names.includes('default'),
+      `${rel(aliasPath)} does not re-export \`default\` — a page file without a ` +
+        `default export is not a page.`,
+    );
+  }
+});
+
+// --- The route-segment-config mirror ------------------------------------------
+//
+// Measurement 2 in the header, turned into an assertion. `getPageStaticInfo`
+// parses each file's own source, so a shim inherits none of its twin's
+// segment config: the literals have to be repeated, and repetition drifts.
+
+/** `export const dynamic = 'force-dynamic'` → `{ dynamic: 'force-dynamic' }`. */
+function segmentConfig(source: string): Record<string, string> {
+  const keys = ['dynamic', 'revalidate', 'runtime', 'fetchCache', 'dynamicParams', 'maxDuration'];
+  const found: Record<string, string> = {};
+  for (const key of keys) {
+    const m = new RegExp(`^export\\s+const\\s+${key}\\s*=\\s*(.+?);`, 'm').exec(source);
+    if (m) found[key] = m[1].trim();
+  }
+  return found;
+}
+
+test('each /records page mirrors its twin\'s route-segment config exactly', () => {
+  for (const file of PAGE_SETTLEMENT_FILES) {
+    const aliasPath = path.join(PAGES_SETTLEMENT, file);
+    const twinPath = path.join(PAGES_PRIOR, file);
+    assert.deepEqual(
+      segmentConfig(readFileSync(aliasPath, 'utf8')),
+      segmentConfig(readFileSync(twinPath, 'utf8')),
+      `Route-segment config differs between ${rel(aliasPath)} and ${rel(twinPath)}.\n` +
+        `\n` +
+        `FIX: declare the same literals in both files. Re-exporting them does NOT\n` +
+        `work: Next reads this config by parsing each file's own source, and a\n` +
+        `re-export binding is invisible to that parse.\n` +
+        `\n` +
+        `WHY THIS IS NOT BOOKKEEPING: the config decides WHEN a page renders. A\n` +
+        `\`dynamic = 'force-dynamic'\` that exists on one address and not the other\n` +
+        `gives one URL fresh content per request and the other a copy frozen at\n` +
+        `build time. Both return 200; only the content is wrong, and only\n` +
+        `sometimes.`,
+    );
+  }
+});

--- a/src/app/api/records/signing-status/route.ts
+++ b/src/app/api/records/signing-status/route.ts
@@ -1,0 +1,15 @@
+// Settlement-era segment for `/api/evidence/signing-status` — the 2026-08-19
+// vocabulary settlement (Appendix J of the Typed Standards specification;
+// civic-ai-tools#160). `/api/records/*` is the canonical segment name;
+// `/api/evidence/*` is a PERMANENT alias, not a deprecation window — published
+// links carry the prior-era form and must keep resolving forever.
+//
+// The handler is defined ONCE, at the prior-era path, and re-exported here, so
+// both segments dispatch to the same function object. The direction was
+// measured rather than assumed — see `src/app/api/records/segment-alias.test.ts`
+// for why the live paths keep their implementations in this phase.
+//
+// Nothing here advertises the new segment: publish responses, JSON-LD, page
+// metadata, share links and the bundle's `detailUrl` all keep emitting the
+// prior-era form until the cutover phase flips them.
+export { GET } from '@/app/api/evidence/signing-status/route';

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -6,6 +6,7 @@ import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { apiTokens, users } from '@/lib/db/schema';
 import { isTrustedRequestOrigin } from '@/lib/allowed-origins';
+import { scopesAuthorizePublish } from '@/lib/publish-scope';
 
 /**
  * Auth resolution for write endpoints (POST /api/evidence,
@@ -65,9 +66,30 @@ export function mintRawToken(): { raw: string; hash: string; prefix: string } {
  * Checks a required scope against an auth result. Cookie auth holds `*`
  * (browser flows are already gated by NextAuth + user session, not by
  * scope). Bearer tokens carry an explicit scope assigned at mint time.
+ *
+ * EXACT-MATCH, deliberately. For the publish scope — the only scope this
+ * deployment mints — use `hasPublishScope` below instead: since the
+ * 2026-08-19 vocabulary settlement that scope has two accepted spellings, and
+ * an exact-match check against either one alone would refuse half the live
+ * tokens.
  */
 export function hasScope(auth: AuthResult, required: string): boolean {
   return auth.scopes.includes('*') || auth.scopes.includes(required);
+}
+
+/**
+ * Does this caller hold publish authorization?
+ *
+ * THE ONE PREDICATE every publish-gated route asks, and the reason it exists
+ * rather than three `hasScope(auth, …) || hasScope(auth, …)` pairs: the
+ * settlement (Appendix J; civic-ai-tools#160) gave the scope a second name,
+ * live 90-day tokens carry the first, and three hand-rolled disjunctions is
+ * three chances for one route to end up refusing a token the other two
+ * accept. The vocabulary itself lives in `src/lib/publish-scope.ts`, which is
+ * free of Next.js imports so the rule is unit-testable on its own.
+ */
+export function hasPublishScope(auth: AuthResult): boolean {
+  return scopesAuthorizePublish(auth.scopes);
 }
 
 /**

--- a/src/lib/evidence/instance-config.test.ts
+++ b/src/lib/evidence/instance-config.test.ts
@@ -4,7 +4,10 @@
 //
 // What these tests cover, post-#258:
 //
-//   1. STRICT ABSENCE: with no EVIDENCE_* identity env set, the nullable
+//   1. STRICT ABSENCE: with no identity env set under EITHER accepted name
+//      (the 2026-08-19 vocabulary settlement gave each variable a canonical
+//      `PUBLISHER_*` spelling beside its prior-era `EVIDENCE_*` one), the
+//      nullable
 //      getters return null, the strict resolvers throw
 //      `InstanceIdentityError` naming the missing variables, and the
 //      packager/notebook surfaces refuse or honestly omit — nothing ever
@@ -27,7 +30,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { missingInstanceIdentityVars } from './unsigned-tier.ts';
 import {
+  INSTANCE_IDENTITY_REQUIRED_SUFFIXES,
   INSTANCE_IDENTITY_REQUIRED_VARS,
   InstanceIdentityError,
   getEvidenceSiteOrigin,
@@ -71,7 +76,17 @@ type UserRecord = typeof users.$inferSelect;
 // on every path. `node --test` runs each file in its own process.
 process.env.EVIDENCE_KEY_ID ??= 'platform:test-suite-kid';
 
-/** Every instance-identity variable the getters read. */
+/**
+ * Every instance-identity variable the getters read, under BOTH accepted
+ * spellings (civic-ai-tools#160 P3).
+ *
+ * Both families are listed because `withIdentityEnv` UNSETS everything it does
+ * not set, and an absence test that cleared only one prefix would be answered
+ * by the other — silently, since the fallback is exactly the mechanism under
+ * test. The prior-era half is also what the reference fixture still uses, so
+ * the parity tests below exercise the fallback path end to end rather than
+ * asserting it in the abstract.
+ */
 const IDENTITY_VARS = [
   'EVIDENCE_SITE_ORIGIN',
   'EVIDENCE_PUBLICATION_HOST',
@@ -83,6 +98,16 @@ const IDENTITY_VARS = [
   'EVIDENCE_PLATFORM_AGENT_ID',
   'EVIDENCE_PLATFORM_AGENT_TITLE',
   'EVIDENCE_PLATFORM_AGENT_URL',
+  'PUBLISHER_SITE_ORIGIN',
+  'PUBLISHER_PUBLICATION_HOST',
+  'PUBLISHER_TRUST_REGISTRY_CANONICAL_URL',
+  'PUBLISHER_TRUST_REGISTRY_LEGACY_URL',
+  'PUBLISHER_SIGNER_BINDING_TIER',
+  'PUBLISHER_SIGNER_IDENTIFIER',
+  'PUBLISHER_SIGNER_DISPLAY_NAME',
+  'PUBLISHER_PLATFORM_AGENT_ID',
+  'PUBLISHER_PLATFORM_AGENT_TITLE',
+  'PUBLISHER_PLATFORM_AGENT_URL',
 ] as const;
 
 /** Run `fn` with the given identity env vars set (and everything else in the
@@ -154,22 +179,22 @@ test('absence: the strict resolvers throw InstanceIdentityError naming the missi
       () => requirePublicationHost(),
       (err: unknown) =>
         err instanceof InstanceIdentityError &&
-        err.missing.includes('EVIDENCE_SITE_ORIGIN'),
+        err.missing.includes('PUBLISHER_SITE_ORIGIN'),
     );
     assert.throws(
       () => getSidecarTrustRegistryUrls(),
       (err: unknown) =>
         err instanceof InstanceIdentityError &&
-        err.missing.includes('EVIDENCE_SITE_ORIGIN'),
+        err.missing.includes('PUBLISHER_SITE_ORIGIN'),
     );
     assert.throws(
       () => getEvidenceSignerIdentity(),
       (err: unknown) =>
         err instanceof InstanceIdentityError &&
         err.missing.length === 3 &&
-        err.missing.includes('EVIDENCE_SIGNER_BINDING_TIER') &&
-        err.missing.includes('EVIDENCE_SIGNER_IDENTIFIER') &&
-        err.missing.includes('EVIDENCE_SIGNER_DISPLAY_NAME'),
+        err.missing.includes('PUBLISHER_SIGNER_BINDING_TIER') &&
+        err.missing.includes('PUBLISHER_SIGNER_IDENTIFIER') &&
+        err.missing.includes('PUBLISHER_SIGNER_DISPLAY_NAME'),
     );
   });
 });
@@ -181,14 +206,46 @@ test('absence: a PARTIAL signer triple throws naming only the missing members', 
       EVIDENCE_SIGNER_IDENTIFIER: 'platform:partial',
     },
     () => {
+      // Set under the PRIOR-ERA spelling and satisfied all the same — while
+      // the one genuinely missing member is reported under its CANONICAL
+      // name, because a refusal must tell the operator the name to set, not
+      // the name being retired (civic-ai-tools#160 P3).
       assert.throws(
         () => getEvidenceSignerIdentity(),
         (err: unknown) =>
           err instanceof InstanceIdentityError &&
           err.missing.length === 1 &&
-          err.missing[0] === 'EVIDENCE_SIGNER_DISPLAY_NAME',
+          err.missing[0] === 'PUBLISHER_SIGNER_DISPLAY_NAME',
       );
       assert.equal(getConfiguredSignerIdentity(), null);
+    },
+  );
+});
+
+test('two-name expand: the canonical spelling is honored, and it wins a tie', () => {
+  // The settlement's expand half, stated where the getters live. The
+  // reference fixture (used throughout this file) is entirely prior-era, so
+  // the FALLBACK leg is already proven by every parity test below; this pins
+  // the other two legs.
+  withIdentityEnv(
+    {
+      PUBLISHER_SITE_ORIGIN: 'https://canonical.example.org',
+      PUBLISHER_PLATFORM_AGENT_TITLE: 'Canonical Instance',
+    },
+    () => {
+      assert.equal(getEvidenceSiteOrigin(), 'https://canonical.example.org');
+      assert.equal(getPlatformTitle(), 'Canonical Instance');
+      // Derivation follows the canonical value, not just the direct read.
+      assert.equal(getPublicationHost(), 'canonical.example.org');
+    },
+  );
+  withIdentityEnv(
+    {
+      PUBLISHER_SITE_ORIGIN: 'https://canonical.example.org',
+      EVIDENCE_SITE_ORIGIN: 'https://prior-era.example.org',
+    },
+    () => {
+      assert.equal(getEvidenceSiteOrigin(), 'https://canonical.example.org');
     },
   );
 });
@@ -286,19 +343,26 @@ test('anti-drift: the reference fixture equals the published packages’ demo co
 });
 
 test('anti-drift: the gate’s required-variable list matches the strict getters’ needs', () => {
+  // The CANONICAL spellings — what a refusal names and what an operator
+  // should set (civic-ai-tools#160 P3). The prior-era `EVIDENCE_*` spelling of
+  // each is still accepted; `missingInstanceIdentityVars` is the one place
+  // that answers the two-name presence question.
   assert.deepEqual([...INSTANCE_IDENTITY_REQUIRED_VARS], [
-    'EVIDENCE_SITE_ORIGIN',
-    'EVIDENCE_SIGNER_BINDING_TIER',
-    'EVIDENCE_SIGNER_IDENTIFIER',
-    'EVIDENCE_SIGNER_DISPLAY_NAME',
-    'EVIDENCE_PLATFORM_AGENT_TITLE',
+    'PUBLISHER_SITE_ORIGIN',
+    'PUBLISHER_SIGNER_BINDING_TIER',
+    'PUBLISHER_SIGNER_IDENTIFIER',
+    'PUBLISHER_SIGNER_DISPLAY_NAME',
+    'PUBLISHER_PLATFORM_AGENT_TITLE',
   ]);
   // The fixture env satisfies the required set (plus the agent id, which the
-  // reference deployment also sets explicitly).
-  for (const name of INSTANCE_IDENTITY_REQUIRED_VARS) {
+  // reference deployment also sets explicitly) — under the PRIOR-ERA names it
+  // still carries, which is the fallback leg proven against a real
+  // configuration rather than a synthetic one.
+  assert.deepEqual(missingInstanceIdentityVars(REFERENCE_IDENTITY_ENV), []);
+  for (const suffix of INSTANCE_IDENTITY_REQUIRED_SUFFIXES) {
     assert.ok(
-      (REFERENCE_IDENTITY_ENV as Record<string, string>)[name],
-      `fixture env must set ${name}`,
+      (REFERENCE_IDENTITY_ENV as Record<string, string>)[`EVIDENCE_${suffix}`],
+      `fixture env must set EVIDENCE_${suffix}`,
     );
   }
 });

--- a/src/lib/evidence/signing.ts
+++ b/src/lib/evidence/signing.ts
@@ -7,7 +7,7 @@
 // `TimeStampReq` DER builder, and the Rekor `hashedrekord` proposal/response
 // codecs. What stays HERE is deliberately implementation-side (ADR-0021 §B):
 //
-//   - CUSTODY — the `EVIDENCE_SIGNING_KEY` env read and the warn-and-null
+//   - CUSTODY — the signing-key env read and the warn-and-null
 //     unsigned fallback (ADR-0021 §E: the core has no env probe; the app's
 //     decision not to sign IS the unsigned tier);
 //   - SUBMISSION — the TSA and Rekor `fetch` legs (no network in the core);
@@ -30,6 +30,11 @@ import {
 } from '@typedstandards/produce-core';
 import { rekorHashForPackage } from './verify-core/signature.ts';
 import { getEvidenceSignerIdentity } from '../site-config.ts';
+// Two accepted names per publisher variable since the 2026-08-19 vocabulary
+// settlement: `PUBLISHER_SIGNING_KEY` / `PUBLISHER_KEY_ID` canonically, with
+// the prior-era `EVIDENCE_*` spellings still honored (Appendix J; see
+// `src/lib/publisher-env.ts` for the precedence rule and the warning).
+import { canonicalEnvName, priorEraEnvName, readPublisherEnv } from '../publisher-env.ts';
 import { isSigningKeyIdConfigured } from './unsigned-tier.ts';
 
 export { rekorHashForPackage };
@@ -49,7 +54,7 @@ export type { SignerIdentity, SignResult };
 // verifier uses to find the public key that must validate this instance's
 // signature, so it is an identity claim, not a formatting detail. A coded
 // default here used to substitute the REFERENCE deployment's kid whenever
-// `EVIDENCE_KEY_ID` was unset — which meant any instance with a signing key
+// the key id was unset — which meant any instance with a signing key
 // and no kid signed with its own key and labeled the result with someone
 // else's identifier. Such a package cannot verify (the registry entry for
 // that kid holds a different public key) and misattributes the publisher.
@@ -61,11 +66,13 @@ export type { SignerIdentity, SignResult };
  *  neutral on purpose — instances run on containers, VMs, and PaaS hosts
  *  alike, so it names the variable and the guide, never a hosting product. */
 export const MISSING_KEY_ID_MESSAGE =
-  'EVIDENCE_KEY_ID is not set in this environment. This instance has no ' +
-  'signing key id to emit and will not substitute one: a package labeled ' +
-  "with a kid it never configured cannot verify and misattributes the " +
-  'publisher. Set EVIDENCE_KEY_ID to the kid of the active entry in this ' +
-  "instance's trust registry — see docs/instance-setup.md.";
+  `${canonicalEnvName('KEY_ID')} is not set in this environment (nor its ` +
+  `prior-era name ${priorEraEnvName('KEY_ID')}, which is still accepted). ` +
+  'This instance has no signing key id to emit and will not substitute one: a ' +
+  'package labeled with a kid it never configured cannot verify and ' +
+  `misattributes the publisher. Set ${canonicalEnvName('KEY_ID')} to the kid ` +
+  "of the active entry in this instance's trust registry — see " +
+  'docs/instance-setup.md.';
 
 /**
  * The configured key identifier, or `null` when none is set.
@@ -79,7 +86,7 @@ export const MISSING_KEY_ID_MESSAGE =
  */
 export function getConfiguredKeyId(): string | null {
   return isSigningKeyIdConfigured(process.env)
-    ? (process.env.EVIDENCE_KEY_ID as string)
+    ? (readPublisherEnv('KEY_ID') as string)
     : null;
 }
 
@@ -105,7 +112,7 @@ export function getActiveKeyId(): string {
 /**
  * Identity bound to the active signing key, for emission as the envelope-side
  * `signer` claim (spec §8.1.1). Resolved from instance config (ADR-0020;
- * the `EVIDENCE_SIGNER_*` triple — REQUIRED identity as of #258, no coded
+ * the `PUBLISHER_SIGNER_*` triple — REQUIRED identity as of #258, no coded
  * default: throws `InstanceIdentityError` naming the missing variables when
  * the triple is incomplete; callers reach this only behind
  * `evaluateSealCommitGate`). It MUST mirror the active key's
@@ -119,8 +126,8 @@ export function getActiveSigner(): SignerIdentity {
 
 /**
  * Sign a package hash with the instance's Ed25519 key using Ed25519ph
- * (SHA-512 pre-hash). Returns null if EVIDENCE_SIGNING_KEY is not
- * configured — the unsigned dev tier (ADR-0020 §B).
+ * (SHA-512 pre-hash). Returns null if the signing key is not configured under
+ * either accepted name — the unsigned dev tier (ADR-0020 §B).
  *
  * The signed message is the UTF-8 bytes of the package hex hash — same
  * convention used on the verify side. Ed25519ph prehashes this internally
@@ -129,15 +136,17 @@ export function getActiveSigner(): SignerIdentity {
  * (and the SPKI public-key derivation retained in `SignResult.publicKey`)
  * is produce-core's; only the key custody lives here.
  *
- * Null is the answer for "no key" ONLY. With a key but no `EVIDENCE_KEY_ID`
+ * Null is the answer for "no key" ONLY. With a key but no configured key id
  * this throws via `getActiveKeyId` instead of degrading: silently skipping
  * the signature there would hide a misconfiguration behind a state
  * (deliberately unsigned) that the operator did not choose.
  */
 export function signPackage(packageHash: string): SignResult | null {
-  const privKeyB64 = process.env.EVIDENCE_SIGNING_KEY;
+  const privKeyB64 = readPublisherEnv('SIGNING_KEY');
   if (!privKeyB64) {
-    console.warn('[signing] EVIDENCE_SIGNING_KEY not set — skipping signature');
+    console.warn(
+      `[signing] ${canonicalEnvName('SIGNING_KEY')} not set — skipping signature`,
+    );
     return null;
   }
   return signEnvelopeHash(packageHash, privKeyB64, getActiveKeyId());

--- a/src/lib/evidence/unsigned-tier.test.ts
+++ b/src/lib/evidence/unsigned-tier.test.ts
@@ -87,8 +87,14 @@ test('KEY WITHOUT KID: refused loudly and specifically, not as a generic unsigne
   // code so the state is diagnosable from the response alone.
   assert.equal(refusal!.status, 500);
   assert.equal(refusal!.body.code, 'signing_key_id_missing');
-  // Actionable: names the missing variable and the guide.
+  // Actionable: names the missing variable and the guide. The CANONICAL
+  // spelling is what an operator is told to set, with the prior-era one named
+  // as still accepted — a refusal that pointed only at the retiring name
+  // would send an operator to configure the variable being removed
+  // (civic-ai-tools#160 P3).
+  assert.match(refusal!.body.error, /PUBLISHER_KEY_ID/);
   assert.match(refusal!.body.error, /EVIDENCE_KEY_ID/);
+  assert.match(refusal!.body.error, /still accepted/);
   assert.match(refusal!.body.error, /instance-setup/);
   // States the real consequence — misattribution and unverifiable evidence —
   // and explicitly rules out the wrong reading (a leaked signing key).

--- a/src/lib/evidence/unsigned-tier.test.ts
+++ b/src/lib/evidence/unsigned-tier.test.ts
@@ -34,7 +34,10 @@ const KID_PRESENT = 'platform:this-instance-2026-08';
 const SIGNED = { EVIDENCE_SIGNING_KEY: KEY_PRESENT, EVIDENCE_KEY_ID: KID_PRESENT };
 /** The defect state: custody without a declared identity. */
 const KEY_NO_KID = { EVIDENCE_SIGNING_KEY: KEY_PRESENT };
-/** The declared instance identity (#258) — presence-only stand-ins. */
+/** The declared instance identity (#258), under the CANONICAL spellings —
+ *  presence-only stand-ins. The prior-era spellings are exercised by the
+ *  partial-identity test below, which is the state a mid-rename instance is
+ *  actually in. */
 const IDENTITY: Record<string, string> = Object.fromEntries(
   INSTANCE_IDENTITY_REQUIRED_VARS.map((name) => [name, 'presence-only-stand-in']),
 );
@@ -122,26 +125,73 @@ test('IDENTITY MISSING: signing pair set + no identity → refused, naming EVERY
 });
 
 test('IDENTITY PARTIAL: names ONLY the missing variables', () => {
+  // Deliberately configured under the PRIOR-ERA spellings — the state a real
+  // instance is in during the expand phase. Presence is satisfied by either
+  // name; the missing ones are reported under their CANONICAL name, because a
+  // refusal must name the variable to set rather than the one being retired
+  // (civic-ai-tools#160 P3).
   const env = {
     ...SIGNED,
     EVIDENCE_SITE_ORIGIN: 'https://instance.example.org',
     EVIDENCE_SIGNER_BINDING_TIER: 'platform',
     EVIDENCE_SIGNER_IDENTIFIER: 'platform:instance',
-    // EVIDENCE_SIGNER_DISPLAY_NAME and EVIDENCE_PLATFORM_AGENT_TITLE absent.
+    // The display name and the platform-agent title are absent under BOTH
+    // spellings.
   };
   const refusal = evaluateSealCommitGate(env);
   assert.ok(refusal);
   assert.equal(refusal!.body.code, 'instance_identity_missing');
-  assert.match(refusal!.body.error, /EVIDENCE_SIGNER_DISPLAY_NAME/);
-  assert.match(refusal!.body.error, /EVIDENCE_PLATFORM_AGENT_TITLE/);
-  // The present variables are NOT named as missing.
-  assert.ok(!refusal!.body.error.includes('EVIDENCE_SITE_ORIGIN'));
-  assert.ok(!refusal!.body.error.includes('EVIDENCE_SIGNER_BINDING_TIER'));
-  assert.ok(!refusal!.body.error.includes('EVIDENCE_SIGNER_IDENTIFIER'));
+  assert.match(refusal!.body.error, /PUBLISHER_SIGNER_DISPLAY_NAME/);
+  assert.match(refusal!.body.error, /PUBLISHER_PLATFORM_AGENT_TITLE/);
+  // The present variables are NOT named as missing — under either spelling.
+  assert.ok(!refusal!.body.error.includes('SITE_ORIGIN'));
+  assert.ok(!refusal!.body.error.includes('SIGNER_BINDING_TIER'));
+  assert.ok(!refusal!.body.error.includes('SIGNER_IDENTIFIER'));
   assert.deepEqual(missingInstanceIdentityVars(env), [
-    'EVIDENCE_SIGNER_DISPLAY_NAME',
-    'EVIDENCE_PLATFORM_AGENT_TITLE',
+    'PUBLISHER_SIGNER_DISPLAY_NAME',
+    'PUBLISHER_PLATFORM_AGENT_TITLE',
   ]);
+});
+
+test('IDENTITY two-name expand: either spelling satisfies the gate; canonical wins a tie', () => {
+  // The whole identity set under the CANONICAL names passes the gate.
+  const canonical = {
+    PUBLISHER_SIGNING_KEY: KEY_PRESENT,
+    PUBLISHER_KEY_ID: KID_PRESENT,
+    ...Object.fromEntries(
+      INSTANCE_IDENTITY_REQUIRED_VARS.map((name) => [name, 'presence-only-stand-in']),
+    ),
+  };
+  assert.equal(evaluateSealCommitGate(canonical), null);
+  assert.deepEqual(missingInstanceIdentityVars(canonical), []);
+
+  // Mixed spellings across the set are fine too — an operator part-way
+  // through the rename is not a broken instance.
+  assert.equal(
+    evaluateSealCommitGate({
+      PUBLISHER_SIGNING_KEY: KEY_PRESENT,
+      EVIDENCE_KEY_ID: KID_PRESENT,
+      PUBLISHER_SITE_ORIGIN: 'https://instance.example.org',
+      EVIDENCE_SIGNER_BINDING_TIER: 'platform',
+      PUBLISHER_SIGNER_IDENTIFIER: 'platform:instance',
+      EVIDENCE_SIGNER_DISPLAY_NAME: 'Instance',
+      PUBLISHER_PLATFORM_AGENT_TITLE: 'Instance',
+    }),
+    null,
+  );
+
+  // Precedence: an EMPTY canonical name shadows a set prior-era one. Empty is
+  // a value in this set, not an absence (`TRUST_REGISTRY_LEGACY_URL=''` omits
+  // a URL from signed output), so the resolver cannot treat it as a miss —
+  // and an operator who explicitly emptied the canonical name meant it.
+  assert.deepEqual(
+    missingInstanceIdentityVars({
+      ...IDENTITY,
+      PUBLISHER_SITE_ORIGIN: '',
+      EVIDENCE_SITE_ORIGIN: 'https://prior-era.example.org',
+    }),
+    ['PUBLISHER_SITE_ORIGIN'],
+  );
 });
 
 test('IDENTITY: precedence — the signing-pair refusals come first (identity is the third check)', () => {
@@ -158,12 +208,12 @@ test('isInstanceIdentityConfigured: presence-only, whitespace counts as absent',
   assert.equal(isInstanceIdentityConfigured(IDENTITY), true);
   assert.equal(isInstanceIdentityConfigured({}), false);
   assert.equal(
-    isInstanceIdentityConfigured({ ...IDENTITY, EVIDENCE_SITE_ORIGIN: '   ' }),
+    isInstanceIdentityConfigured({ ...IDENTITY, PUBLISHER_SITE_ORIGIN: '   ' }),
     false,
   );
   assert.deepEqual(
-    missingInstanceIdentityVars({ ...IDENTITY, EVIDENCE_SITE_ORIGIN: '' }),
-    ['EVIDENCE_SITE_ORIGIN'],
+    missingInstanceIdentityVars({ ...IDENTITY, PUBLISHER_SITE_ORIGIN: '' }),
+    ['PUBLISHER_SITE_ORIGIN'],
   );
 });
 

--- a/src/lib/evidence/unsigned-tier.ts
+++ b/src/lib/evidence/unsigned-tier.ts
@@ -26,9 +26,14 @@
 // read at call time) so the decisions are unit-testable without touching the
 // process environment. No values are ever read beyond presence.
 //
-// SIGNING IS A PAIR. Custody is `EVIDENCE_SIGNING_KEY`; identity is
-// `EVIDENCE_KEY_ID` — the kid a verifier uses to look this instance's public
-// key up in its trust registry. Both halves are required, with no coded
+// SIGNING IS A PAIR. Custody is `PUBLISHER_SIGNING_KEY`; identity is
+// `PUBLISHER_KEY_ID` — the kid a verifier uses to look this instance's public
+// key up in its trust registry. Each also answers to its prior-era `EVIDENCE_`
+// spelling (the 2026-08-19 vocabulary settlement, Appendix J; the precedence
+// rule and the deprecation warning live in `src/lib/publisher-env.ts`), which
+// is why every presence test below goes through `lookupPublisherEnv` rather
+// than indexing the env record by a literal name. Both halves are required,
+// with no coded
 // default for either. A hardcoded default kid used to stand in for the second
 // half, which meant an operator who set a key but no kid left this tier
 // silently and signed every package under the REFERENCE deployment's kid: the
@@ -39,7 +44,8 @@
 // case in which an instance emits a kid it did not configure.
 //
 // IDENTITY IS THE THIRD LEG (#258). The same doctrine now covers the
-// instance-identity set (INSTANCE_IDENTITY_REQUIRED_VARS in site-config.ts):
+// instance-identity set (INSTANCE_IDENTITY_REQUIRED_SUFFIXES in
+// site-config.ts):
 // signed output names the publisher's origin, signer, trust registry, and
 // platform agent, and those used to default to the reference deployment's
 // values. A signing pair with no declared identity is refused
@@ -50,7 +56,8 @@
 // findings A1/A2): custody (key) + declared kid + declared instance
 // identity. The required-variable list lives beside the getters it governs
 // (site-config.ts) so the two cannot drift.
-import { INSTANCE_IDENTITY_REQUIRED_VARS } from '../site-config.ts';
+import { INSTANCE_IDENTITY_REQUIRED_SUFFIXES } from '../site-config.ts';
+import { canonicalEnvName, lookupPublisherEnv } from '../publisher-env.ts';
 
 type EnvLike = Record<string, string | undefined>;
 
@@ -60,18 +67,20 @@ function isPresent(raw: string | undefined): boolean {
   return typeof raw === 'string' && raw.trim().length > 0;
 }
 
-/** Whether this instance holds signing-key custody (`EVIDENCE_SIGNING_KEY`). */
+/** Whether this instance holds signing-key custody (`PUBLISHER_SIGNING_KEY`,
+ *  or its prior-era spelling). */
 export function isSigningKeyConfigured(env: EnvLike = process.env): boolean {
-  return isPresent(env.EVIDENCE_SIGNING_KEY);
+  return isPresent(lookupPublisherEnv('SIGNING_KEY', env).value);
 }
 
 /**
  * Whether this instance has declared its signing identity
- * (`EVIDENCE_KEY_ID`). No default: the kid names a specific entry in a
- * specific trust registry, so guessing one is asserting an identity.
+ * (`PUBLISHER_KEY_ID`, or its prior-era spelling). No default: the kid names a
+ * specific entry in a specific trust registry, so guessing one is asserting an
+ * identity.
  */
 export function isSigningKeyIdConfigured(env: EnvLike = process.env): boolean {
-  return isPresent(env.EVIDENCE_KEY_ID);
+  return isPresent(lookupPublisherEnv('KEY_ID', env).value);
 }
 
 /**
@@ -87,13 +96,19 @@ export function isSigningConfigured(env: EnvLike = process.env): boolean {
 
 /**
  * The instance-identity variables (site-config.ts) NOT set in `env` — empty
- * when the identity is fully declared. Presence-only, like everything here.
+ * when the identity is fully declared. Presence-only, like everything here,
+ * and two-name aware: a variable set under EITHER accepted spelling counts as
+ * present, while a MISSING one is reported under its canonical name (naming
+ * the prior-era spelling in a refusal would tell an operator to set the name
+ * this settlement is retiring).
  * A signing instance without these would emit another deployment's identity
  * into signed output (#258 A1), so the seal/commit gate refuses on any
  * non-empty result, naming exactly these variables.
  */
 export function missingInstanceIdentityVars(env: EnvLike = process.env): string[] {
-  return INSTANCE_IDENTITY_REQUIRED_VARS.filter((name) => !isPresent(env[name]));
+  return INSTANCE_IDENTITY_REQUIRED_SUFFIXES.filter(
+    (suffix) => !isPresent(lookupPublisherEnv(suffix, env).value),
+  ).map(canonicalEnvName);
 }
 
 /** Whether this instance has declared its identity (all required vars set). */

--- a/src/lib/evidence/unsigned-tier.ts
+++ b/src/lib/evidence/unsigned-tier.ts
@@ -57,7 +57,11 @@
 // identity. The required-variable list lives beside the getters it governs
 // (site-config.ts) so the two cannot drift.
 import { INSTANCE_IDENTITY_REQUIRED_SUFFIXES } from '../site-config.ts';
-import { canonicalEnvName, lookupPublisherEnv } from '../publisher-env.ts';
+import {
+  canonicalEnvName,
+  lookupPublisherEnv,
+  priorEraEnvName,
+} from '../publisher-env.ts';
 
 type EnvLike = Record<string, string | undefined>;
 
@@ -136,7 +140,8 @@ export interface SealCommitGateRefusal {
  *
  *   - `unsigned_tier` (403) — no signing key at all. A legitimate tier;
  *     signing is the go-to-production step the operator has not taken yet.
- *   - `signing_key_id_missing` (500) — a key but no `EVIDENCE_KEY_ID`. NOT a
+ *   - `signing_key_id_missing` (500) — a key but no `PUBLISHER_KEY_ID` (nor
+ *     its prior-era spelling). NOT a
  *     legitimate state: the operator intends to sign and the instance is
  *     misconfigured, so this is a server fault, named specifically rather
  *     than folded into the tier message an operator has already moved past.
@@ -179,14 +184,16 @@ export function evaluateSealCommitGate(
       body: {
         error:
           'This instance has a signing key but has not declared its signing ' +
-          'key id: EVIDENCE_KEY_ID is not set in this environment. Sealing ' +
+          `key id: ${canonicalEnvName('KEY_ID')} is not set in this ` +
+          `environment (nor its prior-era name ${priorEraEnvName('KEY_ID')}, ` +
+          'which is still accepted). Sealing ' +
           'and publishing are refused rather than signed under a key id this ' +
           'instance never configured — a package labeled with a kid that ' +
           "resolves to some other deployment's public key cannot verify, and " +
           'claims an identity that is not this instance\'s. (The signing key ' +
           'itself is unaffected: this is a misattribution and verifiability ' +
-          'failure, not a key disclosure.) Set EVIDENCE_KEY_ID to the kid of ' +
-          "the active entry in this instance's trust registry — see " +
+          `failure, not a key disclosure.) Set ${canonicalEnvName('KEY_ID')} ` +
+          "to the kid of the active entry in this instance's trust registry — see " +
           'docs/instance-setup.md.',
         code: 'signing_key_id_missing',
       },
@@ -201,7 +208,9 @@ export function evaluateSealCommitGate(
         'Sealing or publishing evidence requires a signature: an unsigned ' +
         'package can reach neither the sealed nor the public state (ADR-0020). ' +
         'Analyses still run and can be inspected locally; an operator enables ' +
-        'signing (EVIDENCE_SIGNING_KEY and EVIDENCE_KEY_ID, both required) ' +
+        `signing (${canonicalEnvName('SIGNING_KEY')} and ` +
+        `${canonicalEnvName('KEY_ID')}, both required; each also answers to ` +
+        'its prior-era EVIDENCE_* spelling) ' +
         'via docs/instance-setup.md.',
       code: 'unsigned_tier',
     },
@@ -242,7 +251,8 @@ export function evaluateUnsignedRecordPublishGate(
  *     Dev (and test) stay calm: the unsigned tier is the intended first-run
  *     state there. Anywhere else, running unsigned must never be silent, so
  *     an unknown NODE_ENV shows the indicator too.
- *   - `no_key_id` — a signing key with no `EVIDENCE_KEY_ID`. Shown in EVERY
+ *   - `no_key_id` — a signing key with no `PUBLISHER_KEY_ID` (nor its
+ *     prior-era spelling). Shown in EVERY
  *     environment, dev included: it is not an intended state anywhere, and
  *     dev is precisely where an operator wiring signing up should see it
  *     before the same half-configuration reaches a deploy.

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -18,6 +18,9 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { validateRegistry, type TrustRegistry } from './verify-core/index.ts';
 import { getEvidenceSiteOrigin } from '../site-config.ts';
+// Two accepted names for the verify-side registry override since the
+// 2026-08-19 vocabulary settlement (Appendix J) — see `publisher-env.ts`.
+import { readPublisherEnv } from '../publisher-env.ts';
 
 // Re-export the entire browser-safe verification core: the §9.2 check functions,
 // the `verifyEvidence` orchestrator, every status vocabulary, and all result
@@ -50,7 +53,9 @@ interface CacheEntry {
 const registryCache: Map<string, CacheEntry> = new Map();
 
 /** Resolve the URL for the platform trust registry. Can be overridden via
- *  `EVIDENCE_TRUST_REGISTRY_URL` for previews or local dev. The fallback
+ *  `PUBLISHER_TRUST_REGISTRY_URL` (or its prior-era spelling
+ *  `EVIDENCE_TRUST_REGISTRY_URL`, still accepted — the 2026-08-19 vocabulary
+ *  settlement, Appendix J) for previews or local dev. The fallback
  *  tail is the instance's configured origin (ADR-0020), then the reference
  *  origin literal — the VERIFY path's historical resolution, deliberately
  *  byte-identical across #258 (which removed identity defaults from
@@ -58,7 +63,7 @@ const registryCache: Map<string, CacheEntry> = new Map();
  *  charter). In practice the HTTP fetch this URL feeds is the last resort
  *  behind the bundled and on-disk registries below. */
 export function getTrustRegistryUrl(): string {
-  const override = process.env.EVIDENCE_TRUST_REGISTRY_URL;
+  const override = readPublisherEnv('TRUST_REGISTRY_URL');
   if (override) return override;
   const site =
     process.env.NEXTAUTH_URL ||

--- a/src/lib/host-routing.test.ts
+++ b/src/lib/host-routing.test.ts
@@ -76,7 +76,19 @@ const MARKETING_SAMPLES = [
   '/talks/ctfg-vibe-code-2026-07.html',
 ];
 const APP_PRIVATE_SAMPLES = ['/ask', '/dashboard', '/dashboard/settings', '/auth/device', '/dev/notebook-preview'];
-const DUAL_SAMPLES = ['/evidence', '/evidence/some-published-slug'];
+// The published-record pages under BOTH of their addresses (civic-ai-tools#160
+// P3): `/records` is the settlement-era segment, `/evidence` its permanent
+// prior-era alias. Listing both here means every topology assertion in this
+// file — withholding, serving, canonicalization, the loop check — runs against
+// each address, which is the property the settlement actually promises: the
+// two addresses are one surface, so no topology may ever treat them
+// differently.
+const DUAL_SAMPLES = [
+  '/evidence',
+  '/evidence/some-published-slug',
+  '/records',
+  '/records/some-published-slug',
+];
 const OTHER_SAMPLES = [
   '/api/rate-limit', // matcher-excluded in prod, but the function must serve it regardless
   '/_next/static/chunk.js',
@@ -464,11 +476,66 @@ test('classifyPath covers every declared prefix and resists prefix collisions', 
   for (const p of APP_PRIVATE_PATHS) assert.equal(classifyPath(p), 'app-private', p);
   assert.equal(classifyPath('/evidence'), 'dual-served');
   assert.equal(classifyPath('/evidence/slug/extra'), 'dual-served');
+  assert.equal(classifyPath('/records'), 'dual-served');
+  assert.equal(classifyPath('/records/slug/extra'), 'dual-served');
   assert.equal(classifyPath('/aboutus'), 'other');
+  assert.equal(classifyPath('/recordsets'), 'other'); // prefix-collision guard: not /records
   assert.equal(classifyPath('/dashboard-widgets'), 'other');
   assert.equal(classifyPath('/asked'), 'other');
   assert.equal(classifyPath('/auth'), 'other'); // no page lives at /auth itself
   assert.equal(classifyPath('/auth/device/extra'), 'app-private');
+});
+
+// --- The record/evidence segment pair (civic-ai-tools#160 P3) -----------------
+//
+// Appendix J of the Typed Standards specification makes `/records` the
+// canonical address of the published-record pages and keeps `/evidence` as a
+// PERMANENT alias — published links carry the prior-era form. Two addresses,
+// one surface, so the topology must never be able to tell them apart. The
+// tests above already run both through every scenario (see DUAL_SAMPLES); this
+// one states the invariant directly, so a failure names it rather than leaving
+// someone to infer it from four scattered reds.
+
+test('the topology cannot tell /records from /evidence, under any configuration', () => {
+  const configs: [string, ReturnType<typeof readHostRoutingConfig>][] = [
+    ['unset', UNSET],
+    ['split', SPLIT],
+    ['app-only', APP_ONLY],
+    ['serve-marketing', SERVE_MARKETING],
+    ['www-marketing', WWW_MARKETING],
+  ];
+  const hosts = ['example.org', 'app.example.org', 'www.example.org', 'preview-abc.vercel.app', null];
+  const suffixes = ['', '/some-published-slug', '/some-slug/nested'];
+
+  for (const [label, config] of configs) {
+    for (const host of hosts) {
+      for (const suffix of suffixes) {
+        const viaRecords = decideRoute(host, `/records${suffix}`, config);
+        const viaEvidence = decideRoute(host, `/evidence${suffix}`, config);
+        // Canonicalizing redirects carry the pathname, which differs by
+        // construction — compare the DECISION and, for a redirect, the host it
+        // steers to and the path it preserves.
+        assert.equal(
+          viaRecords.kind,
+          viaEvidence.kind,
+          `${label} / ${host} / ${suffix}: '/records${suffix}' decided ` +
+            `'${viaRecords.kind}' while '/evidence${suffix}' decided ` +
+            `'${viaEvidence.kind}'. The two addresses are one surface — a\n` +
+            `topology that withholds or redirects one and serves the other makes\n` +
+            `a published link's survival depend on which spelling it used.`,
+        );
+        if (viaRecords.kind === 'redirect' && viaEvidence.kind === 'redirect') {
+          assert.equal(
+            viaRecords.destination.replace('/records', '/evidence'),
+            viaEvidence.destination,
+            `${label} / ${host} / ${suffix}: the two addresses redirect to ` +
+              `different places ('${viaRecords.destination}' vs ` +
+              `'${viaEvidence.destination}').`,
+          );
+        }
+      }
+    }
+  }
 });
 
 // --- URL helpers (AppChrome exit link, device-flow pairing origin) ---------------
@@ -787,6 +854,11 @@ test('canonicalize: APP_ONLY ignores the host variables, so it canonicalizes not
 test('canonicalize: the CORS-sensitive families are exempt on every host spelling', () => {
   const exempt = [
     '/api/evidence/some-slug/commitment',
+    // The same endpoint under its settlement-era segment (#160 P3). A
+    // third-party verifier resolving a commitment URL is the exact caller
+    // #263 exists for, and it must not start meeting a redirect just because
+    // it used the canonical spelling.
+    '/api/records/some-slug/commitment',
     '/api/session-status',
     '/api',
     '/.well-known/typed-publisher.json',

--- a/src/lib/host-routing.ts
+++ b/src/lib/host-routing.ts
@@ -51,11 +51,13 @@
  * not security: the access gate is sign-in (`SIGN_IN_ALLOWLIST`), and
  * routes keep enforcing their own sessions.
  *
- * Deliberately DUAL-SERVED either way: `/evidence` and `/evidence/[slug]`
- * (public product surface — published URLs must keep resolving on the
- * marketing host; their `(app)` group placement is structural, not an
- * access classification), the whole `/api/*` family, `_next`, and static
- * assets.
+ * Deliberately DUAL-SERVED either way: the published-record pages under BOTH
+ * of their addresses — `/records` and `/records/[slug]` (the settlement-era
+ * segment) and `/evidence` and `/evidence/[slug]` (its permanent prior-era
+ * alias; Appendix J, civic-ai-tools#160) — because they are the public product
+ * surface and published URLs must keep resolving on the marketing host; their
+ * `(app)` group placement is structural, not an access classification. Also
+ * the whole `/api/*` family, `_next`, and static assets.
  *
  * Host MATCHING mirrors `api-auth.ts`'s origin normalization:
  * case-insensitive, port-insensitive, and `www.`-insensitive, so an
@@ -237,8 +239,20 @@ export const APP_PRIVATE_PATHS = [
   '/dev/notebook-preview',
 ] as const;
 
-/** Public product surface served on BOTH hosts (owner-decided; see module doc). */
-export const DUAL_SERVED_PATHS = ['/evidence'] as const;
+/**
+ * Public product surface served on BOTH hosts (owner-decided; see module doc).
+ *
+ * TWO ENTRIES, ONE SURFACE. `/records` is the settlement-era address of the
+ * published-record pages and `/evidence` is its permanent prior-era alias
+ * (Appendix J of the Typed Standards specification; civic-ai-tools#160). They
+ * render the same pages, so they must classify the same way: a `/records` URL
+ * that fell through to `'other'` would still SERVE on both hosts today, but it
+ * would do so by accident rather than by decision, and the reverse guard in
+ * `host-routing.paths.test.ts` would stop noticing if the pages moved.
+ * Whatever the topology does to one address it must do to the other — which is
+ * exactly what listing both here buys.
+ */
+export const DUAL_SERVED_PATHS = ['/evidence', '/records'] as const;
 
 export type PathClass = 'root' | 'marketing' | 'app-private' | 'dual-served' | 'other';
 
@@ -475,8 +489,9 @@ function decidePathAction(role: 'app' | 'marketing', pathname: string): RouteAct
 
   if (role === 'marketing') {
     // The marketing host serves everything it serves today EXCEPT the
-    // app-private routes. Root, marketing pages, evidence, and everything
-    // unclassified are untouched — the apex demo stays byte-identical.
+    // app-private routes. Root, marketing pages, the published-record pages
+    // (under both `/records` and `/evidence`), and everything unclassified are
+    // untouched — the apex demo stays byte-identical.
     return pathClass === 'app-private' ? WITHHOLD : SERVE;
   }
 
@@ -487,8 +502,9 @@ function decidePathAction(role: 'app' | 'marketing', pathname: string): RouteAct
     case 'marketing':
       return WITHHOLD;
     default:
-      // app-private, dual-served evidence, and unclassified (assets, API
-      // under a non-excluded matcher miss, unknown URLs → natural 404).
+      // app-private, the dual-served record pages (either address), and
+      // unclassified (assets, API under a non-excluded matcher miss, unknown
+      // URLs → natural 404).
       return SERVE;
   }
 }
@@ -629,9 +645,10 @@ export function resolveDashboardHref(env: Record<string, string | undefined>): s
  * Where an "Ask" affordance should point (#210 — the `AppChrome` strip).
  *
  * Exactly `resolveDashboardHref`'s shape, and for exactly its reason: the
- * strip renders on the DUAL-SERVED `/evidence` pages, which serve on the
- * marketing host too — where `/ask` is app-private and withheld. A relative
- * href there is a 404, so a split-host instance must carry the app origin.
+ * strip renders on the DUAL-SERVED published-record pages — `/records` and its
+ * permanent prior-era alias `/evidence` — which serve on the marketing host
+ * too, where `/ask` is app-private and withheld. A relative href there is a
+ * 404, so a split-host instance must carry the app origin.
  * Relative everywhere else: unset topology serves `/ask` on whatever host the
  * request arrived on, and an app-only instance is its own app host.
  *

--- a/src/lib/publish-scope.test.ts
+++ b/src/lib/publish-scope.test.ts
@@ -1,0 +1,220 @@
+// The publish scope under both accepted names (civic-ai-tools#160 P3).
+//
+// Group G of the 2026-08-19 vocabulary settlement renames the device-flow
+// scope `evidence:publish` → `records:publish` as an alias-and-deprecate. Two
+// properties have to hold together, and they pull in opposite directions:
+//
+//   AUTHORIZATION must be name-blind. Bearer tokens store their scope as a
+//   string and live 90 days, so every token minted before this change carries
+//   the prior-era name. A gate that checked one spelling would 403 a token
+//   that was valid yesterday and has not expired.
+//
+//   MINTING must be literal. RFC 8628 clients compare the granted scope in
+//   the response against what they asked for, so a client that explicitly
+//   requests the prior-era name has to receive that exact string back — while
+//   a client that asks for nothing gets the canonical one, which is how the
+//   default moves.
+//
+// The last test is the one that will fire for someone else, later: it reads
+// the route sources and fails if a publish gate is ever hand-rolled again
+// instead of asking the shared predicate.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  ACCEPTED_PUBLISH_SCOPES,
+  MISSING_PUBLISH_SCOPE_ERROR,
+  PRIOR_ERA_PUBLISH_SCOPE,
+  PUBLISH_SCOPE,
+  UNSCOPED_WILDCARD,
+  isAcceptedMintScope,
+  resolveMintScope,
+  scopesAuthorizePublish,
+} from './publish-scope.ts';
+
+// --- The vocabulary -----------------------------------------------------------
+
+test('the settlement names are what Appendix J says they are', () => {
+  assert.equal(PUBLISH_SCOPE, 'records:publish');
+  assert.equal(PRIOR_ERA_PUBLISH_SCOPE, 'evidence:publish');
+  assert.deepEqual([...ACCEPTED_PUBLISH_SCOPES], [PUBLISH_SCOPE, PRIOR_ERA_PUBLISH_SCOPE]);
+});
+
+// --- Authorization: name-blind ------------------------------------------------
+
+test('either spelling authorizes a publish', () => {
+  assert.equal(scopesAuthorizePublish([PUBLISH_SCOPE]), true);
+  assert.equal(
+    scopesAuthorizePublish([PRIOR_ERA_PUBLISH_SCOPE]),
+    true,
+    'a token minted before the settlement — 90-day lifetime, still valid — ' +
+      'must keep working against every gated route',
+  );
+});
+
+test('cookie auth\'s wildcard still authorizes, and holding both is fine', () => {
+  assert.equal(scopesAuthorizePublish([UNSCOPED_WILDCARD]), true);
+  assert.equal(scopesAuthorizePublish([PUBLISH_SCOPE, PRIOR_ERA_PUBLISH_SCOPE]), true);
+});
+
+test('nothing else authorizes — the alias widened one name, not the gate', () => {
+  assert.equal(scopesAuthorizePublish([]), false);
+  assert.equal(scopesAuthorizePublish(['']), false);
+  assert.equal(scopesAuthorizePublish(['records:read']), false);
+  assert.equal(scopesAuthorizePublish(['publish']), false);
+  assert.equal(scopesAuthorizePublish(['records:publish:extra']), false);
+  // Prefix and case collisions: scope strings are compared whole and exact.
+  assert.equal(scopesAuthorizePublish(['records']), false);
+  assert.equal(scopesAuthorizePublish(['Records:Publish']), false);
+  assert.equal(scopesAuthorizePublish([' records:publish']), false);
+});
+
+// --- Minting: literal ---------------------------------------------------------
+
+test('an omitted scope mints the canonical name — this is how the default moves', () => {
+  assert.equal(resolveMintScope(undefined), PUBLISH_SCOPE);
+  assert.equal(resolveMintScope(''), PUBLISH_SCOPE);
+  assert.equal(resolveMintScope('   '), PUBLISH_SCOPE);
+});
+
+test('an explicitly requested scope is granted VERBATIM, prior-era included', () => {
+  assert.equal(resolveMintScope(PUBLISH_SCOPE), PUBLISH_SCOPE);
+  assert.equal(
+    resolveMintScope(PRIOR_ERA_PUBLISH_SCOPE),
+    PRIOR_ERA_PUBLISH_SCOPE,
+    'RFC 8628 clients compare the granted scope against what they asked for; ' +
+      'silently upgrading the string fails that comparison for a client that ' +
+      'did nothing wrong',
+  );
+  // Surrounding whitespace is trimmed, as the endpoint always did.
+  assert.equal(resolveMintScope(`  ${PRIOR_ERA_PUBLISH_SCOPE}  `), PRIOR_ERA_PUBLISH_SCOPE);
+});
+
+test('both names are mintable; nothing else is', () => {
+  assert.equal(isAcceptedMintScope(PUBLISH_SCOPE), true);
+  assert.equal(isAcceptedMintScope(PRIOR_ERA_PUBLISH_SCOPE), true);
+  assert.equal(isAcceptedMintScope('records:read'), false);
+  assert.equal(isAcceptedMintScope(''), false);
+});
+
+test('a token minted under EITHER name authorizes every gated route', () => {
+  // The round trip the two properties above only describe separately: what
+  // the mint side produces, the enforcement side must accept. Whichever
+  // string a client ends up with, it can publish.
+  for (const requested of [undefined, PUBLISH_SCOPE, PRIOR_ERA_PUBLISH_SCOPE]) {
+    const minted = resolveMintScope(requested);
+    assert.ok(isAcceptedMintScope(minted), `${minted} is grantable`);
+    assert.equal(
+      scopesAuthorizePublish([minted]),
+      true,
+      `a token minted as "${minted}" must authorize a publish`,
+    );
+  }
+});
+
+// --- The refusal message ------------------------------------------------------
+
+test('the refusal names the canonical scope and says the prior-era one still works', () => {
+  assert.match(MISSING_PUBLISH_SCOPE_ERROR, new RegExp(PUBLISH_SCOPE));
+  assert.match(MISSING_PUBLISH_SCOPE_ERROR, new RegExp(PRIOR_ERA_PUBLISH_SCOPE));
+  assert.match(MISSING_PUBLISH_SCOPE_ERROR, /also accepted/);
+  // A client holding a prior-era token that hits this message for some other
+  // reason must not read it as "your token is the wrong kind" and go mint a
+  // replacement it does not need.
+});
+
+// --- The drift guard ----------------------------------------------------------
+//
+// The properties above are about one module. This one is about the repo: it
+// reads the route sources and fails if a publish gate is ever hand-rolled
+// again. Source text, not behavior — see the limits stated in the messages.
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const API_DIR = path.resolve(HERE, '..', 'app', 'api');
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+
+/** Every `route.ts` under `src/app/api`, repo-relative. */
+function apiRouteFiles(): string[] {
+  return readdirSync(API_DIR, { withFileTypes: true, recursive: true })
+    .filter((e) => e.isFile() && e.name === 'route.ts')
+    .map((e) => path.relative(REPO_ROOT, path.join(e.parentPath, e.name)))
+    .sort();
+}
+
+/**
+ * Source with comments removed, so a doc comment that MENTIONS a scope name
+ * is not read as code that hardcodes one. Crude on purpose: it is a scanner,
+ * not a parser, and it does not model strings containing `//` (none of these
+ * files has one). A false positive here fails loudly and is corrected by
+ * reading the file; a parser that silently mis-scanned would be worse.
+ */
+function codeWithoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+test('the route walker finds the API routes', () => {
+  const files = apiRouteFiles();
+  assert.ok(
+    files.length > 10,
+    `Found only ${files.length} route file(s) under src/app/api — the walker is\n` +
+      `broken, and the guard below would pass vacuously.`,
+  );
+});
+
+test('no API route hardcodes a publish-scope string; the vocabulary lives in one module', () => {
+  const offenders = apiRouteFiles().filter((file) => {
+    const code = codeWithoutComments(readFileSync(path.join(REPO_ROOT, file), 'utf8'));
+    return ACCEPTED_PUBLISH_SCOPES.some((scope) => code.includes(scope));
+  });
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `These route files name a publish scope as a literal in code:\n` +
+      `\n` +
+      `${offenders.map((f) => `    ${f}`).join('\n')}\n` +
+      `\n` +
+      `FIX: import from src/lib/publish-scope.ts — \`hasPublishScope(auth)\` via\n` +
+      `api-auth for a gate, \`MISSING_PUBLISH_SCOPE_ERROR\` for the refusal,\n` +
+      `\`ACCEPTED_PUBLISH_SCOPES\` / \`resolveMintScope\` for the device-flow start.\n` +
+      `\n` +
+      `WHY THIS IS NOT STYLE: the scope has two accepted spellings and will have\n` +
+      `one again after the prior-era name is dropped at a major version. A route\n` +
+      `holding its own literal checks one of them. It does not fail closed and it\n` +
+      `does not fail loudly — it 403s a token the neighbouring route accepts, and\n` +
+      `the only symptom is a publish that half-works: the blob upload is granted\n` +
+      `and the record POST is refused, or the other way round.`,
+  );
+});
+
+test('no API route gates on the publish scope through the exact-match helper', () => {
+  // `hasScope(auth, …)` is exact-match by design and stays, because a future
+  // second scope will want it. Using it for THIS scope is the defect: it can
+  // only name one of the two accepted spellings.
+  const offenders = apiRouteFiles().filter((file) =>
+    codeWithoutComments(readFileSync(path.join(REPO_ROOT, file), 'utf8')).includes(
+      'hasScope(',
+    ),
+  );
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `These route files call hasScope(...) directly:\n` +
+      `\n` +
+      `${offenders.map((f) => `    ${f}`).join('\n')}\n` +
+      `\n` +
+      `FIX: for the publish scope, call \`hasPublishScope(auth)\`. If you are\n` +
+      `gating on a genuinely NEW scope, this guard is the wrong shape and should\n` +
+      `be widened deliberately rather than by deleting the offending line.\n` +
+      `\n` +
+      `WHY: hasScope compares one string. The publish scope is two strings that\n` +
+      `mean the same authorization (Appendix J, alias-and-deprecate), and live\n` +
+      `90-day tokens carry the prior-era one.`,
+  );
+});

--- a/src/lib/publish-scope.ts
+++ b/src/lib/publish-scope.ts
@@ -1,0 +1,101 @@
+// The publish OAuth scope, under both accepted names (civic-ai-tools#160 P3).
+//
+// Group G of the 2026-08-19 vocabulary settlement (Appendix J of the Typed
+// Standards specification) renames the device-flow scope
+// `evidence:publish` → `records:publish`, migration class
+// `alias-and-deprecate`: the token endpoints accept both and mint the new one,
+// both authorize identically, and the prior-era name drops only at a major
+// version.
+//
+// TOKENS ARE THE REASON THIS IS AN ALIAS AND NOT A RENAME. A minted bearer
+// token stores its scope as a string in the database and lives 90 days. Every
+// token minted before this change carries `evidence:publish`, and there is no
+// migration that could fix that without invalidating tokens people are
+// actively using — so the ENFORCEMENT side must treat the two strings as one
+// authorization, permanently enough that no live token ever stops working.
+// That is what `scopesAuthorizePublish` is: one predicate, three call sites,
+// no hand-rolled ORs to fall out of step with each other.
+//
+// THE MINT SIDE IS SEPARATE, and deliberately more permissive than "mint the
+// new one". A client that explicitly ASKS for `evidence:publish` gets exactly
+// that — accepted, and minted as requested — because the device-flow response
+// echoes the granted scope and a client comparing it against what it asked for
+// is doing the correct thing under RFC 8628. Silently upgrading its scope
+// string would break that comparison for a client that has done nothing wrong.
+// A client that asks for NOTHING gets the canonical name, which is how the
+// default moves without anyone being surprised.
+//
+// Kept free of Next.js and database imports so it runs under `node --test`
+// (which resolves neither the `@/` alias nor the request plumbing) — the same
+// reason `src/lib/publisher-env.ts` is its own module. `src/lib/api-auth.ts`
+// wraps it for route callers.
+
+/** The scope minted by default and named in every "you need this" message. */
+export const PUBLISH_SCOPE = 'records:publish';
+
+/**
+ * The prior-era spelling. Accepted for authorization indefinitely — live
+ * tokens carry it — and still mintable on explicit request.
+ */
+export const PRIOR_ERA_PUBLISH_SCOPE = 'evidence:publish';
+
+/**
+ * Every scope string the device-flow start endpoint accepts, canonical first.
+ * The order is the order a human reads them in an error message; nothing
+ * depends on it for correctness.
+ */
+export const ACCEPTED_PUBLISH_SCOPES: readonly string[] = [
+  PUBLISH_SCOPE,
+  PRIOR_ERA_PUBLISH_SCOPE,
+];
+
+/**
+ * The unscoped wildcard cookie auth holds. Browser flows are gated by
+ * NextAuth and a user session rather than by scope, so `*` satisfies every
+ * scope check — unchanged by the settlement, restated here so the publish
+ * predicate below reads completely in one place.
+ */
+export const UNSCOPED_WILDCARD = '*';
+
+/**
+ * Does this set of held scopes authorize a publish?
+ *
+ * The one place the two spellings become one authorization. Pure over a list
+ * of strings so it is unit-testable without a request, a session, or a
+ * database row.
+ */
+export function scopesAuthorizePublish(scopes: readonly string[]): boolean {
+  return scopes.some(
+    (held) => held === UNSCOPED_WILDCARD || ACCEPTED_PUBLISH_SCOPES.includes(held),
+  );
+}
+
+/**
+ * The refusal a bearer token without publish authorization receives.
+ *
+ * Names the CANONICAL scope, because that is what a client should ask for
+ * from here on, and names the prior-era one as still accepted, because a
+ * client holding a token that carries it must not read this message as "your
+ * token is the wrong kind" and go mint a new one it does not need.
+ */
+export const MISSING_PUBLISH_SCOPE_ERROR =
+  `Token missing required scope: ${PUBLISH_SCOPE} ` +
+  `(the prior-era name ${PRIOR_ERA_PUBLISH_SCOPE} is also accepted)`;
+
+/** Is `scope` a string the device-flow start endpoint will grant? */
+export function isAcceptedMintScope(scope: string): boolean {
+  return ACCEPTED_PUBLISH_SCOPES.includes(scope);
+}
+
+/**
+ * The scope to mint for a device-flow request.
+ *
+ * An explicit request is honored verbatim (see the mint-side note above); an
+ * absent one takes the canonical name. Callers validate with
+ * `isAcceptedMintScope` first — this function does not, so that an invalid
+ * scope produces `invalid_scope` rather than being quietly replaced.
+ */
+export function resolveMintScope(requested: string | undefined): string {
+  const trimmed = (requested ?? '').trim();
+  return trimmed.length > 0 ? trimmed : PUBLISH_SCOPE;
+}

--- a/src/lib/publisher-env.test.ts
+++ b/src/lib/publisher-env.test.ts
@@ -1,0 +1,256 @@
+// The two-name expand for the publisher-identity variables (#160 P3).
+//
+// Group A of the 2026-08-19 vocabulary settlement (Appendix J of the Typed
+// Standards specification) moves fourteen variables from the `EVIDENCE_`
+// prefix to `PUBLISHER_`, under the `expand-then-flip` migration class. This
+// file pins the expand half: both names are read, the canonical one wins, the
+// prior-era one warns exactly once, and nothing that already worked stops.
+//
+// WHY THE PRECEDENCE RULE IS TESTED SO HARD. It is `defined`, not `truthy`,
+// and getting that wrong is silent. `EVIDENCE_TRUST_REGISTRY_LEGACY_URL=""` is
+// the documented way to OMIT the legacy registry URL from signed output, so
+// empty is a VALUE in this set. A resolver that fell through on empty would
+// resurrect a URL an operator deliberately suppressed — inside a signed
+// artifact, where it cannot be taken back.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CANONICAL_ENV_PREFIX,
+  PRIOR_ERA_ENV_NAMES,
+  PRIOR_ERA_ENV_PREFIX,
+  PUBLISHER_ENV_NAMES,
+  PUBLISHER_ENV_SUFFIXES,
+  canonicalEnvName,
+  lookupPublisherEnv,
+  priorEraEnvName,
+  priorEraEnvNamesWarned,
+  readPublisherEnv,
+  resetPriorEraEnvWarnings,
+} from './publisher-env.ts';
+// The scripts side carries the same rule in its own idiom because
+// `scripts/preflight-env.mjs` is run as a bare `node …` and cannot import
+// TypeScript. Two implementations of one rule is exactly the shape that
+// drifts, so the two censuses are pinned against each other below.
+import { ENV_SPEC, resolveEnvName } from '../../scripts/preflight-env.mjs';
+
+/** Run `fn` with `console.warn` captured. Restores the real one after. */
+function captureWarnings<T>(fn: () => T): { result: T; warnings: string[] } {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  try {
+    return { result: fn(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+// --- The census ---------------------------------------------------------------
+
+test('the census is Appendix J\'s fourteen variables, with no duplicates', () => {
+  assert.equal(PUBLISHER_ENV_SUFFIXES.length, 14);
+  assert.equal(new Set(PUBLISHER_ENV_SUFFIXES).size, 14, 'no suffix appears twice');
+  assert.deepEqual(
+    [...PUBLISHER_ENV_NAMES].sort(),
+    [...PUBLISHER_ENV_SUFFIXES].map((s) => `${CANONICAL_ENV_PREFIX}${s}`).sort(),
+  );
+  assert.deepEqual(
+    [...PRIOR_ERA_ENV_NAMES].sort(),
+    [...PUBLISHER_ENV_SUFFIXES].map((s) => `${PRIOR_ERA_ENV_PREFIX}${s}`).sort(),
+  );
+  // The two names differ only by prefix — no per-variable renaming rode along
+  // with the prefix change, which is what makes the whole set mechanical.
+  for (const suffix of PUBLISHER_ENV_SUFFIXES) {
+    assert.equal(canonicalEnvName(suffix).replace(/^PUBLISHER_/, ''), suffix);
+    assert.equal(priorEraEnvName(suffix).replace(/^EVIDENCE_/, ''), suffix);
+  }
+});
+
+test('the scripts-side census matches this one, name for name', () => {
+  // `scripts/preflight-env.mjs` cannot import this module (it runs as a bare
+  // `node scripts/preflight-env.mjs`), so it declares the pairs itself. This
+  // is the only thing standing between the two lists and silent divergence —
+  // and divergence here means the preflight passes a configuration the app
+  // refuses, or nags about one it accepts.
+  const specPairs: { name: string; priorEraName?: string }[] = ENV_SPEC.filter(
+    (s: { name: string }) => s.name.startsWith(CANONICAL_ENV_PREFIX),
+  );
+
+  assert.deepEqual(
+    specPairs.map((s) => s.name).sort(),
+    [...PUBLISHER_ENV_NAMES].sort(),
+    'ENV_SPEC and PUBLISHER_ENV_SUFFIXES declare different canonical names.\n' +
+      'FIX: add or remove the entry on whichever side is behind. Both lists are\n' +
+      'the same census (Appendix J, environment row) written twice because the\n' +
+      'preflight script cannot import TypeScript.',
+  );
+  for (const { name, priorEraName } of specPairs) {
+    assert.equal(
+      priorEraName,
+      name.replace(CANONICAL_ENV_PREFIX, PRIOR_ERA_ENV_PREFIX),
+      `${name} declares a prior-era spelling this module would not produce`,
+    );
+  }
+});
+
+// --- Precedence ---------------------------------------------------------------
+
+test('the canonical name is read first', () => {
+  resetPriorEraEnvWarnings();
+  const env = {
+    PUBLISHER_SITE_ORIGIN: 'https://canonical.example.org',
+    EVIDENCE_SITE_ORIGIN: 'https://prior-era.example.org',
+  };
+  const hit = lookupPublisherEnv('SITE_ORIGIN', env);
+  assert.equal(hit.value, 'https://canonical.example.org');
+  assert.equal(hit.name, 'PUBLISHER_SITE_ORIGIN');
+  assert.equal(hit.viaPriorEra, false);
+});
+
+test('the prior-era name answers when the canonical one is entirely unset', () => {
+  resetPriorEraEnvWarnings();
+  const hit = lookupPublisherEnv('KEY_ID', { EVIDENCE_KEY_ID: 'platform:prior-era' });
+  assert.equal(hit.value, 'platform:prior-era');
+  assert.equal(hit.name, 'EVIDENCE_KEY_ID');
+  assert.equal(hit.viaPriorEra, true);
+});
+
+test('neither name set resolves to undefined, reported under the canonical name', () => {
+  resetPriorEraEnvWarnings();
+  const hit = lookupPublisherEnv('KEY_ID', {});
+  assert.equal(hit.value, undefined);
+  assert.equal(hit.name, 'PUBLISHER_KEY_ID');
+  assert.equal(hit.viaPriorEra, false);
+});
+
+test('DEFINED wins, not truthy: an empty canonical name shadows a set prior-era one', () => {
+  resetPriorEraEnvWarnings();
+  const hit = lookupPublisherEnv('TRUST_REGISTRY_LEGACY_URL', {
+    PUBLISHER_TRUST_REGISTRY_LEGACY_URL: '',
+    EVIDENCE_TRUST_REGISTRY_LEGACY_URL: 'https://example.org/.well-known/legacy.json',
+  });
+  assert.equal(hit.value, '', 'empty is a value in this set, not an absence');
+  assert.equal(hit.viaPriorEra, false);
+  // The consequence, stated: the caller that reads this omits the legacy URL
+  // from the signed sidecar, which is exactly what the operator asked for.
+});
+
+test('an empty PRIOR-ERA name is still an answer — the same reason, other side', () => {
+  resetPriorEraEnvWarnings();
+  const hit = lookupPublisherEnv('TRUST_REGISTRY_LEGACY_URL', {
+    EVIDENCE_TRUST_REGISTRY_LEGACY_URL: '',
+  });
+  assert.equal(hit.value, '');
+  assert.equal(hit.viaPriorEra, true);
+});
+
+test('values are returned verbatim — never trimmed, normalized, or inspected', () => {
+  resetPriorEraEnvWarnings();
+  // Presence conventions (whitespace-only counts as absent) belong to the
+  // CALLERS; a resolver that trimmed would silently rewrite a value that
+  // lands in a signed field.
+  assert.equal(readPublisherEnv('SIGNER_IDENTIFIER', { PUBLISHER_SIGNER_IDENTIFIER: '  x  ' }), '  x  ');
+});
+
+// --- The deprecation warning ---------------------------------------------------
+
+test('the prior-era name warns ONCE per variable, naming its successor', () => {
+  resetPriorEraEnvWarnings();
+  const env = { EVIDENCE_SITE_ORIGIN: 'https://prior-era.example.org' };
+  const { warnings } = captureWarnings(() => {
+    readPublisherEnv('SITE_ORIGIN', env);
+    readPublisherEnv('SITE_ORIGIN', env);
+    readPublisherEnv('SITE_ORIGIN', env);
+  });
+  assert.equal(
+    warnings.length,
+    1,
+    'once per VARIABLE, not once per read — these getters run several times ' +
+      'per request, and a line each would bury the signal it exists to raise',
+  );
+  assert.match(warnings[0], /EVIDENCE_SITE_ORIGIN/);
+  assert.match(warnings[0], /PUBLISHER_SITE_ORIGIN/);
+  assert.match(warnings[0], /Both\s+names work today/);
+  assert.deepEqual(priorEraEnvNamesWarned(), ['EVIDENCE_SITE_ORIGIN']);
+});
+
+test('the warning is per variable, so a second variable still warns', () => {
+  resetPriorEraEnvWarnings();
+  const { warnings } = captureWarnings(() => {
+    readPublisherEnv('SITE_ORIGIN', { EVIDENCE_SITE_ORIGIN: 'a' });
+    readPublisherEnv('KEY_ID', { EVIDENCE_KEY_ID: 'b' });
+  });
+  assert.equal(warnings.length, 2);
+  assert.deepEqual(priorEraEnvNamesWarned(), ['EVIDENCE_KEY_ID', 'EVIDENCE_SITE_ORIGIN']);
+});
+
+test('the canonical name never warns, and neither does an unset variable', () => {
+  resetPriorEraEnvWarnings();
+  const { warnings } = captureWarnings(() => {
+    readPublisherEnv('SITE_ORIGIN', { PUBLISHER_SITE_ORIGIN: 'a', EVIDENCE_SITE_ORIGIN: 'b' });
+    readPublisherEnv('KEY_ID', {});
+  });
+  assert.deepEqual(warnings, []);
+});
+
+test('the warning never echoes a value — these variables include a private key', () => {
+  resetPriorEraEnvWarnings();
+  const { warnings } = captureWarnings(() => {
+    readPublisherEnv('SIGNING_KEY', { EVIDENCE_SIGNING_KEY: 'SENTINEL-DO-NOT-LEAK' });
+  });
+  assert.equal(warnings.length, 1);
+  assert.ok(
+    !warnings[0].includes('SENTINEL'),
+    'the deprecation notice must name the variable, never its value',
+  );
+});
+
+test('warn:false resolves without emitting — for probes that inspect config', () => {
+  resetPriorEraEnvWarnings();
+  const { warnings } = captureWarnings(() => {
+    lookupPublisherEnv('SITE_ORIGIN', { EVIDENCE_SITE_ORIGIN: 'a' }, false);
+  });
+  assert.deepEqual(warnings, []);
+  assert.deepEqual(priorEraEnvNamesWarned(), [], 'a silent probe does not consume the once');
+});
+
+// --- Agreement with the scripts-side resolver ---------------------------------
+
+test('both resolvers answer identically across the whole precedence matrix', () => {
+  // The rule is implemented twice (TypeScript here, plain JS in the preflight)
+  // because the script cannot import this module. A disagreement is not a
+  // cosmetic drift: the preflight would pass a configuration the app refuses.
+  const suffix = 'SITE_ORIGIN' as const;
+  const entry = ENV_SPEC.find(
+    (s: { name: string }) => s.name === canonicalEnvName(suffix),
+  ) as { name: string; priorEraName?: string };
+
+  const cases: Record<string, string | undefined>[] = [
+    {},
+    { PUBLISHER_SITE_ORIGIN: 'canonical' },
+    { EVIDENCE_SITE_ORIGIN: 'prior-era' },
+    { PUBLISHER_SITE_ORIGIN: 'canonical', EVIDENCE_SITE_ORIGIN: 'prior-era' },
+    { PUBLISHER_SITE_ORIGIN: '', EVIDENCE_SITE_ORIGIN: 'prior-era' },
+    { PUBLISHER_SITE_ORIGIN: '   ', EVIDENCE_SITE_ORIGIN: 'prior-era' },
+    { EVIDENCE_SITE_ORIGIN: '' },
+  ];
+  resetPriorEraEnvWarnings();
+  captureWarnings(() => {
+    for (const env of cases) {
+      const here = lookupPublisherEnv(suffix, env);
+      const there = resolveEnvName(entry, env);
+      assert.equal(here.name, there.name, `name disagreement for ${JSON.stringify(env)}`);
+      assert.equal(here.value, there.raw, `value disagreement for ${JSON.stringify(env)}`);
+      assert.equal(
+        here.viaPriorEra,
+        there.viaPriorEra,
+        `provenance disagreement for ${JSON.stringify(env)}`,
+      );
+    }
+  });
+});

--- a/src/lib/publisher-env.ts
+++ b/src/lib/publisher-env.ts
@@ -1,0 +1,204 @@
+// Publisher-instance environment names, new-then-old (civic-ai-tools#160 P3).
+//
+// WHAT THIS IS. The 2026-08-19 vocabulary settlement (Appendix J of the Typed
+// Standards specification) retires "evidence" from the infrastructure brand.
+// The fourteen variables that name THIS deployment's publishing identity move
+// from the `EVIDENCE_` prefix to `PUBLISHER_`, under the settlement's
+// `expand-then-flip` migration class:
+//
+//   EXPAND (this module, this phase) — every runtime read accepts BOTH names,
+//   canonical first, and says so out loud when the prior-era name is the one
+//   that answered. Nothing an operator has configured stops working, and an
+//   operator who has already moved gets the new names honored.
+//
+//   FLIP (a later phase) — the deployment guides, `.env.example` and
+//   `docker-compose.yml` start naming `PUBLISHER_*`; the operator adds the new
+//   names, removes the old.
+//
+//   DROP (a later major) — the fallback in `lookupPublisherEnv` goes away.
+//
+// ONE HELPER, NOT FOURTEEN FALLBACKS. Hand-rolling `process.env.PUBLISHER_X ??
+// process.env.EVIDENCE_X` at each of the ~20 read sites would put the
+// migration rule in twenty places and the deprecation warning in none of them.
+// Everything that reads one of these variables goes through here, which is
+// also what makes the eventual drop a one-line edit.
+//
+// THE PRECEDENCE RULE IS `DEFINED`, NOT `TRUTHY`, AND THAT IS DELIBERATE.
+// The canonical name wins whenever it is set to a string — including the EMPTY
+// string — and only an entirely unset canonical name falls through. Truthiness
+// would be wrong: `EVIDENCE_TRUST_REGISTRY_LEGACY_URL=""` is the documented
+// way to OMIT the legacy registry URL from signed output (see
+// `getSidecarTrustRegistryUrls` in site-config.ts), so empty is a value here
+// and not an absence. `scripts/check-compose-env.mjs` exists to protect the
+// same distinction on the compose path. The consequence, stated plainly: an
+// operator who sets the canonical name to empty shadows a prior-era name that
+// still holds a value — which is the right reading of an explicit setting, and
+// is why the fallback is documented rather than silent.
+//
+// PRESENCE-VS-VALUE stays with the CALLER. This module resolves WHICH NAME
+// answered and hands back the raw string; whether whitespace-only counts as
+// absent is the consuming module's convention (`presentOrNull` in
+// site-config.ts, `isPresent` in unsigned-tier.ts and the preflight — all
+// three trim). Nothing here trims, normalizes, or inspects a value: several of
+// these variables are secrets, and one of them lands verbatim in a signed
+// field.
+//
+// THE SCRIPTS SIDE IS SEPARATE ON PURPOSE. `scripts/preflight-env.mjs` is run
+// as a bare `node scripts/preflight-env.mjs`, so it cannot import a TypeScript
+// module; it carries the same rule in its own idiom, keyed off its ENV_SPEC's
+// `priorEraName` field. The two lists are cross-referenced in both directions
+// and pinned against each other by `src/lib/publisher-env.test.ts`, so they
+// cannot drift.
+
+/**
+ * The settlement-era prefix — the canonical name of every variable below.
+ * "Publisher" rather than "record": these variables name the PUBLISHER (its
+ * origin, signer, key, platform agent, registry), not the artifact.
+ */
+export const CANONICAL_ENV_PREFIX = 'PUBLISHER_';
+
+/** The prior-era prefix, accepted for the whole of the expand phase. */
+export const PRIOR_ERA_ENV_PREFIX = 'EVIDENCE_';
+
+/**
+ * The fourteen variables in the settlement's Group A, by the suffix the two
+ * prefixes share. This list IS the census (Appendix J's environment row); it
+ * is not derived from anything, so adding a fifteenth publisher variable means
+ * adding it here.
+ *
+ * `PUBLIC_KEY` is the odd one: nothing reads it at run time — the key-
+ * generation script WRITES it, and the deployment guide documents it. It is
+ * listed because the settlement lists it, and because the writer emits the
+ * canonical name from this list rather than a literal of its own.
+ */
+export const PUBLISHER_ENV_SUFFIXES = [
+  'SIGNING_KEY',
+  'KEY_ID',
+  'PUBLIC_KEY',
+  'SIGNER_BINDING_TIER',
+  'SIGNER_IDENTIFIER',
+  'SIGNER_DISPLAY_NAME',
+  'PLATFORM_AGENT_ID',
+  'PLATFORM_AGENT_TITLE',
+  'PLATFORM_AGENT_URL',
+  'PUBLICATION_HOST',
+  'SITE_ORIGIN',
+  'TRUST_REGISTRY_URL',
+  'TRUST_REGISTRY_CANONICAL_URL',
+  'TRUST_REGISTRY_LEGACY_URL',
+] as const;
+
+/** One of the fourteen suffixes above. */
+export type PublisherEnvSuffix = (typeof PUBLISHER_ENV_SUFFIXES)[number];
+
+/** An env-shaped record. Always passed in, never reached for implicitly. */
+export type EnvRecord = Record<string, string | undefined>;
+
+/** The settlement-era variable name for a suffix, e.g. `PUBLISHER_KEY_ID`. */
+export function canonicalEnvName(suffix: PublisherEnvSuffix): string {
+  return `${CANONICAL_ENV_PREFIX}${suffix}`;
+}
+
+/** The prior-era variable name for a suffix, e.g. `EVIDENCE_KEY_ID`. */
+export function priorEraEnvName(suffix: PublisherEnvSuffix): string {
+  return `${PRIOR_ERA_ENV_PREFIX}${suffix}`;
+}
+
+/** The canonical names, in census order — the list an operator should set. */
+export const PUBLISHER_ENV_NAMES: readonly string[] =
+  PUBLISHER_ENV_SUFFIXES.map(canonicalEnvName);
+
+/** The prior-era names, in census order. */
+export const PRIOR_ERA_ENV_NAMES: readonly string[] =
+  PUBLISHER_ENV_SUFFIXES.map(priorEraEnvName);
+
+/** The outcome of one two-name lookup. */
+export interface PublisherEnvLookup {
+  /** The raw string, verbatim and untrimmed, or `undefined` if neither name is set. */
+  value: string | undefined;
+  /** The variable name that answered, or the canonical name when neither did. */
+  name: string;
+  /** True when the prior-era name supplied the value. */
+  viaPriorEra: boolean;
+}
+
+/**
+ * Variables already warned about in this process. Module-level so the warning
+ * is once-per-variable rather than once-per-read: `getEvidenceSiteOrigin()`
+ * alone is called several times per request, and a log line per call would
+ * bury the signal it exists to raise.
+ */
+const warned = new Set<string>();
+
+/** Drop the once-per-variable memo. For tests and rehearsal drills only. */
+export function resetPriorEraEnvWarnings(): void {
+  warned.clear();
+}
+
+/** The names warned about so far in this process — the memo, read-only. */
+export function priorEraEnvNamesWarned(): string[] {
+  return [...warned].sort();
+}
+
+/**
+ * Emit the once-per-variable deprecation notice.
+ *
+ * SERVER-SIDE AND OPERATOR-FACING, never user-facing: it is a `console.warn`
+ * from a module that only resolves configuration, and no response body, page,
+ * or streamed message carries it. In a browser bundle it cannot fire at all —
+ * neither name is a `NEXT_PUBLIC_` variable, so both read as `undefined` there
+ * and the prior-era branch is unreachable.
+ */
+function warnPriorEra(suffix: PublisherEnvSuffix): void {
+  const oldName = priorEraEnvName(suffix);
+  if (warned.has(oldName)) return;
+  warned.add(oldName);
+  console.warn(
+    `[publisher-env] ${oldName} is the prior-era name for ` +
+      `${canonicalEnvName(suffix)} and supplied this instance's value. Both ` +
+      `names work today; the prior-era one is removed at a future major ` +
+      `version. Rename it in this instance's environment when convenient — ` +
+      `see the 2026-08-19 vocabulary settlement (Appendix J of the Typed ` +
+      `Standards specification).`,
+  );
+}
+
+/**
+ * Resolve one publisher variable across both names, reporting which answered.
+ *
+ * Use this when the caller needs to NAME the variable (a refusal message, a
+ * report row). Callers that only need the value use `readPublisherEnv`.
+ *
+ * @param suffix the shared suffix, e.g. `'KEY_ID'`
+ * @param env the environment to read; pass a fixture in tests
+ * @param warn set false to resolve without emitting the deprecation notice —
+ *   for probes that inspect configuration without consuming it
+ */
+export function lookupPublisherEnv(
+  suffix: PublisherEnvSuffix,
+  env: EnvRecord,
+  warn = true,
+): PublisherEnvLookup {
+  const canonical = env[canonicalEnvName(suffix)];
+  if (typeof canonical === 'string') {
+    return { value: canonical, name: canonicalEnvName(suffix), viaPriorEra: false };
+  }
+  const priorEra = env[priorEraEnvName(suffix)];
+  if (typeof priorEra === 'string') {
+    if (warn) warnPriorEra(suffix);
+    return { value: priorEra, name: priorEraEnvName(suffix), viaPriorEra: true };
+  }
+  return { value: undefined, name: canonicalEnvName(suffix), viaPriorEra: false };
+}
+
+/**
+ * The value of one publisher variable under either name — the read every
+ * runtime consumer wants. Verbatim and untrimmed; `undefined` when neither
+ * name is set.
+ */
+export function readPublisherEnv(
+  suffix: PublisherEnvSuffix,
+  env: EnvRecord = process.env,
+): string | undefined {
+  return lookupPublisherEnv(suffix, env).value;
+}

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -5,6 +5,15 @@
 // graph (via the evidence modules), which resolves neither the `@/` alias nor
 // extensionless specifiers — the same convention as evidence/verify.ts.
 import { describeContentSource, type ContentProvenance } from './content-source.ts';
+// The two-name resolver for the publisher-identity variables (Group A of the
+// 2026-08-19 vocabulary settlement): `PUBLISHER_*` first, `EVIDENCE_*` as the
+// prior-era fallback, with a once-per-variable deprecation warning. Every
+// getter below reads through it rather than touching `process.env` directly.
+import {
+  canonicalEnvName,
+  readPublisherEnv,
+  type PublisherEnvSuffix,
+} from './publisher-env.ts';
 
 /** The Typed Standards protocol site — spec home and neutral verifier. */
 export const TYPED_STANDARDS_URL = 'https://typedstandards.org';
@@ -176,10 +185,21 @@ export function getRoadmapSource(): RoadmapSource | null {
   };
 }
 
-// --- Evidence instance identity (ADR-0020: config, not code; #258:
+// --- Publisher instance identity (ADR-0020: config, not code; #258:
 //     required for signing, never defaulted) --------------------------------
 //
-// Every value that names THIS deployment inside emitted evidence surfaces —
+// TWO ACCEPTED NAMES PER VARIABLE, and the rule is stated here once rather
+// than repeated at every getter. The 2026-08-19 vocabulary settlement
+// (Appendix J of the Typed Standards specification; civic-ai-tools#160) moves
+// this set from the `EVIDENCE_` prefix to `PUBLISHER_`, under the
+// `expand-then-flip` migration class. Every getter below reads
+// `PUBLISHER_<NAME>` first and falls back to `EVIDENCE_<NAME>`, warning once
+// per variable when the prior-era name is what answered — see
+// `src/lib/publisher-env.ts`, which owns the census and the precedence rule.
+// Variable names written below are the CANONICAL ones; the prior-era spelling
+// of each is the same name under the other prefix, and it still works.
+//
+// Every value that names THIS deployment inside emitted record surfaces —
 // the proof sidecar's trust-registry URLs, the envelope `signer` claim, the
 // publication host label, the PROV platform agent, notebook attribution —
 // resolves through the getters below, from the ENVIRONMENT ONLY. There are
@@ -206,7 +226,7 @@ export function getRoadmapSource(): RoadmapSource | null {
 //     from origin, platform-agent URL from origin. Operator-supplied values
 //     may ground derived values; reference constants may not.
 //
-// An instance sets `EVIDENCE_SITE_ORIGIN` plus the signer/key variables and
+// An instance sets `PUBLISHER_SITE_ORIGIN` plus the signer/key variables and
 // every derived surface follows; each item is also individually overridable
 // for split-host deployments. Values are read at CALL time (not module load)
 // so tests and rotation drills can vary them per-process.
@@ -219,18 +239,32 @@ export function getRoadmapSource(): RoadmapSource | null {
 /**
  * The variables an instance MUST set before any signed emission — the
  * identity half of the go-to-production step (the custody half is the
- * `EVIDENCE_SIGNING_KEY` + `EVIDENCE_KEY_ID` pair in unsigned-tier.ts).
- * Everything else in the identity set derives from these (host and URLs from
- * the origin, the agent id from the host) or is a per-item override.
- * `evaluateSealCommitGate` refuses with exactly the missing names.
+ * signing-key + key-id pair in unsigned-tier.ts). Everything else in the
+ * identity set derives from these (host and URLs from the origin, the agent id
+ * from the host) or is a per-item override.
+ *
+ * Declared by SUFFIX because each one has two accepted names since the
+ * 2026-08-19 vocabulary settlement — `PUBLISHER_SITE_ORIGIN` canonically, with
+ * `EVIDENCE_SITE_ORIGIN` still honored. Presence is therefore a two-name
+ * question, and the one place that answers it is
+ * `missingInstanceIdentityVars` in unsigned-tier.ts.
  */
-export const INSTANCE_IDENTITY_REQUIRED_VARS = [
-  'EVIDENCE_SITE_ORIGIN',
-  'EVIDENCE_SIGNER_BINDING_TIER',
-  'EVIDENCE_SIGNER_IDENTIFIER',
-  'EVIDENCE_SIGNER_DISPLAY_NAME',
-  'EVIDENCE_PLATFORM_AGENT_TITLE',
-] as const;
+export const INSTANCE_IDENTITY_REQUIRED_SUFFIXES = [
+  'SITE_ORIGIN',
+  'SIGNER_BINDING_TIER',
+  'SIGNER_IDENTIFIER',
+  'SIGNER_DISPLAY_NAME',
+  'PLATFORM_AGENT_TITLE',
+] as const satisfies readonly PublisherEnvSuffix[];
+
+/**
+ * The same five variables under their CANONICAL names — what a refusal names
+ * and what an operator should set. `evaluateSealCommitGate` refuses with
+ * exactly the missing names from this list, noting that the prior-era
+ * `EVIDENCE_*` spellings are still accepted.
+ */
+export const INSTANCE_IDENTITY_REQUIRED_VARS: readonly string[] =
+  INSTANCE_IDENTITY_REQUIRED_SUFFIXES.map(canonicalEnvName);
 
 /**
  * Thrown when an identity-bearing emission path runs without the instance
@@ -261,14 +295,14 @@ function presentOrNull(raw: string | undefined): string | null {
 }
 
 /**
- * Public origin of this instance for evidence emission (absolute URLs inside
- * emitted proofs and signed output). Env: `EVIDENCE_SITE_ORIGIN`; `null`
+ * Public origin of this instance for record emission (absolute URLs inside
+ * emitted proofs and signed output). Env: `PUBLISHER_SITE_ORIGIN`; `null`
  * when unset — the caller omits (display surfaces) or refuses (emission
  * paths; those sit behind the seal/commit gate). Trailing slash is trimmed
  * so derived URLs stay canonical.
  */
 export function getEvidenceSiteOrigin(): string | null {
-  const raw = presentOrNull(process.env.EVIDENCE_SITE_ORIGIN);
+  const raw = presentOrNull(readPublisherEnv('SITE_ORIGIN'));
   return raw === null ? null : raw.replace(/\/$/, '');
 }
 
@@ -276,11 +310,11 @@ export function getEvidenceSiteOrigin(): string | null {
  * Host label of this instance — the `publicationHost` on
  * `attestation/publishes/v1` nodes, the datHere environment extension's
  * `host` field, and the "via …" attribution host. Env:
- * `EVIDENCE_PUBLICATION_HOST`; derives from the host of
+ * `PUBLISHER_PUBLICATION_HOST`; derives from the host of
  * `getEvidenceSiteOrigin()` when unset; `null` when neither is configured.
  */
 export function getPublicationHost(): string | null {
-  const explicit = presentOrNull(process.env.EVIDENCE_PUBLICATION_HOST);
+  const explicit = presentOrNull(readPublisherEnv('PUBLICATION_HOST'));
   if (explicit) return explicit;
   const origin = getEvidenceSiteOrigin();
   if (origin === null) return null;
@@ -303,7 +337,7 @@ export function requirePublicationHost(): string {
   const host = getPublicationHost();
   if (host === null) {
     throw new InstanceIdentityError(
-      ['EVIDENCE_SITE_ORIGIN'],
+      [canonicalEnvName('SITE_ORIGIN')],
       'a publication host label inside signed output',
     );
   }
@@ -314,7 +348,8 @@ export function requirePublicationHost(): string {
  * Trust-registry URLs emitted into the proof sidecar (spec §8.8.1) — the TOP
  * ADR-0020 correctness item: an instance shipping another deployment's URLs
  * emits proofs pointing at a registry that lacks its key. Envs:
- * `EVIDENCE_TRUST_REGISTRY_CANONICAL_URL` / `EVIDENCE_TRUST_REGISTRY_LEGACY_URL`;
+ * `PUBLISHER_TRUST_REGISTRY_CANONICAL_URL` /
+ * `PUBLISHER_TRUST_REGISTRY_LEGACY_URL`;
  * both default to well-known paths on `getEvidenceSiteOrigin()` (the app
  * parallel-serves both paths from one registry file). Set the legacy var to
  * an empty string to omit `trustRegistryUrlLegacy` entirely — an instance
@@ -332,15 +367,15 @@ export function getSidecarTrustRegistryUrls(): {
 } {
   const origin = getEvidenceSiteOrigin();
   const canonical =
-    presentOrNull(process.env.EVIDENCE_TRUST_REGISTRY_CANONICAL_URL) ??
+    presentOrNull(readPublisherEnv('TRUST_REGISTRY_CANONICAL_URL')) ??
     (origin !== null ? `${origin}/.well-known/typed-publisher.json` : null);
   if (canonical === null) {
     throw new InstanceIdentityError(
-      ['EVIDENCE_SITE_ORIGIN'],
+      [canonicalEnvName('SITE_ORIGIN')],
       "the proof sidecar's trust-registry URL",
     );
   }
-  const legacyRaw = process.env.EVIDENCE_TRUST_REGISTRY_LEGACY_URL;
+  const legacyRaw = readPublisherEnv('TRUST_REGISTRY_LEGACY_URL');
   const legacy =
     legacyRaw === ''
       ? undefined
@@ -354,9 +389,9 @@ export function getSidecarTrustRegistryUrls(): {
 /**
  * Envelope-side signer identity claim for this instance (spec §8.1.1, §8.5)
  * — emitted verbatim inside signed output. Envs:
- * `EVIDENCE_SIGNER_BINDING_TIER` / `EVIDENCE_SIGNER_IDENTIFIER` /
- * `EVIDENCE_SIGNER_DISPLAY_NAME`. These MUST match the `signerIdentity`
- * recorded for the active `EVIDENCE_KEY_ID` in the instance's trust registry
+ * `PUBLISHER_SIGNER_BINDING_TIER` / `PUBLISHER_SIGNER_IDENTIFIER` /
+ * `PUBLISHER_SIGNER_DISPLAY_NAME`. These MUST match the `signerIdentity`
+ * recorded for the active `PUBLISHER_KEY_ID` in the instance's trust registry
  * (verify check #14 cross-checks the two).
  *
  * Throws `InstanceIdentityError` naming exactly the missing variables when
@@ -370,13 +405,13 @@ export function getEvidenceSignerIdentity(): {
   identifier: string;
   displayName: string;
 } {
-  const bindingTier = presentOrNull(process.env.EVIDENCE_SIGNER_BINDING_TIER);
-  const identifier = presentOrNull(process.env.EVIDENCE_SIGNER_IDENTIFIER);
-  const displayName = presentOrNull(process.env.EVIDENCE_SIGNER_DISPLAY_NAME);
+  const bindingTier = presentOrNull(readPublisherEnv('SIGNER_BINDING_TIER'));
+  const identifier = presentOrNull(readPublisherEnv('SIGNER_IDENTIFIER'));
+  const displayName = presentOrNull(readPublisherEnv('SIGNER_DISPLAY_NAME'));
   const missing: string[] = [];
-  if (bindingTier === null) missing.push('EVIDENCE_SIGNER_BINDING_TIER');
-  if (identifier === null) missing.push('EVIDENCE_SIGNER_IDENTIFIER');
-  if (displayName === null) missing.push('EVIDENCE_SIGNER_DISPLAY_NAME');
+  if (bindingTier === null) missing.push(canonicalEnvName('SIGNER_BINDING_TIER'));
+  if (identifier === null) missing.push(canonicalEnvName('SIGNER_IDENTIFIER'));
+  if (displayName === null) missing.push(canonicalEnvName('SIGNER_DISPLAY_NAME'));
   if (missing.length > 0) {
     throw new InstanceIdentityError(
       missing,
@@ -412,7 +447,7 @@ export function getConfiguredSignerIdentity(): {
 /**
  * Display name of this instance for attribution surfaces — the "Generated
  * by …" lines in authored/downloaded notebooks. Reuses
- * `EVIDENCE_PLATFORM_AGENT_TITLE` (one variable names the instance in both
+ * `PUBLISHER_PLATFORM_AGENT_TITLE` (one variable names the instance in both
  * the PROV agent and the human-readable attribution); `null` when unset —
  * attribution surfaces then omit their "Generated by …" line rather than
  * claim a name (#258 A2). Client-rendered surfaces (the notebook download
@@ -420,14 +455,14 @@ export function getConfiguredSignerIdentity(): {
  * this getter reads nothing useful in the browser bundle.
  */
 export function getPlatformTitle(): string | null {
-  return presentOrNull(process.env.EVIDENCE_PLATFORM_AGENT_TITLE);
+  return presentOrNull(readPublisherEnv('PLATFORM_AGENT_TITLE'));
 }
 
 /**
  * Overrides for the PROV platform agent (WHO published, as a prov:Agent
- * inside the signed provenance graph). Envs: `EVIDENCE_PLATFORM_AGENT_ID` /
- * `EVIDENCE_PLATFORM_AGENT_TITLE` / `EVIDENCE_PLATFORM_AGENT_URL`; the agent
- * URL follows `EVIDENCE_SITE_ORIGIN` when unset, so a one-variable instance
+ * inside the signed provenance graph). Envs: `PUBLISHER_PLATFORM_AGENT_ID` /
+ * `PUBLISHER_PLATFORM_AGENT_TITLE` / `PUBLISHER_PLATFORM_AGENT_URL`; the agent
+ * URL follows `PUBLISHER_SITE_ORIGIN` when unset, so a one-variable instance
  * setup re-points the agent too. `undefined` members mean "not configured" —
  * the packager (the sole signing-path consumer) requires title + url and
  * derives a missing id from the publication host; it never substitutes a
@@ -439,10 +474,10 @@ export function getPlatformAgentOverrides(): {
   url?: string;
 } {
   return {
-    id: presentOrNull(process.env.EVIDENCE_PLATFORM_AGENT_ID) ?? undefined,
+    id: presentOrNull(readPublisherEnv('PLATFORM_AGENT_ID')) ?? undefined,
     title: getPlatformTitle() ?? undefined,
     url:
-      presentOrNull(process.env.EVIDENCE_PLATFORM_AGENT_URL) ??
+      presentOrNull(readPublisherEnv('PLATFORM_AGENT_URL')) ??
       getEvidenceSiteOrigin() ??
       undefined,
   };
@@ -456,11 +491,11 @@ export function getPlatformAgentOverrides(): {
  * `EvidenceOriginProvider`, so the browser bundle never needs the env.
  */
 export interface InstanceAttribution {
-  /** Public origin (`EVIDENCE_SITE_ORIGIN`), e.g. `https://example.org`. */
+  /** Public origin (`PUBLISHER_SITE_ORIGIN`), e.g. `https://example.org`. */
   origin: string | null;
-  /** Host label (`EVIDENCE_PUBLICATION_HOST` or derived from the origin). */
+  /** Host label (`PUBLISHER_PUBLICATION_HOST` or derived from the origin). */
   host: string | null;
-  /** Display name (`EVIDENCE_PLATFORM_AGENT_TITLE`). */
+  /** Display name (`PUBLISHER_PLATFORM_AGENT_TITLE`). */
   platformTitle: string | null;
 }
 


### PR DESCRIPTION
Sprint civic-ai-tools#160, Phase P3 — the website expand. Contract: the #160 charter + riders + G1–R1 gate records; canonical mapping per spec Appendix J (`v0.1.6-typed-standards-spec`). Emissions deliberately stay old-form — the flip is P5.

**Model disclosure:** IMPL ran on the opus tier (1M context). **Base note:** main moved under the phase (#284, #286 — zero file overlap, verified); branch rebased onto `87ac799`, all four signed commits intact, pre-phase tag re-cut. ORCH re-verified post-rebase: 817/817 tests, typecheck 0, hard read-only files untouched (`next.config.ts`, `Dockerfile`, `.dockerignore`, `check-standalone-assets.mjs`, compose, env example file, `docs/`, `package.json`/lockfile, db/storage/drizzle), zero guard hits.

## Group B — `/api/records/*` + `/records/*` as canonical segments, old paths permanent aliases
File-based aliasing (next.config held by the parallel sprint — and measured unnecessary): implementations stay at the `evidence/` paths, thin re-export files at `records/` paths. Direction chosen by measurement: the 17 live handlers + 2 pages stay byte-identical so existing-names-must-not-change is structural; the re-export hazard (Next's `getPageStaticInfo` reads segment config from each file's own source, so the `dynamic = 'force-dynamic'` mirror must be re-declared) lands on the unadvertised address and is pinned by test. `DUAL_SERVED_PATHS` gains `/records`. **Live HTTP parity proof** (production server in the worktree — a premise correction; this was assumed impossible): all 15 endpoint pairs MATCH including 405/500/OPTIONS-CORS/anon-401 semantics; prefix-collision control (`/recordsets` → 404). CI + Vercel preview remain the authoritative deployed-topology legs.

## Group A — env reads new-then-old (14 vars)
One shared resolver (`src/lib/publisher-env.ts`); `PUBLISHER_*` wins, `EVIDENCE_*` falls back, once-per-var server-side deprecation warning (no values echoed). **Sharpest finding: precedence is `defined`, not `truthy`** — an empty `EVIDENCE_TRUST_REGISTRY_LEGACY_URL` is the documented way to suppress the legacy URL from signed output, and a truthy rule would resurrect a suppressed URL inside signed artifacts. TS resolver and the `.mjs` preflight resolver are pinned against each other across the precedence matrix. Preflight + compose-check accept either spelling, report which was found, and emit a rename NOTE ledger; `PUBLISHER_PUBLIC_KEY` added as the 14th (external-tool) var with the count pinned.

## Group G — scopes
`records:publish` minted by default; `evidence:publish` authorizes forever-until-major (shared `hasPublishScope`; three enforcement sites + device-code route). Old-token path traced not assumed: scope persisted once, echoed verbatim everywhere, no DB default → no migration; an explicit `evidence:publish` request is granted VERBATIM (RFC 8628 clients compare granted-vs-requested). Two drift guards: no route may hardcode the scope literal or gate via exact-match `hasScope`.

## Group C — confirmed, untouched
This repo resolves produce-core **0.2.0** (premise correction vs "0.2.1") and still emits `evidenceProtocolVersion`; tests/docs pinning the old key enumerated for the P5 bump. No dependency changes in this PR.

## Verification
808→817/817 tests (main baseline 770) · typecheck 0 · lint 0 errors (4 pre-existing warnings) · `npm run build` exit 0 on the DEFAULT builder (Turbopack) — measured against the old CLAUDE.md claim; main's #284 has since landed the re-measure note · compose-check + instance-identity rehearsal PASS · emissions-stay-old-form grep: zero `/records` emissions outside alias files/host-routing/tests · **9 net-is-live probes** (route-config mirror, family drift, dual-served, fallback drop, truthy precedence — caught end-to-end by the rehearsal child process, once-guard, scope acceptance, verbatim grant, hand-rolled gate), each failing loudly then reverted with numstat-proven zero trace.

## Statements pass
Corrected in-scope: host-routing dual-served comments, site-config two-name rule + getter JSDoc, signing/unsigned-tier operator refusals (they told operators to set the *retiring* variable), preflight/compose-check/keygen/rehearsal headers, api-auth JSDoc. **Deliberately-left-for-P5 ledger** (inherited, not mystery): the api-doc sentences P3 falsifies (`evidence-publish.md:57` "currently only evidence:publish" now false; the 403-table stale error string), all `EVIDENCE_*` doc rows, CLAUDE.md route-family/env lines, UI-prose items, and the correct-as-is DO-NOT-FIX list (reference-identity fixture = the fallback leg's proof; exempt-frozen paths; the D3 dual-era emitter; old-wire-key test pins).

## New census flags for the record
- `packager.ts` missing-list pushes prior-era env names (presence logic correct; reported name stale) — P5 item.
- **`evpub_` token prefix** (`api-auth.ts:22`): an opaque credential prefix carrying the excised word inside every live token — not in Appendix J; not renameable without invalidating tokens. Proposed ruling: exempt-frozen row (gate question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BK5jCK8AriSu7L4igZBGGM
