### PR TITLE
skill fallback + notebook prompt: settlement vocabulary (civic#160 P6)

### DIFF
--- a/src/lib/evidence/instance-config.test.ts
+++ b/src/lib/evidence/instance-config.test.ts
@@ -320,12 +320,12 @@ test('skill text: with no config no host appears, and the fallback is generic-on
     }
     assert.ok(
       DATA_COMMONS_SKILL.includes(
-        'published as an evidence package, the evidence chain captures',
+        'published as a record package, the provenance graph captures',
       ),
       'data-commons skill should omit the host with no identity declared',
     );
     assert.ok(
-      !DATA_COMMONS_SKILL.includes('published as an evidence package on '),
+      !DATA_COMMONS_SKILL.includes('published as a record package on '),
     );
   });
 });

--- a/src/lib/mcp/boston-skill.ts
+++ b/src/lib/mcp/boston-skill.ts
@@ -69,5 +69,5 @@ Neighborhoods do NOT map cleanly to Census tracts. When joining Boston operation
 
 ## Attribution
 
-Cite Boston OpenContext analyses with: dataset title, resource UUID, data.boston.gov portal URL, and the SQL / aggregation spec that produced the number. The evidence-package layer captures tool calls and args automatically; your job in the text output is to make the citation human-readable.
+Cite Boston OpenContext analyses with: dataset title, resource UUID, data.boston.gov portal URL, and the SQL / aggregation spec that produced the number. The record-package layer captures tool calls and args automatically; your job in the text output is to make the citation human-readable.
 `;

--- a/src/lib/mcp/data-commons-skill.ts
+++ b/src/lib/mcp/data-commons-skill.ts
@@ -117,7 +117,7 @@ If a question is genuinely ambiguous — "how many New Yorkers earn under $50k?"
 
 Attribute every Data Commons observation with the **source dataset** (e.g., "ACS 5-Year Estimates, 2020-2024"), the **statistical agency** (e.g., "U.S. Census Bureau"), and the **place DCID** and **variable DCID** used, so the answer is reproducible.
 
-When a Data Commons call is part of an analysis published as an evidence package${getPublicationHost() ? ` on ${getPublicationHost()}` : ''}, the evidence chain captures the DCIDs, variable, vintage, and place type automatically. The provenance graph emits Data Commons as a distinct prov:Agent alongside Socrata agents so a reader verifying the package can tell exactly which numbers came from which source.
+When a Data Commons call is part of an analysis published as a record package${getPublicationHost() ? ` on ${getPublicationHost()}` : ''}, the provenance graph captures the DCIDs, variable, vintage, and place type automatically. It emits Data Commons as a distinct prov:Agent alongside Socrata agents so a reader verifying the package can tell exactly which numbers came from which source.
 
 ## Empty or unrelated results
 

--- a/src/lib/mcp/skill-instance-config.test.ts
+++ b/src/lib/mcp/skill-instance-config.test.ts
@@ -48,13 +48,13 @@ test('skill text: override host bakes into DATA_COMMONS_SKILL; SOCRATA fallback 
   // Data Commons skill: host interpolation unchanged (out of P4 scope).
   assert.ok(
     DATA_COMMONS_SKILL.includes(
-      'published as an evidence package on skills.example.org',
+      'published as a record package on skills.example.org',
     ),
     'data-commons skill should carry the override host',
   );
   assert.ok(
     !DATA_COMMONS_SKILL.includes(
-      'published as an evidence package on civicaitools.org',
+      'published as a record package on civicaitools.org',
     ),
     'data-commons skill should not carry the demo host under override',
   );

--- a/src/lib/notebook-author/prompt.ts
+++ b/src/lib/notebook-author/prompt.ts
@@ -42,7 +42,7 @@ export const PINNED_LIBRARIES = {
 /** Default Python runtime version baked into the Vercel Sandbox snapshot. */
 export const PYTHON_RUNTIME_VERSION = '3.13';
 
-/** Reverse-DNS extension keys per OES §9.1.4. */
+/** Reverse-DNS extension keys per the Typed Standards Specification §8.7.4. */
 export const NOTEBOOK_EXTENSION_KEY = 'org.civicaitools.notebook';
 export const EXECUTION_EXTENSION_KEY = 'org.civicaitools.execution';
 /** Phase 2a2: structured two-clause summary populated by the LLM in reproducible-notebook mode. */
@@ -254,7 +254,7 @@ export function buildSynthesisCellSource(args: {
     const llmBody = args.synthesisCode.trimEnd();
     return [
       '# Synthesis — rendered answer for the query above. This cell\'s outputs',
-      '# become section F of the evidence A-G envelope (OES §9.1.4 / ADR-0005).',
+      '# become section F of the A-G envelope (Typed Standards Specification §8.7.4 / ADR-0005).',
       'from IPython.display import display, Markdown',
       '',
       'try:',
@@ -272,7 +272,7 @@ export function buildSynthesisCellSource(args: {
   }
   return [
     '# Synthesis — rendered answer for the query above. This cell\'s outputs',
-    '# become section F of the evidence A-G envelope (OES §9.1.4 / ADR-0005).',
+    '# become section F of the A-G envelope (Typed Standards Specification §8.7.4 / ADR-0005).',
     '# Fallback path: the LLM did not emit a ```python``` block, so the chat-flow',
     '# answer is rendered verbatim as markdown.',
     'from IPython.display import display, Markdown',


### PR DESCRIPTION
The website leg of the three-surface sync (merges LAST). Fallback skill texts mirror the new civic source (hand-edited to match — the sync script's force-run prohibition honored); notebook-author/prompt.ts's generated-notebook comments reworked (record vocabulary + Typed Standards Specification §8.7.4, ADR-0005 kept); two test fixtures updated as consequences. 829/829 / typecheck 0 / lint 0 errors. Flagged for P7: the same stale-citation class in phase-d.ts, packager.ts, schema.ts, validate.ts comments (pre-existing, not falsified by this PR). Model: sonnet tier; ORCH-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BK5jCK8AriSu7L4igZBGGM