### PR TITLE
residue: stale OES citations to verified consolidated-spec sections (civic#160 P7)

### DIFF
--- a/src/app/(app)/evidence/[slug]/page.tsx
+++ b/src/app/(app)/evidence/[slug]/page.tsx
@@ -201,7 +201,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 }
 
 // Type-narrowing accessor for the org.civicaitools.environment extension
-// (OES §9.1.1 requirement 3). Returns null when absent or malformed so
+// (spec §8.7.1 requirement 3). Returns null when absent or malformed so
 // callers can default-fallback for non-datHere packages.
 function getEnvironmentExtension(pkg: EvidencePackage | null | undefined): {
   modelVersion?: string;
@@ -452,12 +452,12 @@ export default async function EvidencePage({ params }: PageProps) {
             <span>datHere content profile</span>
             <span>{'·'}</span>
             <a
-              href="https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/open-evidence-standard.md#91-dathere-content-profile"
+              href="https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/typed-standards-specification.md#87-content-profile-dathere"
               target="_blank"
               rel="noopener noreferrer"
               style={{ color: 'var(--accent)' }}
             >
-              OES §9.1
+              Typed Standards §8.7
             </a>
             <span>{'·'}</span>
             <a
@@ -470,7 +470,7 @@ export default async function EvidencePage({ params }: PageProps) {
         )}
 
         {/* A-G sections AS the page structure for datHere-content-profile
-            packages. ADR-0004 + OES §9.1. The legacy ProvenanceChain /
+            packages. ADR-0004 + spec §8.7. The legacy ProvenanceChain /
             Skill Guidance / Jupyter Notebook / Resources Used sections
             below are suppressed for datHere; their content is subsumed
             here as sections A, B, E, and C respectively. */}
@@ -603,7 +603,7 @@ export default async function EvidencePage({ params }: PageProps) {
             {renderPkg.extensions?.[NOTEBOOK_EXTENSION_KEY] !== undefined ? (
               <Section title="E · Answer notebook">
                 <div style={{ marginBottom: '12px', fontSize: '13px', color: 'var(--text-secondary)' }}>
-                  Re-executing this notebook against the documented runtime + stable upstream data reproduces section F (OES §9.1.3).{' '}
+                  Re-executing this notebook against the documented runtime + stable upstream data reproduces section F (Typed Standards §8.7.3).{' '}
                   <a href={`/api/records/${slug}/bundle`} style={{ color: 'var(--accent)' }}>
                     Download notebook (.ipynb)
                   </a>
@@ -833,7 +833,7 @@ export default async function EvidencePage({ params }: PageProps) {
               if (resolution?.outputIsBlob) blobFields.push('output');
               if (resolution?.skillTextIsBlob) blobFields.push('skill text');
               // Section-C environment metadata (datHere captureMethod only;
-              // org.civicaitools.environment extension per OES §9.1.1).
+              // org.civicaitools.environment extension per spec §8.7.1).
               const env = getEnvironmentExtension(renderPkg);
               const envMcpHosts = env?.mcpServers
                 ?.map((s) => {

--- a/src/app/api/evidence/[slug]/bundle/route.ts
+++ b/src/app/api/evidence/[slug]/bundle/route.ts
@@ -26,9 +26,9 @@ import {
  * GET /api/evidence/[slug]/bundle
  *
  * Returns a datHere-content-profile package as a notebook-embedded
- * serialization per OES §9.2.2 — a single .ipynb file whose root
+ * serialization per spec §8.8.2 — a single .ipynb file whose root
  * metadata carries the commitment view under the commitment-view extension
- * namespace, with a cell-0 metadata table prepended per the §9.2.4
+ * namespace, with a cell-0 metadata table prepended per the §8.8.4
  * reader-affordance convention.
  *
  * The namespace is DUAL-ERA (spec §8.8.2, settlement ruling D3): new bundles
@@ -43,7 +43,7 @@ import {
  *
  * Limitations (prototype):
  * - Returns only the notebook-embedded serialization. Sibling-YAML
- *   serialization (OES §9.2.3) for non-notebook outputs is future work.
+ *   serialization (spec §8.8.3) for non-notebook outputs is future work.
  * - Bundle endpoint refuses non-datHere content profiles with 400. The
  *   spec does not require bundle export for other content profiles, and
  *   the existing canonical package URL remains available for them. The
@@ -57,13 +57,13 @@ const NOTEBOOK_EXTENSION_KEY = 'org.civicaitools.notebook';
 type EvidenceRecord = typeof evidenceRecords.$inferSelect;
 type UserRecord = typeof users.$inferSelect;
 
-// `buildCommitmentView` (the §9.2.1 proof sidecar) now lives in
+// `buildCommitmentView` (the §8.8.1 proof sidecar) now lives in
 // `@/lib/evidence/commitment` so the public commitment endpoint and this
 // notebook-embedded bundle emit the same self-describing proof object
 // (civic-ai-tools-website#116 WS1).
 
 /**
- * Build a cell-0 markdown metadata table per OES §9.2.4 (SHOULD-level
+ * Build a cell-0 markdown metadata table per spec §8.8.4 (SHOULD-level
  * reader affordance). Verification does NOT depend on this cell — the
  * authoritative metadata is the commitment-view namespace at
  * the notebook's root. The cell exists so a reader opening the .ipynb in
@@ -221,7 +221,7 @@ export async function GET(
   // Deep-clone so we don't mutate the cached package
   const notebook = JSON.parse(JSON.stringify(notebookRaw)) as Record<string, unknown>;
 
-  // Inject commitment view at notebook root metadata (OES §9.2.2), carrying the
+  // Inject commitment view at notebook root metadata (spec §8.8.2), carrying the
   // signed lifecycle attestation chain (#119 P3) for offline #10 resolution.
   const lifecycleAttestations = record.basePackageHash
     ? await loadCarriedLifecycleAttestations(record.basePackageHash)
@@ -230,7 +230,7 @@ export async function GET(
   metadata[COMMITMENT_NAMESPACE_KEY] = buildCommitmentView(record, creator, pkg, lifecycleAttestations);
   notebook.metadata = metadata;
 
-  // Prepend cell-0 reader-affordance table (OES §9.2.4)
+  // Prepend cell-0 reader-affordance table (spec §8.8.4)
   const existingCells = Array.isArray(notebook.cells)
     ? (notebook.cells as unknown[])
     : [];

--- a/src/app/api/evidence/[slug]/commitment/route.ts
+++ b/src/app/api/evidence/[slug]/commitment/route.ts
@@ -14,8 +14,8 @@ import { InstanceIdentityError } from '@/lib/site-config';
 /**
  * GET /api/evidence/[hash|slug]/commitment
  *
- * Public, unauthenticated proof sidecar (spec §9.2.1) — the WS1 "unlock" of
- * civic-ai-tools-website#116. Returns the §9.2.1 commitment view for a package
+ * Public, unauthenticated proof sidecar (spec §8.8.1) — the WS1 "unlock" of
+ * civic-ai-tools-website#116. Returns the §8.8.1 commitment view for a package
  * so a third party can resolve its proofs and verify INDEPENDENTLY (client-side,
  * against public infra) instead of trusting a civicaitools.org-rendered verdict.
  * The view is self-describing (carries `packageUrl` + `trustRegistryUrl`), so a

--- a/src/app/api/evidence/route.ts
+++ b/src/app/api/evidence/route.ts
@@ -239,7 +239,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // ADR-0004 §9.1.1: contentProfile=datHere requires full_text prompt
+    // ADR-0004 / spec §8.7.1: contentProfile=datHere requires full_text prompt
     // visibility (the A-G envelope needs section A readable) and a
     // non-empty summary (section G). Other content profiles don't require
     // either. captureMethod is orthogonal — chat-flow-stream, claude-code-
@@ -250,7 +250,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(
           {
             error:
-              'contentProfile "datHere" requires promptVisibility "full_text" (OES §9.1.1 requirement 1).',
+              'contentProfile "datHere" requires promptVisibility "full_text" (Typed Standards §8.7.1 requirement 1).',
           },
           { status: 400 },
         );
@@ -259,7 +259,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(
           {
             error:
-              'contentProfile "datHere" requires a non-empty summary (OES §9.1.1 requirement 6).',
+              'contentProfile "datHere" requires a non-empty summary (Typed Standards §8.7.1 requirement 6).',
           },
           { status: 400 },
         );

--- a/src/components/PublishEvidenceDialog.tsx
+++ b/src/components/PublishEvidenceDialog.tsx
@@ -180,7 +180,7 @@ export default function PublishEvidenceDialog({
       // a datHere-content-profile envelope. The packager auto-adds the
       // `org.civicaitools.environment` extension and promotes `summary`
       // into canonical JSON. For `hash_only` prompts the contentProfile
-      // falls back to default (OES §9.1.1 requires full_text); the package
+      // falls back to default (spec §8.7.1 requires full_text); the package
       // retains its existing shape (summary stays DB-only).
       const contentProfile = promptVisibility === 'full_text' ? 'datHere' : 'default';
 

--- a/src/components/notebook/ChatNotebookOutput.tsx
+++ b/src/components/notebook/ChatNotebookOutput.tsx
@@ -308,7 +308,7 @@ export default function ChatNotebookOutput({
       <Section title="E · Answer notebook">
         <div style={{ marginBottom: '12px', fontSize: '13px', color: 'var(--text-secondary)' }}>
           Re-executing this notebook against the documented runtime + stable
-          upstream data reproduces section F (OES §9.1.3). The notebook
+          upstream data reproduces section F (Typed Standards §8.7.3). The notebook
           metadata records the sandbox runtime versions used at execution.
         </div>
         <NotebookSection notebook={view.notebook} slug={placeholderSlug} />

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -75,7 +75,7 @@ export const captureMethodEnum = pgEnum('capture_method', [
 // `default` — legacy / default content shape. Equivalent to the column
 // being NULL on legacy rows (the route layer never writes 'default'
 // explicitly; absence is treated as default by surfaces).
-// `datHere` — A-G envelope content profile per OES §9.1, with a
+// `datHere` — A-G envelope content profile per spec §8.7, with a
 // deterministic Jupyter notebook in section E reproducing the rendered
 // answer (F). When set, the packager promotes `summary` into canonical
 // JSON and auto-emits the `org.civicaitools.environment` extension.

--- a/src/lib/evidence/commitment.test.ts
+++ b/src/lib/evidence/commitment.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for the §9.2.1 proof-sidecar builder (commitment.ts), the WS1
+// Unit tests for the §8.8.1 proof-sidecar builder (commitment.ts), the WS1
 // core of civic-ai-tools-website#116. These prove the generalization beyond the
 // datHere-shaped inline original AND the security-audit invariants for the
 // net-new public exposure: only intended-public fields leave the server.

--- a/src/lib/evidence/commitment.ts
+++ b/src/lib/evidence/commitment.ts
@@ -9,7 +9,7 @@ import { getSidecarTrustRegistryUrls } from '../site-config.ts';
 import { fromDbValue } from './visibility.ts';
 
 /**
- * Proof sidecar ("commitment view") builder — spec §9.2.1.
+ * Proof sidecar ("commitment view") builder — spec §8.8.1.
  *
  * As of S3a P2 (#166) the neutral §8.8.1 sidecar ASSEMBLY lives in
  * @typedstandards/produce-core (`buildCommitmentView` there takes every proof
@@ -130,7 +130,7 @@ export function readCommitmentNamespace(
 export type { CommitmentLifecycle };
 
 /**
- * Build the §9.2.1 lifecycle summary from a record's legacy columns, or null
+ * Build the §8.8.1 lifecycle summary from a record's legacy columns, or null
  * when the package has no lifecycle history (never withdrawn) — in which case
  * the commitment view omits the `lifecycle` field entirely.
  *
@@ -162,7 +162,7 @@ export function buildCommitmentLifecycle(
 }
 
 /**
- * Build the spec §9.2.1 commitment view from the evidence record + creator + the
+ * Build the spec §8.8.1 commitment view from the evidence record + creator + the
  * signed package JSON. Optional fields (envelope taxonomy, canonicalization,
  * RFC 3161 timestamp, Rekor entry/proof, lifecycle) are conditionally spread so
  * absent values don't appear as `null` in the serialized output — the

--- a/src/lib/evidence/identifier.test.ts
+++ b/src/lib/evidence/identifier.test.ts
@@ -1,6 +1,6 @@
 // Tests for identifier resolution on the public commitment endpoint
 // (civic-ai-tools-website#116 durable backend half): a bare base-package hash
-// and a slug MUST resolve to the same §9.2.1 commitment, hash matching MUST be
+// and a slug MUST resolve to the same §8.8.1 commitment, hash matching MUST be
 // case-insensitive, slug resolution MUST be unchanged, and a non-public package
 // MUST stay unreachable by hash.
 //
@@ -121,7 +121,7 @@ function resolveFromStore(
 
 /**
  * Mirror of the commitment route's full pipeline: resolve → public-visibility
- * gate → build the §9.2.1 view. `pkg` is passed null (the route degrades to
+ * gate → build the §8.8.1 view. `pkg` is passed null (the route degrades to
  * DB-sourced proofs when the blob can't be fetched), which is enough to compare
  * commitment identity across address forms.
  */

--- a/src/lib/evidence/packager.test.ts
+++ b/src/lib/evidence/packager.test.ts
@@ -229,9 +229,9 @@ test('buildEvidencePackage: with captureMethod, metadata.captureMethod matches i
 
 // --- ADR-0004: datHere content profile ---
 //
-// The datHere content profile (OES §9.1, ADR-0004) promotes `summary` to
+// The datHere content profile (spec §8.7, ADR-0004) promotes `summary` to
 // canonical-JSON and auto-emits the `org.civicaitools.environment`
-// extension. Both are required for datHere conformance per §9.1.1. For
+// extension. Both are required for datHere conformance per §8.7.1. For
 // non-datHere content profiles the canonical JSON shape stays byte-
 // identical to pre-ADR-0004 — neither field appears, so pre-ADR packages
 // hash the same. contentProfile is orthogonal to captureMethod (ADR-0003).

--- a/src/lib/evidence/packager.ts
+++ b/src/lib/evidence/packager.ts
@@ -82,11 +82,11 @@ export type CaptureMethod =
  *
  * - `default` — legacy content shape. Pre-ADR-0004 packages omit the
  *   `contentProfile` field entirely; verifiers treat absence as `default`.
- *   No additional normative requirements beyond §4 of the standard.
- * - `datHere` — A-G envelope content profile (OES §9.1) with a
+ *   No additional normative requirements beyond §8.1 of the specification.
+ * - `datHere` — A-G envelope content profile (spec §8.7) with a
  *   deterministic Jupyter notebook in section E reproducing the rendered
  *   answer (F) against the documented runtime + stable upstream data.
- *   Packages with this profile MUST satisfy §9.1.1 requirements
+ *   Packages with this profile MUST satisfy §8.7.1 requirements
  *   (full-text prompt, system prompt present, environment metadata
  *   present, notebook present, rendered answer present, summary present).
  *
@@ -136,7 +136,7 @@ export interface PackageInput {
   /**
    * Content profile label per ADR-0004. Optional; absence is treated as
    * `default`. Set to `'datHere'` to produce an A-G envelope package
-   * (OES §9.1), which triggers two additional packager behaviors:
+   * (spec §8.7), which triggers two additional packager behaviors:
    * `summary` is emitted into canonical JSON (covered by the package
    * hash) and `extensions["org.civicaitools.environment"]` is auto-
    * emitted. Both behaviors are no-ops when contentProfile is `default`
@@ -274,7 +274,7 @@ export interface EvidencePackage {
   output: string | BlobRef;
   /** OTel trace, either inline or referenced by hash. */
   trace: Record<string, unknown> | BlobRef;
-  /** Short, indexable, citation-ready summary (OES §4.1, ADR-0004).
+  /** Short, indexable, citation-ready summary (spec §8.1.1, ADR-0004).
    *  Required when `metadata.captureMethod === 'datHere'`; optional and
    *  typically absent for other capture methods (where summary lives on
    *  the DB row only). When present in the canonical JSON, it is covered
@@ -406,7 +406,7 @@ export function buildEvidencePackage(input: PackageInput): { pkg: EvidencePackag
     instanceProvenanceConfig(),
   );
 
-  // datHere policy (ADR-0004/0006, OES §9.1.1): producerProfile auto-derive,
+  // datHere policy (ADR-0004/0006, spec §8.7.1): producerProfile auto-derive,
   // canonicalization-rule selection, the summary-emission gate, and the
   // `org.civicaitools.environment` extension layered onto caller-supplied
   // extensions — all derived by the harness; the environment's `host` is this

--- a/src/lib/notebook-author/phase-d.ts
+++ b/src/lib/notebook-author/phase-d.ts
@@ -5,7 +5,7 @@
  * outputs embedded. It:
  *   1. Extracts prominent metrics from the metric-capture cell's stdout
  *      (the cell synthesize.ts inserts before the synthesis cell).
- *   2. Appends the comparison cell per ADR-0005 §5 / OES §9.1.4: original
+ *   2. Appends the comparison cell per ADR-0005 §5 / spec §8.7.4: original
  *      values as Python literals, `recompute_key_metrics()` reading from
  *      the dfN DataFrames in the notebook's namespace, and a delta loop.
  *   3. Stamps `metadata.extensions[org.civicaitools.execution]` with the
@@ -153,7 +153,7 @@ export function buildComparisonCell(args: {
     '# Original values were captured when the notebook was first executed by the',
     '# publisher\'s pipeline. On re-execution against live data, the same metrics',
     '# are extracted from the DataFrames computed above and a per-key delta is',
-    '# printed below. See ADR-0005 §5 / OES §9.1.4 for the canonical shape.',
+    '# printed below. See ADR-0005 §5 / Typed Standards §8.7.4 for the canonical shape.',
     '',
     `# ORIGINAL VALUES (captured at executedAt = ${executedAt})`,
     ...literalLines,

--- a/src/lib/notebook-author/validate.ts
+++ b/src/lib/notebook-author/validate.ts
@@ -1,6 +1,6 @@
 /**
  * Light-touch schema validator for the executed-notebook extensions per
- * OES §9.1.4 (specified by ADR-0005). Phase 1 owns this local sanity check
+ * spec §8.7.4 (specified by ADR-0005). Phase 1 owns this local sanity check
  * before the route returns the notebook; Phase 3 owns the full packager-
  * side enforcement when executed notebooks become evidence-package
  * payloads.
@@ -61,7 +61,7 @@ export function validateNotebookProvenance(notebook: Notebook): ValidationResult
 
 /**
  * Validate that `metadata.extensions[org.civicaitools.execution]` matches
- * the OES §9.1.4 shape: executedAt (ISO-8601 UTC), environment.python
+ * the spec §8.7.4 shape: executedAt (ISO-8601 UTC), environment.python
  * (non-empty string), environment.libraries (object), executionDuration_ms
  * (non-negative integer); sandboxId and comparisonCellPresent are optional.
  */


### PR DESCRIPTION
Comment/string/label-only (+39/−39, 14 files; zero logic/schema/imports — schema.ts is one // line, proven in the report). Every mapping verified against both documents per the P6 method (the snapshot's own absorption table + heading lists + body text), incl. the detail page's deep link to the frozen snapshot → the consolidated spec at the derived-not-guessed anchor. Beyond the routed ledger, the re-grep surfaced eight §9.2.1 commitment-view citations coexisting with 21 CORRECT §9.2 check-list citations — same number, two meanings — all resolved to §8.8.1; blob-ref.ts's 'check #9' verified correct and left alone. 829/829; typecheck 0; lint 0 errors. Model: opus (1M). ORCH-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BK5jCK8AriSu7L4igZBGGM