### PR TITLE
civic#155 P1: website code/scripts — B1 registry-order fix, E15 gate, E4/E12 defaults

### DIFF
--- a/docs/api/records-publish.md
+++ b/docs/api/records-publish.md
@@ -412,7 +412,7 @@ Callers publishing through `POST /api/records` do not set these themselves — t
 | `PUBLISHER_SIGNING_KEY`        | `EVIDENCE_SIGNING_KEY` | Base64 DER PKCS8 Ed25519 private key. Sensitive.                        |
 | `PUBLISHER_KEY_ID`             | `EVIDENCE_KEY_ID` | Stable kid string naming **your** active trust-registry entry (e.g. `platform:evidence-2026-04` — kids are exempt-frozen; each lives inside every envelope its key has signed). Non-sensitive, no coded default: with a signing key set and this unset, the instance refuses to seal or publish rather than sign under an undeclared key id. |
 | `PUBLISHER_PUBLIC_KEY`         | `EVIDENCE_PUBLIC_KEY` | Public half of the signing key. Used only for registry updates.         |
-| `PUBLISHER_TRUST_REGISTRY_URL` | `EVIDENCE_TRUST_REGISTRY_URL` | Optional override for the default `${NEXTAUTH_URL}/.well-known/...` URL that **this instance's own verify route** fetches. Never part of signed output. Useful for previews. |
+| `PUBLISHER_TRUST_REGISTRY_URL` | `EVIDENCE_TRUST_REGISTRY_URL` | Optional override for the default `${NEXTAUTH_URL}/.well-known/...` URL that **this instance's own verify route** would fetch if it ever reached that step. Never part of signed output. In practice inert — see [`docs/key-rotation.md`](../key-rotation.md#environment-variables). |
 
 The full instance-identity set (origin, signer claim, platform agent, the emit-side registry URLs) is in [`docs/instance-setup.md`](../instance-setup.md).
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -523,15 +523,18 @@ from the origin, the agent id from the host; the *required* identity set
 itself is in the disable-when-absent table, not here — see
 [`docs/instance-setup.md`](instance-setup.md)),
 **`PUBLISHER_TRUST_REGISTRY_URL`** (the **consume**-side counterpart, and
-the one publisher variable that is not about what you emit: it changes
-which trust registry *this instance's own verify route* fetches, useful on
-previews and in local dev, and never appears in signed output. Unset, it
-resolves `NEXTAUTH_URL` → `PUBLISHER_SITE_ORIGIN` → the reference origin
-with the legacy well-known path appended, and is in any case the last
-resort behind the bundled and on-disk registries — see
-[`docs/key-rotation.md`](key-rotation.md#environment-variables), which
-documents it alongside `PUBLISHER_PUBLIC_KEY`, the keygen-written public
-half the app never reads), `SITE_BRAND_ACCENT` and `SITE_SPONSOR_URL`/`SITE_SPONSOR_PREFIX`
+the one publisher variable that is not about what you emit: it supplies the
+URL fed to the HTTP-fetch fallback in this instance's own verify route, and
+never appears in signed output. Unset, it resolves `NEXTAUTH_URL` →
+`PUBLISHER_SITE_ORIGIN` → the reference origin with the legacy well-known
+path appended — but that resolved URL is dead code on the real call path,
+not merely a last resort: the verify route always resolves the registry
+from a build-time-embedded import of the checked-in registry file first,
+which cannot fail short of corrupting that file, so the on-disk read and
+this HTTP fetch never run. See
+[`docs/key-rotation.md`](key-rotation.md#environment-variables) for the
+measurement, where it's documented alongside `PUBLISHER_PUBLIC_KEY`, the
+keygen-written public half the app never reads), `SITE_BRAND_ACCENT` and `SITE_SPONSOR_URL`/`SITE_SPONSOR_PREFIX`
 (a palette and a preposition are not identity claims, so those three do
 have defaults; the rest of the chrome set is in the disable-when-absent
 table above — see [Branding and

--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -169,8 +169,9 @@ operator-supplied configuration, never from another deployment's identity:
 Two more publisher variables exist outside this table:
 `PUBLISHER_PUBLIC_KEY` (written by the keygen script for registry edits, never
 read at run time) and `PUBLISHER_TRUST_REGISTRY_URL` (the **verify-side
-consume** override — which registry *your* verify route fetches, never part of
-signed output). Both are documented in
+consume** override — feeds the HTTP-fetch fallback your verify route would
+use if it ever reached that step, which in practice it doesn't; never part
+of signed output). Both are documented in
 [`docs/key-rotation.md`](key-rotation.md#environment-variables).
 
 Check the wiring with the presence-only preflight (no values are read or

--- a/docs/key-rotation.md
+++ b/docs/key-rotation.md
@@ -71,23 +71,46 @@ re-deriving the public key from the private one. It is written by
 
 A fourth variable, **`PUBLISHER_TRUST_REGISTRY_URL`** (prior era:
 `EVIDENCE_TRUST_REGISTRY_URL`), is optional. It is the **verify-side consume
-override**: it changes which registry *this instance's own verify route*
-fetches when it checks a package's key trust. Useful for previews or local dev
-when you want verification to hit a different registry.
+override**: it feeds the URL an HTTP fetch would use if the verify path ever
+reached that step when it checks a package's key trust.
 
 Its default resolution, in order, is `NEXTAUTH_URL`, then
 `PUBLISHER_SITE_ORIGIN`, then the reference origin — with
 `/.well-known/evidence-public-keys.json` appended (the legacy path; both paths
-serve the same bytes). In practice this HTTP fetch is the **last resort**: the
-verify path tries the bundled and on-disk registries first, so an instance
-serving its own registry rarely reaches it.
+serve the same bytes). **In practice this HTTP fetch is dead code on this
+instance's own verify route, not merely a last resort:** `loadTrustRegistry()`
+resolves the registry from a build-time-embedded import of the checked-in
+`public/.well-known/evidence-public-keys.json` first, and that import is
+compiled into the bundle unconditionally — it cannot fail at runtime short of
+corrupting the checked-in file, which would break verification for every
+package (the same malformed file also backs the on-disk step and the
+default HTTP URL, which points at this instance's own copy of it). The on-disk
+read and the HTTP fetch (fed by this variable) never run, in dev, test,
+preview, or production alike (validation accepts any well-formed `keys`
+array, including an empty one, so even a degenerate registry file
+short-circuits the chain — nothing short of removing or malforming the
+file makes step 1 fail). This is not a "rarely reaches it" case of
+last-resort behavior; the two callers (`/api/evidence/[slug]/verify` and
+`/commitment`) both call `loadTrustRegistry()` with no URL argument, so the
+override changes a value that is never consumed. Measured directly in
+`src/lib/evidence/verify.test.ts` ("B1" test): with the override set, the
+process `chdir`'d away from the project root so the on-disk read is
+genuinely non-viable (not merely untested — it hits ENOENT), and `fetch`
+spied to fail the test if invoked, `loadTrustRegistry()` still returns the
+real embedded registry. Both intermediate steps are ruled out this way,
+not just the final one — the override is provably never reached through
+the real call path. Treat this variable as inert on a normal
+deployment; it is not a lever for making a preview or local-dev instance
+verify against a different registry. (Why the HTTP-fetch fallback exists
+at all despite being unreachable here is not independently verified by
+this measurement — see `verify.ts`'s `getTrustRegistryUrl` docstring.)
 
 It is deliberately **distinct from the two emit-side variables**, which control
 what the signed proof sidecar tells a *third-party* verifier to fetch:
 
 | Variable | Direction | Effect |
 | --- | --- | --- |
-| `PUBLISHER_TRUST_REGISTRY_URL` | consume | Which registry this instance fetches when verifying. Never appears in signed output. |
+| `PUBLISHER_TRUST_REGISTRY_URL` | consume | Feeds the HTTP-fetch fallback in `loadTrustRegistry()`, which the embedded-registry step preempts on every real call path (see above) — inert in practice. Never appears in signed output. |
 | `PUBLISHER_TRUST_REGISTRY_CANONICAL_URL` | emit | The sidecar's `trustRegistryUrl`. Defaults to `<origin>/.well-known/typed-publisher.json`. |
 | `PUBLISHER_TRUST_REGISTRY_LEGACY_URL` | emit | The sidecar's `trustRegistryUrlLegacy`. Defaults to `<origin>/.well-known/evidence-public-keys.json`; set it to the **empty string** to omit the field entirely. Empty is not absent here — an instance with no pre-ADR-0012 client base has no legacy path to honor. |
 

--- a/docs/rate-limit-headroom.md
+++ b/docs/rate-limit-headroom.md
@@ -83,5 +83,5 @@ Optional, independent of the above: set `AUTHENTICATED_RATE_LIMIT` (now also env
 
 ## Demo-day checklist tie-in
 
-- Run `op run --env-file=.env.local -- node scripts/preflight-env.mjs` — confirms the auth + KV vars Option A/B depend on are present.
+- Confirm the auth + KV vars Option A/B depend on are present: `node scripts/preflight-env.mjs`, with the environment supplied however you inject secrets (`op run --env-file=.env.local -- node scripts/preflight-env.mjs` is one convention, not a requirement — any env-injection mechanism works, just never a plaintext dot-file literal).
 - If Option B is active, confirm `ANONYMOUS_RATE_LIMIT` is set in Vercel **production** (not just preview) and remember to delete it after the event.

--- a/scripts/backfill-rekor-entry-body.ts
+++ b/scripts/backfill-rekor-entry-body.ts
@@ -18,6 +18,11 @@
  * DRY RUN by default (writes nothing, reports the plan). Pass `--apply` to write.
  * Migration 0011 (the nullable column) must already be applied.
  *
+ * `op run` is recommended so DATABASE_URL and friends reach the process
+ * environment this way; any env-injection mechanism is acceptable (CI
+ * secrets, container secrets, a secret manager) — never a plaintext literal
+ * in a dot-file:
+ *
  *   Dry run:  op run --env-file=.env.local -- npx tsx scripts/backfill-rekor-entry-body.ts
  *   Apply:    op run --env-file=.env.local -- npx tsx scripts/backfill-rekor-entry-body.ts --apply
  */

--- a/scripts/eval-models.mjs
+++ b/scripts/eval-models.mjs
@@ -8,10 +8,18 @@
  * token usage, latency, and tools called for manual scoring.
  *
  * Usage:
- *   OPENROUTER_API_KEY=sk-or-... node scripts/eval-models.mjs
+ *   OPENROUTER_API_KEY=<your-key> SOCRATA_MCP_URL=https://your-mcp-host \
+ *     node scripts/eval-models.mjs
+ *
+ * Required env vars:
+ *   SOCRATA_MCP_URL  — MCP server URL. No fallback (civic-ai-tools#155 P1
+ *                      E4): this used to default to the project's hosted
+ *                      endpoint, which would silently route an
+ *                      unconfigured run's queries through infrastructure
+ *                      the caller does not operate. Point it at the Socrata
+ *                      MCP deployment this eval run should query.
  *
  * Optional env vars:
- *   SOCRATA_MCP_URL  — MCP server URL (default: https://socrata-mcp.civicaitools.org)
  *   EVAL_MODELS      — comma-separated model IDs to test (default: all)
  *   EVAL_QUERIES     — comma-separated query indices to test, 1-based (default: all)
  *
@@ -33,7 +41,11 @@ if (!OPENROUTER_API_KEY) {
   process.exit(1);
 }
 
-const MCP_URL = process.env.SOCRATA_MCP_URL || 'https://socrata-mcp.civicaitools.org';
+const MCP_URL = process.env.SOCRATA_MCP_URL;
+if (!MCP_URL) {
+  console.error('Error: SOCRATA_MCP_URL environment variable is required (no reference-host default)');
+  process.exit(1);
+}
 
 const openrouter = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',

--- a/scripts/eval-models.test.mjs
+++ b/scripts/eval-models.test.mjs
@@ -1,0 +1,43 @@
+// Tests for scripts/eval-models.mjs (civic-ai-tools#155 P1 E4).
+//
+// SOCRATA_MCP_URL used to default to https://socrata-mcp.civicaitools.org
+// when unset, silently routing an unconfigured run's queries through
+// infrastructure the caller does not operate. It now refuses with a named
+// error instead. Spawned as a CHILD PROCESS so the refusal is exercised the
+// same way an operator would trigger it, before any model/MCP call is made.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  './eval-models.mjs',
+);
+
+test('refuses with a named error when OPENROUTER_API_KEY is unset', () => {
+  const env = { ...process.env };
+  delete env.OPENROUTER_API_KEY;
+  delete env.SOCRATA_MCP_URL;
+
+  const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf-8', timeout: 15_000, env });
+
+  assert.equal(result.status, 1, `expected exit 1\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stderr, /OPENROUTER_API_KEY/);
+});
+
+test('refuses with a named error when SOCRATA_MCP_URL is unset (no reference-host default)', () => {
+  const env = { ...process.env, OPENROUTER_API_KEY: 'not-a-real-key' };
+  delete env.SOCRATA_MCP_URL;
+
+  const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf-8', timeout: 15_000, env });
+
+  assert.equal(result.status, 1, `expected exit 1\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stderr, /SOCRATA_MCP_URL/);
+  // The old default must not appear anywhere in the refusal.
+  assert.doesNotMatch(result.stdout + result.stderr, /socrata-mcp\.civicaitools\.org/);
+});

--- a/scripts/executor-parity.mjs
+++ b/scripts/executor-parity.mjs
@@ -37,11 +37,16 @@
  *   node --experimental-strip-types scripts/executor-parity.mjs run \
  *     --driver container --out parity-container.json
  *
- * Usage (vercel-sandbox leg — needs Vercel Sandbox auth; run through the
- * 1Password wrapper so the op:// references resolve; ONE command):
+ * Usage (vercel-sandbox leg — needs Vercel Sandbox auth). `op run` is
+ * recommended so the op:// references in .env.parity.local resolve into the
+ * process environment in one command:
  *
  *   op run --env-file=.env.parity.local -- node --experimental-strip-types \
  *     scripts/executor-parity.mjs run --driver vercel-sandbox --out parity-vercel.json
+ *
+ * Any env-injection mechanism that gets the Vercel Sandbox auth values into
+ * the process environment is acceptable (CI secrets, container secrets, a
+ * secret manager) — never a plaintext literal in a dot-file.
  *
  * Compare (exit 0 = parity, exit 1 = mismatch, differences listed):
  *
@@ -76,7 +81,8 @@ function usage(message) {
       '                          [--out <path>] [--timeout-ms <n>] [--expect <success|error|timeout>]',
       '  executor-parity.mjs compare <a.json> <b.json>',
       '',
-      'vercel-sandbox leg (auth via 1Password wrapper), one command:',
+      'vercel-sandbox leg (op run recommended for auth; any env-injection',
+      'mechanism works — never a plaintext dot-file literal), one command:',
       '  op run --env-file=.env.parity.local -- node --experimental-strip-types \\',
       '    scripts/executor-parity.mjs run --driver vercel-sandbox --out parity-vercel.json',
     ].join('\n'),

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -318,7 +318,7 @@ export const ENV_SPEC = [
   { name: 'ROADMAP_GITHUB_URL', readBy: 'build-and-runtime', tier: 'optional', purpose: '/roadmap "view source" link and byline label (unset: derived from ROADMAP_RAW_URL)', hasFallback: true },
 
   // --- Optional / feature / ops ---
-  { name: 'PUBLISHER_TRUST_REGISTRY_URL', priorEraName: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'External trust-registry override', hasFallback: true },
+  { name: 'PUBLISHER_TRUST_REGISTRY_URL', priorEraName: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'Trust-registry HTTP-fetch override — inert on every real call path (the embedded registry preempts it); retire-or-repair decision pending at G1', hasFallback: true },
   // WRITTEN, NEVER READ — the fourteenth variable of the settlement's Group A,
   // and the one this inventory used to miss precisely because the inventory
   // was derived from `process.env.*` reads. scripts/generate-signing-key.ts

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -28,10 +28,15 @@
  * NAME alone. No unbounded input from the environment reaches the output,
  * which is what the "never echoed" test in the suite pins down.
  *
- * Run it through 1Password so the op:// references in .env.local resolve into
- * this process's environment:
+ * `op run` is recommended for local use so the op:// references in
+ * .env.local resolve into this process's environment:
  *
  *   op run --env-file=.env.local -- node scripts/preflight-env.mjs
+ *
+ * Any env-injection mechanism is acceptable — CI secrets, container
+ * secrets, a secret manager — as long as the values reach this process's
+ * environment some other way. The one hard line: never a plaintext literal
+ * in a checked-in or local dot-file.
  *
  * Exit code is 0 when every REQUIRED variable (as resolved for the selected
  * profile) is present and the selectors are all recognized; 1 otherwise, so

--- a/scripts/publish-with-blob-ref.mjs
+++ b/scripts/publish-with-blob-ref.mjs
@@ -9,11 +9,15 @@
 //
 // Usage:
 //   export CIVICAITOOLS_SESSION_TOKEN="<__Secure-next-auth.session-token value>"
-//   node scripts/publish-with-blob-ref.mjs [--base-url https://...]
+//   node scripts/publish-with-blob-ref.mjs --base-url https://...
 //
-// When --base-url is omitted, defaults to https://www.civicaitools.org.
-// For preview URLs, supply the full hostname (including the path-protection
-// cookie value if the preview has SSO — upload flow will 401 without it).
+// --base-url is required (civic-ai-tools#155 P1 E4): this script exists to
+// smoke-test a specific deployed instance end-to-end, so it refuses to guess
+// which one rather than silently defaulting to the reference production
+// host — the same reasoning behind removing SOCRATA_MCP_URL's hosted-host
+// default (see docs/deploy.md). For preview URLs, supply the full hostname
+// (including the path-protection cookie value if the preview has SSO —
+// upload flow will 401 without it).
 
 import crypto from 'node:crypto';
 import process from 'node:process';
@@ -24,7 +28,15 @@ function arg(name, fallback) {
   return i >= 0 ? args[i + 1] : fallback;
 }
 
-const BASE_URL = arg('--base-url', 'https://www.civicaitools.org').replace(/\/$/, '');
+const rawBaseUrl = arg('--base-url', undefined);
+if (!rawBaseUrl) {
+  console.error(
+    'Missing required flag --base-url. This script targets a specific deployed ' +
+      'instance and refuses to guess which one — pass e.g. --base-url https://your-instance.example.',
+  );
+  process.exit(2);
+}
+const BASE_URL = rawBaseUrl.replace(/\/$/, '');
 const SESSION_TOKEN = process.env.CIVICAITOOLS_SESSION_TOKEN;
 if (!SESSION_TOKEN) {
   console.error(

--- a/scripts/publish-with-blob-ref.test.mjs
+++ b/scripts/publish-with-blob-ref.test.mjs
@@ -1,0 +1,53 @@
+// Tests for scripts/publish-with-blob-ref.mjs (civic-ai-tools#155 P1 E4).
+//
+// The script used to default --base-url to https://www.civicaitools.org
+// when omitted, silently routing an unconfigured run against the reference
+// production host. It now refuses with a named error instead. Spawned as a
+// CHILD PROCESS, the same idiom used elsewhere in this repo's script tests
+// (see generate-signing-key.test.mjs), so the refusal is exercised exactly
+// as an operator would trigger it — no network call is ever reached in
+// either case below.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  './publish-with-blob-ref.mjs',
+);
+
+test('refuses with a named error when --base-url is omitted', () => {
+  const env = { ...process.env };
+  delete env.CIVICAITOOLS_SESSION_TOKEN;
+
+  const result = spawnSync(process.execPath, [SCRIPT], {
+    encoding: 'utf-8',
+    timeout: 15_000,
+    env,
+  });
+
+  assert.equal(result.status, 2, `expected exit 2\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stderr, /--base-url/);
+  // The old default must not appear anywhere in the refusal — this is a
+  // named-flag refusal, not a silent fallback to the reference host.
+  assert.doesNotMatch(result.stdout + result.stderr, /www\.civicaitools\.org/);
+});
+
+test('with --base-url present, proceeds to the next check (missing session token)', () => {
+  const env = { ...process.env };
+  delete env.CIVICAITOOLS_SESSION_TOKEN;
+
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, '--base-url', 'https://example.invalid'],
+    { encoding: 'utf-8', timeout: 15_000, env },
+  );
+
+  assert.equal(result.status, 2, `expected exit 2\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stderr, /CIVICAITOOLS_SESSION_TOKEN/);
+});

--- a/scripts/rehearse-storage-s3.mjs
+++ b/scripts/rehearse-storage-s3.mjs
@@ -38,8 +38,10 @@
  *   - Per-leg PASS/FAIL output, final summary line, non-zero exit on any
  *     failure — the transcript is the phase evidence.
  *
- * Intended invocation for the real-bucket run (credentials via the
- * 1Password env-injection wrapper only; never a dot-file):
+ * Intended invocation for the real-bucket run. `op run` is recommended for
+ * credentials; any env-injection mechanism is acceptable (CI secrets,
+ * container secrets, a secret manager) — never a plaintext literal in a
+ * dot-file:
  *
  *   op run --env-file=<file> -- node scripts/rehearse-storage-s3.mjs
  *
@@ -91,11 +93,15 @@ S5 P2 hosted-S3 storage rehearsal harness — four legs:
 round-trip byte parity, presigned-PUT grant (incl. rejections),
 anonymous public read, GC sweep (fresh + aged).
 
-usage:
+usage (op run recommended; any env-injection mechanism that gets these
+variables into the process environment is acceptable — CI secrets,
+container secrets, a secret manager — never a plaintext literal in a
+dot-file):
   op run --env-file=<file> -- node scripts/rehearse-storage-s3.mjs
 
-The env file provides (op:// references resolved by the wrapper — the
-harness itself never reads a dot-file and never prints a credential value):
+With op run, the env file provides op:// references resolved by the
+wrapper — the harness itself never reads a dot-file and never prints a
+credential value. The variables it needs either way:
 
   BLOB_DRIVER=s3          required — the harness refuses any other driver
   S3_BUCKET               required

--- a/scripts/sync-fallback.mjs
+++ b/scripts/sync-fallback.mjs
@@ -62,7 +62,14 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const MCP_URL = process.env.SOCRATA_MCP_URL || 'https://socrata-mcp.civicaitools.org';
+// civic-ai-tools#155 P1 E4 (premise-checked): this script refuses to run at
+// all unless --force-clobber overrides the REFUSAL below, and that path is
+// itself discouraged (see the header) — so stripping this default is
+// cosmetic, not a live-defect fix; the script is inert on every normal
+// invocation regardless. Stripped anyway for consistency with the rest of
+// this repo's reference-host-default removal (civic-ai-tools#155 P1 E4):
+// no fallback to the hosted MCP endpoint, even on the discouraged path.
+const MCP_URL = process.env.SOCRATA_MCP_URL;
 
 async function fetchGuidance() {
   // 1. Initialize MCP session
@@ -145,6 +152,13 @@ async function fetchGuidance() {
 async function main() {
   if (!process.argv.includes('--force-clobber')) {
     console.error(REFUSAL);
+    process.exit(1);
+  }
+  if (!MCP_URL) {
+    console.error(
+      'sync-fallback: SOCRATA_MCP_URL environment variable is required (no reference-host default). ' +
+        'Even on this discouraged --force-clobber path, this script will not guess which MCP server to fetch from.',
+    );
     process.exit(1);
   }
   console.warn(

--- a/scripts/sync-fallback.test.mjs
+++ b/scripts/sync-fallback.test.mjs
@@ -1,0 +1,48 @@
+// Tests for scripts/sync-fallback.mjs (civic-ai-tools#155 P1 E4, premise-
+// checked).
+//
+// This script is DEAD/FROZEN by its own docstring: the verbatim-paste model
+// it implements is unsound post-#258/post-posture-split, and it refuses to
+// run at all unless the discouraged --force-clobber flag is passed. That
+// refusal is the primary, load-bearing behavior this suite pins down.
+// SOCRATA_MCP_URL used to default to https://socrata-mcp.civicaitools.org
+// on the --force-clobber path; stripping that default is COSMETIC here (the
+// script is inert on every normal invocation regardless — see the module
+// comment above MCP_URL in the script) but is still exercised below for
+// consistency with the rest of this repo's reference-host-default removal.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  './sync-fallback.mjs',
+);
+
+test('refuses to run at all without --force-clobber (primary, load-bearing behavior)', () => {
+  const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf-8', timeout: 15_000 });
+
+  assert.equal(result.status, 1, `expected exit 1\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stderr, /REFUSING to run/);
+  assert.match(result.stderr, /unsound/);
+});
+
+test('with --force-clobber, refuses with a named error when SOCRATA_MCP_URL is unset (no reference-host default)', () => {
+  const env = { ...process.env };
+  delete env.SOCRATA_MCP_URL;
+
+  const result = spawnSync(process.execPath, [SCRIPT, '--force-clobber'], {
+    encoding: 'utf-8',
+    timeout: 15_000,
+    env,
+  });
+
+  assert.equal(result.status, 1, `expected exit 1\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.match(result.stderr, /SOCRATA_MCP_URL/);
+  assert.doesNotMatch(result.stdout + result.stderr, /socrata-mcp\.civicaitools\.org/);
+});

--- a/src/app/(app)/dev/notebook-preview/gate.test.ts
+++ b/src/app/(app)/dev/notebook-preview/gate.test.ts
@@ -1,0 +1,41 @@
+// civic-ai-tools#155 P1 E15 — unit coverage for the production gate on
+// /dev/notebook-preview. See gate.ts for why this logic is extracted out of
+// page.tsx (JSX; not importable by this repo's plain-node test runner).
+//
+// This proves the GATE CONDITION is correct under `node --test
+// --experimental-strip-types` (this repo's `npm test`), run locally. It does
+// not by itself prove the deployed route 404s — that was verified
+// separately via `NODE_ENV=production next build && next start`, hitting
+// `/dev/notebook-preview` on the local server (see PR/gate notes).
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isNotebookPreviewGated } from './gate.ts';
+
+test('isNotebookPreviewGated: true when NODE_ENV=production', () => {
+  assert.equal(isNotebookPreviewGated({ NODE_ENV: 'production' } as NodeJS.ProcessEnv), true);
+});
+
+test('isNotebookPreviewGated: false for development', () => {
+  assert.equal(isNotebookPreviewGated({ NODE_ENV: 'development' } as NodeJS.ProcessEnv), false);
+});
+
+test('isNotebookPreviewGated: false for test', () => {
+  assert.equal(isNotebookPreviewGated({ NODE_ENV: 'test' } as NodeJS.ProcessEnv), false);
+});
+
+test('isNotebookPreviewGated: false when NODE_ENV is unset', () => {
+  assert.equal(isNotebookPreviewGated({} as NodeJS.ProcessEnv), false);
+});
+
+test('isNotebookPreviewGated: defaults to the real process.env, which this test run is not production', () => {
+  // Confirms the default parameter actually reads `process.env` (not just
+  // that a fixture object works) without mutating the ambient NODE_ENV,
+  // which Next.js's type augmentation declares read-only. `npm test` never
+  // runs with NODE_ENV=production, so this pins the negative case against
+  // the real environment.
+  assert.notEqual(process.env.NODE_ENV, 'production');
+  assert.equal(isNotebookPreviewGated(), false);
+});

--- a/src/app/(app)/dev/notebook-preview/gate.ts
+++ b/src/app/(app)/dev/notebook-preview/gate.ts
@@ -1,0 +1,13 @@
+// civic-ai-tools#155 P1 E15 (R5, owner-ruled at G0): `/dev/notebook-preview`
+// is a live, reachable production route today — there is no `middleware.ts`
+// in this repo, `next.config.ts` has no `/dev` handling, and the page opts
+// into dynamic rendering. Gate it with `notFound()` unless NODE_ENV is not
+// 'production'. No new env knob: NODE_ENV is Next.js's own existing signal.
+//
+// Extracted from page.tsx so the gate condition has a colocated test —
+// page.tsx is JSX and this repo's test runner (`node --test
+// --experimental-strip-types`) cannot import .tsx modules directly (Node's
+// type-stripping does not transform JSX syntax).
+export function isNotebookPreviewGated(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.NODE_ENV === 'production';
+}

--- a/src/app/(app)/dev/notebook-preview/page.tsx
+++ b/src/app/(app)/dev/notebook-preview/page.tsx
@@ -13,11 +13,17 @@
  * `node:fs`, so the fixture is generated server-side and handed to a
  * client wrapper.
  *
- * Not linked from anywhere; reachable only by direct URL. Excluded from
- * production by route placement under /dev/*.
+ * Not linked from anywhere; reachable only by direct URL. Gated explicitly
+ * below via `notFound()` when `NODE_ENV === 'production'` (civic-ai-tools#155
+ * P1 E15) — route placement under `/dev/*` gates nothing on its own: there is
+ * no `middleware.ts` in this repo and `next.config.ts` has no `/dev`
+ * handling, and this page opts into dynamic rendering (`force-dynamic`
+ * below), so absent this check it is a live, reachable production route.
  */
+import { notFound } from 'next/navigation';
 import { buildSampleExecutedNotebook } from '@/components/notebook/__dev__/sampleExecutedNotebook';
 import NotebookPreviewClient from './NotebookPreviewClient';
+import { isNotebookPreviewGated } from './gate';
 
 // Opt out of static prerendering — the client component reads `?state=` via
 // `useSearchParams`, which requires a dynamic page or a Suspense boundary.
@@ -25,6 +31,9 @@ import NotebookPreviewClient from './NotebookPreviewClient';
 export const dynamic = 'force-dynamic';
 
 export default function NotebookPreviewPage() {
+  if (isNotebookPreviewGated()) {
+    notFound();
+  }
   const { notebook, validation } = buildSampleExecutedNotebook();
   return <NotebookPreviewClient notebook={notebook} validation={validation} />;
 }

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -7,6 +7,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'crypto';
+import os from 'node:os';
 import canonicalize from 'canonicalize';
 import {
   verifySignature,
@@ -263,19 +264,29 @@ test('Rotation scenario: old key deprecated + new key active, both resolve corre
   assert.equal(forged.verified, false);
 });
 
-// --- loadTrustRegistry: filesystem read path (Bug 1 fix) ---
+// --- loadTrustRegistry: resolves without ever reaching the network ---
 //
+// NOTE (civic-ai-tools#155 P1 B1, corrected): these two tests were
+// originally written to exercise the on-disk read path, on the theory that
 // Vercel preview deployments put an HTML auth wall in front of
-// `/.well-known/*` URLs, so the loader must read the registry from disk
-// instead of fetching HTTP. These tests exercise that path against the
-// real file checked into `public/.well-known/evidence-public-keys.json`.
+// `/.well-known/*` URLs, so the loader falls back to reading the registry
+// from disk instead of fetching HTTP. Measurement showed that's not what
+// actually happens: `loadTrustRegistry`'s step 1 (the build-time-embedded
+// JSON import) resolves the registry unconditionally, before the on-disk
+// read is ever attempted — so what these tests actually exercise is step 1,
+// not the disk fallback. They're kept (and still pass) because they
+// correctly assert the outward behavior — an unreachable HTTP URL doesn't
+// stop the loader from returning a real registry — the "filesystem path"
+// framing just wasn't the accurate mechanism. See the "B1" test below for a
+// test that pins down which step actually supplies the result.
 
-test('loadTrustRegistry reads the checked-in registry from disk', async () => {
+test('loadTrustRegistry resolves the checked-in registry even with an unreachable HTTP URL', async () => {
   clearTrustRegistryCache();
   // Point the HTTP URL at a guaranteed-invalid host; the loader should
-  // still succeed because the filesystem path is tried first.
+  // still succeed because an earlier resolution step (embedded JSON; see
+  // the B1 test below) already supplies a valid registry.
   const registry = await loadTrustRegistry('http://127.0.0.1:1/invalid');
-  assert.ok(registry, 'loadTrustRegistry returned undefined even though the on-disk registry exists');
+  assert.ok(registry, 'loadTrustRegistry returned undefined even though the embedded/on-disk registry exists');
   assert.ok(registry!.keys.length > 0);
   const activeKey = registry!.keys.find((k) => k.status === 'active');
   assert.ok(activeKey, 'registry should have at least one active key');
@@ -283,12 +294,72 @@ test('loadTrustRegistry reads the checked-in registry from disk', async () => {
   assert.ok(activeKey!.publicKey && !activeKey!.publicKey.includes('REPLACE_WITH'));
 });
 
-test('loadTrustRegistry caches the disk read across calls', async () => {
+test('loadTrustRegistry caches the resolved registry across calls', async () => {
   clearTrustRegistryCache();
   const a = await loadTrustRegistry('http://127.0.0.1:1/invalid');
   const b = await loadTrustRegistry('http://127.0.0.1:1/invalid');
-  // Same reference → served from cache, not re-read.
+  // Same reference → served from cache, not re-resolved.
   assert.strictEqual(a, b);
+});
+
+// --- B1 (civic-ai-tools#155 P1): PUBLISHER_TRUST_REGISTRY_URL is unreachable
+// via the real callers ---
+//
+// The two production callers (`/api/evidence/[slug]/verify` and
+// `/commitment`) both invoke `loadTrustRegistry()` with NO argument, so the
+// only way `PUBLISHER_TRUST_REGISTRY_URL` (or its prior-era alias) can
+// affect the result is by changing the `url` fed to the HTTP-fetch step —
+// and that step only runs when BOTH the build-time embedded import AND the
+// on-disk read fail.
+//
+// This test measures BOTH intermediate steps, not just the final one: it
+// `process.chdir()`s to a directory with no `public/.well-known/...` file
+// before calling `loadTrustRegistry()`, which makes the on-disk read
+// (step 2) genuinely non-viable in-process (ENOENT, silently swallowed —
+// see `readTrustRegistryFromDisk`), and spies `fetch` to fail the test if
+// the HTTP step (step 3) is ever reached. If the registry still resolves
+// under BOTH of those conditions, step 1 — the build-time embedded import —
+// is provably the sole source, not merely the likely one. (Step 1 itself
+// cannot fail at runtime without corrupting the checked-in
+// `public/.well-known/evidence-public-keys.json`, which would break
+// verification for every package; signing itself does not read this file.)
+test('B1: PUBLISHER_TRUST_REGISTRY_URL override never reaches the disk or fetch steps via the real call path', async () => {
+  clearTrustRegistryCache();
+  const priorOverride = process.env.PUBLISHER_TRUST_REGISTRY_URL;
+  const priorLegacy = process.env.EVIDENCE_TRUST_REGISTRY_URL;
+  process.env.PUBLISHER_TRUST_REGISTRY_URL = 'https://override.invalid.example/registry.json';
+  delete process.env.EVIDENCE_TRUST_REGISTRY_URL;
+
+  const originalCwd = process.cwd();
+  // Not the project root, so readTrustRegistryFromDisk's
+  // path.join(process.cwd(), 'public/.well-known/...') is guaranteed ENOENT
+  // — step 2 becomes genuinely non-viable, not just untested.
+  process.chdir(os.tmpdir());
+
+  let fetchCalled = false;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() => {
+    fetchCalled = true;
+    throw new Error('fetch must not be called: embedded JSON should resolve the registry first');
+  }) as typeof fetch;
+
+  try {
+    // Mirrors the real callers: no url argument, so getTrustRegistryUrl()
+    // (which reads the override above) supplies the default — and that
+    // default is never used because step 1 (embedded JSON) already succeeds.
+    const registry = await loadTrustRegistry();
+    assert.equal(fetchCalled, false, 'the HTTP fetch step ran even though the embedded registry should have resolved first');
+    assert.ok(registry, 'loadTrustRegistry returned undefined even with the disk step made non-viable');
+    assert.ok(registry!.keys.some((k) => k.kid === 'platform:evidence-2026-04'));
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.chdir(originalCwd);
+    if (priorOverride === undefined) delete process.env.PUBLISHER_TRUST_REGISTRY_URL;
+    else process.env.PUBLISHER_TRUST_REGISTRY_URL = priorOverride;
+    if (priorLegacy === undefined) delete process.env.EVIDENCE_TRUST_REGISTRY_URL;
+    else process.env.EVIDENCE_TRUST_REGISTRY_URL = priorLegacy;
+    clearTrustRegistryCache();
+  }
 });
 
 // --- Legacy embedded keys (pre-#66 packages) ---

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -52,16 +52,43 @@ interface CacheEntry {
 
 const registryCache: Map<string, CacheEntry> = new Map();
 
-/** Resolve the URL for the platform trust registry. Can be overridden via
- *  `PUBLISHER_TRUST_REGISTRY_URL` (or its prior-era spelling
- *  `EVIDENCE_TRUST_REGISTRY_URL`, still accepted — the 2026-08-19 vocabulary
- *  settlement, Appendix J) for previews or local dev. The fallback
- *  tail is the instance's configured origin (ADR-0020), then the reference
- *  origin literal — the VERIFY path's historical resolution, deliberately
- *  byte-identical across #258 (which removed identity defaults from
- *  signing/emission paths only; this resolution's defects are a separate
- *  charter). In practice the HTTP fetch this URL feeds is the last resort
- *  behind the bundled and on-disk registries below. */
+/** Resolve the URL fed to the HTTP-fetch fallback in `loadTrustRegistry`.
+ *  Can be overridden via `PUBLISHER_TRUST_REGISTRY_URL` (or its prior-era
+ *  spelling `EVIDENCE_TRUST_REGISTRY_URL`, still accepted — the 2026-08-19
+ *  vocabulary settlement, Appendix J). The fallback tail is the instance's
+ *  configured origin (ADR-0020), then the reference origin literal — the
+ *  VERIFY path's historical resolution, deliberately byte-identical across
+ *  #258 (which removed identity defaults from signing/emission paths only;
+ *  this resolution's defects are a separate charter).
+ *
+ *  This is NOT a "useful for previews or local dev" lever: on this
+ *  instance's own verify route (`loadTrustRegistry()` called with no
+ *  argument, as both callers do — see below), the URL this function
+ *  produces is never actually fetched. Step 1 of `loadTrustRegistry`'s
+ *  resolution chain — the build-time-embedded import of the checked-in
+ *  registry file — succeeds unconditionally: `validateRegistry` accepts
+ *  ANY object whose `keys` is an array (including an empty one — `[].every`
+ *  is vacuously true), so step 1 returns a value for every well-formed JSON
+ *  file, not only a populated one. Only outright corrupting or removing the
+ *  checked-in file could make step 1 fail. That preempts both the on-disk
+ *  read and this HTTP fetch on every real call path, in dev, test, preview,
+ *  and production alike. Measured in `verify.test.ts` ("B1" test) for BOTH
+ *  intermediate steps, not just the final one: with this override set, the
+ *  process `chdir`'d away from the project root so the on-disk read is
+ *  genuinely non-viable (ENOENT, not merely untested), and `fetch` spied to
+ *  fail the test if invoked, `loadTrustRegistry()` still returns the
+ *  embedded registry untouched.
+ *
+ *  Why steps 2–3 (and this function) exist at all despite being unreachable
+ *  from this app's own callers is NOT independently verified here — this
+ *  function has no importer besides `loadTrustRegistry`'s default parameter
+ *  in this same file (confirmed by search: no other module in this repo
+ *  calls `getTrustRegistryUrl` or passes a non-default `url` to
+ *  `loadTrustRegistry`). An "external adopters reusing this module" story
+ *  is plausible but unmeasured; don't repeat it as settled fact (civic-ai-
+ *  tools#155 P1 B1 — this replaces the prior docstring's unqualified
+ *  "useful for previews" claim, which the measurement disproved; avoid
+ *  swapping in a second unmeasured rationale in its place). */
 export function getTrustRegistryUrl(): string {
   const override = readPublisherEnv('TRUST_REGISTRY_URL');
   if (override) return override;
@@ -86,8 +113,12 @@ export async function loadTrustRegistry(
   //   1. Build-time bundled JSON (always present in the deploy artifact)
   //   2. On-disk read (dev server, tests running from project root)
   //   3. HTTP fetch (external verifiers / cross-origin)
-  // The HTTP path exists for external adopters; our own verify route should never
-  // need it because the bundled import is authoritative.
+  // On OUR OWN verify route (both callers pass no `url`), steps 2 and 3 are
+  // dead code, not merely a fallback: step 1 succeeds for any well-formed
+  // checked-in registry file, including a degenerate `{"keys":[]}` — see
+  // getTrustRegistryUrl's docstring above for the measurement (B1 test in
+  // verify.test.ts) and for what is and isn't verified about why steps 2-3
+  // exist at all.
   const resolved =
     validateRegistry(embeddedTrustRegistry as unknown) ??
     (await readTrustRegistryFromDisk()) ??


### PR DESCRIPTION
## Summary

Phase P1 of civic-ai-tools#155 (docs tail + publish-skill portability, portability charter 6). Anchor: https://github.com/npstorey/civic-ai-tools/issues/155. Sprint-definition comment: https://github.com/npstorey/civic-ai-tools/issues/155#issuecomment-5371958717. G0 gate record: https://github.com/npstorey/civic-ai-tools/issues/155#issuecomment-5372637203.

**Model disclosure:** IMPL ran on Sonnet 5; ORCH on Sonnet 5 with Opus 5 as advisor.

### B1 — `PUBLISHER_TRUST_REGISTRY_URL` doc correction (premise-checked)
Measured (not assumed): `loadTrustRegistry()`'s step 1 — a build-time-embedded import of the checked-in registry file — resolves unconditionally on every real call path (both production callers pass no URL argument), so the on-disk read and the HTTP fetch fed by this variable never run. The prior docs claimed the override was "useful for previews or local dev," which is false — corrected across `docs/key-rotation.md`, `docs/deploy.md`, `docs/instance-setup.md`, and `docs/api/records-publish.md`. No code-behavior change; this is a documentation-accuracy fix with a new regression test (`verify.test.ts`, "B1" test) that measures both intermediate steps directly (chdir away from the project root + a fetch spy), not just the observable outcome.

### E15 — gate `/dev/notebook-preview` (R5)
The route's docstring claimed it was "Excluded from production by route placement under `/dev/*`" — false; there's no `middleware.ts` and the page is `force-dynamic`. Gated with `notFound()` unless `NODE_ENV === 'production'`, no new env knob. Verified via `NODE_ENV=production next build && next start` (404) and `next dev` (200, confirming the gate isn't a de facto deletion) — both local-build claims; worth spot-checking the preview deploy on this PR too.

### E4 — strip reference-production defaults
`publish-with-blob-ref.mjs` (`--base-url` now required), `eval-models.mjs` (`SOCRATA_MCP_URL` now required), `sync-fallback.mjs` (same, though this script is dead/frozen by its own "DO NOT RUN" docstring — stripping its default is cosmetic, not a live-defect fix; noted as a premise-check finding, not a regression). All three refuse with a named error.

### E12 — env-injection wording (R3)
"`op run` recommended; any env-injection mechanism is acceptable ... never a plaintext literal in a dot-file" applied across `preflight-env.mjs`, `executor-parity.mjs`, `rehearse-storage-s3.mjs`, `backfill-rekor-entry-body.ts`, `docs/rate-limit-headroom.md`. `vercel-sandbox.ts` and two `deploy.md` sites checked and left unchanged (already correctly framed).

## Verification (ORCH-independent, this session)
- `npm test`: 841/841 pass (matches IMPL's report)
- `npm run lint`: 0 errors, 4 warnings — confirmed pre-existing against `origin/main` (one shifted line number in a touched file, checked by diffing against main's copy)
- `npm run typecheck`: clean
- Pre-push sensitivity scan (added lines per commit, not net diff): 0 matches
- `gitleaks detect` over the branch's commits: no leaks
- All 4 commits carry `Signed-off-by: Nathan Storey <npstorey@users.noreply.github.com>`, literal match to commit author

## Test plan
- [x] Full test suite passes
- [x] Lint/typecheck clean
- [x] Production build 404s `/dev/notebook-preview`; dev server serves it (200)
- [ ] Confirm this PR's Vercel preview also 404s `/dev/notebook-preview` (preview runs a production build — stronger evidence than local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)