### PR TITLE
civic#155 P1b: retire PUBLISHER_TRUST_REGISTRY_URL (B1 follow-up)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,8 +292,10 @@ services:
       EVIDENCE_TRUST_REGISTRY_CANONICAL_URL:
       PUBLISHER_TRUST_REGISTRY_LEGACY_URL:
       EVIDENCE_TRUST_REGISTRY_LEGACY_URL:
-      PUBLISHER_TRUST_REGISTRY_URL:
-      EVIDENCE_TRUST_REGISTRY_URL:
+      # PUBLISHER_TRUST_REGISTRY_URL / EVIDENCE_TRUST_REGISTRY_URL retired
+      # (civic-ai-tools#155 P1b) — fed a dead on-disk-read/HTTP-fetch fallback
+      # in loadTrustRegistry that P1 measured as unreachable on every real
+      # call path; the owner ruled to retire rather than repair.
       # Chrome branding and content sources. Also passed as build args above:
       # prerendered pages bake them, dynamic pages read them here.
       SITE_BRAND_NAME:

--- a/docs/api/records-publish.md
+++ b/docs/api/records-publish.md
@@ -412,7 +412,14 @@ Callers publishing through `POST /api/records` do not set these themselves — t
 | `PUBLISHER_SIGNING_KEY`        | `EVIDENCE_SIGNING_KEY` | Base64 DER PKCS8 Ed25519 private key. Sensitive.                        |
 | `PUBLISHER_KEY_ID`             | `EVIDENCE_KEY_ID` | Stable kid string naming **your** active trust-registry entry (e.g. `platform:evidence-2026-04` — kids are exempt-frozen; each lives inside every envelope its key has signed). Non-sensitive, no coded default: with a signing key set and this unset, the instance refuses to seal or publish rather than sign under an undeclared key id. |
 | `PUBLISHER_PUBLIC_KEY`         | `EVIDENCE_PUBLIC_KEY` | Public half of the signing key. Used only for registry updates.         |
-| `PUBLISHER_TRUST_REGISTRY_URL` | `EVIDENCE_TRUST_REGISTRY_URL` | Optional override for the default `${NEXTAUTH_URL}/.well-known/...` URL that **this instance's own verify route** would fetch if it ever reached that step. Never part of signed output. In practice inert — see [`docs/key-rotation.md`](../key-rotation.md#environment-variables). |
+
+`PUBLISHER_TRUST_REGISTRY_URL` (prior era: `EVIDENCE_TRUST_REGISTRY_URL`) used
+to be listed here — an optional override for the URL this instance's own
+verify route would fetch if it ever reached that step. civic-ai-tools#155 P1
+measured that it never did on any real call path, and civic-ai-tools#155 P1b
+retired the variable outright; it is no longer read anywhere. See
+[`docs/key-rotation.md`](../key-rotation.md#environment-variables) for the
+history.
 
 The full instance-identity set (origin, signer claim, platform agent, the emit-side registry URLs) is in [`docs/instance-setup.md`](../instance-setup.md).
 
@@ -793,6 +800,8 @@ These are implementation details that may surprise an external client. None of t
 ---
 
 ## Change log
+
+- **2026-08-21** — **`PUBLISHER_TRUST_REGISTRY_URL` retired** (civic-ai-tools#155 P1b, following the P1 measurement below). The verify-side consume override — the URL an HTTP fetch would use if `loadTrustRegistry()` ever reached that step — is deleted outright, along with the on-disk-read and HTTP-fetch code paths it fed. `loadTrustRegistry()` now takes no `url` argument and resolves solely from the build-time-embedded trust registry; that was already the sole source on every real call path (see the 2026-04-18 entry below and [`docs/key-rotation.md`](../key-rotation.md#environment-variables) for the full history). The prior-era spelling `EVIDENCE_TRUST_REGISTRY_URL` is retired identically. Every instance replaces the checked-in registry file at build time, so no instance needed the lever, and it was never part of signed output — no client-visible or wire change.
 
 - **2026-08-19** — **Vocabulary settlement: `evidence` → `records` on this API's public surface** (Appendix J of the [Typed Standards specification](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/typed-standards-specification.md); [ADR-0025](https://github.com/npstorey/civic-ai-tools/blob/main/docs/adr/0025-vocabulary-settlement-evidence-excision.md); anchor [civic-ai-tools#160](https://github.com/npstorey/civic-ai-tools/issues/160)). The word "evidence" overclaimed in the artifact/infrastructure position — a signed package shows *how* an answer was produced, not that it is correct — so it is excised there and retained only in its epistemic sense (`content/evidence/v1`, `contentType: "evidence"`, the `supportedBy`/`opposedBy` relations, all unchanged). **Nothing an existing integration does stops working**, by design:
     - **Route segments.** `/api/records/*` and `/records/*` are canonical; `/api/evidence/*` and `/evidence/*` are **permanent aliases** serving the identical handlers — not a deprecation window. Every published link, citation, and OG card carrying the prior-era form keeps resolving forever.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -522,19 +522,7 @@ derives from the required identity set above when unset: host and URLs
 from the origin, the agent id from the host; the *required* identity set
 itself is in the disable-when-absent table, not here — see
 [`docs/instance-setup.md`](instance-setup.md)),
-**`PUBLISHER_TRUST_REGISTRY_URL`** (the **consume**-side counterpart, and
-the one publisher variable that is not about what you emit: it supplies the
-URL fed to the HTTP-fetch fallback in this instance's own verify route, and
-never appears in signed output. Unset, it resolves `NEXTAUTH_URL` →
-`PUBLISHER_SITE_ORIGIN` → the reference origin with the legacy well-known
-path appended — but that resolved URL is dead code on the real call path,
-not merely a last resort: the verify route always resolves the registry
-from a build-time-embedded import of the checked-in registry file first,
-which cannot fail short of corrupting that file, so the on-disk read and
-this HTTP fetch never run. See
-[`docs/key-rotation.md`](key-rotation.md#environment-variables) for the
-measurement, where it's documented alongside `PUBLISHER_PUBLIC_KEY`, the
-keygen-written public half the app never reads), `SITE_BRAND_ACCENT` and `SITE_SPONSOR_URL`/`SITE_SPONSOR_PREFIX`
+`SITE_BRAND_ACCENT` and `SITE_SPONSOR_URL`/`SITE_SPONSOR_PREFIX`
 (a palette and a preposition are not identity claims, so those three do
 have defaults; the rest of the chrome set is in the disable-when-absent
 table above — see [Branding and
@@ -561,6 +549,15 @@ rate-limit and token-budget tuning knobs
 `S3_REGION` / `S3_FORCE_PATH_STYLE` / `S3_PUBLIC_BASE_URL` (coded
 defaults described in the storage section), and analytics
 (`NEXT_PUBLIC_GA_MEASUREMENT_ID`).
+
+**Retired:** `PUBLISHER_TRUST_REGISTRY_URL` (prior era:
+`EVIDENCE_TRUST_REGISTRY_URL`) used to sit in this list — the verify-side
+consume override, distinct from the two emit-side registry-URL overrides
+above. civic-ai-tools#155 P1 measured the HTTP fetch it fed as dead code on
+every real call path, and civic-ai-tools#155 P1b retired the variable and
+that fetch outright. See
+[`docs/key-rotation.md`](key-rotation.md#environment-variables) for the
+full history.
 
 One build-time caveat: `NEXT_PUBLIC_*` values are inlined into client
 bundles at build time, so a run-time pass-through cannot change them —

--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -166,13 +166,18 @@ operator-supplied configuration, never from another deployment's identity:
 | `PUBLISHER_PLATFORM_AGENT_ID` | `EVIDENCE_PLATFORM_AGENT_ID` | PROV platform-agent id inside the signed provenance graph. | the publication host |
 | `PUBLISHER_PLATFORM_AGENT_URL` | `EVIDENCE_PLATFORM_AGENT_URL` | PROV platform-agent URL. | `PUBLISHER_SITE_ORIGIN` |
 
-Two more publisher variables exist outside this table:
+One more publisher variable exists outside this table:
 `PUBLISHER_PUBLIC_KEY` (written by the keygen script for registry edits, never
-read at run time) and `PUBLISHER_TRUST_REGISTRY_URL` (the **verify-side
-consume** override — feeds the HTTP-fetch fallback your verify route would
-use if it ever reached that step, which in practice it doesn't; never part
-of signed output). Both are documented in
+read at run time). Documented in
 [`docs/key-rotation.md`](key-rotation.md#environment-variables).
+
+A second variable used to live here too — `PUBLISHER_TRUST_REGISTRY_URL`, the
+**verify-side consume** override, which fed an HTTP-fetch fallback your
+verify route would use if it ever reached that step. civic-ai-tools#155 P1
+measured that it never did on any real call path, and civic-ai-tools#155 P1b
+retired the variable outright; see
+[`docs/key-rotation.md`](key-rotation.md#environment-variables) for the
+history.
 
 Check the wiring with the presence-only preflight (no values are read or
 printed): `node scripts/preflight-env.mjs`.

--- a/docs/key-rotation.md
+++ b/docs/key-rotation.md
@@ -46,7 +46,7 @@ need a separate scope field.
 
 ## Environment variables
 
-**Names.** All four variables below took the `EVIDENCE_` prefix before the
+**Names.** All three variables below took the `EVIDENCE_` prefix before the
 2026-08-19 vocabulary settlement (Appendix J; [civic-ai-tools#160](https://github.com/npstorey/civic-ai-tools/issues/160)).
 The prior-era spelling of each is **still read** as a fallback, so an existing
 deployment keeps working with no edit; it logs a one-time deprecation warning
@@ -69,53 +69,34 @@ holds the public key counterpart and is not directly read by the signing code
 re-deriving the public key from the private one. It is written by
 `scripts/generate-signing-key.ts`.
 
-A fourth variable, **`PUBLISHER_TRUST_REGISTRY_URL`** (prior era:
-`EVIDENCE_TRUST_REGISTRY_URL`), is optional. It is the **verify-side consume
-override**: it feeds the URL an HTTP fetch would use if the verify path ever
-reached that step when it checks a package's key trust.
+**Retired: `PUBLISHER_TRUST_REGISTRY_URL`.** A fourth variable used to exist
+here — `PUBLISHER_TRUST_REGISTRY_URL` (prior era: `EVIDENCE_TRUST_REGISTRY_URL`),
+the **verify-side consume override**. It fed the URL an HTTP fetch would use
+if the verify path ever reached that step when checking a package's key
+trust. civic-ai-tools#155 P1 measured that HTTP fetch as dead code on every
+real call path: `loadTrustRegistry()` resolves the registry from a
+build-time-embedded import of the checked-in
+`public/.well-known/evidence-public-keys.json` first, and that import
+succeeds unconditionally for any well-formed registry file (including a
+degenerate `{"keys":[]}`), so the on-disk read and the HTTP fetch behind this
+variable never ran — in dev, test, preview, or production. Neither production
+caller (`/api/evidence/[slug]/verify`, `/commitment`) ever passed a URL that
+would have exercised it. Given that, civic-ai-tools#155 P1b retired the
+variable, and the on-disk-read/HTTP-fetch code it fed, outright — every
+instance replaces the checked-in registry file at build time, so no instance
+needed the lever, and a knob that silently did nothing was worse than no
+knob. The variable is no longer read anywhere; setting it now does nothing
+and produces no warning.
 
-Its default resolution, in order, is `NEXTAUTH_URL`, then
-`PUBLISHER_SITE_ORIGIN`, then the reference origin — with
-`/.well-known/evidence-public-keys.json` appended (the legacy path; both paths
-serve the same bytes). **In practice this HTTP fetch is dead code on this
-instance's own verify route, not merely a last resort:** `loadTrustRegistry()`
-resolves the registry from a build-time-embedded import of the checked-in
-`public/.well-known/evidence-public-keys.json` first, and that import is
-compiled into the bundle unconditionally — it cannot fail at runtime short of
-corrupting the checked-in file, which would break verification for every
-package (the same malformed file also backs the on-disk step and the
-default HTTP URL, which points at this instance's own copy of it). The on-disk
-read and the HTTP fetch (fed by this variable) never run, in dev, test,
-preview, or production alike (validation accepts any well-formed `keys`
-array, including an empty one, so even a degenerate registry file
-short-circuits the chain — nothing short of removing or malforming the
-file makes step 1 fail). This is not a "rarely reaches it" case of
-last-resort behavior; the two callers (`/api/evidence/[slug]/verify` and
-`/commitment`) both call `loadTrustRegistry()` with no URL argument, so the
-override changes a value that is never consumed. Measured directly in
-`src/lib/evidence/verify.test.ts` ("B1" test): with the override set, the
-process `chdir`'d away from the project root so the on-disk read is
-genuinely non-viable (not merely untested — it hits ENOENT), and `fetch`
-spied to fail the test if invoked, `loadTrustRegistry()` still returns the
-real embedded registry. Both intermediate steps are ruled out this way,
-not just the final one — the override is provably never reached through
-the real call path. Treat this variable as inert on a normal
-deployment; it is not a lever for making a preview or local-dev instance
-verify against a different registry. (Why the HTTP-fetch fallback exists
-at all despite being unreachable here is not independently verified by
-this measurement — see `verify.ts`'s `getTrustRegistryUrl` docstring.)
-
-It is deliberately **distinct from the two emit-side variables**, which control
-what the signed proof sidecar tells a *third-party* verifier to fetch:
+It was deliberately **distinct from the two emit-side variables below**, which
+remain live and control what the signed proof sidecar tells a *third-party*
+verifier to fetch:
 
 | Variable | Direction | Effect |
 | --- | --- | --- |
-| `PUBLISHER_TRUST_REGISTRY_URL` | consume | Feeds the HTTP-fetch fallback in `loadTrustRegistry()`, which the embedded-registry step preempts on every real call path (see above) — inert in practice. Never appears in signed output. |
 | `PUBLISHER_TRUST_REGISTRY_CANONICAL_URL` | emit | The sidecar's `trustRegistryUrl`. Defaults to `<origin>/.well-known/typed-publisher.json`. |
 | `PUBLISHER_TRUST_REGISTRY_LEGACY_URL` | emit | The sidecar's `trustRegistryUrlLegacy`. Defaults to `<origin>/.well-known/evidence-public-keys.json`; set it to the **empty string** to omit the field entirely. Empty is not absent here — an instance with no pre-ADR-0012 client base has no legacy path to honor. |
 
-Setting the consume override when you meant an emit variable is the mistake
-this table exists to prevent: it changes nothing a third party sees.
 The full tier-by-tier reference is [`docs/deploy.md`](deploy.md).
 
 ## Preventive rotation

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -318,9 +318,16 @@ export const ENV_SPEC = [
   { name: 'ROADMAP_GITHUB_URL', readBy: 'build-and-runtime', tier: 'optional', purpose: '/roadmap "view source" link and byline label (unset: derived from ROADMAP_RAW_URL)', hasFallback: true },
 
   // --- Optional / feature / ops ---
-  { name: 'PUBLISHER_TRUST_REGISTRY_URL', priorEraName: 'EVIDENCE_TRUST_REGISTRY_URL', tier: 'optional', purpose: 'Trust-registry HTTP-fetch override — inert on every real call path (the embedded registry preempts it); retire-or-repair decision pending at G1', hasFallback: true },
-  // WRITTEN, NEVER READ — the fourteenth variable of the settlement's Group A,
-  // and the one this inventory used to miss precisely because the inventory
+  // civic-ai-tools#155 P1b: PUBLISHER_TRUST_REGISTRY_URL (prior era:
+  // EVIDENCE_TRUST_REGISTRY_URL) was retired here — it fed an on-disk read
+  // and HTTP-fetch fallback in src/lib/evidence/verify.ts's loadTrustRegistry
+  // that P1 measured as dead code on every real call path (the build-time
+  // embedded registry import always resolves first). The owner ruled to
+  // retire rather than repair; the variable is no longer read anywhere.
+  // WRITTEN, NEVER READ — the fourteenth variable of the settlement's shipped
+  // Group A (now the thirteenth entry in this inventory, following
+  // civic-ai-tools#155 P1b's retirement of PUBLISHER_TRUST_REGISTRY_URL
+  // above), and the one this inventory used to miss precisely because the inventory
   // was derived from `process.env.*` reads. scripts/generate-signing-key.ts
   // emits it beside the private key so an operator has the public half to
   // publish in their trust registry; no app code loads it. Listed as

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -181,12 +181,25 @@ test('two-name expand: the canonical name wins whenever it is DEFINED, empty inc
 });
 
 test('two-name expand: every publisher variable in the census is declared with both names', () => {
-  // The census is Appendix J's environment row: fourteen variables. This
-  // inventory used to hold thirteen — PUBLIC_KEY is written by the keygen
-  // script and never read, so an inventory derived from `process.env.*` reads
-  // could not see it. Pinned at fourteen so the gap cannot reopen.
+  // The census is Appendix J's environment row (typed-standards-specification.md
+  // §Appendix J): fourteen variables at the time the vocabulary settlement
+  // shipped. This inventory used to hold thirteen — PUBLIC_KEY is written by
+  // the keygen script and never read, so an inventory derived from
+  // `process.env.*` reads could not see it — then fourteen once PUBLIC_KEY
+  // was added.
+  //
+  // civic-ai-tools#155 P1b retired PUBLISHER_TRUST_REGISTRY_URL /
+  // EVIDENCE_TRUST_REGISTRY_URL outright (it fed a dead on-disk-read/
+  // HTTP-fetch fallback in loadTrustRegistry that P1 measured as unreachable
+  // on every real call path; the owner ruled to retire rather than repair).
+  // That drops this inventory to thirteen. Appendix J's shipped census still
+  // says fourteen and still lists EVIDENCE_TRUST_REGISTRY_URL — this test
+  // now diverges from that normative table on purpose, tracking the
+  // reference implementation's actual (smaller) surface. Reconciling
+  // Appendix J's census with the retirement is an owner-level spec decision
+  // out of scope for P1b; flagged at the P1b gate, not resolved here.
   const publisherEntries = ENV_SPEC.filter((s) => s.name.startsWith('PUBLISHER_'));
-  assert.equal(publisherEntries.length, 14, 'the settlement names fourteen variables');
+  assert.equal(publisherEntries.length, 13, 'civic-ai-tools#155 P1b retired PUBLISHER_TRUST_REGISTRY_URL, dropping the census from fourteen to thirteen');
   for (const entry of publisherEntries) {
     assert.equal(
       entry.priorEraName,

--- a/src/lib/evidence/verify.test.ts
+++ b/src/lib/evidence/verify.test.ts
@@ -7,7 +7,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'crypto';
-import os from 'node:os';
 import canonicalize from 'canonicalize';
 import {
   verifySignature,
@@ -264,29 +263,29 @@ test('Rotation scenario: old key deprecated + new key active, both resolve corre
   assert.equal(forged.verified, false);
 });
 
-// --- loadTrustRegistry: resolves without ever reaching the network ---
+// --- loadTrustRegistry: resolves solely from the embedded JSON import ---
 //
-// NOTE (civic-ai-tools#155 P1 B1, corrected): these two tests were
-// originally written to exercise the on-disk read path, on the theory that
-// Vercel preview deployments put an HTML auth wall in front of
-// `/.well-known/*` URLs, so the loader falls back to reading the registry
-// from disk instead of fetching HTTP. Measurement showed that's not what
-// actually happens: `loadTrustRegistry`'s step 1 (the build-time-embedded
-// JSON import) resolves the registry unconditionally, before the on-disk
-// read is ever attempted — so what these tests actually exercise is step 1,
-// not the disk fallback. They're kept (and still pass) because they
-// correctly assert the outward behavior — an unreachable HTTP URL doesn't
-// stop the loader from returning a real registry — the "filesystem path"
-// framing just wasn't the accurate mechanism. See the "B1" test below for a
-// test that pins down which step actually supplies the result.
+// civic-ai-tools#155 P1b: `loadTrustRegistry` used to be a three-step
+// resolution chain (build-time bundled JSON → on-disk read → HTTP fetch),
+// with the last two steps fed by an optional `PUBLISHER_TRUST_REGISTRY_URL`
+// / `EVIDENCE_TRUST_REGISTRY_URL` override. civic-ai-tools#155 P1 measured
+// that steps 2-3 were dead code on every real call path — the embedded
+// import always resolves first, and neither production caller ever passed a
+// `url`. The owner ruled to retire the override rather than repair it, so
+// P1b deleted `getTrustRegistryUrl`, the on-disk read, and the HTTP fetch
+// outright. `loadTrustRegistry` now takes NO arguments (the `url` parameter
+// is gone along with what it fed) and resolves only from the build-time
+// embedded registry. The tests below replace the old three (two "resolves
+// without reaching the network" tests plus the "B1" override-unreachability
+// test) — there is no longer a disk/network step or an override to prove
+// unreachable, so those tests' premises no longer apply. What's still worth
+// pinning: the loader returns valid registry data, and it caches across
+// calls.
 
-test('loadTrustRegistry resolves the checked-in registry even with an unreachable HTTP URL', async () => {
+test('loadTrustRegistry resolves the checked-in registry from the embedded JSON', async () => {
   clearTrustRegistryCache();
-  // Point the HTTP URL at a guaranteed-invalid host; the loader should
-  // still succeed because an earlier resolution step (embedded JSON; see
-  // the B1 test below) already supplies a valid registry.
-  const registry = await loadTrustRegistry('http://127.0.0.1:1/invalid');
-  assert.ok(registry, 'loadTrustRegistry returned undefined even though the embedded/on-disk registry exists');
+  const registry = await loadTrustRegistry();
+  assert.ok(registry, 'loadTrustRegistry returned undefined even though the embedded registry exists');
   assert.ok(registry!.keys.length > 0);
   const activeKey = registry!.keys.find((k) => k.status === 'active');
   assert.ok(activeKey, 'registry should have at least one active key');
@@ -296,70 +295,10 @@ test('loadTrustRegistry resolves the checked-in registry even with an unreachabl
 
 test('loadTrustRegistry caches the resolved registry across calls', async () => {
   clearTrustRegistryCache();
-  const a = await loadTrustRegistry('http://127.0.0.1:1/invalid');
-  const b = await loadTrustRegistry('http://127.0.0.1:1/invalid');
+  const a = await loadTrustRegistry();
+  const b = await loadTrustRegistry();
   // Same reference → served from cache, not re-resolved.
   assert.strictEqual(a, b);
-});
-
-// --- B1 (civic-ai-tools#155 P1): PUBLISHER_TRUST_REGISTRY_URL is unreachable
-// via the real callers ---
-//
-// The two production callers (`/api/evidence/[slug]/verify` and
-// `/commitment`) both invoke `loadTrustRegistry()` with NO argument, so the
-// only way `PUBLISHER_TRUST_REGISTRY_URL` (or its prior-era alias) can
-// affect the result is by changing the `url` fed to the HTTP-fetch step —
-// and that step only runs when BOTH the build-time embedded import AND the
-// on-disk read fail.
-//
-// This test measures BOTH intermediate steps, not just the final one: it
-// `process.chdir()`s to a directory with no `public/.well-known/...` file
-// before calling `loadTrustRegistry()`, which makes the on-disk read
-// (step 2) genuinely non-viable in-process (ENOENT, silently swallowed —
-// see `readTrustRegistryFromDisk`), and spies `fetch` to fail the test if
-// the HTTP step (step 3) is ever reached. If the registry still resolves
-// under BOTH of those conditions, step 1 — the build-time embedded import —
-// is provably the sole source, not merely the likely one. (Step 1 itself
-// cannot fail at runtime without corrupting the checked-in
-// `public/.well-known/evidence-public-keys.json`, which would break
-// verification for every package; signing itself does not read this file.)
-test('B1: PUBLISHER_TRUST_REGISTRY_URL override never reaches the disk or fetch steps via the real call path', async () => {
-  clearTrustRegistryCache();
-  const priorOverride = process.env.PUBLISHER_TRUST_REGISTRY_URL;
-  const priorLegacy = process.env.EVIDENCE_TRUST_REGISTRY_URL;
-  process.env.PUBLISHER_TRUST_REGISTRY_URL = 'https://override.invalid.example/registry.json';
-  delete process.env.EVIDENCE_TRUST_REGISTRY_URL;
-
-  const originalCwd = process.cwd();
-  // Not the project root, so readTrustRegistryFromDisk's
-  // path.join(process.cwd(), 'public/.well-known/...') is guaranteed ENOENT
-  // — step 2 becomes genuinely non-viable, not just untested.
-  process.chdir(os.tmpdir());
-
-  let fetchCalled = false;
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (() => {
-    fetchCalled = true;
-    throw new Error('fetch must not be called: embedded JSON should resolve the registry first');
-  }) as typeof fetch;
-
-  try {
-    // Mirrors the real callers: no url argument, so getTrustRegistryUrl()
-    // (which reads the override above) supplies the default — and that
-    // default is never used because step 1 (embedded JSON) already succeeds.
-    const registry = await loadTrustRegistry();
-    assert.equal(fetchCalled, false, 'the HTTP fetch step ran even though the embedded registry should have resolved first');
-    assert.ok(registry, 'loadTrustRegistry returned undefined even with the disk step made non-viable');
-    assert.ok(registry!.keys.some((k) => k.kid === 'platform:evidence-2026-04'));
-  } finally {
-    globalThis.fetch = originalFetch;
-    process.chdir(originalCwd);
-    if (priorOverride === undefined) delete process.env.PUBLISHER_TRUST_REGISTRY_URL;
-    else process.env.PUBLISHER_TRUST_REGISTRY_URL = priorOverride;
-    if (priorLegacy === undefined) delete process.env.EVIDENCE_TRUST_REGISTRY_URL;
-    else process.env.EVIDENCE_TRUST_REGISTRY_URL = priorLegacy;
-    clearTrustRegistryCache();
-  }
 });
 
 // --- Legacy embedded keys (pre-#66 packages) ---

--- a/src/lib/evidence/verify.ts
+++ b/src/lib/evidence/verify.ts
@@ -9,18 +9,14 @@
 //
 // What stays HERE (server-only, deliberately outside verify-core's browser-safe
 // boundary): the trust-registry LOADER. It resolves the platform registry from
-// the build-time bundled JSON → on-disk read → HTTP fetch, using `fs` / `path` /
-// `process.env`. verify-core's `verifyKeyTrust` takes the registry as DATA; this
-// loader is how the server obtains it. WS3's browser client obtains the registry
-// by fetching the sidecar's `trustRegistryUrl` instead.
+// the build-time bundled JSON. (Prior to civic-ai-tools#155 P1b this chain also
+// had an on-disk read and an HTTP-fetch fallback, fed by a
+// `PUBLISHER_TRUST_REGISTRY_URL` override; both were retired as dead code — see
+// the loader below.) verify-core's `verifyKeyTrust` takes the registry as DATA;
+// this loader is how the server obtains it. WS3's browser client obtains the
+// registry by fetching the sidecar's `trustRegistryUrl` instead.
 
-import { promises as fs } from 'fs';
-import path from 'path';
 import { validateRegistry, type TrustRegistry } from './verify-core/index.ts';
-import { getEvidenceSiteOrigin } from '../site-config.ts';
-// Two accepted names for the verify-side registry override since the
-// 2026-08-19 vocabulary settlement (Appendix J) — see `publisher-env.ts`.
-import { readPublisherEnv } from '../publisher-env.ts';
 
 // Re-export the entire browser-safe verification core: the §9.2 check functions,
 // the `verifyEvidence` orchestrator, every status vocabulary, and all result
@@ -28,20 +24,42 @@ import { readPublisherEnv } from '../publisher-env.ts';
 // both consume.
 export * from './verify-core/index.ts';
 
-// Build-time import of the checked-in trust registry. This is the most reliable
-// source on Vercel: a filesystem read relies on `process.cwd()` resolving to a
-// directory that actually contains the bundled `public/` folder, and an HTTP
-// fetch back to our own origin is blocked by preview-deployment auth walls. The
-// static import has Next.js bundle the JSON into the function's module graph at
-// build time so `loadTrustRegistry` can return a result synchronously.
+// Build-time import of the checked-in trust registry — the sole source now
+// (civic-ai-tools#155 P1b). It was always the most reliable of the three
+// resolution steps this loader used to try: a filesystem read relies on
+// `process.cwd()` resolving to a directory that actually contains the bundled
+// `public/` folder, and an HTTP fetch back to our own origin is blocked by
+// preview-deployment auth walls — both were retired as dead code once P1
+// measured that this embedded import alone already satisfied every real call
+// path. The static import has Next.js bundle the JSON into the function's
+// module graph at build time so `loadTrustRegistry` can return a result
+// synchronously.
 import embeddedTrustRegistry from '../../../public/.well-known/evidence-public-keys.json' with { type: 'json' };
 
 // --- Registry loader ---
 //
-// Module-level TTL cache around the resolution chain. Keeps per-request latency
-// low without re-reading for every `/evidence/[slug]` page load. The verify route
+// Module-level TTL cache around the resolution. Keeps per-request latency low
+// without re-reading for every `/evidence/[slug]` page load. The verify route
 // calls `loadTrustRegistry()` and passes the result into verify-core's
 // `verifyKeyTrust`.
+//
+// civic-ai-tools#155 P1b: this used to be a three-step resolution chain
+// (build-time bundled JSON → on-disk read → HTTP fetch, the last two fed by
+// an optional `PUBLISHER_TRUST_REGISTRY_URL` / `EVIDENCE_TRUST_REGISTRY_URL`
+// override). P1 measured that steps 2-3 are dead code on every real call
+// path: `validateRegistry` accepts any well-formed `{"keys": [...]}` object
+// (even an empty array), so step 1 always resolves for a checked-in registry
+// file that parses at all, and neither production caller (`/verify`,
+// `/commitment`) ever passed a `url`. The owner ruled to retire the override
+// rather than repair it — every instance replaces the checked-in registry
+// file at build time, so no instance needs the lever, and a knob that
+// silently does nothing is worse than no knob. `loadTrustRegistry` now
+// resolves solely from the embedded JSON import; there is no `url` parameter
+// and no on-disk or network fallback. A `TrustRegistry | undefined` return
+// type is kept because `validateRegistry` can still (in principle) reject a
+// corrupted checked-in file — that failure mode predates and is orthogonal to
+// this retirement, so callers keep handling `undefined` via verify-core's
+// existing `registry_unavailable` status.
 
 const REGISTRY_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -50,121 +68,18 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-const registryCache: Map<string, CacheEntry> = new Map();
+let registryCache: CacheEntry | undefined;
 
-/** Resolve the URL fed to the HTTP-fetch fallback in `loadTrustRegistry`.
- *  Can be overridden via `PUBLISHER_TRUST_REGISTRY_URL` (or its prior-era
- *  spelling `EVIDENCE_TRUST_REGISTRY_URL`, still accepted — the 2026-08-19
- *  vocabulary settlement, Appendix J). The fallback tail is the instance's
- *  configured origin (ADR-0020), then the reference origin literal — the
- *  VERIFY path's historical resolution, deliberately byte-identical across
- *  #258 (which removed identity defaults from signing/emission paths only;
- *  this resolution's defects are a separate charter).
- *
- *  This is NOT a "useful for previews or local dev" lever: on this
- *  instance's own verify route (`loadTrustRegistry()` called with no
- *  argument, as both callers do — see below), the URL this function
- *  produces is never actually fetched. Step 1 of `loadTrustRegistry`'s
- *  resolution chain — the build-time-embedded import of the checked-in
- *  registry file — succeeds unconditionally: `validateRegistry` accepts
- *  ANY object whose `keys` is an array (including an empty one — `[].every`
- *  is vacuously true), so step 1 returns a value for every well-formed JSON
- *  file, not only a populated one. Only outright corrupting or removing the
- *  checked-in file could make step 1 fail. That preempts both the on-disk
- *  read and this HTTP fetch on every real call path, in dev, test, preview,
- *  and production alike. Measured in `verify.test.ts` ("B1" test) for BOTH
- *  intermediate steps, not just the final one: with this override set, the
- *  process `chdir`'d away from the project root so the on-disk read is
- *  genuinely non-viable (ENOENT, not merely untested), and `fetch` spied to
- *  fail the test if invoked, `loadTrustRegistry()` still returns the
- *  embedded registry untouched.
- *
- *  Why steps 2–3 (and this function) exist at all despite being unreachable
- *  from this app's own callers is NOT independently verified here — this
- *  function has no importer besides `loadTrustRegistry`'s default parameter
- *  in this same file (confirmed by search: no other module in this repo
- *  calls `getTrustRegistryUrl` or passes a non-default `url` to
- *  `loadTrustRegistry`). An "external adopters reusing this module" story
- *  is plausible but unmeasured; don't repeat it as settled fact (civic-ai-
- *  tools#155 P1 B1 — this replaces the prior docstring's unqualified
- *  "useful for previews" claim, which the measurement disproved; avoid
- *  swapping in a second unmeasured rationale in its place). */
-export function getTrustRegistryUrl(): string {
-  const override = readPublisherEnv('TRUST_REGISTRY_URL');
-  if (override) return override;
-  const site =
-    process.env.NEXTAUTH_URL ||
-    getEvidenceSiteOrigin() ||
-    'https://civicaitools.org';
-  return `${site.replace(/\/$/, '')}/.well-known/evidence-public-keys.json`;
-}
-
-/** Filesystem location of the registry within the Next.js build output. */
-const REGISTRY_PUBLIC_PATH = path.join('public', '.well-known', 'evidence-public-keys.json');
-
-export async function loadTrustRegistry(
-  url: string = getTrustRegistryUrl(),
-): Promise<TrustRegistry | undefined> {
-  const cached = registryCache.get(url);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.registry;
+export async function loadTrustRegistry(): Promise<TrustRegistry | undefined> {
+  if (registryCache && registryCache.expiresAt > Date.now()) {
+    return registryCache.registry;
   }
-  // Resolution order:
-  //   1. Build-time bundled JSON (always present in the deploy artifact)
-  //   2. On-disk read (dev server, tests running from project root)
-  //   3. HTTP fetch (external verifiers / cross-origin)
-  // On OUR OWN verify route (both callers pass no `url`), steps 2 and 3 are
-  // dead code, not merely a fallback: step 1 succeeds for any well-formed
-  // checked-in registry file, including a degenerate `{"keys":[]}` — see
-  // getTrustRegistryUrl's docstring above for the measurement (B1 test in
-  // verify.test.ts) and for what is and isn't verified about why steps 2-3
-  // exist at all.
-  const resolved =
-    validateRegistry(embeddedTrustRegistry as unknown) ??
-    (await readTrustRegistryFromDisk()) ??
-    (await fetchTrustRegistry(url));
-  registryCache.set(url, { registry: resolved, expiresAt: Date.now() + REGISTRY_TTL_MS });
+  const resolved = validateRegistry(embeddedTrustRegistry as unknown);
+  registryCache = { registry: resolved, expiresAt: Date.now() + REGISTRY_TTL_MS };
   return resolved;
 }
 
 /** For tests / rotation drills: drop the in-memory cache. */
 export function clearTrustRegistryCache(): void {
-  registryCache.clear();
-}
-
-async function readTrustRegistryFromDisk(): Promise<TrustRegistry | undefined> {
-  try {
-    const localPath = path.join(process.cwd(), REGISTRY_PUBLIC_PATH);
-    const json = await fs.readFile(localPath, 'utf-8');
-    return validateRegistry(JSON.parse(json));
-  } catch (err) {
-    // Not all runtimes have the file at the expected path (e.g. unit tests run
-    // from a different cwd). Silently fall through so callers can still try the
-    // HTTP URL.
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-      console.warn('[verify] Failed to read trust registry from disk:', err instanceof Error ? err.message : err);
-    }
-    return undefined;
-  }
-}
-
-async function fetchTrustRegistry(url: string): Promise<TrustRegistry | undefined> {
-  try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
-    if (!res.ok) {
-      console.warn(`[verify] Trust registry fetch returned ${res.status}`);
-      return undefined;
-    }
-    const ct = res.headers.get('content-type') || '';
-    if (!ct.includes('json')) {
-      // Vercel preview protection returns an HTML auth wall with 200 OK. Refuse
-      // to treat that as the registry.
-      console.warn(`[verify] Trust registry fetch returned unexpected content-type "${ct}"`);
-      return undefined;
-    }
-    return validateRegistry(await res.json());
-  } catch (err) {
-    console.warn('[verify] Trust registry fetch failed:', err instanceof Error ? err.message : err);
-    return undefined;
-  }
+  registryCache = undefined;
 }

--- a/src/lib/publisher-env.test.ts
+++ b/src/lib/publisher-env.test.ts
@@ -1,9 +1,12 @@
 // The two-name expand for the publisher-identity variables (#160 P3).
 //
 // Group A of the 2026-08-19 vocabulary settlement (Appendix J of the Typed
-// Standards specification) moves fourteen variables from the `EVIDENCE_`
-// prefix to `PUBLISHER_`, under the `expand-then-flip` migration class. This
-// file pins the expand half: both names are read, the canonical one wins, the
+// Standards specification) moves thirteen variables from the `EVIDENCE_`
+// prefix to `PUBLISHER_`, under the `expand-then-flip` migration class. (A
+// fourteenth, `TRUST_REGISTRY_URL`, was also moved at the time — it was
+// retired outright, not renamed, by civic-ai-tools#155 P1b; see
+// `PUBLISHER_ENV_SUFFIXES`'s docstring in `publisher-env.ts`.) This file pins
+// the expand half: both names are read, the canonical one wins, the
 // prior-era one warns exactly once, and nothing that already worked stops.
 //
 // WHY THE PRECEDENCE RULE IS TESTED SO HARD. It is `defined`, not `truthy`,
@@ -52,9 +55,13 @@ function captureWarnings<T>(fn: () => T): { result: T; warnings: string[] } {
 
 // --- The census ---------------------------------------------------------------
 
-test('the census is Appendix J\'s fourteen variables, with no duplicates', () => {
-  assert.equal(PUBLISHER_ENV_SUFFIXES.length, 14);
-  assert.equal(new Set(PUBLISHER_ENV_SUFFIXES).size, 14, 'no suffix appears twice');
+// civic-ai-tools#155 P1b: Appendix J's shipped environment row still says
+// fourteen and still lists `EVIDENCE_TRUST_REGISTRY_URL`; that variable was
+// retired outright (not renamed) here, dropping this census to thirteen.
+// Reconciling the spec's count is a follow-up owner decision, not this test's.
+test('the census is Appendix J\'s thirteen variables (post-#155-P1b), with no duplicates', () => {
+  assert.equal(PUBLISHER_ENV_SUFFIXES.length, 13);
+  assert.equal(new Set(PUBLISHER_ENV_SUFFIXES).size, 13, 'no suffix appears twice');
   assert.deepEqual(
     [...PUBLISHER_ENV_NAMES].sort(),
     [...PUBLISHER_ENV_SUFFIXES].map((s) => `${CANONICAL_ENV_PREFIX}${s}`).sort(),

--- a/src/lib/publisher-env.ts
+++ b/src/lib/publisher-env.ts
@@ -2,9 +2,13 @@
 //
 // WHAT THIS IS. The 2026-08-19 vocabulary settlement (Appendix J of the Typed
 // Standards specification) retires "evidence" from the infrastructure brand.
-// The fourteen variables that name THIS deployment's publishing identity move
+// The thirteen variables that name THIS deployment's publishing identity move
 // from the `EVIDENCE_` prefix to `PUBLISHER_`, under the settlement's
-// `expand-then-flip` migration class:
+// `expand-then-flip` migration class. (Appendix J's shipped environment row
+// still says fourteen and still lists `EVIDENCE_TRUST_REGISTRY_URL` — that
+// variable was retired outright, not renamed, by civic-ai-tools#155 P1b;
+// reconciling the spec's census is a follow-up owner decision, not done
+// here.)
 //
 //   EXPAND (this module, this phase) — every runtime read accepts BOTH names,
 //   canonical first, and says so out loud when the prior-era name is the one
@@ -17,7 +21,7 @@
 //
 //   DROP (a later major) — the fallback in `lookupPublisherEnv` goes away.
 //
-// ONE HELPER, NOT FOURTEEN FALLBACKS. Hand-rolling `process.env.PUBLISHER_X ??
+// ONE HELPER, NOT THIRTEEN FALLBACKS. Hand-rolling `process.env.PUBLISHER_X ??
 // process.env.EVIDENCE_X` at each of the ~20 read sites would put the
 // migration rule in twenty places and the deprecation warning in none of them.
 // Everything that reads one of these variables goes through here, which is
@@ -61,15 +65,23 @@ export const CANONICAL_ENV_PREFIX = 'PUBLISHER_';
 export const PRIOR_ERA_ENV_PREFIX = 'EVIDENCE_';
 
 /**
- * The fourteen variables in the settlement's Group A, by the suffix the two
+ * The thirteen variables in the settlement's Group A, by the suffix the two
  * prefixes share. This list IS the census (Appendix J's environment row); it
- * is not derived from anything, so adding a fifteenth publisher variable means
- * adding it here.
+ * is not derived from anything, so adding a fourteenth publisher variable
+ * means adding it here.
  *
  * `PUBLIC_KEY` is the odd one: nothing reads it at run time — the key-
  * generation script WRITES it, and the deployment guide documents it. It is
  * listed because the settlement lists it, and because the writer emits the
  * canonical name from this list rather than a literal of its own.
+ *
+ * `TRUST_REGISTRY_URL` used to be the fourteenth entry — the verify-side
+ * consume override. civic-ai-tools#155 P1b retired it outright (not renamed):
+ * `readPublisherEnv('TRUST_REGISTRY_URL')` had exactly one caller
+ * (`getTrustRegistryUrl` in `src/lib/evidence/verify.ts`), which P1 measured
+ * as feeding dead code, and P1b deleted along with it. Appendix J's shipped
+ * environment row still lists it and still says fourteen; reconciling that is
+ * a follow-up spec decision, not done here.
  */
 export const PUBLISHER_ENV_SUFFIXES = [
   'SIGNING_KEY',
@@ -83,12 +95,11 @@ export const PUBLISHER_ENV_SUFFIXES = [
   'PLATFORM_AGENT_URL',
   'PUBLICATION_HOST',
   'SITE_ORIGIN',
-  'TRUST_REGISTRY_URL',
   'TRUST_REGISTRY_CANONICAL_URL',
   'TRUST_REGISTRY_LEGACY_URL',
 ] as const;
 
-/** One of the fourteen suffixes above. */
+/** One of the thirteen suffixes above. */
 export type PublisherEnvSuffix = (typeof PUBLISHER_ENV_SUFFIXES)[number];
 
 /** An env-shaped record. Always passed in, never reached for implicitly. */


### PR DESCRIPTION
## Summary

Phase P1b of civic-ai-tools#155, a small follow-up to P1 (#291, merged). Anchor: https://github.com/npstorey/civic-ai-tools/issues/155. G1 gate record (owner's retire ruling): https://github.com/npstorey/civic-ai-tools/issues/155#issuecomment-5375001217.

**Model disclosure:** IMPL ran on Sonnet 5; ORCH on Sonnet 5 with Opus 5 as advisor.

P1 measured that `PUBLISHER_TRUST_REGISTRY_URL` (prior-era `EVIDENCE_TRUST_REGISTRY_URL`) was dead code on every real call path — the build-time-embedded trust registry import always resolves first, so the on-disk read and HTTP fetch this variable fed never ran. The owner ruled to **retire** the variable outright rather than repair it (no instance needs the lever; every instance replaces the checked-in registry file at build time).

This PR executes the retirement:
- `src/lib/evidence/verify.ts`: deleted `getTrustRegistryUrl`, `readTrustRegistryFromDisk`, `fetchTrustRegistry`. `loadTrustRegistry()` now takes no arguments and resolves solely from the embedded JSON import.
- **Scope note (ORCH-ratified):** deleting the sole caller of `readPublisherEnv('TRUST_REGISTRY_URL')` orphaned an entry in `src/lib/publisher-env.ts`'s `PUBLISHER_ENV_SUFFIXES` census, which is cross-checked byte-for-byte against `scripts/preflight-env.mjs`'s `ENV_SPEC` by design (the module's own docstring: "cannot drift"). Left alone, that cross-check test would fail. Removed the suffix there too, narrowing the `PublisherEnvSuffix` type — verified by independent review: `tsc --noEmit` passing is compile-time proof no other module referenced it, and a repo-wide grep confirms zero remaining references outside comments describing the removal.
- `scripts/preflight-env.mjs` / `.test.mjs`: dropped the `ENV_SPEC` row; the "fourteen variables" census assertion now asserts thirteen.
- `docker-compose.yml`: dropped the bare pass-through pair (the `_CANONICAL_URL`/`_LEGACY_URL` emit-side pairs are untouched — different, still-live variables).
- `.env.example`: **no change** — confirmed (twice, independently) that this file never listed the variable in the first place, so there was nothing to remove. This also supersedes a planning-doc item (N5) that once proposed *adding* this variable to the template — moot now that it's retired rather than documented.
- Four doc sites (`key-rotation.md`, `deploy.md`, `instance-setup.md`, `records-publish.md`) rewritten from present-tense "inert in practice" to past-tense "existed, was measured dead, was retired." Two historical changelog entries in `records-publish.md` (2026-08-19, 2026-04-18) that mention the variable are preserved untouched, per no-information-loss — a new 2026-08-21 entry documents the retirement instead of rewriting history.

## Flagged, not fixed: Appendix J is now stale
The Typed Standards specification's Appendix J (`civic-ai-tools/docs/architecture/typed-standards-specification.md`) normatively lists 14 reference-implementation environment variables including `EVIDENCE_TRUST_REGISTRY_URL`. Post-retirement the real count is 13. This PR does **not** touch the spec — that's a different repo, a normative document, and civic#155's own charter explicitly excludes spec text changes from this sprint ("the spec... any spec text is a spec session"). Pointer comments are left at the three census sites naming this as an open follow-up for the owner to route through the normal spec-change process.

## Verification (ORCH-independent, this session)
- `npm test`: 840/840 pass (re-ran myself; matches IMPL's report)
- `npm run lint`: 0 errors, 4 pre-existing warnings (same four as P1, unrelated to this diff)
- `npm run typecheck`: clean
- Pre-push sensitivity scan (added lines per commit): 0 matches
- `gitleaks detect`: no leaks
- Commit carries `Signed-off-by: Nathan Storey <npstorey@users.noreply.github.com>`, literal match to author
- Independently re-read every file's diff (verify.ts/test.ts, publisher-env.ts/test.ts, preflight-env.mjs/test.mjs, docker-compose.yml, all four doc sites) and confirmed zero remaining live references to the retired variable repo-wide, and zero touch to `.env.example`

## Test plan
- [x] Full test suite passes
- [x] Lint/typecheck clean
- [x] Repo-wide grep: zero live references to `getTrustRegistryUrl` / `PUBLISHER_TRUST_REGISTRY_URL` / `EVIDENCE_TRUST_REGISTRY_URL` outside preserved changelog history and removal-explaining comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)