### PR TITLE
civic#155 P2: website docs — key-rotation split, records-publish portability pass, E14/N3/N4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,10 @@ Optional (production only):
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX  # Google Analytics 4
 ```
 
-Required in production (Upstash via Vercel KV):
+Recommended in production, not required (Upstash via Vercel KV) — the rate
+limiter degrades gracefully without it, falling back to per-process memory
+(resets on restart; not shared across instances), which is fine for a
+single-node instance but not durable or shared across serverless instances:
 ```
 KV_URL=
 KV_REST_API_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ explore/page.tsx
 
 This is the local-dev set for the reference deployment; the full tier-by-tier environment reference for an instance (drivers, signing, instance identity) is [`docs/deploy.md`](docs/deploy.md).
 
-The 14 publisher-identity variables take the `PUBLISHER_` prefix as of the 2026-08-19 vocabulary settlement (Appendix J); each prior-era `EVIDENCE_` spelling is still read as a fallback, canonical-wins-when-defined, with a one-time server-side deprecation warning. `src/lib/publisher-env.ts` is the single resolver.
+The 13 publisher-identity variables take the `PUBLISHER_` prefix as of the 2026-08-19 vocabulary settlement (Appendix J); each prior-era `EVIDENCE_` spelling is still read as a fallback, canonical-wins-when-defined, with a one-time server-side deprecation warning. `src/lib/publisher-env.ts` is the single resolver. A fourteenth, the verify-side trust-registry consume override (`PUBLISHER_TRUST_REGISTRY_URL`), was retired outright in civic-ai-tools#155 P1b rather than renamed — it fed dead code on every real call path, so it was deleted along with that path instead of joining this list.
 
 Required in `.env.local`:
 ```

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ the same pass and their old filenames remain as permanent stubs.
 | --- | --- |
 | [`docs/deploy.md`](docs/deploy.md) | Self-hosted deployment end to end: bring-up, driver seams, environment reference, sign-in, migrations, storage, scheduler, managed-platform notes. |
 | [`docs/instance-setup.md`](docs/instance-setup.md) | Instance identity and signing — keygen, trust registry, identity variables. The go-to-production step. |
-| [`docs/key-rotation.md`](docs/key-rotation.md) | Signing-key rotation runbook, preventive and incident-response. |
+| [`docs/key-rotation.md`](docs/key-rotation.md) | Signing-key rotation runbook, preventive and incident-response — host/tool-agnostic. |
+| [`docs/reference-operator/key-rotation.md`](docs/reference-operator/key-rotation.md) | The same runbook's reference-deployment-specific mechanics (registry-edit PR flow, Vercel dashboard, 1Password). |
 | [`docs/api/records-publish.md`](docs/api/records-publish.md) | The publish API contract and integrator entry point. |
 | [`docs/api/records-commitment.md`](docs/api/records-commitment.md) | The public proof sidecar served for each published package. |
 | [`docs/design-principles.md`](docs/design-principles.md) | UX and data-model principles for AI-output and provenance surfaces. |

--- a/docs/api/records-publish.md
+++ b/docs/api/records-publish.md
@@ -22,6 +22,18 @@ This document describes the request and response contract so external clients ca
 > Already-published packages are byte-identical and still verify: identifiers
 > frozen inside a signature are never rewritten (Appendix J §J.4).
 
+**Substitute your own origin.** This contract describes the reference
+deployment, civicaitools.org — every `civicaitools.org` URL below that a
+client is instructed to call (sign-in, dashboard, `POST /api/records`, the
+well-known registry paths, and so on) is that deployment's concrete example.
+Running your own instance means substituting its own origin
+(`PUBLISHER_SITE_ORIGIN`; see [`docs/instance-setup.md`](../instance-setup.md))
+wherever this document names `civicaitools.org` as a host to call. Where the
+text instead states a fact about what the reference deployment itself does
+— e.g. "signed by the civicaitools.org platform" — that's describing that
+specific deployment's behavior, not instructing a reader to call that host;
+those references are left as-is.
+
 ## Repositories & layers
 
 This contract spans three repositories. If you're integrating, here's how they relate:
@@ -45,7 +57,7 @@ _Last updated: 2026-08-05 — see the [change log](#change-log) for dated change
 A successful publish:
 
 1. Builds a structured record package from the request body (canonical JSON, SHA-256 hashed).
-2. Writes the package JSON blob to Vercel Blob at `evidence-packages/<packageHash>.json` (public, content-addressable).
+2. Writes the package JSON blob to Vercel Blob at `evidence-packages/<packageHash>.json` (public, content-addressable; the `evidence-packages/` prefix is **exempt-frozen** under Appendix J — the path is hash-frozen inside every already-signed `packageUrl`, so it is recorded rather than renamed).
 3. Signs the hash with the platform Ed25519 key (Ed25519ph), requests an RFC 3161 timestamp from freetsa.org, and publishes to the Sigstore Rekor transparency log. Signing and external calls are best-effort — publishing still succeeds if any of them fail.
 4. Inserts an `evidence_records` row in the Neon Postgres database, keyed by a content-addressable slug `{title-slug}-{6-char-hex-of-packageHash}`.
 5. Returns the slug, the page URL, and the package hash.
@@ -63,7 +75,7 @@ The endpoint accepts two auth methods. **Bearer tokens are preferred for program
 External clients — Claude Code publish skills, CI jobs, local CLIs, anything not running in a signed-in browser — should authenticate with a bearer token obtained through the [device authorization grant (RFC 8628)](https://datatracker.ietf.org/doc/html/rfc8628):
 
 1. **Client starts the flow.** POST `/api/auth/device/code` with a JSON body `{ "name": "my client", "scope": "records:publish" }`. Both `records:publish` and the prior-era `evidence:publish` are accepted; an explicit request is granted **verbatim**, so a client comparing the granted scope against what it asked for still matches. Omitting `scope` mints `records:publish`. The response includes a `device_code` (opaque, client-held), a short `user_code` for the human to type, a `verification_uri`, a `verification_uri_complete` (prefilled with the user code), an `expires_in` (seconds until the codes expire — currently 900 = 15 min), and a polling `interval` (seconds between polls — currently 5).
-2. **User approves in a browser.** The client displays the `user_code` and directs the user to `verification_uri_complete`. The user signs in at civicaitools.org with GitHub if not already signed in, reviews the client name and scope, and clicks **Approve** (or **Deny**).
+2. **User approves in a browser.** The client displays the `user_code` and directs the user to `verification_uri_complete`. The user signs in (at civicaitools.org with GitHub on the reference deployment — your own instance's origin and sign-in provider otherwise) if not already signed in, reviews the client name and scope, and clicks **Approve** (or **Deny**).
 3. **Client polls for the token.** POST `/api/auth/device/token` with `{ "device_code": "..." }` at the returned interval. Responses:
     - `200 OK` with `{ access_token, token_type: "Bearer", expires_at, expires_in, scope }` — approved; save the token.
     - `400 { "error": "authorization_pending" }` — keep polling.
@@ -72,11 +84,11 @@ External clients — Claude Code publish skills, CI jobs, local CLIs, anything n
     - `400 { "error": "invalid_grant" }` — unknown or already-exchanged code.
 4. **Use the token.** Send `Authorization: Bearer <access_token>` on subsequent writes to `/api/records` and `/api/blob/upload-token`. Tokens are valid for 90 days; re-run the flow when the token expires or is revoked.
 
-Tokens are stored server-side as SHA-256 hashes — a database compromise leaks hashes, not usable tokens. Each token carries a scope. Two spellings of the publish scope exist and **both authorize identically, permanently**: `records:publish` (canonical, minted by default) and `evidence:publish` (prior era — carried by every token minted before 2026-08-19, and still mintable on explicit request). There is no migration and no token is invalidated. Future capabilities will introduce new scope names rather than widening either of these. Tokens can be revoked anytime from the [dashboard Tokens tab](https://www.civicaitools.org/dashboard); a revoked token starts returning `401` on the next request.
+Tokens are stored server-side as SHA-256 hashes — a database compromise leaks hashes, not usable tokens. Each token carries a scope. Two spellings of the publish scope exist and **both authorize identically, permanently**: `records:publish` (canonical, minted by default) and `evidence:publish` (prior era — carried by every token minted before 2026-08-19, and still mintable on explicit request). There is no migration and no token is invalidated. Future capabilities will introduce new scope names rather than widening either of these. Tokens can be revoked anytime from the [dashboard Tokens tab](https://civicaitools.org/dashboard); a revoked token starts returning `401` on the next request.
 
 ### Session cookie (legacy, browser-friendly)
 
-The endpoint still accepts a NextAuth session cookie — `__Secure-next-auth.session-token` in production, `next-auth.session-token` in development — for browser flows and one-off scripts. Sign in at `https://civicaitools.org` with GitHub, then send the cookie as a `Cookie` header. Cookie-authed writes receive an `X-Auth-Deprecated: cookie` response header and a server-side log line nudging toward bearer tokens; no removal date is set.
+The endpoint still accepts a NextAuth session cookie — `__Secure-next-auth.session-token` in production, `next-auth.session-token` in development — for browser flows and one-off scripts. Sign in (at `https://civicaitools.org` on the reference deployment, or your own instance's origin) with GitHub, then send the cookie as a `Cookie` header. Cookie-authed writes receive an `X-Auth-Deprecated: cookie` response header and a server-side log line nudging toward bearer tokens; no removal date is set.
 
 ### Server-side validation
 
@@ -156,7 +168,7 @@ Send exactly one auth header — when both are present, the `Authorization` head
 - **`datHere` requirements (OES §9.1.1)** — When `contentProfile === "datHere"`, the route additionally enforces:
     1. `promptVisibility` MUST be `"full_text"` (the A-G envelope needs section A readable). 400 with explicit error on `"hash_only"`.
     2. `summary` MUST be non-empty (section G). 400 on missing or blank.
-    3. The packager auto-emits `extensions["org.civicaitools.environment"]` with section-C metadata: `modelVersion` (from `model`), `temperature` (prototype placeholder `0` pending capture work), `mcpServers` (derived from `skillMetadata.mcpServerUrl`), `toolDefinitions` (prototype placeholder `[]`), `host` (`"civicaitools.org"`).
+    3. The packager auto-emits `extensions["org.civicaitools.environment"]` with section-C metadata: `modelVersion` (from `model`), `temperature` (prototype placeholder `0` pending capture work), `mcpServers` (derived from `skillMetadata.mcpServerUrl`), `toolDefinitions` (prototype placeholder `[]`), `host` (derived from `PUBLISHER_PUBLICATION_HOST` — see [`docs/instance-setup.md`](../instance-setup.md); `"civicaitools.org"` on the reference deployment).
     4. `summary` is also promoted to a top-level field in canonical JSON (so it is covered by the package hash); for non-datHere content profiles, `summary` continues to live on the database row only and the package JSON shape stays byte-identical to pre-ADR-0004.
   Callers supplying their own `extensions["org.civicaitools.notebook"]` (e.g., the chat-flow publish dialog) see it preserved alongside the auto-emitted environment extension.
 
@@ -321,7 +333,7 @@ await fetch('https://civicaitools.org/api/records', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    Cookie: `__Secure-next-auth.session-token=${process.env.CIVIC_EVIDENCE_SESSION_COOKIE}`,
+    Cookie: `__Secure-next-auth.session-token=${process.env.CIVIC_RECORD_SESSION_COOKIE}`,
   },
   body: JSON.stringify({
     trace: { resourceSpans: [] },
@@ -540,7 +552,7 @@ Two honesty notes integrating clients should know:
 A sealed claim is promoted to the public state by creating the publication pair:
 
 - **`POST /api/records/:slug/publish`** — authorization: publisher-only (the record's creator, via bearer token holding the publish scope under either accepted spelling, or session cookie; delegated-publisher is a future ADR per Q20). Body: `{ "runEvaluation"?: boolean, "evaluatorModel"?: string }` — see [the publication gate](#the-publication-gate-live-since-2026-06-12) for the default-on adversarial evaluation that runs first. Flow: the adversarial eval runs and its signed node is emitted; the visibility transition is a compare-and-set (a concurrent second publish loses the race and gets `409`); then the content is re-homed from its random sealed-mode capability key to the canonical hash-addressed key and two independently signed + timestamped + Rekor-included nodes are emitted:
-  1. `attestation/publishes/v1` — payload `targetNodeId` (the package's envelope hash), `publicationHost` (`"civicaitools.org"`), `releasedAt`.
+  1. `attestation/publishes/v1` — payload `targetNodeId` (the package's envelope hash), `publicationHost` (derived from `PUBLISHER_PUBLICATION_HOST` — see [`docs/instance-setup.md`](../instance-setup.md); `"civicaitools.org"` on the reference deployment), `releasedAt`.
   2. `attestation/locatedAt/v1` — payload `targetNodeId`, `uri` (the now-public content URL), `targetContentHash` (multihash; matches the target's own `contentHash` — named `targetContentHash` rather than the §8.12.1 table's `contentHash` because that key is the attestation envelope's own fingerprint; registered as open-questions Q48), optional `contentLength`.
 
   Returns `{ published: true, evaluationNodeId?, publishesNodeId, locatedAtNodeId, url }` (`evaluationNodeId` present unless `runEvaluation: false`). On pair-emission failure the canonical blob is rolled back, the visibility flip is reverted, and the record stays sealed (`500`; retryable — never half-published; an already-emitted evaluation node survives harmlessly and counts for the retry).
@@ -609,7 +621,7 @@ Hosts express the eval requirement in their self-attestation — a `content/host
 }
 ```
 
-`requiresAdversarialEvalOnPublication` accepts `false`, `true` (presence-only), or the structured form above (score floor and/or evaluator binding-tier floor — `null` means no floor on that axis). Hosts that declare a requirement refuse to serve publication records lacking a conforming evaluation; hosts that don't declare it serve either. The full host self-attestation (well-known location, transparency-log registration, third-party host evaluations) is the proposed-issue 008 deliverable and lands when that work is promoted; this contract fixes only the field shape so partner pipelines can implement the consumer-side check now.
+`requiresAdversarialEvalOnPublication` accepts `false`, `true` (presence-only), or the structured form above (score floor and/or evaluator binding-tier floor — `null` means no floor on that axis). Hosts that declare a requirement refuse to serve publication records lacking a conforming evaluation; hosts that don't declare it serve either. The full host self-attestation (well-known location, transparency-log registration, third-party host evaluations) is the proposed-issue 008 deliverable and lands when that work is promoted; this contract fixes only the field shape so partner pipelines can implement the consumer-side check now. Unlike `publicationHost` above, `hostIdentifier` is not derived from any `PUBLISHER_*` variable today — this whole node is a specified-but-unbuilt shape (nothing in `src/` constructs a `content/host/v1` node yet); when it is implemented, `hostIdentifier` is expected to be the instance's own public origin (`PUBLISHER_SITE_ORIGIN`), shown as `https://civicaitools.org` here as the reference deployment's value.
 
 ---
 
@@ -641,7 +653,7 @@ RFC 3161 timestamp and Rekor submission are non-blocking. Failures for either ar
 ### 1. Publish an analysis with `curl`
 
 ```bash
-# Preferred: $CIVIC_EVIDENCE_TOKEN holds a bearer token obtained via
+# Preferred: $CIVIC_RECORD_TOKEN holds a bearer token obtained via
 # `publish.py --login` or a direct device-flow exchange against
 # /api/auth/device/{code,token}.
 #
@@ -650,7 +662,7 @@ RFC 3161 timestamp and Rekor submission are non-blocking. Failures for either ar
 
 curl -sS -X POST https://civicaitools.org/api/records \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${CIVIC_EVIDENCE_TOKEN}" \
+  -H "Authorization: Bearer ${CIVIC_RECORD_TOKEN}" \
   -d '{
     "trace": { "resourceSpans": [] },
     "prompt": "How many 311 noise complaints did Manhattan receive last year?",
@@ -757,9 +769,9 @@ const res = await fetch('https://civicaitools.org/api/records', {
   headers: {
     'Content-Type': 'application/json',
     // Preferred bearer path:
-    'Authorization': `Bearer ${process.env.CIVIC_EVIDENCE_TOKEN}`,
+    'Authorization': `Bearer ${process.env.CIVIC_RECORD_TOKEN}`,
     // Legacy alternative (cookie):
-    // 'Cookie': `__Secure-next-auth.session-token=${process.env.CIVIC_EVIDENCE_SESSION_COOKIE}`,
+    // 'Cookie': `__Secure-next-auth.session-token=${process.env.CIVIC_RECORD_SESSION_COOKIE}`,
   },
   body: JSON.stringify({
     trace: { resourceSpans: [] },

--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -39,11 +39,16 @@ or a log.
 
 ## 2. Pick a key identifier (kid)
 
-Conventionally `platform:evidence-YYYY-MM` (the year-month you activate it).
+Conventionally `platform:record-YYYY-MM` (the year-month you activate it) —
+the settlement vocabulary (civic-ai-tools#160) for kids minted from now on.
 Keep the `platform:` prefix — it scopes the key to your instance's platform
 identity and leaves room for per-user scopes later without a registry schema
 migration. The kid is not secret; it is the registry lookup handle for the
-matching public key.
+matching public key. (The reference deployment's own live kid,
+`platform:evidence-2026-04`, predates this convention and is exempt-frozen —
+see [`docs/key-rotation.md`](key-rotation.md) — but a first-time kid on a
+new instance has no such history to preserve, so mint it under the current
+convention.)
 
 ## 3. Publish your trust registry
 
@@ -65,7 +70,7 @@ Replace the demo deployment's registry file with your own. Template:
   },
   "keys": [
     {
-      "kid": "platform:evidence-YYYY-MM",
+      "kid": "platform:record-YYYY-MM",
       "publicKey": "<base64 DER SPKI public key from step 1>",
       "signerIdentity": {
         "bindingTier": "platform",

--- a/docs/key-rotation.md
+++ b/docs/key-rotation.md
@@ -8,6 +8,13 @@ rotations (scheduled) and compromise rotations (incident response). The two
 paths differ only in the final registry status you flip the previous key to
 — `deprecated` for preventive, `revoked` for compromise.
 
+This is the host/tool-agnostic version of the runbook — it describes the
+*shape* of each step so it applies to any instance, regardless of how you
+host it or where you store secrets. For how the reference deployment
+(civicaitools.org) does each reference-specific step concretely — the
+registry-edit PR flow, the Vercel dashboard, 1Password — see
+[`docs/reference-operator/key-rotation.md`](reference-operator/key-rotation.md).
+
 ## Background
 
 Record packages are signed with an Ed25519 key referenced by a stable
@@ -97,6 +104,11 @@ verifier to fetch:
 | `PUBLISHER_TRUST_REGISTRY_CANONICAL_URL` | emit | The sidecar's `trustRegistryUrl`. Defaults to `<origin>/.well-known/typed-publisher.json`. |
 | `PUBLISHER_TRUST_REGISTRY_LEGACY_URL` | emit | The sidecar's `trustRegistryUrlLegacy`. Defaults to `<origin>/.well-known/evidence-public-keys.json`; set it to the **empty string** to omit the field entirely. Empty is not absent here — an instance with no pre-ADR-0012 client base has no legacy path to honor. |
 
+Both are read by `getSidecarTrustRegistryUrls()` in
+[`src/lib/site-config.ts`](../src/lib/site-config.ts), which the publish
+route calls to build each package's proof sidecar — this is the emit-side
+code path the table above describes.
+
 The full tier-by-tier reference is [`docs/deploy.md`](deploy.md).
 
 ## Preventive rotation
@@ -105,22 +117,29 @@ Run when the previous key has been in service long enough to warrant a
 scheduled swap. No incident. Pre-rotation record packages remain
 verifiable after the rotation.
 
-1. **Generate a new keypair outside Claude Code.** In a separate terminal:
+1. **Generate a new keypair outside any AI-agent session.** In a separate
+   terminal:
 
    ```bash
-   openssl genpkey -algorithm Ed25519 -out new-evidence.pem
+   openssl genpkey -algorithm Ed25519 -out new-signing-key.pem
    ```
 
    Derive the base64 DER PKCS8 encoding of the private key and the DER SPKI
-   encoding of the public key. Record both in 1Password as a new item named
-   after the new kid.
+   encoding of the public key. Store both securely in your secret manager,
+   under an entry named after the new kid. See
+   [`docs/reference-operator/key-rotation.md`](reference-operator/key-rotation.md)
+   for how the reference deployment does this specifically.
 
-2. **Pick a new kid.** Conventionally `platform:evidence-YYYY-MM`, bumped
-   by the rotation month. Keep the `platform:` prefix.
+2. **Pick a new kid.** Conventionally `platform:record-YYYY-MM` for kids
+   minted from now on (the settlement vocabulary — civic-ai-tools#160),
+   bumped by the rotation month. Keep the `platform:` prefix. The reference
+   deployment's live kid, `platform:evidence-2026-04`, is **exempt-frozen**
+   (Appendix J, see the per-key fields table above) and never changes —
+   rotating away from it names a successor under the new convention, it
+   does not rename the existing entry.
 
-3. **Update the trust registry.** In a PR on the `civic-ai-tools-website`
-   repo, edit
-   [`public/.well-known/evidence-public-keys.json`](../public/.well-known/evidence-public-keys.json):
+3. **Update your trust registry**, however your instance publishes config
+   changes:
 
    - Insert the new key as `active` with the new `activatedAt` ISO
      timestamp.
@@ -133,17 +152,22 @@ verifiable after the rotation.
      **every** registry edit, not only rotations — a verifier that only has a
      stale snapshot cannot see a revocation made after this date.
 
-4. **Merge and deploy the registry** before rotating env vars. Verifiers
+   See [`docs/reference-operator/key-rotation.md`](reference-operator/key-rotation.md)
+   for the reference deployment's PR-based registry-edit flow.
+
+4. **Deploy the registry** before rotating env vars. Verifiers
    must be able to see the new key before they see any package signed by
    it.
 
-5. **Update Vercel env vars.** In the Vercel dashboard (not the CLI from a
-   Claude Code session), set `PUBLISHER_SIGNING_KEY` and
-   `PUBLISHER_KEY_ID` to the new values on both production and preview.
-   (If this instance still carries the prior-era `EVIDENCE_*` names, rotating
-   is the natural moment to rename them — set the `PUBLISHER_*` pair and
-   delete the old one rather than leaving both.)
-   Trigger a redeploy.
+5. **Update your signing env vars.** Set `PUBLISHER_SIGNING_KEY` and
+   `PUBLISHER_KEY_ID` to the new values, via whatever mechanism your
+   deployment uses, on every environment that serves production traffic.
+   (If this instance still carries the prior-era `EVIDENCE_*` names,
+   rotating is the natural moment to rename them — set the `PUBLISHER_*`
+   pair and delete the old one rather than leaving both.) Redeploy or
+   restart so the new values take effect. See
+   [`docs/reference-operator/key-rotation.md`](reference-operator/key-rotation.md)
+   for the reference deployment's Vercel-dashboard mechanic.
 
 6. **Smoke test.** Publish a fresh record package, verify it via the
    `/records/[slug]` verify action (key trust should read "Signed with
@@ -159,18 +183,21 @@ two differences: the previous key becomes `revoked` rather than
 (because we cannot distinguish legitimate pre-exposure signatures from
 forged ones).
 
-1. **Rotate `PUBLISHER_SIGNING_KEY` in Vercel first.** Do not wait for the
-   registry PR. Exposure time is the variable that matters most; every
-   minute the compromised key stays active is a minute an attacker could
-   mint a forged signature.
+1. **Rotate your signing env var first.** Do not wait for the registry
+   update. Exposure time is the variable that matters most; every minute
+   the compromised key stays active is a minute an attacker could mint a
+   forged signature. See
+   [`docs/reference-operator/key-rotation.md`](reference-operator/key-rotation.md)
+   for the reference deployment's Vercel-dashboard mechanic, and why it
+   deliberately isn't done from the CLI inside an AI-agent session.
 
-2. **Generate the new keypair, pick a new kid, update 1Password** as in
-   preventive rotation.
+2. **Generate the new keypair, pick a new kid, and store both securely** as
+   in preventive rotation.
 
 3. **Update the trust registry.** Insert the new key as `active`, flip the
    compromised key's `status` to `revoked`, set `revokedAt` to the exposure
    detection timestamp (or earlier if known), and leave `deprecatedAt` as
-   `null`. Merge and deploy.
+   `null`. Deploy.
 
 4. **Audit exposed packages.** Enumerate every package previously signed
    with the revoked key. Withdraw any that cannot be re-published (public
@@ -183,22 +210,35 @@ forged ones).
    key trust row should read "Key revoked — do not trust" and its
    `verified` flag should be `false`.
 
-6. **Post-mortem.** Write up the exposure vector and add any new harness
-   controls (PreToolUse hook patterns, deny rules, 1Password migrations)
-   to the security hardening plan.
+6. **Post-mortem.** Write up the exposure vector and add any new controls
+   (secret-manager migrations, access-pattern guardrails, agent-harness
+   deny rules) to your security hardening plan. See
+   [`docs/reference-operator/key-rotation.md`](reference-operator/key-rotation.md)
+   for the reference deployment's specific checklist.
 
 ## Notes
 
-- Never paste private key material into a Claude Code session. Always use a
-  separate terminal for key generation and 1Password for storage.
+- Never paste private key material into an AI-agent session. Always use a
+  separate terminal for key generation, and store the result in your secret
+  manager. See
+  [`docs/reference-operator/key-rotation.md`](reference-operator/key-rotation.md)
+  for the reference deployment's specific tooling.
 - Rekor entries from the previous key remain in the transparency log
   forever — that's by design. After rotation, those entries are still
   fetchable but verifying them against the trust registry applies the new
   `deprecated` or `revoked` semantics.
 - The in-memory registry cache on the verify route is scoped to the
-  serverless function instance. After the registry file changes, callers
-  may see the old file for up to an hour per warm instance; force
-  invalidation by redeploying.
+  running process, not to any one deployment topology. After the registry
+  file changes, callers may see the old file for up to an hour per warm
+  process — until that process is replaced or restarted. What "force
+  invalidation" means depends on your deployment:
+  - **Serverless (e.g. Vercel).** A redeploy spins up fresh function
+    instances, which is sufficient — each starts with an empty cache.
+  - **Long-lived process (e.g. this repo's `docker-compose.yml`, where the
+    app runs as one `restart: unless-stopped` container).** A "redeploy"
+    doesn't happen automatically the way it does on Vercel; the equivalent
+    action is restarting the app service — `docker compose restart app`,
+    or whatever your actual redeploy mechanism is.
 - When rotating the kid, every subsequent published package hashes the new
   kid into its canonical JSON. Pre-rotation packages keep their old kid
   baked in, so the verify route must look up both old and new keys in the

--- a/docs/reference-operator/key-rotation.md
+++ b/docs/reference-operator/key-rotation.md
@@ -1,0 +1,66 @@
+# Key rotation — reference deployment specifics
+
+The generic runbook at [`docs/key-rotation.md`](../key-rotation.md) describes
+key rotation in host/tool-agnostic terms so it applies to any instance. This
+page collects the parts that are specific to how the **reference
+deployment** (civicaitools.org, this repo's own production) actually carries
+out each step: the PR flow for editing the trust registry, the Vercel
+dashboard for signing env vars, and 1Password for key storage. Where the
+generic runbook says "see the reference-operator doc," the matching
+procedure is here.
+
+Follow the generic runbook for the rotation itself — what to do and in what
+order. Come here for how the reference deployment does that concretely.
+
+## Storing key material
+
+The reference deployment records a newly generated keypair in 1Password, as
+a new item named after the new kid (this is what generic preventive-rotation
+step 1 / compromise-rotation step 2 mean by "store both securely in your
+secret manager").
+
+Never paste private key material into a Claude Code session — always use a
+separate terminal for key generation, then hand the derived base64 values to
+1Password for storage.
+
+## Updating the trust registry (PR flow)
+
+In a PR on the `civic-ai-tools-website` repo, edit
+[`public/.well-known/evidence-public-keys.json`](../../public/.well-known/evidence-public-keys.json):
+
+- Insert the new key as `active` with the new `activatedAt` ISO timestamp.
+- Flip the previous key's `status` to `deprecated` (preventive rotation) or
+  `revoked` (compromise rotation), set the matching `deprecatedAt` or
+  `revokedAt` to the same ISO timestamp, and leave the other status-date
+  field `null`.
+- Bump the document-level `generatedAt` to the current ISO timestamp.
+
+Merge and deploy the registry before rotating env vars — verifiers must be
+able to see the new key before they see any package signed by it.
+
+## Updating signing env vars (Vercel)
+
+In the Vercel dashboard (**not** the CLI from a Claude Code session), set
+`PUBLISHER_SIGNING_KEY` and `PUBLISHER_KEY_ID` to the new values on both
+production and preview, then trigger a redeploy.
+
+For a **compromise rotation**, do this step first, before the registry PR —
+exposure time is the variable that matters most, and setting the env var in
+the Vercel dashboard is faster than waiting on a PR merge. This is also why
+the reference deployment does this from the dashboard rather than scripting
+it from a Claude Code session: a compromised-key rotation is exactly the
+moment you don't want a private key value passing through an agent session,
+even transiently.
+
+## Post-mortem checklist
+
+The reference deployment's post-mortem checklist for a compromise rotation
+includes reviewing the Claude Code PreToolUse hook patterns and deny rules
+that touched the exposed key, and any 1Password migrations needed to close
+the exposure vector — the concrete instances of the generic runbook's
+"access-pattern guardrails" and "secret-manager migrations" post-mortem
+items.
+
+---
+
+Back to the generic runbook: [`docs/key-rotation.md`](../key-rotation.md).

--- a/scripts/publish-with-blob-ref.mjs
+++ b/scripts/publish-with-blob-ref.mjs
@@ -64,6 +64,9 @@ const SAMPLE_OUTPUT = [
 ].join('\n');
 const OUTPUT_BYTES = new TextEncoder().encode(SAMPLE_OUTPUT);
 const OUTPUT_HASH = crypto.createHash('sha256').update(OUTPUT_BYTES).digest('hex');
+// `evidence-refs/` is exempt-frozen under Appendix J (civic-ai-tools#160): the
+// prefix is hash-frozen inside every already-signed BlobRef, so it's
+// recorded rather than renamed. See docs/api/records-publish.md.
 const OUTPUT_PATHNAME = `evidence-refs/${OUTPUT_HASH}.md`;
 const OUTPUT_CONTENT_TYPE = 'text/markdown';
 


### PR DESCRIPTION
## Summary

Phase P2 of civic-ai-tools#155, following P1/P1b (both merged: #291, #292). Anchor: https://github.com/npstorey/civic-ai-tools/issues/155.

**Model disclosure:** IMPL ran on Sonnet 5; ORCH on Sonnet 5 with Opus 5 as advisor.

### B1/B2 — split `docs/key-rotation.md` (R1)
Generic runbook (`docs/key-rotation.md`) now describes each step in host/tool-agnostic terms; every reference-operator-specific mechanic (the registry-edit PR flow, the Vercel dashboard, 1Password) relocated to a new `docs/reference-operator/key-rotation.md`, cross-linked both directions. No-information-loss content-moved checklist verified against the diff by ORCH: every relocated procedure has a named new home, nothing summarized away.

### R2 (B2a) — new-kid vocabulary
`platform:record-YYYY-MM` recommended for kids minted from now on; the reference deployment's live kid (`platform:evidence-2026-04`) stated as exempt-frozen and never renamed. Applied consistently across `key-rotation.md` and `docs/instance-setup.md` (the charter's B2a row named both files).

### B2b — container cache invalidation
The registry-cache "force invalidation by redeploying" note now covers both topologies: a Vercel redeploy (fresh function instances) and a `docker-compose` long-lived process (`docker compose restart app`). No new cache-clear endpoint added — a docs gap, not a code gap (confirmed `clearTrustRegistryCache()` has no production caller).

### B3/B3a/B3b/B3c — `docs/api/records-publish.md` portability pass
Substitute-your-origin framing sentence added; sign-in-flow instructional references genericized; dashboard link fixed from `www.` to apex (consistent with P1's code-side precedent removing the `www.` default); `PUBLISHER_PUBLICATION_HOST` cross-referenced as the actual source of `host`/`publicationHost` example values (previously shown as hardcoded literals). Curl/fetch worked examples left literal per judgment, with the framing note covering substitution. Illustrative placeholder env vars `CIVIC_EVIDENCE_TOKEN`/`CIVIC_EVIDENCE_SESSION_COOKIE` renamed to `CIVIC_RECORD_*` — confirmed zero code/test references to the old names in either repo, purely a doc example rename.

### B4 — registry-URL code path
Added one sentence naming `getSidecarTrustRegistryUrls()` in `src/lib/site-config.ts` as the emit-side code path — confirmed still accurate at current SHA.

### E14 — KV requirement self-contradiction
`CLAUDE.md:234` reframed from "Required in production" to "Recommended, not required — degrades gracefully," matching `docs/deploy.md`'s already-correct language.

### N3 — frozen blob-key framing
`evidence-packages/` given the same exempt-frozen framing sentence already present for `evidence-refs/`; a matching one-line comment added in `scripts/publish-with-blob-ref.mjs`.

### N4/R7 — prose classification pass
Every old-vocabulary occurrence in `README.md`, `CLAUDE.md`, `docs/instance-setup.md`, `docs/api/records-publish.md` classified: framed-and-kept or fixed. `records-publish.md`'s `EVIDENCE_` count dropped from 14 to 9 (5 unframed illustrative placeholders fixed); the rest — alias tables, historical changelog entries — correctly left as framed prior-era references.

### Fix-on-top (ORCH catch, one round)
`CLAUDE.md:213` still said "The 14 publisher-identity variables" in live present-tense prose — stale since P1b's retirement dropped the real count to 13. Fixed and distinguished from `records-publish.md:824`'s identical-looking "14 publisher variables," which is correctly left untouched inside a dated historical changelog entry.

## Verification (ORCH-independent, this session)
- `npm test`: 840/840 pass (re-ran at both pre- and post-fix-on-top heads)
- `npm run lint`: 0 errors, 4 pre-existing warnings (unrelated files)
- `npm run typecheck`: clean
- `npm run check:compose-env`: PASS
- Pre-push sensitivity scan: 0 matches across all 5 commits
- `gitleaks detect`: no leaks
- All 5 commits carry `Signed-off-by: Nathan Storey <npstorey@users.noreply.github.com>`, literal match to author
- Verified relative links in the new `docs/reference-operator/key-rotation.md` resolve; verified zero remaining `CIVIC_EVIDENCE_*` references anywhere in either repo; re-ran the N4 census myself and confirmed IMPL's reported counts exactly

## Test plan
- [x] Full test suite passes
- [x] Lint/typecheck/compose-env clean
- [x] No-information-loss: every relocated key-rotation procedure has a verified new home
- [x] Zero unframed old-vocabulary residue in touched files (classification counts above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)