### PR TITLE
Rebuild the project instruction layer: CLAUDE.md 374 -> 120 lines, path-scoped rules, committed agents and hooks

### DIFF
--- a/.claude/agents/cold-read.md
+++ b/.claude/agents/cold-read.md
@@ -1,0 +1,40 @@
+---
+name: cold-read
+description: Fresh-context reviewer for a finished PR in this repo — reads only the diff, the repo's docs, and the stated acceptance criteria, and reports gaps that affect correctness or the stated requirements. Fixes nothing.
+---
+
+You are a cold reader. Your value is that you did not watch the work happen.
+
+**What you read:** the PR diff, the repo's own documentation (`CLAUDE.md`, `.claude/rules/`, the
+`docs/` files the diff touches), and the acceptance criteria you were given. That is the whole
+inventory.
+
+**What you must not read:** the implementation chat, the ORCH transcript, the phase contract's
+reasoning, or any account of how the change came to be. If someone offers you that context, decline
+it. A verdict coloured by the author's assumptions is the one thing a cold read cannot produce.
+
+**What you report:** gaps that affect **correctness** or **the stated requirements**. Specifically:
+
+- a stated acceptance criterion the diff does not actually meet;
+- a defect in the changed code — wrong behaviour, an unhandled case, a broken invariant;
+- a claim in the diff (a comment, a doc line, a commit message, a PR-body assertion) that is false
+  against the code at this revision;
+- a check the criteria required that the evidence does not show being run.
+
+**What you leave alone:** style, naming, structure you would have done differently, refactors the
+criteria did not ask for, and anything outside the diff. Preference is not a finding.
+
+**You fix nothing.** No edits, no commits, no pushes, no suggested patches applied. Your output is a
+report.
+
+Your report:
+
+1. **What I ran** — the exact commands and their results, or an explicit statement that you ran
+   nothing and reviewed by reading only.
+2. **Findings** — most severe first. Each one: file and line, what is wrong, and the concrete
+   scenario in which it is wrong. If a finding is a suspicion rather than a confirmation, label it
+   as such.
+3. **Criteria** — each stated acceptance criterion, marked met / not met / cannot tell from the
+   diff, with one line of reasoning.
+4. **Nothing found** is a complete and useful report. Say it plainly; do not manufacture findings to
+   justify the pass.

--- a/.claude/agents/impl.md
+++ b/.claude/agents/impl.md
@@ -1,0 +1,42 @@
+---
+name: impl
+description: IMPL agent for one gated-sprint phase in this repo — implements the phase on its own branch and reports evidence per CLAUDE.md. Spawned by an ORCH session with a phase contract from a sprint anchor issue.
+---
+
+You are the IMPL agent for exactly one phase of a gated sprint in `civic-ai-tools-website`.
+
+Your phase contract arrives from the ORCH session: task, context, non-goals, binary acceptance
+criteria with runnable checks, blast zone, riders. This file is the standing part — what is true of
+every phase here regardless of what the contract says.
+
+Ground rules:
+
+- **Read before porting — verify, don't trust.** Read the sprint contract (anchor issue) and your
+  phase definition, then the referenced source material itself. A premise in the contract that does
+  not match the repo at HEAD gets flagged, not silently resolved. Paths, commands, and line
+  references in a contract are claims to check, not facts to act on.
+- **One branch per phase**, named as the phase plan specifies; PR to `main`. You do not merge, do
+  not push rollback tags, and never deploy — ORCH handles merge and tags on evidence-pass. Never
+  push to `main`.
+- **Stay inside the declared blast zone.** Keep the diff confined to the paths the phase names;
+  repos and paths the contract marks read-only stay untouched. Out-of-scope findings go in the phase
+  report as flags for later phases — do not fix them.
+- **Follow CLAUDE.md**: the stakeholder boundary (neutral phrasing in every artifact that lands in
+  this public repo), secret hygiene, and the rules section. Read `.claude/rules/` entries for the
+  paths you are touching. `git commit -s` on every commit — the DCO trailer must match the author
+  email exactly.
+- **Never bypass a guard.** If a hook or the pre-push guard blocks, resolve the cause and rebuild
+  the branch history so the flagged bytes never land in outgoing commits. Surface the block in your
+  report; escalate to the owner rather than working around it.
+
+Phase report (your final message, mirrored into the PR body):
+
+- branch + diff stat, with an explicit blast-zone statement;
+- full output of every check CI gates on — `npm test`, `npm run build`, `npm run typecheck`,
+  `npm run lint`, `npm run check:compose-env` — pasted, not summarized. Run `npm ci` first: a stale
+  `node_modules` produces failures that look like code defects;
+- the model you ran on;
+- everything flagged-not-fixed, and every contract premise that did not survive the check.
+
+Report outcomes faithfully — a red test, a skipped step, or a partial phase is reported as such,
+never smoothed over.

--- a/.claude/hooks/drizzle-migrate-guard.sh
+++ b/.claude/hooks/drizzle-migrate-guard.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# PreToolUse:Bash guard — escalate schema-applying drizzle-kit runs to the owner.
+#
+# WHY. `drizzle-kit migrate` against the remote database can print its normal
+# output and exit 0 without applying anything: on the @neondatabase/serverless
+# path an authentication failure is swallowed and looks byte-for-byte like
+# "no migrations to run". A migration lost that way is discovered later, in
+# production, under time pressure. This hook makes the owner see the run and
+# attaches the only reliable detection — the psql read-back — to the prompt.
+# The trapdoors are written up in docs/db-migrations.md.
+#
+# CONTRACT. PreToolUse decisions are allow | deny | ask ("escalate to the user"
+# is spelled "ask"; "escalate" is not a value the CLI accepts). This hook never
+# denies: applying a migration is legitimate work, it just must not happen
+# unattended. Exit 0 with no output on every other command, so the normal
+# permission flow is untouched.
+#
+# Matches drizzle-kit migrate/push however it is spelled: directly, via npx, or
+# through the package scripts (npm run db:migrate). `drizzle-kit generate` and
+# `drizzle-kit studio` are deliberately NOT matched — neither applies schema.
+
+set -uo pipefail
+
+input=$(cat)
+
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -n "$command" ] || exit 0
+
+applies_schema=0
+
+# drizzle-kit migrate | drizzle-kit push, with any flags between the two words
+# ruled out: the subcommand is the first bare word after the binary name.
+if printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]_./-])drizzle-kit[[:space:]]+(migrate|push)([[:space:]]|$)'; then
+  applies_schema=1
+fi
+
+# The package scripts that wrap them (see package.json: db:migrate).
+if printf '%s' "$command" | grep -Eq '(npm|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?db:(migrate|push)([[:space:]]|$)'; then
+  applies_schema=1
+fi
+
+[ "$applies_schema" -eq 1 ] || exit 0
+
+reason='verify with psql after — drizzle-kit can print success without applying. A clean exit is not proof: on the remote @neondatabase/serverless path an auth failure produces output identical to "no migrations to run". Read the schema back with `op run --env-file=.env.local -- sh -c '"'"'psql "$DATABASE_URL" -c "\d <table>"'"'"'` before reporting the migration applied. See docs/db-migrations.md.'
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "ask",
+    permissionDecisionReason: $reason
+  }
+}'
+exit 0

--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "drizzle/**"
+  - "src/lib/db/**"
+---
+
+# Database and migrations
+
+Before generating, applying, or reviewing a migration, read
+[`docs/db-migrations.md`](../../docs/db-migrations.md). It carries the failure modes that make a
+migration run *look* like it worked:
+
+- **A clean exit from `drizzle-kit migrate` is not proof.** On the remote `@neondatabase/serverless`
+  path an authentication failure produces output identical to "no migrations to run". Verify with a
+  direct `psql` read-back every time.
+- **`op run` needs an `sh -c` wrapper** whenever the payload dereferences an injected variable, or
+  the outer shell expands it to empty first and `psql` silently connects to local defaults.
+- **Never point a local stack at `.env.local`.** `docker compose up` runs the one-shot `migrate`
+  service against the in-stack Postgres before the app boots; `.env.local` holds hosted-database
+  credentials, and sourcing it into a "local" migrate run is how a remote database gets migrated by
+  accident.
+
+[`docs/deploy.md`](../../docs/deploy.md#database-and-migrations) is the operator-facing companion:
+the compose path, the direct path for fork operators, and why the visibility-rename pair `0014` +
+`0015` must stay two files in that order.
+
+Commands: `npm run db:generate` (author), `npm run db:migrate` (apply), `npm run db:studio`.
+A `PreToolUse` hook (`.claude/hooks/drizzle-migrate-guard.sh`) escalates `drizzle-kit
+migrate`/`push` to the owner with the read-back reminder attached — that prompt is the rule, not an
+obstacle to route around.

--- a/.claude/rules/evidence-surfaces.md
+++ b/.claude/rules/evidence-surfaces.md
@@ -1,0 +1,40 @@
+---
+paths:
+  - "src/lib/evidence/**"
+  - "src/app/api/evidence/**"
+  - "src/components/evidence/**"
+---
+
+# Record surfaces
+
+You are in the record-system core — packaging, signing, verification, provenance, attestation,
+lifecycle — or in one of the surfaces that renders it. Four pointers before you change anything here.
+
+- **[`docs/design-principles.md`](../../docs/design-principles.md)** — read it before changing the
+  record detail page, chat output rendering, the provenance graph, or any other AI-output /
+  attestation surface. Disclosure not validation, hierarchy not equality, narrative not metadata,
+  axes not chips, user language not implementation language.
+- **[`docs/api/records-publish.md`](../../docs/api/records-publish.md)** — the record-publish
+  contract, including the repositories-and-layers orientation.
+- **[`civic-ai-tools/docs/trust-and-evidence.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/trust-and-evidence.md)**
+  — what a published record does and does not establish for a reader. A signature attests that the
+  package was signed and is unaltered; it does not attest that the labelled capture mechanism ran.
+  Read it before writing any copy that tells a reader what verification proves.
+- **Canonical spec drafts** live in
+  [`civic-ai-tools/docs/architecture/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/architecture)
+  — package shape, signing, `captureMethod`, withdrawal, the typed-claims layer. Sections with open
+  questions carry `⚠ Subject to Open Question #N` callouts pointing at `open-questions.md`. Where
+  this codebase diverges from a draft, the codebase wins and the spec gets updated to match.
+
+## The directory name is not a rename candidate
+
+`src/lib/evidence/`, `src/app/api/evidence/`, `src/components/evidence/` and the type names inside
+them stay on the prior-era spelling. The 2026-08-19 vocabulary settlement (Appendix J) renamed the
+wire and reader-facing vocabulary to "record"; these are internal identifiers that never cross the
+wire, and it deliberately left them alone. Do not "finish the rename" here.
+
+What *is* reader-facing and did move: the routes (`/records`, `/api/records/*`, with `/evidence` and
+`/api/evidence/*` kept as permanent aliases — the route files under `src/app/api/records/` are thin
+re-exports of the implementations here) and the 13 `PUBLISHER_`-prefixed environment variables, each
+of which still reads its prior-era `EVIDENCE_` spelling as a fallback through the single resolver at
+`src/lib/publisher-env.ts`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/drizzle-migrate-guard.sh",
+            "timeout": 5,
+            "statusMessage": "Checking for schema-applying migrations..."
+          }
+        ]
+      }
+    ]
+  },
+  "sandbox": {
+    "_shakedown": "Measured 2026-08-22 with enabled:true. `npm ci` passed under the sandbox, so the allowlist and excludedCommands below are right. The rest of the check set needs loopback socket binds, which the sandbox denies: `npm test` went 872 pass/0 fail -> 870 pass/2 fail, both `listen EPERM: operation not permitted 127.0.0.1` in src/lib/openrouter-streaming.test.ts (issue #249), and `npm run build` died with 'binding to a port / Operation not permitted (os error 1)' in Turbopack's PostCSS worker pool. Hence enabled:false. TWO THINGS WORTH KNOWING BEFORE YOU FLIP IT BACK. (1) Enabling the sandbox once is sticky for the rest of that session: after flipping to false, in-process binds and `npm test` recovered (872/0) but every SPAWNED process still hit the bind denial, and `npm run build` stayed red even with this whole file moved aside. Start a fresh session to measure, not a flipped one. (2) `npx next build --webpack` builds clean under exactly those conditions, because it skips the worker pool — which is the CLAUDE.md rule, confirmed rather than assumed.",
+    "enabled": false,
+    "allowUnsandboxedCommands": false,
+    "excludedCommands": ["gh *", "git *"],
+    "filesystem": {
+      "allowWrite": ["~/.npm"]
+    },
+    "network": {
+      "allowedDomains": [
+        "registry.npmjs.org",
+        "github.com",
+        "api.github.com",
+        "objects.githubusercontent.com",
+        "codeload.github.com",
+        "openrouter.ai",
+        "socrata-mcp-server.onrender.com",
+        "api.datacommons.org",
+        "fonts.googleapis.com",
+        "fonts.gstatic.com"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 civic-ai-tools-website
 scripts/eval-results-*.json
 .env*.bak
+
+# claude code — personal overrides only; the rest of .claude/ is committed
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,374 +1,120 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-The reference implementation of a record-publishing platform for AI-assisted analysis of civic open data. Users ask plain-language questions about public data; the app answers them against live sources through MCP (Model Context Protocol) servers, can re-run an analysis as an executed notebook, and packages the result as a **signed record package** anyone can verify independently. The side-by-side comparison of a model answering with and without live data access is one of the surfaces the app offers — the thing it publishes is the record. Built with Next.js (App Router) in TypeScript, deployed on Vercel for the reference deployment.
-
-**Production URL:** https://civicaitools.org/
+The reference implementation of a record-publishing platform for AI-assisted analysis of civic open
+data: users ask plain-language questions, the app answers them against live sources through MCP
+servers, and packages each result as a **signed record package** anyone can verify independently.
+Next.js (App Router) + TypeScript; reference deployment https://civicaitools.org/.
 
 ## Strategic context — what not to include in this repo
 
-This repo is public. Strategic and relationship context — specific external stakeholders, prospective collaborators, pre-meeting strategy, private outreach plans, named individuals' opinions or quotes — lives in local-only planning docs outside this repo (workspace `CLAUDE.md`, `ROADMAP.md`, per-user auto-memory), not here.
-
-When contributing code, docs, commit messages, issue bodies, PR descriptions, or starter prompts for implementation chats that will commit to this repo, use neutral phrasing: "an external stakeholder," "an upcoming demo," "a follow-up meeting" — not specific names. If a task prompt you received includes strategic context, scrub it before producing any content destined for this repo.
+This repo is public. Strategic and relationship context — specific external stakeholders,
+prospective collaborators, pre-meeting strategy, private outreach plans, named individuals' opinions
+or quotes — lives in local-only planning docs outside this repo. In code, docs, commit messages,
+issues, PRs, and starter prompts destined for this repo use neutral phrasing ("an external
+stakeholder," "an upcoming demo"); if a prompt you received carries strategic context, scrub it.
 
 ## Secret hygiene
 
-Never `cat`, `head`, `tail`, or otherwise dump the full contents of `.env*` files, `auth.json` files, `credentials*` files, `*.pem`, `*.key`, or any file under `~/.ssh`, `~/.aws`, or `~/Library/Application Support/*/auth.json`. If you need a single env var value, `grep '^VAR_NAME=' .env.local` for just that variable name (not the value). For CLI session tokens, prefer running the CLI command directly over reading its session file. If you think you need to dump a secrets file, stop and ask first.
-
-This repo's `.env.local` contains critical infrastructure secrets including the Ed25519 signing key (`PUBLISHER_SIGNING_KEY`, still read under its prior-era name `EVIDENCE_SIGNING_KEY`) that anchors the cryptographic chain over published records. Secrets live in 1Password — `.env.local` files contain only `op://` references, not real values. Never generate, display, or handle signing keys or other sensitive values from within a Claude Code session; use a separate terminal.
+Never `cat`, `head`, `tail`, or otherwise dump `.env*`, `auth.json`, `credentials*`, `*.pem`, `*.key`, or
+anything under `~/.ssh` or `~/.aws`; for one variable, `grep '^VAR_NAME=' .env.local` — the name, never the
+value. Secrets belong in 1Password and reach a process through `op run`; `.env.local` should hold `op://`
+references rather than literals (migration open: civic-ai-tools-website#101 — assume literals are still on
+disk). `PUBLISHER_SIGNING_KEY` (still read under its prior-era name `EVIDENCE_SIGNING_KEY`) is the Ed25519
+key anchoring the cryptographic chain over every published record: never generate, display, or handle a
+signing key inside a Claude Code session — use a separate terminal. A sandboxed agent session **does**
+execute the global pre-push sensitivity hook (measured via `GIT_TRACE=1`, even against a filesystem
+remote) — don't design an owner-run leg around the assumption that it doesn't.
 
 ## Commands
 
-```bash
-# Development
-npm run dev          # Start dev server at localhost:3000
-npm run build        # Production build
-npm run start        # Start production server
-npm run lint         # Run ESLint
-```
+| Command | Healthy output |
+|---|---|
+| `npm test` | `# pass 872` / `# fail 0` (`node --test` TAP summary) |
+| `npm run build` | `✓ Compiled successfully`, then the Route (app) table |
+| `npm run typecheck` | no output, exit 0 — **run after `npm run build`** (tsconfig includes `.next/types`, which the build emits) |
+| `npm run lint` | `✖ 4 problems (0 errors, 4 warnings)` — warnings are the baseline; **zero errors** is the gate |
+| `npm run check:compose-env` | `RESULT: PASS — every variable this profile reads can reach the container.` |
+| `npm run check:standalone` | `[standalone-assets] OK — 3 runtime-read asset(s) present and byte-identical` — needs a standalone build first; `npm run build:standalone` does both |
+| `npm run dev` | dev server on localhost:3000 |
+
+CI (`.github/workflows/ci.yml`) runs the first five plus a `.well-known` byte-identity check and is
+**credential-free by construction** — never add a `secrets.` reference or a placeholder-credential
+`env:` block to make a step pass; the keyless build is the invariant it protects. `check:standalone`
+runs in the paths-filtered, deliberately-not-required `standalone.yml`. A stale `node_modules` fails
+tests in ways that look like code defects — `npm ci` first.
 
 ## Information Architecture
 
-Each page has a distinct purpose. Use this framing to decide where new features belong:
-
-| Page | Route | Star of the page | User goal |
-|------|-------|-------------------|-----------|
-| **Home** | `/` | The result content | "Show me why MCP matters" |
-| **Explore** | `/explore` | The process | "Show me how this works" |
-| **About** | `/about` | The prose | "Explain this to me" |
-| **Project** | `/project` | Mission + proof | "What is this project, and does it work?" |
-| **Learn** | `/learn` | Educational content | "Teach me the concepts" |
-| **Record index** | `/records` | The published registry | "Show me what's been published" |
-| **Record detail** | `/records/[slug]` | One signed analysis | "Let me scrutinize this analysis" |
-| **Directory** | `/directory` | MCP-server inventory | "What sources can I connect to?" |
-| **Roadmap** | `/roadmap` | Plans + commitments | "Where is this project going?" |
-| **Dashboard** | `/dashboard` | The user's own publishes | "Manage my records" |
-| **Ask** | `/ask` | The query form (signed-in) | "Answer a question against live data and publish it" |
-
-`/ask` is the signed-in query mount (app front-door v0.1.0): the same shared `QuerySurface` as home, in signed-in configuration — app-private in the host topology (`src/lib/host-routing.ts`), so it 404s on the marketing host and is where the app host's `/` redirects.
-
-(`/auth/device` is the device-flow pairing screen; `/dev/notebook-preview` is a dev-only preview harness, not user-facing.)
-
-The BPMN visualization lives on `/explore`. The About page is purely educational prose with a CTA linking to `/explore`.
-
-## Design principles
-
-UX and data-model principles for AI-output and provenance surfaces are documented at [`docs/design-principles.md`](docs/design-principles.md). Read before making changes to the record detail page, chat output rendering, provenance graph, or any other AI-output / attestation surface. The five-word summary: **disclosure not validation, hierarchy not equality, narrative not metadata, axes not chips, user language not implementation language.**
-
-## Architecture documentation
-
-Canonical architecture documents and spec drafts live in the hub repo at [`civic-ai-tools/docs/architecture/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/architecture). Read before making changes that touch the record-package shape, signing/verification, captureMethod, withdrawal lifecycle, typed-claims layer, or any other surface where the spec is authoritative. The Open Evidence Standard and Civic Claim Vocabulary drafts are both internal working drafts (pre-v0.1, not for external review); sections subject to open questions are marked inline with `⚠ Subject to Open Question #N` callouts. The canonical home for unresolved architectural decisions is [`open-questions.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/open-questions.md) — spec sections cite by Q-number. The project's discipline for moving questions through to resolution is documented in [`working-method.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/working-method.md) (companion to `xanadu-doctrine.md`); the registry is the front door, GitHub issues are the execution back end, ADRs record settled decisions, specs reflect canonical state. The same doctrine also covers memory and instruction surfaces (CLAUDE.md / MEMORY.md) with their own inclusion conditions. The third companion doctrine, [`chat-type-taxonomy.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/architecture/chat-type-taxonomy.md), governs conversation surfaces — which kind of chat (strategic, planning, orchestration, implementation, meta) is appropriate for which kind of work; together the three doctrines cover spec growth (Xanadu), surface content placement (working method), and conversational surface (chat-type taxonomy). When this codebase diverges from the spec drafts, the codebase wins and the spec gets updated to match.
-
-## Architecture
-
-```
-Frontend (Next.js App Router + Tailwind CSS)
-    │
-    ├── / (home)           → Query form + side-by-side streaming results
-    ├── /explore           → BPMN diagram + trace replay + live queries
-    ├── /about             → Educational prose, system prompt disclosure, CTA to /explore
-    │
-API Routes (Serverless)
-    ├── POST /api/compare        → Runs parallel LLM calls (with/without MCP)
-    ├── GET  /api/compare-stream → SSE streaming endpoint for live queries
-    ├── GET  /api/models         → Available models list
-    ├── GET  /api/rate-limit     → User quota status
-    └── /api/auth/[...nextauth]  → GitHub OAuth
-    │
-External Services
-    ├── Model endpoint (OpenAI-compatible; OpenRouter by default, swappable via MODEL_API_BASE_URL)
-    ├── socrata-mcp-server (Socrata data via HTTP/SSE at /mcp endpoint)
-    └── Upstash Redis via @vercel/kv (Rate limiting)
-```
-
-The diagram shows the comparison path as the reference deployment runs it. The stack is not hardwired to these services: the model endpoint (`src/lib/model-client.ts`), the Postgres database, the blob-storage driver (`src/lib/storage/`), and the notebook-executor driver (`src/lib/sandbox/`) are all configurable seams. [`docs/deploy.md`](docs/deploy.md) is the reference for the driver decisions and what each seam accepts.
-
-## Key Implementation Details
-
-### OpenRouter Integration (`lib/openrouter.ts`)
-- Uses `openai` npm package with `baseURL: 'https://openrouter.ai/api/v1'`
-- Tool calling follows OpenAI function calling format
-- Same model used for both with/without MCP comparisons
-- **Tool iteration cap** to prevent infinite loops — see `maxIterations` in `src/lib/openrouter-streaming.ts` for the current value (cited rather than restated here so this line can't drift out of sync with the code)
-- **Force final response**: If iteration limit hit with no content, makes one more call without tools to get a summary
-
-### MCP Tool Execution Flow
-1. OpenRouter returns `tool_calls` in response
-2. Backend intercepts and calls socrata-mcp-server via HTTP POST to `/mcp`
-3. Server uses JSON-RPC format with SSE response
-4. Tool results returned to model for final response
-
-### MCP Server Communication (`lib/mcp/client.ts`)
-```typescript
-// 1. Initialize session first:
-POST ${SOCRATA_MCP_URL}/mcp
-Headers: { 'Accept': 'application/json, text/event-stream' }
-Body: {
-  jsonrpc: '2.0',
-  id: Date.now(),
-  method: 'initialize',
-  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: {...} }
-}
-// Response header contains: mcp-session-id
-
-// 2. Make tool calls with session ID:
-POST ${SOCRATA_MCP_URL}/mcp
-Headers: { 'mcp-session-id': sessionId }
-Body: {
-  jsonrpc: '2.0',
-  id: Date.now(),
-  method: 'tools/call',
-  params: { name: 'get_data', arguments: { type: 'query', portal: '...', ... } }
-}
-```
-
-### MCP Tool Types (`lib/mcp/tools.ts`)
-The `get_data` tool supports these operation types:
-- `catalog`: Search for datasets matching a query
-- `metadata`: Get metadata about a specific dataset (pass dataset_id in `query` param)
-- `query`: Execute a SoQL query against a dataset
-- `metrics`: Get metrics/statistics about a dataset
-
-### Socrata Skill Module (`lib/mcp/socrata-skill.ts`)
-Domain knowledge injected into the LLM system prompt:
-- Known dataset IDs and key fields for NYC, Chicago, SF
-- SoQL query patterns and syntax
-- **SoQL date functions** (NOT standard SQL!): `date_trunc_ym()`, `date_extract_m()`, etc.
-- Anti-hallucination guidelines
-- Portal-specific guidance
-
-### Rate Limiting (`lib/rate-limit.ts`)
-- Anonymous: 10 requests/day (tracked by IP)
-- Authenticated: 25 requests/day (tracked by GitHub user ID)
-- Key format in Upstash: `rate:{user_id_or_ip}:{YYYY-MM-DD}`
-- Falls back to in-memory store if KV not configured (resets on deploy)
-
-### Streaming & SSE (`lib/streaming.ts`, `lib/sse-client.ts`, `lib/openrouter-streaming.ts`)
-- Home page uses SSE via `/api/compare-stream` for real-time progress updates
-- Progress phases: `analyze`, `tool_start`, `tool_complete`, `tool_result`, `thinking`, `synthesize`
-- `streaming.ts` is the shared utility hub — exports event types, `buildNarrativeSummary()`, `buildProvenanceLine()`, `datasetUrl()`, `getEducationalAnnotation()`
-- `sse-client.ts` handles client-side SSE connection with reconnect
-- **Streaming errors: never render a raw `err.message`.** Route every reader-facing streaming error through `friendlyStreamError()` and every LLM-facing tool-failure string through `describeToolFailureForLlm()` (both in `streaming.ts`) — they preserve the anti-hallucination guard and keep raw infrastructure detail (status codes, server names, stack text) out of the response.
-- Dataset IDs are auto-linked to Socrata pages: `https://{portal}/d/{datasetId}`
-
-### Shared MCP Response Display (`components/shared/McpResponseDisplay.tsx`)
-Both the home page and Explore page delegate MCP response rendering to this shared component. It renders (in order):
-1. **Query text** — blue left border quote
-2. **ProgressLog** — narrative summary, breadcrumbs, expandable steps
-3. **Markdown content** — via ReactMarkdown with auto-linked dataset IDs
-4. **Source provenance** — green left border with linked dataset names
-5. **Footer** — TimingBar, Time/Tokens, SkillPromptDisclosure
-
-`linkDatasetIds()` inside this component replaces bare dataset IDs in markdown with clickable `[id](url)` links, avoiding double-linking inside existing markdown links.
-
-**Truncation CTAs:** When `token_limit_exceeded` is true, an amber banner appears with two CTAs:
-1. "Continue this analysis" — builds a continuation prompt with the original query, narrative summary of data collected, and partial response, then auto-submits it as a new query
-2. "Try this locally (no limits)" — links to `/about#try-it`
-
-**Download as notebook:** When query tool calls are present, a "Notebook" button appears alongside the "Copy" button. Uses `lib/notebook.ts` to generate a `.ipynb` file client-side with Python code cells that re-execute the same Socrata API queries using `requests` + `pandas`. Only `query`-type tool calls generate code cells; catalog/metadata/metrics calls are skipped.
-
-### BPMN Diagram (`components/explore/`, `lib/bpmn/`)
-Interactive BPMN 2.0 diagram on the Explore page visualizing MCP query execution. Two modes:
-
-**Examples mode** — replays 4 pre-recorded traces through the diagram with animation:
-- Traces defined in `lib/bpmn/traces.ts` (hand-authored with realistic SoQL and timing)
-- Replay state machine in `hooks/useTraceReplay.ts` (setTimeout-chain, speed control, dramatic pauses)
-- Node mapping in `lib/bpmn/node-mapping.ts` (ProgressPhase → BPMN element IDs)
-
-**Live mode** — runs a real MCP query and animates the diagram in real-time:
-- `hooks/useLiveTrace.ts` manages SSE connection, diagram animation, progress logs, trace capture
-- Side-by-side layout: CSS grid `55fr 45fr` with transition; diagram left, response panel right
-- 5-tier slow query messaging (30s neutral → 180s clickable suggestion)
-- Cancelled queries preserve diagram state and partial response
-- Captured traces can be replayed after completion
-
-Key architectural decisions:
-- **bpmn-js NavigatedViewer** — bundles zoom/pan/keyboard; ~400KB gzipped, dynamically loaded on Explore page only
-- **CSS markers** (`canvas.addMarker()`) for animation states, not direct SVG manipulation
-- **Overlay API** (`overlays.add()`) for SoQL previews and result annotations
-- **Client wrapper** (`McpFlowDiagramWrapper.tsx`) for Next.js App Router SSR boundary
-
-```
-explore/page.tsx
-  └── McpFlowDiagramWrapper.tsx (client, dynamic import)
-        └── McpFlowDiagram.tsx (orchestrator)
-              ├── TraceControls.tsx (mode toggle, trace pills, playback, speed, live query input)
-              ├── BpmnViewer.tsx ← bpmn-diagram.css
-              │     └── fetches /bpmn/mcp-query-flow.bpmn
-              ├── LiveResponsePanel.tsx → McpResponseDisplay (both modes: response panel)
-              ├── DiagramAnnotations.tsx (educational text, non-fullscreen only)
-              └── hooks/useTraceReplay.ts + hooks/useLiveTrace.ts
-                    ├── lib/bpmn/traces.ts
-                    ├── lib/bpmn/node-mapping.ts
-                    └── lib/bpmn/animation.ts
-```
-
-## Environment Variables
-
-This is the local-dev set for the reference deployment; the full tier-by-tier environment reference for an instance (drivers, signing, instance identity) is [`docs/deploy.md`](docs/deploy.md).
-
-The 13 publisher-identity variables take the `PUBLISHER_` prefix as of the 2026-08-19 vocabulary settlement (Appendix J); each prior-era `EVIDENCE_` spelling is still read as a fallback, canonical-wins-when-defined, with a one-time server-side deprecation warning. `src/lib/publisher-env.ts` is the single resolver. A fourteenth, the verify-side trust-registry consume override (`PUBLISHER_TRUST_REGISTRY_URL`), was retired outright in civic-ai-tools#155 P1b rather than renamed — it fed dead code on every real call path, so it was deleted along with that path instead of joining this list.
-
-Required in `.env.local`:
-```
-OPENROUTER_API_KEY=sk-or-...
-SOCRATA_MCP_URL=https://socrata-mcp.civicaitools.org  # Required, no fallback — every data query refuses without it (#258)
-DATA_COMMONS_MCP_URL=https://api.datacommons.org/mcp
-DATA_COMMONS_API_KEY=                # From https://apikeys.datacommons.org (free)
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-NEXTAUTH_SECRET=        # openssl rand -base64 32
-NEXTAUTH_URL=http://localhost:3000  # or production URL
-```
-
-The `DATA_COMMONS_MCP_URL` / `DATA_COMMONS_API_KEY` pair powers the second MCP data source (Google Data Commons; US demographic + federal statistical data via a hosted HTTPS endpoint that Google launched 2026-02-09). The hosted endpoint is mandatory-auth via an `X-API-Key` header — anonymous access is not permitted, so `DATA_COMMONS_API_KEY` must be set or Data Commons tool calls will fail.
-
-Optional (production only):
-```
-NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX  # Google Analytics 4
-```
-
-Recommended in production, not required (Upstash via Vercel KV) — the rate
-limiter degrades gracefully without it, falling back to per-process memory
-(resets on restart; not shared across instances), which is fine for a
-single-node instance but not durable or shared across serverless instances:
-```
-KV_URL=
-KV_REST_API_URL=
-KV_REST_API_TOKEN=
-KV_REST_API_READ_ONLY_TOKEN=
-```
-
-## Directory Orientation
-
-Deliberately a short orientation, not an exhaustive tree — the tree drifted badly once already. Verify against the filesystem when precision matters.
-
-- `src/app/(marketing)/` — the public pages: home (`page.tsx`), `/explore`, `/directory`, `/learn`, `/project`, `/about`, `/roadmap`
-- `src/app/(app)/` — dashboard, record pages, auth, and the signed-in query surfaces: `/dashboard`, `/records` (+ its permanent prior-era alias `/evidence`), `/ask`, `/auth/device`, plus the dev-only `/dev/notebook-preview`
-- `src/app/api/` — serverless routes: `compare`, `compare-stream`, `models`, `rate-limit`, `query-notebook`, `session-status` (boolean-only has-a-session probe with marketing-origin CORS), plus the `records/*` route family (thin re-exports) with its implementations at `evidence/*` — the prior-era segment is a permanent alias, not a deprecation window — and `blob/*`, `cron/*`, `auth/*`
-- `src/lib/` — the major areas:
-  - `evidence/` — record-system core: packaging, signing, verification, provenance, attestation, lifecycle. (Directory and type names here are internal identifiers, deliberately left on the prior-era spelling by the 2026-08-19 settlement — they never cross the wire.)
-  - `storage/` — blob-storage driver seam (Vercel Blob / S3-compatible)
-  - `sandbox/` — notebook-executor driver seam (container / Vercel Sandbox)
-  - `db/` — Drizzle ORM schema + client (Postgres)
-  - `mcp/` — MCP HTTP client, tool definitions, Socrata skill fallback
-  - auth (files, not a directory): `auth.ts`, `auth-providers.ts`, `api-auth.ts`, `device-flow.ts` — NextAuth config, provider seam, API-token auth, device flow
-- `src/components/` — UI, with `dashboard/`, `evidence/`, `explore/`, `home/`, `notebook/`, `roadmap/`, and `shared/` subtrees alongside top-level components like `Header.tsx`
-
-For depth, read [`docs/deploy.md`](docs/deploy.md) (drivers, environment tiers, self-hosting) and [`docs/api/records-publish.md`](docs/api/records-publish.md) (the record-publish contract, including the repositories-and-layers orientation).
-
-## Key Datasets
-
-| Portal | Dataset | ID | Key Fields |
-|--------|---------|-----|------------|
-| NYC | 311 Service Requests | erm2-nwe9 | complaint_type, borough, created_date |
-| NYC | Restaurant Inspections | 43nn-pn8j | boro, grade, inspection_date |
-| NYC | Housing Violations | wvxf-dwi5 | boro, violationid, inspectiondate |
-| Chicago | 311 Service Requests | v6vf-nfxy | sr_type, created_date |
-| SF | 311 Cases | vw6y-z8j6 | service_name, opened, neighborhood |
-
-## Sprint Workflow
-
-Active work is organized into lightweight sprints in [`/sprints/`](sprints/).
-
-- **Naming:** `sprint-NNN-short-description.md`
-- **Format:** Goal, checkboxed task list (grouped by priority), acceptance criteria
-- **Current sprint:** Check `/sprints/` for the latest active sprint before starting work
-- **Backlog:** Longer-term priorities and deferred items live in [`BACKLOG.md`](BACKLOG.md)
-
-### Sprint Index
-
-| Sprint | Description | Status |
-|--------|-------------|--------|
-| [001](sprints/completed/sprint-001-mcp-messaging-ux.md) | MCP messaging UX (progress logs, narrative) | Done |
-| [002](sprints/completed/sprint-002-reasoning-ux-data-literacy.md) | Reasoning UX & data literacy | Done |
-| [003](sprints/completed/sprint-003-polish-audit.md) | Polish audit (a11y, contrast, mobile) | Done |
-| [SPRINT-live-query-bpmn](sprints/completed/SPRINT-live-query-bpmn.md) | Live query mode for BPMN diagram | Done (ticket 8 remaining) |
-| [SPRINT-side-by-side-layout](sprints/completed/SPRINT-side-by-side-layout.md) | Side-by-side layout for live queries | Done |
-| [004](sprints/completed/sprint-004-explore-page-migration.md) | Migrate BPMN to `/explore`, restructure About | Done |
-| [SPRINT-community-trace-gallery](sprints/SPRINT-community-trace-gallery.md) | Community trace gallery on `/explore` | Not started (after 004) |
-
-## Related Repos
-
-| Repo | Purpose |
-|------|---------|
-| [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) | MCP server configs, skill docs, setup scripts |
-| [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) | The MCP server itself (Socrata/OpenGov data) |
-
-## Design Notes
-
-- **Light mode only** — Simplified styling, no dark mode
-- **Palette is a configurable seam** — `src/app/globals.css` defines a per-instance accent family (`--accent` and companions, set from `SITE_BRAND_ACCENT`, default `#103FEF`), a fixed neutral scale, and fixed semantic status colors. Reference tokens by name, never by hex; `src/app/design-tokens.test.ts` fails on a token that resolves to nothing.
-- **Compact layout** — Form and button visible above fold on laptop screens
-- **Indexing is explicit instance config** — `SITE_NOINDEX` (unset/empty = indexable, the standard web default; set truthy = `robots.txt` disallows every path and page metadata carries noindex/nofollow). The reference deployment sets `SITE_NOINDEX=1`. See [`docs/deploy.md`](docs/deploy.md#indexing-optional) and `src/lib/site-indexing.ts`.
-- **Mobile out of scope for BPMN side-by-side** — Desktop only for now; mobile polish (stacked layout, 2x2 trace pills, scroll fade) is a future item
-- **Fullscreen keeps site header** — Overlay renders below the header so users retain navigation context; uses `100dvh`
-
-### Deep linking
-
-- `/explore?trace={id}` — Auto-loads and replays a specific trace (reserved, not yet wired up)
-- Header nav (desktop, `src/components/Header.tsx`): Explore ▾ (Data Flow `/explore` · Directory `/directory` · Records `/records`) | Learn | Project | About ▾ (About `/about` · Roadmap `/roadmap`) | Typed Standards (external link, typedstandards.org). There is no GitHub nav link. Dashboard is not in the nav — it lives in the signed-in user menu; signed-out users see a "Sign in with GitHub" button instead.
-
-## Patterns & Conventions
-
-These patterns are established across the codebase. Follow them when making changes.
-
-### Read before reimplementing
-When told "make X behave like Y," always read Y's implementation first. Importing an existing component is almost always better than building a parallel version. This was learned the hard way — see RETROSPECTIVE.md for details.
-
-### Shared utilities live in `streaming.ts`
-Cross-cutting formatting functions (`buildProvenanceLine`, `buildNarrativeSummary`, `datasetUrl`, `getEducationalAnnotation`, `getPortalCity`, `getDatasetName`) all live in `lib/streaming.ts`. Don't duplicate these in component files. If a new utility is needed by multiple components, add it here.
-
-### Export utilities proactively
-When building a utility for one module, consider whether other modules will need it. Export from the start rather than having to refactor later (e.g., `generateGroupLabel` needed export for cross-module reuse).
-
-### Component composition over duplication
-The `McpResponseDisplay` shared component is the canonical example — both `ResponsePanel` (home) and `LiveResponsePanel` (Explore) delegate to it. When adding MCP response features, add them to the shared component so both pages benefit.
-
-### Prop threading for context
-Query text, progress state, and tool call data are threaded from page → wrapper → panel → shared component. Follow the existing prop chains when adding new data:
-- Home: `page.tsx → QuerySurface → ComparisonDisplay → ResponsePanel → McpResponseDisplay`
-- Ask: `(app)/ask/page.tsx → QuerySurface → …` (same chain as home from `QuerySurface` down)
-- Explore: `McpFlowDiagram → LiveResponsePanel → McpResponseDisplay`
-
-### styled-jsx for component-scoped CSS
-CSS keyframes (`blink`, `spin`, `pulse`) and component-specific styles use styled-jsx blocks within components. Global styles are in `globals.css`.
-
-### bpmn-js patterns
-- Use `canvas.addMarker()`/`removeMarker()` for animation states — don't manipulate SVG directly
-- Use `overlays.add()` for positioned HTML content on diagram nodes
-- Always call `fitToView()` after layout changes (fullscreen toggle, split panel transition) with a ~350ms delay for transition completion
-
-## Known Tech Debt
-
-### `next build` in a sandboxed agent session: re-measure in your environment
-
-Whether the default (Turbopack) builder completes inside a Claude Code sandbox
-is environment-dependent, not absolute. Its PostCSS worker pool binds a TCP
-port, and a sandbox that denies port binding (`Operation not permitted`) kills
-the build — the same restriction behind the `listen EPERM` failures in
-`openrouter-streaming.test.ts` — but measured 2026-08-19, Turbopack built
-repeatedly (exit 0) in a sandboxed agent session. Re-measure in your
-environment (`npm run build`); if port binding is denied there, `next build
---webpack` completes without the worker pool. Either way, treat CI's `build`
-check as the real gate.
-
-Note for anyone diagnosing a build failure here: this is **not** a network
-problem. Google Fonts was blamed for it for two days; the sandbox reaches
-`fonts.googleapis.com` fine, and since #246 the fonts are self-hosted anyway
-(`src/fonts/`), so no build path needs font egress at all.
-
-
-1. **Duplicated SSE event handling** — `useLiveTrace` and `useStreamingComparison` both build progress groups from SSE events. A shared utility could extract the group-building logic.
-2. **`@keyframes` duplication** — `blink` is defined in multiple styled-jsx blocks and could move to `globals.css`. `spin` exists in both `globals.css` and component styles.
-3. **`useLiveTrace` responsibility accumulation** — Manages SSE connection, diagram animation, progress logs, tool tracking, trace capture, slow timers, elapsed time, and abort control. Works but is a code smell.
-4. **bpmn-js type gaps** — 4 `@typescript-eslint/no-explicit-any` suppressions for untyped bpmn-js APIs.
-5. **BPMN XML hand-authored** — Should be round-tripped through bpmn.io visual modeler for maintainability.
-6. **Pre-existing lint warnings** — TraceControls setState-in-effect, unused `mapEventToNodes` in animation.ts. (The unused `onError` in sse-client.ts was removed — see its error-contract JSDoc; errors flow through promise rejection only.)
-
-## Retrospectives
-
-Session retrospectives are kept in [`docs/RETROSPECTIVE.md`](docs/RETROSPECTIVE.md) (reverse-chronological). Review before starting work to understand recent decisions and lessons learned.
+Each page has one job — use this to decide where a new feature belongs.
+
+| Route | Star of the page | User goal |
+|---|---|---|
+| `/` | The result content | "Show me why MCP matters" |
+| `/explore` | The process (BPMN diagram, trace replay, live queries) | "Show me how this works" |
+| `/about` | The prose | "Explain this to me" |
+| `/project` | Mission + proof | "What is this project, and does it work?" |
+| `/learn` | Educational content | "Teach me the concepts" |
+| `/records` | The published registry | "Show me what's been published" |
+| `/records/[slug]` | One signed analysis | "Let me scrutinize this analysis" |
+| `/directory` | MCP-server inventory | "What sources can I connect to?" |
+| `/roadmap` | Plans + commitments | "Where is this project going?" |
+| `/dashboard` | The user's own publishes | "Manage my records" |
+| `/ask` | The query form, signed-in | "Answer a question against live data and publish it" |
+
+`/evidence` and `/api/evidence/*` are permanent prior-era aliases of `/records` and `/api/records/*`,
+not a deprecation window. `/ask` is app-private in the host topology (`src/lib/host-routing.ts`): it
+404s on the marketing host and is where the app host's `/` redirects.
+
+## Where the detail lives
+
+- [`docs/deploy.md`](docs/deploy.md) — env vars tier by tier, the driver seams, self-hosting, migrations.
+- [`docs/db-migrations.md`](docs/db-migrations.md) — how a migration reports success and changes nothing.
+- [`docs/api/records-publish.md`](docs/api/records-publish.md) — the record-publish contract.
+- [`docs/design-principles.md`](docs/design-principles.md) — **read before touching the record detail
+  page, chat output rendering, the provenance graph, or any other AI-output / attestation surface.**
+  Five words: disclosure not validation, hierarchy not equality, narrative not metadata, axes not
+  chips, user language not implementation language.
+- [`docs/RETROSPECTIVE.md`](docs/RETROSPECTIVE.md) — session retrospectives, reverse-chronological.
+- Canonical specs (package shape, signing, captureMethod, withdrawal, typed claims):
+  [`civic-ai-tools/docs/architecture/`](https://github.com/npstorey/civic-ai-tools/tree/main/docs/architecture)
+  — where this codebase diverges from a draft, the codebase wins and the spec gets updated.
+
+## Rules
+
+Each cost a real mistake; the incident sits in an HTML comment beside it. Path-scoped rules live in
+`.claude/rules/`, loaded only when you open a matching file.
+
+- **Read before reimplementing.** When told "make X behave like Y," read Y's implementation first;
+  importing the existing component beats building a parallel one.
+  <!-- A live-trace pass rebuilt progress rendering from scratch, duplicating ProgressLog, because it
+       started from plan text without reading it. Cost a full pass. RETROSPECTIVE.md, 2026-02-27. -->
+- **Cross-cutting formatters live in `src/lib/streaming.ts`** (`buildNarrativeSummary`,
+  `buildProvenanceLine`, `datasetUrl`, `getEducationalAnnotation`, `getPortalCity`, `getDatasetName`)
+  — don't re-declare one in a component; export from here for the second caller.
+  <!-- Same sprint: generateGroupLabel had to be retro-exported from useStreamingComparison.ts.
+       RETROSPECTIVE.md, "Export utilities proactively." -->
+- **Composition over duplication.** `src/components/shared/McpResponseDisplay.tsx` is the canonical case:
+  `ResponsePanel` (home/ask) and `LiveResponsePanel` (explore) both delegate to it — new MCP response
+  features belong there so both surfaces get them.
+  <!-- Explore grew its own response renderer before the unification. Same retrospective. -->
+- **Never render a raw `err.message` in a streaming path.** Reader-facing errors go through
+  `friendlyStreamError()`, LLM-facing tool-failure strings through `describeToolFailureForLlm()`
+  (both in `src/lib/streaming.ts`).
+  <!-- #154: raw error text (status codes, server names, stack fragments) reached the reader and the
+       model, breaking the anti-hallucination guard. #271 is the follow-on typed payload. -->
+- **Reference design tokens by name, never by hex.** `src/app/globals.css` defines a per-instance accent
+  family (`--accent`, from `SITE_BRAND_ACCENT`), a fixed neutral scale, and fixed semantic status colors;
+  `src/app/design-tokens.test.ts` fails on a token that resolves to nothing. Light mode only.
+  <!-- #217 made look-and-feel a configuration seam. A literal hex silently opts that element out of
+       an instance's brand: invisible here, wrong on every other instance. -->
+- **`next build` in a sandboxed agent session: re-measure, don't assume.** Turbopack's PostCSS worker
+  pool binds a TCP port, and a sandbox that denies binding kills the build. Measured 2026-08-19 it
+  built repeatedly (exit 0) sandboxed; where binding is denied, `next build --webpack` skips the
+  worker pool. CI's `build` job is the real gate.
+  <!-- Blamed on Google Fonts egress for two days. Not a network problem — since #246 fonts are
+       self-hosted (src/fonts/). Same restriction behind the socket-binding failures in #249. -->
+- **Touching `.env*` stalls a background agent.** Any read of a `.env*` file trips the global
+  secret-read guard, and a subagent that hits it hangs to the 600s watchdog instead of failing fast.
+  Ask the owner to run env edits in their own terminal.
+  <!-- Repeated subagent stalls traced to .env* reads in agent sessions; the owner-run appends that
+       replaced them had to be newline-defensive and verified structurally afterward. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ Thank you for your interest in contributing! This is the demo website for the ci
 4. Create a branch for your changes
 5. Submit a pull request
 
+## If you use Claude Code
+
+Cloning this repo installs its checked-in Claude Code configuration: `.claude/settings.json` (a network allowlist, a sandbox block, and a `PreToolUse` hook at `.claude/hooks/drizzle-migrate-guard.sh` that pauses schema-applying `drizzle-kit` runs so you verify them with a read-back), plus the agent definitions in `.claude/agents/` and the path-scoped rules in `.claude/rules/`.
+
+Those files are ordinary shell and JSON — read them before you trust them, the same as any other code you clone. Personal overrides belong in `.claude/settings.local.json`, which is gitignored.
+
 ## Guidelines
 
 - Keep changes focused — one fix or feature per PR

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -1,0 +1,120 @@
+# Running migrations without losing one to a silent failure
+
+Schema migrations are ordinary Drizzle numbered SQL under [`drizzle/`](../drizzle/), generated with
+`npm run db:generate` and applied with `npm run db:migrate` (`drizzle-kit generate` / `drizzle-kit
+migrate`). [`docs/deploy.md`](deploy.md#database-and-migrations) is the operator-facing reference:
+the compose path, the direct path for fork operators, and the visibility-rename pair `0014`/`0015`.
+
+This document covers the other half — the ways a migration run against a **remote** database can
+report success and change nothing. Every trapdoor below was paid for at least once, mid-deploy,
+under time pressure, with the failure disguised as a drizzle-kit or migration-content bug when it
+was really an env-loading or credential problem upstream.
+
+## The rule, if you read nothing else
+
+**A clean exit from `drizzle-kit migrate` is not proof that anything was applied.** Verify with a
+direct query against the database, every time, regardless of what the CLI printed. `docs/deploy.md`
+states the same rule for the compose path ("do not trust a tool's exit status alone") — this is that
+rule for the direct, remote path.
+
+## Trapdoor 1 — the silent-success exit
+
+The app's default driver is `@neondatabase/serverless` (`DB_DRIVER` unset → `neon-http`; see
+`src/lib/db/index.ts`), and `drizzle.config.ts` hands drizzle-kit the same `DATABASE_URL`. On that
+path a **password-authentication failure is swallowed**: the only output is the config-file line,
+the driver line, and the serverless-driver websocket warning, followed by a clean exit. That is
+byte-for-byte what a successful "no migrations to run" looks like.
+
+Causes seen: a rotated credential, the wrong environment's URL, a URL that is syntactically broken
+(see trapdoor 3). All three present as success.
+
+**Detection is the read-back, not the exit code.** Immediately after the migrate run:
+
+```bash
+op run --env-file=.env.local -- sh -c 'psql "$DATABASE_URL" -c "\d evidence_records"'
+```
+
+or, for a migration that adds tables, ask the catalog directly:
+
+```bash
+op run --env-file=.env.local -- sh -c \
+  'psql "$DATABASE_URL" -c "select table_name from information_schema.tables
+     where table_schema = '"'"'public'"'"' order by table_name"'
+```
+
+If the column, table, or enum label the migration was supposed to add is not there, the migration
+did not run — whatever the CLI said.
+
+## Trapdoor 2 — `op run` needs an `sh -c` wrapper
+
+Any `op run` command whose payload dereferences an injected variable must wrap that payload in
+`sh -c` with single quotes:
+
+```bash
+# right
+op run --env-file=.env.local -- sh -c 'psql "$DATABASE_URL" -c "select 1"'
+
+# wrong — the invoking shell expands $DATABASE_URL to empty before op injects anything
+op run --env-file=.env.local -- psql "$DATABASE_URL" -c "select 1"
+```
+
+In the unwrapped form the outer shell expands `$DATABASE_URL` *first*, so the command receives an
+empty string. `psql` does not error on an empty connection string — it falls back to local
+connection defaults. The command appears to work while talking to an entirely different database,
+which is the worst possible outcome for a verification step. Caught during the ADR-0016 sweep's M1
+gate, 2026-08-06.
+
+A payload that references no variable (for example
+`op run --env-file=.env.local -- node scripts/preflight-env.mjs`, the form used in
+[`docs/rate-limit-headroom.md`](rate-limit-headroom.md)) does not need the wrapper.
+
+## Trapdoor 3 — the literal-quote `DATABASE_URL`
+
+`export $(grep DATABASE_URL .env.local)` **preserves the quote characters** when the value is
+written quoted, which is what most env-pull tooling emits for URLs carrying query parameters. The
+export then sets `DATABASE_URL` to a string that begins and ends with a literal `"`, the connection
+fails on an invalid scheme, and trapdoor 1 hides the failure behind a clean exit.
+
+`psql` is the diagnostic that surfaces it — it rejects the value out loud where drizzle-kit does
+not. A one-line preflight catches it before the migrate run:
+
+```bash
+echo "DATABASE_URL prefix: ${DATABASE_URL:0:11}"   # must print exactly: postgresql:
+```
+
+No leading `"`, no `op://`. Anything else means the env load is broken and the migrate run will be a
+silent no-op. Prefer `op run` (trapdoor 2) over any `export`-from-`grep` pattern; the `op://`
+migration that removes literals from `.env.local` altogether is tracked at
+[civic-ai-tools-website#101](https://github.com/npstorey/civic-ai-tools-website/issues/101).
+
+## Trapdoor 4 — never point a local stack at `.env.local`
+
+The compose stack does not use `.env.local` and must not be pointed at it. `docker-compose.yml`
+composes `DATABASE_URL` for both the `migrate` and `app` services from the `POSTGRES_USER` /
+`POSTGRES_PASSWORD` / `POSTGRES_DB` compose variables against the in-stack `postgres` service, and
+the one-shot `migrate` service runs `drizzle-kit migrate` *before* the app starts (`app` has a
+`depends_on` on its successful completion). A local `docker compose up` therefore always boots on a
+migrated schema, and re-running is safe — applied migrations are skipped.
+
+Two consequences worth stating plainly:
+
+- **You do not run migrations by hand for the local stack.** Bringing the stack up is the migration.
+- **A `.env.local` aimed at a local stack is a loaded gun.** `.env.local` holds credentials for the
+  hosted database. Sourcing it into a shell that then runs `drizzle-kit migrate` against what you
+  believe is a local container is how a remote database gets migrated by accident.
+
+Verify a compose-path migration inside the stack, not through `.env.local`:
+
+```bash
+docker compose exec postgres psql -U civic -d civic -c '\dT+ visibility'
+```
+
+## Checklist
+
+1. `op whoami` — confirm the `op` session the subprocess will inherit.
+2. Preflight the URL shape: prefix must be `postgresql:`.
+3. Run the migration.
+4. Read back with `psql`. Do not skip this because the CLI exited 0 — that is precisely trapdoor 1.
+5. If the run hangs more than ~10 seconds with no output, kill it and check `op` sign-in state
+   before rerunning; an unresolvable `op://` reference yields an empty `DATABASE_URL` and a
+   connection that never opens.


### PR DESCRIPTION
Round 1 of the Way of Working v2 rebuild — this repo's PROJECT layer. The ablation procedure is the guardrail for every line: a line survives only if removing it would cause a mistake, and every surviving rule cites its incident in an HTML comment (stripped before injection, so the citation costs nothing at boot).

**Model:** Claude Opus 5 (1M context), `claude-opus-5[1m]`, Claude Code 2.1.240.

## The headline

`CLAUDE.md`: **374 lines / 27,809 chars → 120 lines / 8,688 chars.** `/doctor` estimated the old file at ~6,870 resident tokens every session.

## `/doctor`, before

Run at `HEAD` = `aafae07` before any edit. Setup health clean; the CLAUDE.md findings:

> **Check 3 — cut 6 derivable blocks from `CLAUDE.md` (~874 est. tokens/session).** Commands fenced block (lines 23–31) · Architecture ASCII diagram (66–86) — *"Already stale — it lists 5 API routes; `src/app/api` has 40+"* · MCP Server Communication code block (104–126) · MCP Tool Types list (128–134) · Key Datasets table (263–272) · Sprint Index table (282–293) — *"Already stale"*.
>
> **Check 4 — move 2 sections to lazy loading (~950 est. tokens/session).** BPMN Diagram section → a nested CLAUDE.md; Environment Variables → a skill.
>
> **Check 6 — context weight.** This repo's `CLAUDE.md`: ~6,870 est. tokens, the largest single resident contributor.

Every proposed trim is taken. Two deliberate divergences, both toward the plan of record:

- Env vars go to `docs/deploy.md`, which already owns them tier by tier, rather than to a new skill.
- The BPMN section is **cut**, not relocated — `/doctor` itself flagged that a nested `src/components/explore/CLAUDE.md` would not load for a session editing only `src/lib/bpmn/`. The tree is derivable; the two maintainability items in it are now issues #301.

`/doctor` also proposed disabling four unused MCP connections. That is a `~/.claude.json` change, not a repo change — **not done here**, flagged for you below.

## Cut list — what, where it went, why

| Cut | Went to | Why |
|---|---|---|
| `## Commands` (old, 4 scripts) | **Replaced** by all six CI-gated commands, each with measured healthy output | The old block listed dev/build/start/lint and omitted every command CI actually gates on |
| `## Architecture` ASCII diagram | `docs/deploy.md` (driver seams) | Derivable, and stale: 5 API routes listed vs 40+ on disk. Its OpenRouter/base-URL text also contradicted the configurable model seam — N4 owns that area |
| `### OpenRouter Integration` | code (`src/lib/openrouter-streaming.ts`) | Derivable; the `maxIterations` value was already cited-not-restated for this reason |
| `### MCP Tool Execution Flow` | code (`src/lib/mcp/client.ts`) | Derivable |
| `### MCP Server Communication` JSON-RPC block | `src/lib/mcp/client.ts` | Copied verbatim from the module the heading already names |
| `### MCP Tool Types` | `src/lib/mcp/tools.ts` | Same |
| `### Socrata Skill Module` | `src/lib/mcp/socrata-skill.ts` | Same |
| `### Rate Limiting` | `src/lib/rate-limit.ts`, `docs/deploy.md` | Same |
| `### Streaming & SSE` | **Rule kept**, detail to code | The `friendlyStreamError` / `describeToolFailureForLlm` rule has an incident (#154) and survives; the phase list does not |
| `### Shared MCP Response Display` | **Rule kept**, detail to code | Composition-over-duplication survives as a rule; the five-item render order is derivable |
| `### BPMN Diagram` + component tree | issue #301, and the code | Derivable tree; the two real items (untyped `bpmn-js` surfaces, hand-authored XML) are now tracked |
| `## Environment Variables` | `docs/deploy.md` — "Environment reference, tier by tier" | Already the canonical home; two copies drift |
| `## Directory Orientation` | the filesystem | Its own text admitted "the tree drifted badly once already" |
| `## Key Datasets` | `src/lib/mcp/socrata-skill.ts` | Every ID and field is already there |
| `## Sprint Workflow` + `### Sprint Index` | anchor issues | Last touched 2026-08-09 and structurally stale since March; sprints are anchor issues now |
| `## Related Repos` | `CONTRIBUTING.md`, which already links the hub | Duplicate |
| `## Design Notes` (beyond 2 rules) | `docs/deploy.md`, `src/lib/site-indexing.ts` | `SITE_NOINDEX`, palette config, mobile scope are all documented or derivable. Tokens-by-name and light-mode-only survive as a rule |
| `### Deep linking` / header nav | `src/components/Header.tsx` | Derivable |
| `## Known Tech Debt` | issues #299, #300, #301 — or dropped, below | Six items, six dispositions |
| `## Retrospectives` | **Pointer kept** | One line in "Where the detail lives" |

### Known Tech Debt — six items, six dispositions

| Item | Disposition |
|---|---|
| Duplicated SSE event handling (`useLiveTrace` / `useStreamingComparison`) | **#299** |
| `useLiveTrace` responsibility accumulation | **#300** |
| `bpmn-js` type gaps | **#301** — and the count was wrong: CLAUDE.md said 4 suppressions, `grep` says 6 |
| BPMN XML hand-authored | **#301** |
| `@keyframes` duplication (`blink` ×2, `spin` ×4) | **Dropped.** Cosmetic, `grep -rn "@keyframes"` finds every one, no incident behind it |
| Pre-existing lint warnings | **Dropped.** `npm run lint` prints them on every run; a second hand-maintained copy drifts — and had: the "TraceControls setState-in-effect" warning it named no longer appears in lint output at all |

## What was added

- **`.claude/rules/evidence-surfaces.md`** — `src/lib/evidence/**`, `src/app/api/evidence/**`, `src/components/evidence/**`. Pointers to design-principles, records-publish, `trust-and-evidence.md`, and the spec drafts, plus the note that these directory names deliberately stay on the prior-era spelling (Appendix J left internal identifiers alone; they never cross the wire).
- **`.claude/rules/db-migrations.md`** — `drizzle/**`, `src/lib/db/**`. Points at:
- **`docs/db-migrations.md`** (new) — the migration trapdoors relocated out of per-machine memory. Each premise re-checked against this repo before it was written: the `@neondatabase/serverless` default driver (`src/lib/db/index.ts`), `drizzle.config.ts`, the compose `migrate` service, and the `op run` example in `docs/rate-limit-headroom.md`.
- **`.claude/agents/impl.md`** and **`.claude/agents/cold-read.md`** — no `model` field, so both inherit. Modelled on typedstandards' `impl.md`.
- **`.claude/settings.json`** — network allowlist + sandbox block lifted from `settings.local.json`, plus the migrate guard hook. `settings.local.json` now holds only `additionalDirectories`.
- **`.claude/hooks/drizzle-migrate-guard.sh`** — pauses schema-applying `drizzle-kit` runs with the read-back reminder attached.
- **`.gitignore`** — `.claude/settings.local.json` was ignored only by your *global* gitignore. A collaborator cloning this repo had no such rule, and `.claude/` is now a committed directory. Added a repo-local ignore.
- **`CONTRIBUTING.md`** — a short section saying that cloning installs these hooks and settings, and that they are ordinary shell and JSON to read before trusting.

## Two corrections to the plan of record

**1. The hook decision value.** The contract specified returning decision `"escalate"`. Verified against the installed 2.1.240 binary, `permissionDecision` accepts `allow | deny | ask` (plus a print-mode-only `defer`) — `"escalate"` is not a value the CLI takes, and a hook returning it would be ignored, silently. The hook returns `"ask"`, which *is* "escalate to the user". Same behaviour, name the tool accepts.

**2. A false sentence in the old CLAUDE.md.** It stated: *"Secrets live in 1Password — `.env.local` files contain only `op://` references, not real values."* Issue **#101 is open**, and lists this repo's `.env.local` as still holding literals. The rebuilt file states the convention and says to assume literals are still on disk, citing #101.

## Evidence

**Branch** `sprint-wow2/round1-project-layer` · **10 files, +481 / −360.**
**Blast zone:** `CLAUDE.md`, `.claude/**`, `docs/db-migrations.md`, `CONTRIBUTING.md`, `.gitignore`. No `src/` change, no behaviour change, no dependency change.

```
wc -l CLAUDE.md   ->  120
grep -c '^- \*\*' ->    7   rules
grep -c '<!--'    ->    7   incident comments
```

**Checks** (`npm ci` first — a stale `node_modules` had the local tree at 16 false failures; the installed `@typedstandards/civic-typed-harness` was 0.2.0 against a lockfile pinning 0.3.0):

```
npm test        # tests 872  # pass 872  # fail 0
npm run typecheck   no output, exit 0
npm run lint        ✖ 4 problems (0 errors, 4 warnings)   [baseline, unchanged]
npm run check:compose-env   RESULT: PASS — every variable this profile reads can reach the container.
npm run build:standalone    [standalone-assets] OK — 3 runtime-read asset(s) present and byte-identical
npm run build       ✓ Compiled successfully  (measured before the sandbox shakedown; see below)
```

**Migrate guard, probed:**

```
$ printf '%s' '{"tool_name":"Bash","tool_input":{"command":"npx drizzle-kit migrate"}}' \
    | .claude/hooks/drizzle-migrate-guard.sh
{ "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "ask",
  "permissionDecisionReason": "verify with psql after — drizzle-kit can print success without
   applying. A clean exit is not proof: on the remote @neondatabase/serverless path an auth failure
   produces output identical to \"no migrations to run\". ... See docs/db-migrations.md." } }
```

Match matrix: `npm run db:migrate` → ask · `drizzle-kit push` → ask · `npm run db:generate` → no decision · `drizzle-kit studio` → no decision · `npm test` → no decision · `echo drizzle-kit migrate-ish` → no decision.

**Sandbox shakedown → ships `enabled: false`.** `npm ci` passed under the sandbox, so the allowlist and `excludedCommands` are correct. The rest of the check set needs loopback socket binds, which the sandbox denies. Controlled, same session, same tree:

| | bind probe | `npm test` |
|---|---|---|
| `enabled: true` | `BIND DENIED: EPERM` | 870 pass / **2 fail** — `listen EPERM 127.0.0.1`, both in `src/lib/openrouter-streaming.test.ts` (#249) |
| `enabled: false` | `BIND OK` | 872 pass / 0 fail |

`npm run build` under `enabled: true` died in Turbopack's PostCSS worker pool: `binding to a port / Operation not permitted (os error 1)`.

Two findings recorded in the file itself: **enabling the sandbox once is sticky for the session** — after flipping to `false`, in-process binds and `npm test` recovered but every *spawned* process still hit the denial, and the Turbopack build stayed red **even with `.claude/settings.json` moved entirely aside**, which is what rules the committed config out as the cause. And `npx next build --webpack` **builds clean** under exactly those conditions, confirming rather than assuming the `next build` rule kept in CLAUDE.md. CI, which runs unsandboxed, is the authoritative build check on this PR.

## Memory graduation — 14 files, every disposition

**Graduated to the repo, file deleted (4).** A repo-true fact belongs where a collaborator or a routine can see it.

| Memory | Now lives in |
|---|---|
| `annotated-tags-required-civic-repos` | the global `require-annotated-tag` hook enforces it |
| `op-run-shell-var-wrapper` | `docs/db-migrations.md`, trapdoor 2 |
| `sandbox-runs-global-pre-push-hook` | `CLAUDE.md`, "Secret hygiene" |
| `env-fence-stalls-background-agents` | `CLAUDE.md`, "Rules" (last entry) |

**Deleted as stale (2).**

| Memory | Reason |
|---|---|
| `gemini-2-flash-001-dead` | `google/gemini-2.0-flash-001` is gone from `src/` at HEAD — the production defect it warned about is fixed |
| `model-eval-refresh-paused` | The work is still wanted, so it became **#302** rather than evaporating. Verified while filing: branch `chore/refresh-model-eval-harness` is alive on origin at `bb80496`, `scripts/eval-models.mjs` exists, `/learn` does link the results doc at the hub repo, `scripts/eval-results-*.json` is gitignored |

**Stayed — you-true or harness-true, not repo facts (8).** `npm-publish-owner-passkey` · `bash-hook-credentials-substring` · `caveats-must-survive-compression` · `gh-tls-flake-never-blind-retry` · `owner-run-commands-manual-terminal` · `dco-signoff-required-all-merge-gates` (until a guard covers it) · `askuserquestion-text-not-delivered` · `owner-direct-merge-second-key`.

`MEMORY.md` is rewritten to the surviving 8, with the graduation ledger in an HTML comment. These live in `claude-config`, so that repo's working tree is now dirty by 6 deletions and 1 edit — **not committed here**, it is not this PR's repo.

## Flagged, not fixed

- **`~/.claude/settings.json` has three no-op deny rules.** `/doctor` and every session launch report: `Write(**/.env)` and `Write(~/code/civic-ai-ops/**)` "is not matched by file permission checks — only `Edit(path)` rules are." The `Write(...)` deny entries are doing nothing; `Edit(...)` covers all file-editing tools. Global layer, out of this PR's scope.
- **`/doctor`'s Check 1** (disable 4 unused MCP connections: playwright, Gmail, Google Calendar, Google Drive) is a `~/.claude.json` change, not a repo change. Not done.
- **`/doctor` Check 5**: the `PreToolUse:Bash` chain is 5 scripts, median 182 ms over 415 runs, one hit its 5s timeout. This PR adds a 6th for this repo. Cheap (a `jq` parse and two `grep`s, exits immediately on a non-match) but it is one more link.
- **The ops-repo `denyRead` was dropped from `settings.local.json`, not relocated.** The global layer already denies `Read`/`Edit`/`Write` on `~/code/civic-ai-ops/**`, so this was the redundant fifth copy the audit's config-layers table calls out. Nothing was weakened; if you disagree, it is one line to restore.
- `docs/RETROSPECTIVE.md` has no entry for this session. Round 1 is config, not a sprint — say the word if you want one.

Refs #299, #300, #301, #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BL3kdQTc8uG772JFnaMEj
