### PR TITLE
feat: make the model endpoint a wire dialect, not just a base URL (#30 P1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,20 @@ GITHUB_CLIENT_SECRET=
 # SERVE_MARKETING=1   # Serve the marketing site on hosts matching neither APP_HOST nor
 #                     # MARKETING_HOST. Leave unset on an instance — unset withholds the
 #                     # reference deployment's marketing pages.
+
+# --- Model endpoint (a wire dialect, not just a base URL) ---
+# MODEL_API_KEY is the canonical name for the model API key.
+# OPENROUTER_API_KEY above is its prior-era name and still works; set either.
+MODEL_API_KEY=replace-me-with-your-model-api-key
+# Wire dialect: openai-compatible (default) or azure-openai.
+# Leave commented for the default; an unrecognized value is refused, not ignored.
+#MODEL_API_KIND=openai-compatible
+# Chat-completions endpoint. Under azure-openai this is the RESOURCE ENDPOINT
+# (the https:// origin, no path). Commented out = the built-in default.
+#MODEL_API_BASE_URL=https://example-resource.example.net
+# Required when MODEL_API_KIND=azure-openai, ignored otherwise. There is no
+# safe default: an api-version gates which request and response fields exist.
+#MODEL_API_VERSION=2024-10-21
+# Auth mode: bearer | api-key. Derived from MODEL_API_KIND when unset.
+# 'entra' is reserved in the enum and refused - there is no code behind it.
+#MODEL_API_AUTH=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,10 @@
 #
 # EXTERNAL BY DESIGN: the model endpoint and the MCP data endpoints are
 # network services, not containers here. Supply them by environment
-# (MODEL_API_BASE_URL / OPENROUTER_API_KEY, SOCRATA_MCP_URL,
-# DATA_COMMONS_MCP_URL / DATA_COMMONS_API_KEY).
+# (MODEL_API_KIND / MODEL_API_BASE_URL / MODEL_API_KEY, SOCRATA_MCP_URL,
+# DATA_COMMONS_MCP_URL / DATA_COMMONS_API_KEY). The model endpoint is a wire
+# dialect, not just a URL: MODEL_API_KIND=azure-openai additionally needs
+# MODEL_API_VERSION, and reads MODEL_API_BASE_URL as the resource endpoint.
 #
 # CONFIGURATION: every value written into this file is a neutral
 # local-development placeholder. Entries listed as a bare NAME are
@@ -265,8 +267,18 @@ services:
       OIDC_CLIENT_SECRET:
       OIDC_PROVIDER_NAME:
       SIGN_IN_ALLOWLIST:
+      # The model endpoint. MODEL_API_KEY is the canonical credential name and
+      # OPENROUTER_API_KEY its prior-era spelling; both are listed as bare
+      # pass-throughs so an env file written under either name still delivers
+      # its value. MODEL_API_KIND selects the wire dialect and is left unpinned
+      # (bare) so this file stays on the OpenAI-compatible default;
+      # MODEL_API_VERSION is required only under `azure-openai`.
+      MODEL_API_KEY:
       OPENROUTER_API_KEY:
+      MODEL_API_KIND:
       MODEL_API_BASE_URL:
+      MODEL_API_VERSION:
+      MODEL_API_AUTH:
       SOCRATA_MCP_URL:
       SOCRATA_APP_TOKEN:
       DATA_COMMONS_MCP_URL:

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -9,18 +9,19 @@
  * PUBLISHER_SIGNING_KEY, the MCP endpoints, the model key), so a one-shot
  * "is everything wired?" check removes that failure mode.
  *
- * INSTANCE-AWARE: an instance is not one fixed deployment shape. The three
- * driver-selector variables — DB_DRIVER, BLOB_DRIVER, EXECUTOR_DRIVER — pick
- * which backing service each seam talks to, and which OTHER variables are
- * load-bearing follows from that choice. This script resolves the selectors
- * first, then resolves every other variable's tier against them, so a
- * self-hosted instance is neither passed while unrunnable nor nagged about
- * variables its profile will never read. See `resolveSpec` below.
+ * INSTANCE-AWARE: an instance is not one fixed deployment shape. The four
+ * driver-selector variables — DB_DRIVER, BLOB_DRIVER, EXECUTOR_DRIVER,
+ * MODEL_API_KIND — pick which backing service each seam talks to, and which
+ * OTHER variables are load-bearing follows from that choice. This script
+ * resolves the selectors first, then resolves every other variable's tier
+ * against them, so a self-hosted instance is neither passed while unrunnable
+ * nor nagged about variables its profile will never read. See `resolveSpec`
+ * below.
  *
- * SECRET HYGIENE (absolute): for every variable except the three driver
+ * SECRET HYGIENE (absolute): for every variable except the four driver
  * selectors, this script reads only whether `process.env[NAME]` is a
  * non-empty string — it never prints, logs, hashes, stores, or transmits any
- * value, not even its length. The three selectors are the sole exception and
+ * value, not even its length. The four selectors are the sole exception and
  * are not secrets: their value space is a closed set of non-secret enum
  * literals (see DRIVER_SEAMS). Even for those, the raw string is never
  * echoed: it is matched against the known literals, and the output carries
@@ -58,11 +59,19 @@
 import { fileURLToPath } from 'node:url';
 
 /**
- * The three driver seams. Each maps a selector variable to its closed set of
+ * The four driver seams. Each maps a selector variable to its closed set of
  * accepted values and the value the code substitutes when the selector is
  * unset. The defaults MUST mirror the app: src/lib/db/index.ts,
- * src/lib/storage/index.ts, src/lib/sandbox/execute.ts each read
- * `env.X_DRIVER || '<default>'` and throw on anything outside `values`.
+ * src/lib/storage/index.ts, src/lib/sandbox/execute.ts, src/lib/model-client.ts
+ * each read `env.X || '<default>'` and throw on anything outside `values`.
+ *
+ * MODEL_API_KIND is a seam and not a plain row on purpose. It selects a WIRE
+ * DIALECT, and which other variables are load-bearing follows from that choice
+ * exactly as it does for the storage and executor seams — `azure-openai`
+ * promotes MODEL_API_VERSION and MODEL_API_BASE_URL to required. The
+ * alternative idiom (`requiredUnlessAllPresent`) does not fit: it DEMOTES a
+ * required tier when a substitute set is present, and this is a PROMOTION
+ * driven by a selector, which is what `requiredWhen` already expresses.
  *
  * These are the only variables whose VALUE this script reads (see the secret
  * hygiene note at the top): they are non-secret enum selectors, and only a
@@ -72,6 +81,7 @@ export const DRIVER_SEAMS = {
   db: { env: 'DB_DRIVER', default: 'neon-http', values: ['neon-http', 'node-postgres'] },
   blob: { env: 'BLOB_DRIVER', default: 'vercel-blob', values: ['vercel-blob', 's3'] },
   executor: { env: 'EXECUTOR_DRIVER', default: 'vercel-sandbox', values: ['vercel-sandbox', 'container'] },
+  model: { env: 'MODEL_API_KIND', default: 'openai-compatible', values: ['openai-compatible', 'azure-openai'] },
 };
 
 /**
@@ -113,7 +123,11 @@ export const DRIVER_SEAMS = {
  *     script or an eval harness); enumerated here for completeness only, and
  *     never something a deployment must deliver to the container.
  *
- * TWO ACCEPTED NAMES for the publisher-identity set:
+ * TWO ACCEPTED NAMES. Used by the publisher-identity set (thirteen rows) and,
+ * since website#30 P1, by the model credential — MODEL_API_KEY, whose
+ * prior-era spelling is OPENROUTER_API_KEY. The mechanism is the same in both
+ * cases; only the rename it serves differs, so nothing below is specific to
+ * the publisher prefix beyond its worked example:
  *   - `priorEraName: 'EVIDENCE_X'` — the entry's `name` is the CANONICAL
  *     `PUBLISHER_X` spelling introduced by the 2026-08-19 vocabulary
  *     settlement (Appendix J of the Typed Standards specification;
@@ -158,8 +172,30 @@ export const OIDC_PROVIDER_SET = ['OIDC_ISSUER', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_
 
 export const ENV_SPEC = [
   // --- Core query path (every demo query depends on these) ---
-  { name: 'OPENROUTER_API_KEY', tier: 'required', purpose: 'LLM access — every query (no fallback)' },
-  { name: 'MODEL_API_BASE_URL', tier: 'optional', purpose: 'Chat-completions endpoint override — any OpenAI-compatible endpoint (default: OpenRouter)', hasFallback: true },
+  // The model endpoint is a WIRE DIALECT, not merely a base URL — see
+  // src/lib/model-client.ts. MODEL_API_KIND is the `model` seam above; the
+  // three rows under it are what that seam makes load-bearing.
+  //
+  // MODEL_API_KEY is the canonical name; OPENROUTER_API_KEY is its prior-era
+  // spelling and is still read by the app (expand half — nothing flips in this
+  // phase). Same two-name mechanism as the publisher set below.
+  { name: 'MODEL_API_KEY', priorEraName: 'OPENROUTER_API_KEY', tier: 'required', purpose: 'LLM access — every query (no fallback)' },
+  // Selector, not a setting: unset declares the OpenAI-compatible dialect.
+  { name: 'MODEL_API_KIND', tier: 'optional', purpose: "Model wire dialect — 'openai-compatible' (default) or 'azure-openai' (deployment-name routing, api-key header, api-version query)", hasFallback: true },
+  // Under the default dialect this is an override with a coded fallback.
+  // Under `azure-openai` it is the RESOURCE ENDPOINT and there is no fallback
+  // to borrow — the built-in default names a different service in a different
+  // dialect — so the seam promotes it, and the promotion drops the fallback
+  // claim (see resolveSpec).
+  { name: 'MODEL_API_BASE_URL', tier: 'optional', purpose: 'Chat-completions endpoint — any OpenAI-compatible endpoint (default: OpenRouter); the resource endpoint when MODEL_API_KIND=azure-openai', hasFallback: true, requiredWhen: { model: 'azure-openai' } },
+  // No coded default is possible: an api-version gates which request and
+  // response fields the endpoint honors, so a guessed one silently changes
+  // what comes back. Inert under the default dialect.
+  { name: 'MODEL_API_VERSION', tier: 'optional', purpose: 'Azure OpenAI api-version query parameter (required when MODEL_API_KIND=azure-openai; ignored otherwise)', requiredWhen: { model: 'azure-openai' } },
+  // Derived from MODEL_API_KIND unless declared: 'bearer' under the default
+  // dialect, 'api-key' under azure-openai. 'entra' is RESERVED in the enum
+  // with no code behind it — setting it is a typed refusal, not a fallback.
+  { name: 'MODEL_API_AUTH', tier: 'optional', purpose: "Model auth mode — 'bearer' or 'api-key'; derived from MODEL_API_KIND when unset ('entra' is reserved, not implemented)", hasFallback: true },
   // No coded fallback (#258 C4): the fallback used to point at the reference
   // deployment's hosted endpoint, silently routing an unconfigured instance's
   // queries through infrastructure it does not operate. Absent, every data
@@ -171,7 +207,9 @@ export const ENV_SPEC = [
   // Selector, not a setting: unset declares the managed serverless driver.
   // DATABASE_URL is load-bearing under BOTH drivers (neon() and pg.Pool both
   // read it), so the db seam has no tier flips — only the selector itself.
-  { name: 'DB_DRIVER', tier: 'optional', purpose: "DB driver — 'neon-http' (default) or 'node-postgres' (any Postgres over TCP)", hasFallback: true },
+  // web#194 #5: the hazard was in a code comment, where the operator who needs
+  // it cannot see it. It now renders in the report.
+  { name: 'DB_DRIVER', tier: 'optional', purpose: "DB driver — 'neon-http' (default) or 'node-postgres' (any Postgres over TCP). Unset silently selects the managed serverless driver: a plain Postgres host is never reached", hasFallback: true },
   // Vercel Blob credential: not read at all off that driver (src/lib/storage/index.ts
   // dynamic-imports only the selected driver), so demanding it under s3 would
   // fail an instance that is not on Vercel.
@@ -218,7 +256,17 @@ export const ENV_SPEC = [
 
   // --- Sign-in path (the rate-limit headroom option; OAuth) ---
   { name: 'NEXTAUTH_SECRET', tier: 'required', purpose: 'NextAuth session encryption' },
-  { name: 'NEXTAUTH_URL', tier: 'required', purpose: 'OAuth callback base URL (must match the deploy origin)' },
+  // web#194 #1, ruled (sprint #30 G0 D9): STAYS `required`, and declares no
+  // `hasFallback`. Three app-side reads do derive an origin when this is unset
+  // — api-auth.ts from the request host, device-flow.ts from the request
+  // origin then localhost, evidence/verify.ts from getEvidenceSiteOrigin() —
+  // but those are REQUEST-DERIVED VALUES, not configuration: they answer "what
+  // host is this request on", which is not the same question as "what origin
+  // did the OAuth app register". NextAuth itself is a fourth consumer and
+  // infers only from VERCEL_URL, i.e. not at all off that platform. Declaring
+  // a fallback here would pass a self-hosted instance whose sign-in callbacks
+  // are broken, which is the worse failure.
+  { name: 'NEXTAUTH_URL', tier: 'required', purpose: 'OAuth callback base URL (must match the deploy origin) — no fallback: the app-side origins are request-derived, not configuration, and none covers the OAuth callback' },
   // The GitHub pair now GATES its provider (auth-providers.ts): with either
   // half absent the button is not rendered at all, rather than rendered
   // broken. That is what makes an honest retier possible — the pair is
@@ -335,7 +383,13 @@ export const ENV_SPEC = [
   // ever being asked to deliver it to the container.
   { name: 'PUBLISHER_PUBLIC_KEY', priorEraName: 'EVIDENCE_PUBLIC_KEY', readBy: 'external-tool', tier: 'optional', purpose: 'Public half of the signing keypair — written by scripts/generate-signing-key.ts for the trust-registry entry; never read by the app' },
   { name: 'CIVICAITOOLS_SESSION_TOKEN', readBy: 'external-tool', tier: 'optional', purpose: 'publish-record skill (Claude Code) auth' },
-  { name: 'CRON_SECRET', tier: 'optional', purpose: 'Cron endpoint auth (blob-gc, portal refresh)' },
+  // web#194 #2: retiered from `optional`. The one scheduled job this repo
+  // declares (vercel.json, `0 4 * * *` → src/app/api/cron/blob-gc/route.ts)
+  // fails closed on an absent secret, so without it the sweep 401s on every
+  // invocation, forever, with no operator-visible signal. The purpose text
+  // also named a "portal refresh" endpoint that does not exist — blob-gc is
+  // the only cron route in the tree.
+  { name: 'CRON_SECRET', tier: 'recommended', purpose: 'Cron endpoint auth (orphan-blob GC, the only scheduled job) — absent, every run 401s and abandoned uploads accumulate' },
   { name: 'NEXT_PUBLIC_GA_MEASUREMENT_ID', readBy: 'build', tier: 'optional', purpose: 'Google Analytics 4' },
 
   // --- Tuning knobs with coded defaults (previously unenumerated; the app
@@ -594,7 +648,18 @@ export function resolveSpec(drivers, spec = ENV_SPEC, env = {}) {
     }
     const promoted = s.requiredWhen && conditionMet(s.requiredWhen, drivers);
     if (promoted) {
-      applicable.push({ ...s, tier: 'required' });
+      // The promotion also drops any `hasFallback` claim. A driver that makes
+      // a variable load-bearing is by definition a driver the coded fallback
+      // does not cover — MODEL_API_BASE_URL's fallback is an OpenAI-compatible
+      // gateway, which is the wrong service in the wrong dialect for
+      // MODEL_API_KIND=azure-openai. Left in place, the row would land in the
+      // soft `requiredOnFallback` bucket and the run would PASS a
+      // configuration the app refuses at the first request. No pre-existing
+      // row carries both fields, so this is inert for every profile that
+      // shipped before the model seam.
+      const promotedEntry = { ...s, tier: 'required' };
+      delete promotedEntry.hasFallback;
+      applicable.push(promotedEntry);
       continue;
     }
     // An alternative set covers this variable's need: demote rather than
@@ -641,7 +706,13 @@ export function evaluateEnv(env, spec = ENV_SPEC) {
   // acceptability can be confirmed, without failing the run.
   const missingRequired = rows.filter((r) => r.tier === 'required' && !r.present && !r.hasFallback);
   const requiredOnFallback = rows.filter((r) => r.tier === 'required' && !r.present && r.hasFallback);
-  const missingRecommended = rows.filter((r) => r.tier === 'recommended' && !r.present);
+  // web#194 #6: `hasFallback` excludes a recommended row from the degraded-
+  // feature nag for the same reason it softens a required one — the code
+  // substitutes a built-in default, so the feature is not degraded, it is
+  // running on the coded value. Without the filter the report named
+  // DATA_COMMONS_MCP_URL and BOSTON_OPENCONTEXT_MCP_URL as degraded features
+  // when both have working defaults.
+  const missingRecommended = rows.filter((r) => r.tier === 'recommended' && !r.present && !r.hasFallback);
   const partialGroups = evaluateGroups(env, drivers, ENV_GROUPS, spec);
   // Variables supplied under a prior-era name. Warn-only and never a failure:
   // both spellings work, and the expand half of the settlement exists exactly

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -22,6 +22,10 @@ import {
 
 const REQUIRED = ENV_SPEC.filter((s) => s.tier === 'required').map((s) => s.name);
 const RECOMMENDED = ENV_SPEC.filter((s) => s.tier === 'recommended').map((s) => s.name);
+// web#194 #6: a recommended variable with a coded fallback is not a degraded
+// feature and is not nagged about, so the two sets are counted separately.
+const RECOMMENDED_WITH_FALLBACK = ENV_SPEC.filter((s) => s.tier === 'recommended' && s.hasFallback).map((s) => s.name);
+const RECOMMENDED_NO_FALLBACK = ENV_SPEC.filter((s) => s.tier === 'recommended' && !s.hasFallback).map((s) => s.name);
 
 /** Build an env object with every required var present (non-empty). */
 function envWithAllRequired() {
@@ -142,10 +146,21 @@ test('two-name expand: either spelling satisfies presence, and the report names 
 
   // And the deprecation notice lists every one of them, with its successor.
   assert.ok(result.deprecatedNames.length > 0);
+  // Only prior-era names are listed as deprecated. Asserted against each
+  // entry's DECLARED `priorEraName` rather than against the `EVIDENCE_`
+  // prefix: since website#30 P1 the mechanism carries a second rename
+  // (MODEL_API_KEY ← OPENROUTER_API_KEY) that shares no prefix with the first.
+  const priorEraNames = new Set(
+    ENV_SPEC.filter((s) => typeof s.priorEraName === 'string').map((s) => s.priorEraName),
+  );
   assert.ok(
-    result.deprecatedNames.every((r) => r.name.startsWith('EVIDENCE_')),
+    result.deprecatedNames.every((r) => priorEraNames.has(r.name)),
     'only prior-era names are listed as deprecated',
   );
+  // Both renames are represented, so the assertion above cannot pass vacuously
+  // on a single-prefix census.
+  assert.ok(result.deprecatedNames.some((r) => r.name.startsWith('EVIDENCE_')));
+  assert.ok(result.deprecatedNames.some((r) => r.canonicalName === 'MODEL_API_KEY'));
   const report = renderReport(result);
   assert.match(report, /EVIDENCE_KEY_ID → rename to PUBLISHER_KEY_ID/);
   assert.match(report, /removed at a future/);
@@ -214,20 +229,205 @@ test('two-name expand: every publisher variable in the census is declared with b
   );
 });
 
+// --- The model credential's two names (website#30 P1, D4) --------------------
+
+test('MODEL_API_KEY alone satisfies the run', () => {
+  const env = envWithAllRequired(); // sets the canonical name
+  assert.ok(env.MODEL_API_KEY, 'the canonical name is the one the spec declares');
+  assert.equal(env.OPENROUTER_API_KEY, undefined);
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, true);
+  assert.ok(!result.missingRequired.some((r) => r.canonicalName === 'MODEL_API_KEY'));
+  // Nothing deprecated is reported when only the canonical name is set.
+  assert.ok(!result.deprecatedNames.some((r) => r.canonicalName === 'MODEL_API_KEY'));
+});
+
+test('OPENROUTER_API_KEY alone satisfies the run and warns via viaPriorEra', () => {
+  const env = envWithAllRequired();
+  delete env.MODEL_API_KEY;
+  env.OPENROUTER_API_KEY = 'present';
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, true, 'an instance that never renamed still passes');
+
+  const row = result.rows.find((r) => r.canonicalName === 'MODEL_API_KEY');
+  assert.equal(row.present, true);
+  assert.equal(row.name, 'OPENROUTER_API_KEY', 'the report names the variable the operator set');
+  assert.equal(row.viaPriorEra, true);
+
+  const deprecated = result.deprecatedNames.find((r) => r.canonicalName === 'MODEL_API_KEY');
+  assert.ok(deprecated, 'the prior-era spelling is reported as deprecated');
+  assert.equal(deprecated.name, 'OPENROUTER_API_KEY');
+
+  const report = renderReport(result);
+  assert.match(report, /OPENROUTER_API_KEY → rename to MODEL_API_KEY/);
+  // A NOTE, never a failure — expand-before-flip: nothing flips in this phase.
+  assert.ok(!report.includes('RESULT: FAIL'));
+});
+
+test('both names set resolves to the canonical one, without error', () => {
+  const env = envWithAllRequired();
+  env.OPENROUTER_API_KEY = 'prior-era';
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, true);
+  const row = result.rows.find((r) => r.canonicalName === 'MODEL_API_KEY');
+  assert.equal(row.name, 'MODEL_API_KEY');
+  assert.equal(row.viaPriorEra, false);
+  assert.ok(!result.deprecatedNames.some((r) => r.canonicalName === 'MODEL_API_KEY'));
+
+  // Same DEFINED-not-truthy precedence as the publisher set: an emptied
+  // canonical name shadows a prior-era name that still holds a value. The rule
+  // must match src/lib/model-client.ts, which resolves the credential the same
+  // way — a preflight that fell through on empty would PASS a configuration
+  // the app refuses.
+  const entry = ENV_SPEC.find((s) => s.name === 'MODEL_API_KEY');
+  const shadowed = resolveEnvName(entry, { MODEL_API_KEY: '', OPENROUTER_API_KEY: 'prior-era' });
+  assert.equal(shadowed.name, 'MODEL_API_KEY');
+  assert.equal(shadowed.raw, '');
+  assert.equal(shadowed.viaPriorEra, false);
+
+  env.MODEL_API_KEY = '';
+  assert.equal(evaluateEnv(env).ok, false, 'an emptied canonical name is a miss, not a fall-through');
+});
+
+// --- The model seam (website#30 P1) -----------------------------------------
+
+test('the model seam is a declared driver seam whose default is the current behavior', () => {
+  assert.deepEqual(DRIVER_SEAMS.model, {
+    env: 'MODEL_API_KIND',
+    default: 'openai-compatible',
+    values: ['openai-compatible', 'azure-openai'],
+  });
+  // Unset, the profile is still the default one: no banner, nothing promoted.
+  const result = evaluateEnv(envWithAllRequired());
+  assert.equal(result.profile.drivers.model, 'openai-compatible');
+  assert.equal(result.profile.isDefault, true);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.notApplicable, []);
+});
+
+test('MODEL_API_KIND=azure-openai promotes the version and the resource endpoint to HARD misses', () => {
+  const env = { ...envWithAllRequired(), MODEL_API_KIND: 'azure-openai' };
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false);
+  const missing = result.missingRequired.map((r) => r.name).sort();
+  assert.deepEqual(missing, ['MODEL_API_BASE_URL', 'MODEL_API_VERSION']);
+  // MODEL_API_BASE_URL declares hasFallback for the DEFAULT dialect. The
+  // promotion must drop that claim, or the row lands in the soft
+  // `requiredOnFallback` bucket and the run PASSES a configuration
+  // src/lib/model-client.ts refuses at the first request.
+  assert.ok(!result.requiredOnFallback.some((r) => r.name === 'MODEL_API_BASE_URL'));
+
+  env.MODEL_API_BASE_URL = 'https://example-resource.example.net';
+  env.MODEL_API_VERSION = '2099-01-01-preview';
+  const configured = evaluateEnv(env);
+  assert.equal(configured.ok, true);
+  assert.match(renderReport(configured), /PROFILE:.*model=azure-openai/);
+});
+
+test('the promotion is inert for every row that shipped before the model seam', () => {
+  // The `hasFallback`-dropping promotion is a shared code path. It can only
+  // change a row that declares BOTH fields; MODEL_API_BASE_URL is the first.
+  const both = ENV_SPEC.filter((s) => s.requiredWhen && s.hasFallback).map((s) => s.name);
+  assert.deepEqual(both, ['MODEL_API_BASE_URL']);
+});
+
+test('an unrecognized MODEL_API_KIND fails the run and is never echoed', () => {
+  const env = { ...envWithAllRequired(), MODEL_API_KIND: 'anthropic-native-SENTINEL' };
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false);
+  assert.ok(result.driverErrors.includes('MODEL_API_KIND'));
+  const report = renderReport(result);
+  assert.ok(!report.includes('anthropic-native-SENTINEL'), 'the offending value never reaches the report');
+  assert.ok(report.includes('MODEL_API_KIND'));
+  // Resolution falls back to the seam default so the rest of the table renders.
+  assert.equal(result.profile.drivers.model, 'openai-compatible');
+});
+
 test('missing recommended variables do not fail the run', () => {
   const env = envWithAllRequired(); // recommended vars all absent
   const result = evaluateEnv(env);
   assert.equal(result.ok, true);
-  assert.equal(result.missingRecommended.length, RECOMMENDED.length);
+  assert.equal(result.missingRecommended.length, RECOMMENDED_NO_FALLBACK.length);
+});
+
+test('web#194 #6: a recommended variable with a coded fallback is not nagged as degraded', () => {
+  // A fallback-backed variable is not a degraded feature — the code runs on
+  // its built-in default. The report used to list these anyway.
+  const result = evaluateEnv(envWithAllRequired());
+  const named = result.missingRecommended.map((r) => r.name);
+  for (const name of RECOMMENDED_WITH_FALLBACK) {
+    assert.ok(!named.includes(name), `${name} has a coded fallback and must not be nagged`);
+  }
+  // …and the ones that genuinely degrade are still named.
+  assert.deepEqual(named.sort(), [...RECOMMENDED_NO_FALLBACK].sort());
+  assert.ok(RECOMMENDED_WITH_FALLBACK.length > 0, 'the exclusion is exercised, not vacuous');
+  assert.ok(RECOMMENDED_NO_FALLBACK.length > 0, 'the nag still has something to say');
+  // The two sets partition the recommended tier — nothing is counted twice or
+  // dropped by the split.
+  assert.deepEqual(
+    [...RECOMMENDED_WITH_FALLBACK, ...RECOMMENDED_NO_FALLBACK].sort(),
+    [...RECOMMENDED].sort(),
+  );
+});
+
+test('web#194 #2: CRON_SECRET is recommended, and its purpose names the job that exists', () => {
+  // The only scheduled job in the tree is the orphan-blob sweep
+  // (vercel.json → src/app/api/cron/blob-gc/route.ts), which fails closed on
+  // an absent secret. The prior purpose text also named a "portal refresh"
+  // endpoint that does not exist.
+  const entry = ENV_SPEC.find((s) => s.name === 'CRON_SECRET');
+  assert.equal(entry.tier, 'recommended');
+  assert.ok(!entry.hasFallback, 'a dead cron job is not a coded fallback');
+  assert.ok(!/portal refresh/i.test(entry.purpose), 'the phantom endpoint is gone');
+  assert.match(entry.purpose, /orphan-blob GC/);
+  // Absent, it is named as a degraded feature — and never fails the run.
+  const result = evaluateEnv(envWithAllRequired());
+  assert.equal(result.ok, true);
+  assert.ok(result.missingRecommended.some((r) => r.name === 'CRON_SECRET'));
+});
+
+test('web#194 #5: the DB_DRIVER hazard renders in the report, not only in a code comment', () => {
+  const entry = ENV_SPEC.find((s) => s.name === 'DB_DRIVER');
+  assert.match(entry.purpose, /Unset silently selects the managed serverless driver/);
+  assert.ok(renderReport(evaluateEnv(envWithAllRequired())).includes('Unset silently selects'));
+});
+
+test('D9: NEXTAUTH_URL stays required and declares no fallback', () => {
+  // Ruled at sprint #30 G0. The three app-side origins (api-auth.ts,
+  // device-flow.ts, evidence/verify.ts) are request-derived values, not
+  // configuration, and NextAuth's own inference covers only one platform — so
+  // a declared fallback would pass an instance whose OAuth callbacks are
+  // broken.
+  const entry = ENV_SPEC.find((s) => s.name === 'NEXTAUTH_URL');
+  assert.equal(entry.tier, 'required');
+  assert.ok(!entry.hasFallback);
+  assert.match(entry.purpose, /request-derived, not configuration/);
+
+  const env = envWithAllRequired();
+  delete env.NEXTAUTH_URL;
+  const result = evaluateEnv(env);
+  assert.equal(result.ok, false, 'an absent callback URL is a hard miss, not a soft note');
+  assert.ok(result.missingRequired.some((r) => r.name === 'NEXTAUTH_URL'));
+  assert.ok(!result.requiredOnFallback.some((r) => r.name === 'NEXTAUTH_URL'));
+});
+
+test('#4b (already shipped): CIVICAITOOLS_SESSION_TOKEN is untouched by this pass', () => {
+  const entry = ENV_SPEC.find((s) => s.name === 'CIVICAITOOLS_SESSION_TOKEN');
+  assert.deepEqual(entry, {
+    name: 'CIVICAITOOLS_SESSION_TOKEN',
+    readBy: 'external-tool',
+    tier: 'optional',
+    purpose: 'publish-record skill (Claude Code) auth',
+  });
 });
 
 test('renderReport never emits a variable value — only names and statuses', () => {
   const env = envWithAllRequired();
   // Use a recognizable sentinel value; it must never appear in the report.
-  env.OPENROUTER_API_KEY = 'sk-or-SECRET-SENTINEL-DO-NOT-LEAK';
+  env.MODEL_API_KEY = 'sk-SECRET-SENTINEL-DO-NOT-LEAK';
   const report = renderReport(evaluateEnv(env));
   assert.ok(!report.includes('SECRET-SENTINEL'), 'report must not contain any env value');
-  assert.ok(report.includes('OPENROUTER_API_KEY'), 'report should list the variable name');
+  assert.ok(report.includes('MODEL_API_KEY'), 'report should list the variable name');
   assert.ok(report.includes('PASS'), 'report should show an overall PASS');
 });
 

--- a/src/lib/model-client.test.ts
+++ b/src/lib/model-client.test.ts
@@ -1,28 +1,60 @@
-// Tests for the request-path model-credential guard (#178).
+// Tests for the endpoint-configuration layer and the request-path guard
+// (#178, and the endpoint-generic model layer, website#30 P1).
 //
 // A fresh instance with no model API key must fail fast and typed — never
 // hang. The factory stays lazy (no import-time validation); these tests cover
 // the guard check, the typed construction failure (including the empty-string
-// key the SDK constructor would otherwise silently accept), and error
-// classification. All key values are obviously fake fixtures.
+// key the SDK constructor would otherwise silently accept), error
+// classification, the two accepted credential names, and — on the wire,
+// against a local fake server — what each dialect actually emits.
+//
+// ENVIRONMENT OF VERIFICATION: every wire claim below is verified against a
+// LOCAL FAKE HTTP SERVER under Node, in this repository's test runner. None of
+// it is a claim about a real Azure OpenAI resource: the fixture proves the
+// request this app constructs, not that any resource accepts it.
+//
+// All key values are obviously fake fixtures.
 //
 // Run with: npm test   (or: node --test --experimental-strip-types src/lib/model-client.test.ts)
 
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import {
   ModelConfigurationError,
   getMissingModelCredentialError,
   createModelClient,
   getModelClient,
+  getModelApiBaseUrl,
+  getModelApiKind,
+  getModelApiAuth,
   classifyModelError,
   _resetDefaultModelClientForTests,
 } from './model-client.ts';
 
 const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
+const FAKE_AZURE_KEY = 'azure-test-obviously-fake-key-do-not-use';
+const FAKE_API_VERSION = '2099-01-01-preview';
 
 const savedEnv: Record<string, string | undefined> = {};
-const ENV_KEYS = ['OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'MODEL_API_BASE_URL'];
+const ENV_KEYS = [
+  // The credential, both accepted names.
+  'MODEL_API_KEY',
+  'OPENROUTER_API_KEY',
+  // The endpoint settings this layer reads.
+  'MODEL_API_KIND',
+  'MODEL_API_BASE_URL',
+  'MODEL_API_VERSION',
+  'MODEL_API_AUTH',
+  // Variables the SDK itself defaults from. Cleared so a developer's shell
+  // cannot change what these tests measure.
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_VERSION',
+  'AZURE_OPENAI_API_KEY',
+  'AZURE_OPENAI_ENDPOINT',
+];
 
 beforeEach(() => {
   for (const k of ENV_KEYS) {
@@ -40,14 +72,24 @@ afterEach(() => {
   _resetDefaultModelClientForTests();
 });
 
+// --- The request-path guard (#178) -----------------------------------------
+
 test('guard returns a typed error when the key is unset', () => {
   const err = getMissingModelCredentialError();
   assert.ok(err instanceof ModelConfigurationError);
   assert.equal(err!.code, 'model_not_configured');
+  // The message names the canonical variable AND the prior-era name that is
+  // still accepted, so an operator on either spelling reads an actionable fix.
+  assert.match(err!.message, /MODEL_API_KEY/);
   assert.match(err!.message, /OPENROUTER_API_KEY/);
 });
 
 test('guard returns a typed error when the key is empty or whitespace', () => {
+  process.env.MODEL_API_KEY = '';
+  assert.ok(getMissingModelCredentialError() instanceof ModelConfigurationError);
+  process.env.MODEL_API_KEY = '   ';
+  assert.ok(getMissingModelCredentialError() instanceof ModelConfigurationError);
+  delete process.env.MODEL_API_KEY;
   process.env.OPENROUTER_API_KEY = '';
   assert.ok(getMissingModelCredentialError() instanceof ModelConfigurationError);
   process.env.OPENROUTER_API_KEY = '   ';
@@ -55,6 +97,10 @@ test('guard returns a typed error when the key is empty or whitespace', () => {
 });
 
 test('guard returns null when a key is present', () => {
+  process.env.MODEL_API_KEY = FAKE_KEY;
+  assert.equal(getMissingModelCredentialError(), null);
+  delete process.env.MODEL_API_KEY;
+  // The prior-era name satisfies the guard on its own — nothing flips here.
   process.env.OPENROUTER_API_KEY = FAKE_KEY;
   assert.equal(getMissingModelCredentialError(), null);
 });
@@ -63,6 +109,9 @@ test('createModelClient throws the typed error when no key resolves', () => {
   assert.throws(() => createModelClient(), ModelConfigurationError);
   // Empty string: the SDK constructor would accept this and send a blank
   // bearer token upstream — the typed throw must catch it too.
+  process.env.MODEL_API_KEY = '';
+  assert.throws(() => createModelClient(), ModelConfigurationError);
+  delete process.env.MODEL_API_KEY;
   process.env.OPENROUTER_API_KEY = '';
   assert.throws(() => createModelClient(), ModelConfigurationError);
 });
@@ -74,16 +123,23 @@ test('createModelClient accepts a per-call key even when the env is empty', () =
 
 test('getModelClient throws typed when unconfigured, builds once configured', () => {
   assert.throws(() => getModelClient(), ModelConfigurationError);
-  process.env.OPENROUTER_API_KEY = FAKE_KEY;
+  process.env.MODEL_API_KEY = FAKE_KEY;
   _resetDefaultModelClientForTests();
   assert.ok(getModelClient());
 });
 
 test('classifyModelError distinguishes not-configured from auth-rejected', () => {
   assert.equal(classifyModelError(new ModelConfigurationError('x')), 'model_not_configured');
-  // The SDK constructor's own message shape (belt and braces).
+  // The SDK constructor's own message shape (belt and braces). Both the
+  // OpenAI and the Azure constructor use this wording.
   assert.equal(
     classifyModelError(new Error('Missing credentials. Please pass an `apiKey`.')),
+    'model_not_configured',
+  );
+  assert.equal(
+    classifyModelError(
+      new Error('Missing credentials. Please pass one of `apiKey` and `azureADTokenProvider`.'),
+    ),
     'model_not_configured',
   );
   // Upstream auth rejections carry a status on the SDK's APIError.
@@ -94,3 +150,288 @@ test('classifyModelError distinguishes not-configured from auth-rejected', () =>
   assert.equal(classifyModelError(new Error('fetch failed')), null);
   assert.equal(classifyModelError(null), null);
 });
+
+// --- The default dialect is untouched --------------------------------------
+
+test('with no new variables set, the default endpoint resolves exactly as before', () => {
+  assert.equal(getModelApiBaseUrl(), 'https://openrouter.ai/api/v1');
+  assert.equal(getModelApiKind(), 'openai-compatible');
+  assert.equal(getModelApiAuth(), 'bearer');
+  // An explicit base URL still overrides it, dialect unchanged.
+  process.env.MODEL_API_BASE_URL = 'https://gateway.example.net/v1';
+  assert.equal(getModelApiBaseUrl(), 'https://gateway.example.net/v1');
+  assert.equal(getModelApiKind(), 'openai-compatible');
+});
+
+// --- The two accepted credential names -------------------------------------
+
+test('the credential resolves under either name, canonical winning when DEFINED', async () => {
+  const server = await startCapturingServer();
+  try {
+    process.env.MODEL_API_BASE_URL = server.baseUrl;
+
+    // Prior-era name alone answers.
+    process.env.OPENROUTER_API_KEY = 'prior-era-obviously-fake-key';
+    await createModelClient().chat.completions.create({
+      model: 'test/model',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    assert.equal(server.requests.at(-1)!.headers.authorization, 'Bearer prior-era-obviously-fake-key');
+
+    // Canonical name wins when both are set.
+    process.env.MODEL_API_KEY = 'canonical-obviously-fake-key';
+    await createModelClient().chat.completions.create({
+      model: 'test/model',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    assert.equal(server.requests.at(-1)!.headers.authorization, 'Bearer canonical-obviously-fake-key');
+
+    // …and it wins even when DEFINED-but-empty, which is a refusal rather than
+    // a fall-through. The rule mirrors src/lib/publisher-env.ts and
+    // scripts/preflight-env.mjs exactly; a reader that disagreed with the
+    // preflight would accept a configuration the other refuses.
+    process.env.MODEL_API_KEY = '';
+    assert.throws(() => createModelClient(), ModelConfigurationError);
+  } finally {
+    await server.close();
+  }
+});
+
+// --- On the wire: what each dialect actually emits --------------------------
+//
+// Built from the request the SDK emits, captured — not from a description of
+// it. The assertions below were written after standing this server and reading
+// what arrived (openai@6.16.0, Node 22, macOS).
+
+test('WIRE (local fake, Node): the default dialect sends bearer auth to the plain path', async () => {
+  const server = await startCapturingServer();
+  try {
+    process.env.MODEL_API_BASE_URL = server.baseUrl;
+    process.env.MODEL_API_KEY = FAKE_KEY;
+
+    await createModelClient().chat.completions.create({
+      model: 'test/model-slug',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    assert.equal(server.requests.length, 1);
+    const req = server.requests[0];
+    const url = new URL(req.url, 'http://127.0.0.1');
+    assert.equal(url.pathname, '/chat/completions');
+    assert.equal(url.searchParams.get('api-version'), null);
+    assert.equal(req.headers.authorization, `Bearer ${FAKE_KEY}`);
+    assert.equal(req.headers['api-key'], undefined);
+    // The model slug rides in the body, not the path.
+    assert.equal(JSON.parse(req.body).model, 'test/model-slug');
+  } finally {
+    await server.close();
+  }
+});
+
+test('WIRE (local fake, Node): the azure dialect sends api-key auth, no Authorization, a deployment path and an api-version', async () => {
+  const server = await startCapturingServer();
+  try {
+    process.env.MODEL_API_KIND = 'azure-openai';
+    process.env.MODEL_API_BASE_URL = server.baseUrl;
+    process.env.MODEL_API_VERSION = FAKE_API_VERSION;
+    process.env.MODEL_API_KEY = FAKE_AZURE_KEY;
+
+    await createModelClient().chat.completions.create({
+      model: 'example-deployment',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    assert.equal(server.requests.length, 1);
+    const req = server.requests[0];
+    const url = new URL(req.url, 'http://127.0.0.1');
+
+    // 1. Deployment-name routing: the `model` parameter becomes the path
+    //    segment. This is what makes the deployment name the wire identity.
+    assert.equal(url.pathname, '/openai/deployments/example-deployment/chat/completions');
+    // 2. The api-version rides as a query parameter, not a header or a path.
+    assert.equal(url.searchParams.get('api-version'), FAKE_API_VERSION);
+    // 3. `api-key` header auth — and NO bearer token. Both halves matter: a
+    //    client that sent both would leak the key to a second auth channel.
+    assert.equal(req.headers['api-key'], FAKE_AZURE_KEY);
+    assert.equal(req.headers.authorization, undefined);
+    // 4. The body is unchanged, deployment name included as `model`.
+    assert.equal(JSON.parse(req.body).model, 'example-deployment');
+  } finally {
+    await server.close();
+  }
+});
+
+test('WIRE (local fake, Node): a resource endpoint written with a trailing slash or an /openai suffix resolves the same', async () => {
+  const server = await startCapturingServer();
+  try {
+    process.env.MODEL_API_KIND = 'azure-openai';
+    process.env.MODEL_API_VERSION = FAKE_API_VERSION;
+    process.env.MODEL_API_KEY = FAKE_AZURE_KEY;
+
+    for (const written of [`${server.baseUrl}/`, `${server.baseUrl}/openai`, `${server.baseUrl}/openai/`]) {
+      process.env.MODEL_API_BASE_URL = written;
+      await createModelClient().chat.completions.create({
+        model: 'example-deployment',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const url = new URL(server.requests.at(-1)!.url, 'http://127.0.0.1');
+      assert.equal(
+        url.pathname,
+        '/openai/deployments/example-deployment/chat/completions',
+        `resource endpoint written as ${written}`,
+      );
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+// --- Every refusal is typed, names its variable, and precedes any call ------
+
+test('an unrecognized MODEL_API_KIND is refused by name, before any upstream call', async () => {
+  const server = await startCapturingServer();
+  try {
+    process.env.MODEL_API_BASE_URL = server.baseUrl;
+    process.env.MODEL_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_KIND = 'anthropic-native';
+
+    const guard = getMissingModelCredentialError();
+    assert.ok(guard instanceof ModelConfigurationError);
+    assert.match(guard!.message, /MODEL_API_KIND/);
+    // The accepted values are named, so the fix does not require the docs.
+    assert.match(guard!.message, /openai-compatible/);
+    assert.match(guard!.message, /azure-openai/);
+
+    assert.throws(() => createModelClient(), ModelConfigurationError);
+    assert.throws(() => getModelClient(), ModelConfigurationError);
+    assert.equal(server.requests.length, 0, 'nothing reached the endpoint');
+  } finally {
+    await server.close();
+  }
+});
+
+test('azure-openai without MODEL_API_VERSION is refused by name, before any upstream call', async () => {
+  const server = await startCapturingServer();
+  try {
+    process.env.MODEL_API_KIND = 'azure-openai';
+    process.env.MODEL_API_BASE_URL = server.baseUrl;
+    process.env.MODEL_API_KEY = FAKE_AZURE_KEY;
+    // MODEL_API_VERSION deliberately unset.
+
+    const guard = getMissingModelCredentialError();
+    assert.ok(guard instanceof ModelConfigurationError);
+    assert.equal(guard!.code, 'model_not_configured');
+    assert.match(guard!.message, /MODEL_API_VERSION/);
+    assert.match(guard!.message, /azure-openai/);
+
+    assert.throws(() => createModelClient(), ModelConfigurationError);
+    assert.equal(server.requests.length, 0, 'nothing reached the endpoint');
+
+    // Empty and whitespace-only are absent too.
+    process.env.MODEL_API_VERSION = '   ';
+    assert.throws(() => createModelClient(), ModelConfigurationError);
+
+    // Set, and the refusal lifts.
+    process.env.MODEL_API_VERSION = FAKE_API_VERSION;
+    assert.equal(getMissingModelCredentialError(), null);
+  } finally {
+    await server.close();
+  }
+});
+
+test('azure-openai without MODEL_API_BASE_URL is refused by name — the built-in default is never borrowed', () => {
+  process.env.MODEL_API_KIND = 'azure-openai';
+  process.env.MODEL_API_VERSION = FAKE_API_VERSION;
+  process.env.MODEL_API_KEY = FAKE_AZURE_KEY;
+
+  const guard = getMissingModelCredentialError();
+  assert.ok(guard instanceof ModelConfigurationError);
+  assert.match(guard!.message, /MODEL_API_BASE_URL/);
+  assert.throws(() => createModelClient(), ModelConfigurationError);
+});
+
+test('MODEL_API_AUTH derives from the kind, and an explicit contradiction is refused by name', () => {
+  assert.equal(getModelApiAuth('openai-compatible'), 'bearer');
+  assert.equal(getModelApiAuth('azure-openai'), 'api-key');
+
+  process.env.MODEL_API_AUTH = 'bearer';
+  assert.equal(getModelApiAuth('openai-compatible'), 'bearer');
+  assert.throws(
+    () => getModelApiAuth('azure-openai'),
+    (err: unknown) =>
+      err instanceof ModelConfigurationError &&
+      /MODEL_API_AUTH/.test(err.message) &&
+      /MODEL_API_KIND/.test(err.message),
+  );
+});
+
+test('MODEL_API_AUTH=entra is reserved in the enum with no code behind it', () => {
+  process.env.MODEL_API_AUTH = 'entra';
+  assert.throws(
+    () => getModelApiAuth('azure-openai'),
+    (err: unknown) =>
+      err instanceof ModelConfigurationError &&
+      /MODEL_API_AUTH/.test(err.message) &&
+      /reserved/i.test(err.message),
+  );
+  // An unrecognized value is a different refusal, and names the enum.
+  process.env.MODEL_API_AUTH = 'basic';
+  assert.throws(
+    () => getModelApiAuth('openai-compatible'),
+    (err: unknown) => err instanceof ModelConfigurationError && /MODEL_API_AUTH/.test(err.message),
+  );
+});
+
+// --- Fake endpoint -----------------------------------------------------------
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | undefined>;
+  body: string;
+}
+
+/**
+ * A local HTTP server that records every inbound request and answers with a
+ * minimal chat-completion body. Bound to 127.0.0.1 on an ephemeral port: it
+ * never leaves the machine and reads nothing from the environment.
+ */
+async function startCapturingServer(): Promise<{
+  baseUrl: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: CapturedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      requests.push({
+        method: req.method ?? '',
+        url: req.url ?? '',
+        headers: req.headers as Record<string, string | undefined>,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          id: 'chatcmpl-fixture',
+          object: 'chat.completion',
+          created: 1,
+          model: 'fixture',
+          choices: [
+            { index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}

--- a/src/lib/model-client.ts
+++ b/src/lib/model-client.ts
@@ -1,31 +1,86 @@
-import OpenAI from 'openai';
+import OpenAI, { AzureOpenAI } from 'openai';
 import type { ModelErrorCode } from './streaming.ts';
 
 /**
  * Model-client factory — the single place the chat-completions endpoint is
- * configured. The app speaks the OpenAI-compatible API, so any
- * OpenAI-compatible endpoint works: set MODEL_API_BASE_URL to point at it.
- * Unset, the default below preserves the demo deployment's behavior
- * (OpenRouter). The API key stays OPENROUTER_API_KEY in either case unless a
- * per-call key is passed in (e.g. a user-supplied key on the replay/evaluate
- * routes).
+ * configured. The endpoint is a WIRE DIALECT, not merely a base URL:
+ *
+ *   MODEL_API_KIND=openai-compatible  (default) — the OpenAI-compatible API.
+ *     `MODEL_API_BASE_URL` points at any endpoint that speaks it; unset, the
+ *     default below preserves the reference deployment's behavior
+ *     (OpenRouter). Auth is `Authorization: Bearer <key>`.
+ *
+ *   MODEL_API_KIND=azure-openai — an Azure OpenAI resource. `MODEL_API_BASE_URL`
+ *     is the RESOURCE ENDPOINT (e.g. https://example-resource.example.net);
+ *     requests route to /openai/deployments/{deployment}/chat/completions,
+ *     carry `api-version=MODEL_API_VERSION` as a query parameter, and
+ *     authenticate with an `api-key` header instead of a bearer token. The
+ *     deployment name is whatever the caller passes as `model` — see
+ *     `createModelClient` for the measurement behind that claim.
+ *
+ * The credential is `MODEL_API_KEY`, with `OPENROUTER_API_KEY` accepted as its
+ * prior-era name (expand half of the rename — the prior-era spelling keeps
+ * working indefinitely in this phase; nothing flips). Precedence mirrors
+ * `src/lib/publisher-env.ts` and `scripts/preflight-env.mjs` exactly: the
+ * canonical name wins whenever it is DEFINED, empty string included. A
+ * per-call key (a user-supplied key on the replay/evaluate routes) overrides
+ * both.
  *
  * Construction is lazy on purpose: no client is built at import time, so
  * importing a module that uses the factory never requires the key to be
- * present (e.g. during `next build`). Credential validation therefore lives on
- * the request path: routes call `getMissingModelCredentialError()` up front,
- * and `createModelClient` throws a typed `ModelConfigurationError` (instead of
- * the SDK's generic constructor error) the first time a request actually needs
- * the missing key. See issue #178 — a fresh instance with an incomplete env
- * file must fail loudly, not hang.
+ * present (e.g. during `next build`). Credential and endpoint validation
+ * therefore live on the request path: routes call
+ * `getMissingModelCredentialError()` up front, and `createModelClient` throws
+ * a typed `ModelConfigurationError` (instead of the SDK's generic constructor
+ * error) the first time a request actually needs the missing value. See issue
+ * #178 — a fresh instance with an incomplete env file must fail loudly, not
+ * hang.
  */
 
 const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
 
+/** The credential's canonical name, and the prior-era name still accepted. */
+const CANONICAL_KEY_NAME = 'MODEL_API_KEY';
+const PRIOR_ERA_KEY_NAME = 'OPENROUTER_API_KEY';
+
 /**
- * Typed, operator-actionable configuration failure: the environment has no
- * usable model credential. Distinct from an upstream auth rejection (a key
- * that exists but the endpoint refuses) — see `classifyModelError`.
+ * The wire dialects this factory speaks. A closed set: an unrecognized
+ * `MODEL_API_KIND` is a typed refusal, never a silent fall-through to the
+ * default, because falling through would send OpenAI-compatible requests at
+ * an endpoint the operator told us speaks something else.
+ */
+export const MODEL_API_KINDS = ['openai-compatible', 'azure-openai'] as const;
+export type ModelApiKind = (typeof MODEL_API_KINDS)[number];
+const DEFAULT_MODEL_API_KIND: ModelApiKind = 'openai-compatible';
+
+/**
+ * Auth modes. `entra` is RESERVED — it names the Microsoft Entra token-provider
+ * path (`azureADTokenProvider` in the SDK) so that the enum does not have to
+ * change when that ships, and there is deliberately no code behind it: setting
+ * it is a typed refusal, not a silent fallback to `api-key`.
+ */
+export const MODEL_API_AUTH_MODES = ['bearer', 'api-key', 'entra'] as const;
+export type ModelApiAuth = (typeof MODEL_API_AUTH_MODES)[number];
+
+/**
+ * `MODEL_API_AUTH` is DERIVED from `MODEL_API_KIND` by default. Each dialect's
+ * client emits exactly one auth shape (measured — see the test), so an
+ * explicit value that contradicts the kind describes a request this factory
+ * cannot produce; it is refused rather than ignored.
+ */
+const DERIVED_AUTH: Record<ModelApiKind, Exclude<ModelApiAuth, 'entra'>> = {
+  'openai-compatible': 'bearer',
+  'azure-openai': 'api-key',
+};
+
+/**
+ * Typed, operator-actionable configuration failure: the environment cannot
+ * describe a usable model endpoint. Distinct from an upstream auth rejection
+ * (a key that exists but the endpoint refuses) — see `classifyModelError`.
+ *
+ * Every message names the variable at fault and the fix. These are operability
+ * refusals: they are raised on the request path, before any upstream call, and
+ * none of them ever reaches a published record.
  */
 export class ModelConfigurationError extends Error {
   readonly code: ModelErrorCode = 'model_not_configured';
@@ -37,20 +92,189 @@ export class ModelConfigurationError extends Error {
 }
 
 const MISSING_CREDENTIAL_MESSAGE =
-  'No model API key is configured: OPENROUTER_API_KEY is missing or empty in the server environment. ' +
-  'Set it (any OpenAI-compatible endpoint configured via MODEL_API_BASE_URL still reads its key from OPENROUTER_API_KEY) and restart the server.';
+  `No model API key is configured: ${CANONICAL_KEY_NAME} is missing or empty in the server environment ` +
+  `(its prior-era name ${PRIOR_ERA_KEY_NAME} is still accepted and was not set either). ` +
+  `Set ${CANONICAL_KEY_NAME} and restart the server; whichever endpoint MODEL_API_BASE_URL names reads its key from it.`;
+
+/** Trimmed environment read: unset, empty and whitespace-only are all absent. */
+function readSetting(name: string): string | undefined {
+  const raw = process.env[name];
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+/**
+ * Resolve the credential's name and raw value under the two accepted names.
+ *
+ * The precedence rule is DEFINED, not truthy — the canonical name wins even
+ * when set to the empty string. That mirrors `src/lib/publisher-env.ts` and
+ * `resolveEnvName` in `scripts/preflight-env.mjs`, and the agreement is the
+ * point: a preflight that resolved differently from this reader would pass a
+ * configuration the app then refuses.
+ */
+function resolveModelApiKeyFromEnv(): {
+  name: string;
+  raw: string | undefined;
+  viaPriorEra: boolean;
+} {
+  const canonical = process.env[CANONICAL_KEY_NAME];
+  if (typeof canonical === 'string') {
+    return { name: CANONICAL_KEY_NAME, raw: canonical, viaPriorEra: false };
+  }
+  const priorEra = process.env[PRIOR_ERA_KEY_NAME];
+  if (typeof priorEra === 'string') {
+    return { name: PRIOR_ERA_KEY_NAME, raw: priorEra, viaPriorEra: true };
+  }
+  return { name: CANONICAL_KEY_NAME, raw: undefined, viaPriorEra: false };
+}
+
+/**
+ * The resolved wire dialect. Unset or empty takes the default; anything
+ * outside the closed set is a typed refusal naming the variable and the
+ * accepted values. Mirrors the driver-selector convention in
+ * `scripts/preflight-env.mjs` (`env.X || '<default>'`, throw outside the set),
+ * which is what lets the preflight agree with this reader.
+ */
+export function getModelApiKind(): ModelApiKind {
+  const raw = readSetting('MODEL_API_KIND');
+  if (raw === undefined) return DEFAULT_MODEL_API_KIND;
+  if ((MODEL_API_KINDS as readonly string[]).includes(raw)) return raw as ModelApiKind;
+  throw new ModelConfigurationError(
+    `MODEL_API_KIND is set to a value this build does not recognize. ` +
+      `Set it to one of: ${MODEL_API_KINDS.join(', ')} (or leave it unset for ${DEFAULT_MODEL_API_KIND}), and restart the server.`,
+  );
+}
+
+/** The resolved auth mode: derived from the kind unless explicitly declared. */
+export function getModelApiAuth(kind: ModelApiKind = getModelApiKind()): ModelApiAuth {
+  const derived = DERIVED_AUTH[kind];
+  const raw = readSetting('MODEL_API_AUTH');
+  if (raw === undefined) return derived;
+  if (!(MODEL_API_AUTH_MODES as readonly string[]).includes(raw)) {
+    throw new ModelConfigurationError(
+      `MODEL_API_AUTH is set to a value this build does not recognize. ` +
+        `Set it to one of: ${MODEL_API_AUTH_MODES.join(', ')} (or leave it unset to derive it from MODEL_API_KIND), and restart the server.`,
+    );
+  }
+  if (raw === 'entra') {
+    throw new ModelConfigurationError(
+      `MODEL_API_AUTH=entra is reserved and not implemented in this build. ` +
+        `Use MODEL_API_AUTH=api-key with MODEL_API_KEY, or leave MODEL_API_AUTH unset to derive it from MODEL_API_KIND.`,
+    );
+  }
+  if (raw !== derived) {
+    throw new ModelConfigurationError(
+      `MODEL_API_AUTH=${raw} contradicts MODEL_API_KIND=${kind}, which authenticates with '${derived}'. ` +
+        `Leave MODEL_API_AUTH unset to derive it, or change MODEL_API_KIND to the dialect you meant.`,
+    );
+  }
+  return raw as ModelApiAuth;
+}
+
+/**
+ * Resolved chat-completions base URL (env override or the default above).
+ *
+ * Under `azure-openai` this is the RESOURCE ENDPOINT rather than an
+ * OpenAI-style base; `azureBaseUrl` below derives the client's base from it.
+ * Unchanged for the default dialect: unset still resolves to the reference
+ * deployment's endpoint.
+ */
+export function getModelApiBaseUrl(): string {
+  return process.env.MODEL_API_BASE_URL || DEFAULT_BASE_URL;
+}
+
+/**
+ * The Azure client's base URL, derived from the resource endpoint.
+ *
+ * Measured, not assumed (Node 22, local fake server — see the test): the SDK's
+ * own `endpoint` option does exactly `${endpoint}/openai`, and passing that
+ * result as `baseURL` produces a byte-identical request. `baseURL` is passed
+ * instead of `endpoint` for two reasons: `endpoint` and `baseURL` are mutually
+ * exclusive in the SDK constructor AND `baseURL` silently defaults from
+ * `process.env.OPENAI_BASE_URL`, so an unrelated variable in the environment
+ * would otherwise turn a correct configuration into a constructor throw.
+ *
+ * An endpoint already written with the `/openai` suffix is accepted as-is, so
+ * that a documented resource URL copied either way resolves the same.
+ */
+function azureBaseUrl(resourceEndpoint: string): string {
+  const trimmed = resourceEndpoint.trim().replace(/\/+$/, '');
+  return trimmed.endsWith('/openai') ? trimmed : `${trimmed}/openai`;
+}
+
+/** The fully resolved endpoint configuration. Presence-checked, never echoed. */
+export interface ModelEndpointConfig {
+  kind: ModelApiKind;
+  auth: ModelApiAuth;
+  /** As configured: an OpenAI-style base URL, or an Azure resource endpoint. */
+  baseUrl: string;
+  /** Present only under `azure-openai`, where it is required. */
+  apiVersion?: string;
+}
+
+/**
+ * Resolve every endpoint setting, or throw the first typed refusal.
+ *
+ * Reads no credential: this is the shape of the endpoint, not the right to
+ * call it. Order is deliberate — the dialect is resolved first because every
+ * other question ("is a version required?", "is the base URL a resource
+ * endpoint?") is asked of a dialect.
+ */
+export function resolveModelEndpointConfig(): ModelEndpointConfig {
+  const kind = getModelApiKind();
+  const auth = getModelApiAuth(kind);
+
+  if (kind !== 'azure-openai') {
+    return { kind, auth, baseUrl: getModelApiBaseUrl() };
+  }
+
+  // Under the Azure dialect an api-version is part of every URL. There is no
+  // safe default: versions gate which request and response fields exist, so a
+  // guessed one silently changes what the endpoint answers. Refuse instead —
+  // an operability refusal, raised before any upstream call.
+  const apiVersion = readSetting('MODEL_API_VERSION');
+  if (apiVersion === undefined) {
+    throw new ModelConfigurationError(
+      `MODEL_API_VERSION is required when MODEL_API_KIND=azure-openai and is missing or empty in the server environment. ` +
+        `Set it to the api-version your deployment accepts (the value your resource's documentation gives for chat completions) and restart the server.`,
+    );
+  }
+
+  // Equally, no default resource endpoint exists — the built-in default is an
+  // OpenAI-compatible gateway, which would be the wrong host in the wrong
+  // dialect. `getModelApiBaseUrl()` is not consulted here on purpose: its
+  // fallback is exactly the value that must not be accepted.
+  const resourceEndpoint = readSetting('MODEL_API_BASE_URL');
+  if (resourceEndpoint === undefined) {
+    throw new ModelConfigurationError(
+      `MODEL_API_BASE_URL is required when MODEL_API_KIND=azure-openai and is missing or empty in the server environment. ` +
+        `Set it to your resource endpoint (the https:// origin of the resource, without a path) and restart the server.`,
+    );
+  }
+
+  return { kind, auth, baseUrl: resourceEndpoint, apiVersion };
+}
 
 /**
  * Request-path guard: returns a typed `ModelConfigurationError` when the
- * environment holds no usable model credential (missing or empty
- * OPENROUTER_API_KEY), or null when a credential is present. Detectable before
- * any upstream call — routes use this to fail fast instead of opening the
- * model pipeline. Deliberately a check-and-return (not a throw) so routes can
- * shape their own response (SSE error event vs. JSON status).
+ * environment cannot describe a usable model endpoint — an unrecognized
+ * dialect, a dialect missing a setting it requires, or no usable credential
+ * (missing or empty `MODEL_API_KEY`, with `OPENROUTER_API_KEY` accepted as its
+ * prior-era name) — or null when a request could be made. Detectable before
+ * any upstream call: routes use this to fail fast instead of opening the model
+ * pipeline. Deliberately a check-and-return (not a throw) so routes can shape
+ * their own response (SSE error event vs. JSON status).
  */
 export function getMissingModelCredentialError(): ModelConfigurationError | null {
-  const key = process.env.OPENROUTER_API_KEY;
-  if (!key || key.trim() === '') {
+  try {
+    resolveModelEndpointConfig();
+  } catch (error) {
+    if (error instanceof ModelConfigurationError) return error;
+    throw error;
+  }
+  const { raw } = resolveModelApiKeyFromEnv();
+  if (!raw || raw.trim() === '') {
     return new ModelConfigurationError(MISSING_CREDENTIAL_MESSAGE);
   }
   return null;
@@ -63,7 +287,7 @@ export function getMissingModelCredentialError(): ModelConfigurationError | null
  *
  * - `model_not_configured`: our typed guard error, or the SDK's own
  *   missing-credentials constructor error (belt and braces — the guard should
- *   fire first).
+ *   fire first; both the OpenAI and the Azure constructor use that wording).
  * - `model_auth_rejected`: the configured endpoint answered 401/403 (or an
  *   equivalent auth rejection), i.e. a credential exists but was refused
  *   upstream. Shape-based (`status` on the SDK's APIError) rather than
@@ -81,27 +305,47 @@ export function classifyModelError(error: unknown): ModelErrorCode | null {
   return null;
 }
 
-/** Resolved chat-completions base URL (env override or the default above). */
-export function getModelApiBaseUrl(): string {
-  return process.env.MODEL_API_BASE_URL || DEFAULT_BASE_URL;
-}
-
 /**
  * Build a new client against the configured endpoint. Pass `apiKey` to use a
- * caller-supplied key; omitted, the key comes from OPENROUTER_API_KEY.
+ * caller-supplied key; omitted, the key comes from `MODEL_API_KEY` (or its
+ * prior-era name `OPENROUTER_API_KEY`).
  *
- * Throws a typed `ModelConfigurationError` when no usable key resolves. This
- * replaces two silent-failure shapes: the SDK's generic constructor error for
- * an unset key, and — worse — an empty-string key, which the SDK constructor
- * accepts and then sends as a blank bearer token upstream.
+ * Throws a typed `ModelConfigurationError` when the endpoint configuration is
+ * unusable or no key resolves. That replaces three silent-failure shapes: the
+ * SDK's generic constructor error for an unset key; an empty-string key, which
+ * the OpenAI constructor accepts and then sends as a blank bearer token
+ * upstream; and the Azure constructor's api-version error, which names the
+ * SDK's own `OPENAI_API_VERSION` variable rather than this app's.
+ *
+ * WHAT THE AZURE CLIENT EMITS, measured rather than assumed (Node 22, against
+ * a local fake HTTP server; see `model-client.test.ts`): with `baseURL` set to
+ * `<resource>/openai` and `apiVersion` supplied, `chat.completions.create`
+ * POSTs to `/openai/deployments/{model}/chat/completions?api-version=…` with
+ * an `api-key` header and NO `Authorization` header, where `{model}` is the
+ * value the caller passed as `model` — so on this dialect the `model`
+ * parameter carries the DEPLOYMENT NAME. The request body is unchanged, model
+ * slug included. Selecting the deployment per call rather than pinning one on
+ * the client is what keeps a single lazily-built client usable for the
+ * analysis and evaluator models alike.
  */
 export function createModelClient(opts: { apiKey?: string } = {}): OpenAI {
-  const apiKey = opts.apiKey ?? process.env.OPENROUTER_API_KEY;
+  const config = resolveModelEndpointConfig();
+  const apiKey = opts.apiKey ?? resolveModelApiKeyFromEnv().raw;
   if (!apiKey || apiKey.trim() === '') {
     throw new ModelConfigurationError(MISSING_CREDENTIAL_MESSAGE);
   }
+
+  if (config.kind === 'azure-openai') {
+    return new AzureOpenAI({
+      baseURL: azureBaseUrl(config.baseUrl),
+      apiKey,
+      // Non-null: `resolveModelEndpointConfig` refuses this dialect without it.
+      apiVersion: config.apiVersion!,
+    });
+  }
+
   return new OpenAI({
-    baseURL: getModelApiBaseUrl(),
+    baseURL: config.baseUrl,
     apiKey,
   });
 }


### PR DESCRIPTION
P1 of the gated sprint on #30 (Wave N4 — endpoint-generic model layer). Branch `sprint-30/p1-endpoint-layer`, off `main` at `89476b9`.

**IMPL model: Opus 5.** ORCH routes the merge gate; this branch is not merged, tagged, or deployed by the IMPL.

---

## Blast zone

```
 docker-compose.yml             |  16 +-
 scripts/preflight-env.mjs      | 111 ++++++++++---
 scripts/preflight-env.test.mjs | 208 +++++++++++++++++++++++-
 src/lib/model-client.test.ts   | 353 ++++++++++++++++++++++++++++++++++++++++-
 src/lib/model-client.ts        | 320 ++++++++++++++++++++++++++++++++-----
 5 files changed, 938 insertions(+), 70 deletions(-)
```

Five files, all inside the declared blast zone. `scripts/check-compose-env.mjs` was **not** edited — the guard needed no new row, only the ENV_SPEC rows and the matching compose entries. No `.env*` file was read or written. No dependency added. Nothing outside the zone was touched; out-of-zone findings are flagged below, not fixed.

---

## The four new variables, with their ADR-0024 §C classification

The §C test: *if this value were wrong, would the error appear in bytes a third party verifies?*

| Variable | §C classification | Reasoning |
|---|---|---|
| `MODEL_API_KIND` | **On the path (§C.3)** | Off the path in P1 alone — nothing here reaches a package. But P3 derives `gen_ai.system` from it, and it selects which endpoint answers, hence which model actually produced an analysis whose declared identity lands under the signature. §C.3 exactly ("changes an input to either of those, without appearing in them itself"), and §C's tie-breaker — when unclear, treat as on-path — points the same way. Consequences carried: closed enum, no silent fall-through on an unrecognized value, and the value is never echoed by the preflight. |
| `MODEL_API_BASE_URL` | **On the path (§C.3)** | Same reasoning; pre-existing variable, tier unchanged for the default dialect. Its mismatch guard is D3's, landing in P3. Note the sprint rider it inherits: this value is an infrastructure hostname and must not reach signed output. |
| `MODEL_API_KEY` | **Off the path** | A wrong key produces an auth rejection, not a false record. It appears in no package, no sidecar, no well-known document, and changes no input to one. Secret; presence-checked only, never echoed. |
| `MODEL_API_VERSION` | **Off the path** | Operability only. Its refusal-when-absent is **not** an ADR-0024 §A refusal — it is chosen because an api-version gates which request and response fields the endpoint honors, so a guessed default silently changes what comes back. Per the contract: it never lands in a record. |
| `MODEL_API_AUTH` | **Off the path** | Wire mechanics. Wrong value = a request the endpoint refuses, visible immediately to the operator, invisible to any verifier. |

---

## What the Azure dialect actually emits — measured, not described

`openai@6.16.0` exports `AzureOpenAI` and no dependency was added. The charter's sketch was checked against the SDK before anything was built on it; **the sketch held in every respect**, and the exact shape is recorded here because it is now the only description a deploying implementer has.

Captured from a local fake HTTP server (Node 22, macOS, `openai@6.16.0`), with `baseURL = <resource>/openai`, `apiVersion` supplied, and `chat.completions.create({ model: 'example-deployment', … })`:

```
POST /openai/deployments/example-deployment/chat/completions?api-version=2099-01-01-preview
api-key: <the key>
(no authorization header)
body: {"model":"example-deployment","messages":[…]}
```

Three details worth stating because they are load-bearing and were not obvious from the type declarations alone:

1. **The deployment name rides in the `model` parameter.** `AzureOpenAI.buildRequest` prepends `/deployments/${this.deploymentName || body.model}` for a fixed set of endpoints that includes `/chat/completions`. Passing the deployment per call — rather than pinning one on the client — is what keeps one lazily-built client usable for the analysis and evaluator models alike. The body is forwarded unchanged, `model` included.
2. **`baseURL` is passed instead of the SDK's `endpoint` option**, deliberately. They are mutually exclusive in the constructor *and* `baseURL` silently defaults from `process.env.OPENAI_BASE_URL`, so an unrelated variable in an operator's environment would otherwise turn a correct configuration into a constructor throw. Measured: `endpoint: X` and `baseURL: X + '/openai'` produce byte-identical requests.
3. **The SDK's own api-version error names the wrong variable.** Its constructor throws referencing `OPENAI_API_VERSION`, which no operator of this app sets. Our typed refusal fires first and names `MODEL_API_VERSION`.

### Environment of verification, stated plainly

**Every Azure claim in this PR is verified against a local fake HTTP server under Node, in this repository's test runner. None of it is a claim about a real Azure OpenAI resource.** The fixture proves the request this app constructs; it does not prove that any resource accepts it.

### What the fixture necessarily cannot prove — the live-wiring checklist

Per ORCH's addendum (the G-accept gate is gone; the live leg belongs to the deploying implementer). This list is offered as the checklist for that work rather than as a caveat:

- **Auth acceptance.** That a real resource accepts an `api-key` header for the key issued to it, and that key rotation behaves as expected.
- **The api-version value itself.** The fixture uses `2099-01-01-preview`, an obvious placeholder. Which api-version strings a given deployment accepts, and which request/response fields each admits, is resource-specific and unverified here.
- **Deployment-name resolution.** That the deployment name an operator configures exists on the resource, and that a wrong one produces a recognizable error rather than a silent fallback.
- **Response-body shape.** The fixture returns a hand-written OpenAI-shaped completion. A real deployment's field set — content filter annotations, `prompt_filter_results`, usage accounting, and whether `usage` appears on the final streaming chunk — is unverified.
- **Streaming.** Only the non-streaming `chat.completions.create` path is exercised. The app's real query path streams (`src/lib/openrouter-streaming.ts`); SSE framing against a real resource is unverified.
- **Error mapping under load.** 401/403 classification is unit-tested against synthetic error shapes only. Real 429s, content-filter refusals, and quota exhaustion are unverified — and `model_rate_limited` is P4's, not here.
- **Tool/function calling.** Untouched by this phase and unexercised against the Azure dialect.

---

## The riders (#194), line by line

Read against `git diff 89476b9 -- scripts/preflight-env.mjs`. The rendered default report was diffed before/after; the delta is exactly the list below and nothing else.

- **#2 — `CRON_SECRET`.** `optional` → `recommended`, purpose rewritten. Verified against the tree, not the issue: `vercel.json` declares exactly one cron (`0 4 * * *` → `/api/cron/blob-gc`), and `src/app/api/cron/blob-gc/route.ts:30-34` fails closed on an absent secret. There is no portal-refresh endpoint anywhere in `src/`. New text names the orphan-blob sweep and its consequence. No `hasFallback` — a permanently dead scheduled job is not a coded fallback — so it now appears in the degraded-feature note.
- **#5 — `DB_DRIVER`.** The hazard moves from a code comment into the rendered purpose. Claim verified at `src/lib/db/index.ts:25` (`process.env.DB_DRIVER || 'neon-http'`).
- **#6 — `missingRecommended`.** Now excludes `hasFallback` rows. Measured at **`:644`**, not `:642` — see the premise corrections below. Effect on the default report: `SANDBOX_SNAPSHOT_ID`, `DATA_COMMONS_MCP_URL` and `BOSTON_OPENCONTEXT_MCP_URL` drop out of the nag; `DATA_COMMONS_API_KEY` stays; `CRON_SECRET` joins.
- **D9 — `NEXTAUTH_URL`.** Stays `required`, declares no `hasFallback`. The three app-side origins are documented in both the code comment and the rendered purpose as request-derived values rather than configuration, with the reason: they answer "what host is this request on", not "what origin did the OAuth app register", and NextAuth's own fourth inference covers one platform only.
- **#4b — `CIVICAITOOLS_SESSION_TOKEN`.** Confirmed already shipped and left **byte-identical** to `89476b9` (verified by diffing the line content; only its line number moved, 337 → 385). A test now pins the whole entry so a later pass cannot drift it silently.

### Every change to the default rendered report

Beyond the four riders, the phase's own work changes the report in exactly these ways, listed so none is unannounced:

1. The `OPENROUTER_API_KEY` row becomes `MODEL_API_KEY` (purpose text unchanged, tier unchanged, required count still 15).
2. Three new rows in OPTIONAL: `MODEL_API_KIND`, `MODEL_API_VERSION`, `MODEL_API_AUTH`.
3. `MODEL_API_BASE_URL`'s purpose gains the azure clause.
4. When a non-default profile prints its banner, it carries a fourth pair (`model=…`); the banner still does not print for a default profile. `check:compose-env`'s PROFILE line gains the same pair unconditionally, as that report always prints it.

---

## One design decision worth a reviewer's attention

**`MODEL_API_KIND` is declared as a fourth driver seam, not as a plain ENV_SPEC row.**

The contract offered `requiredUnlessAllPresent` for `MODEL_API_VERSION`'s conditional requirement and asked me to say why if it did not fit. It does not fit: that field **demotes** a required tier when a substitute set is present, and this is a **promotion** driven by a selector. `requiredWhen: { model: 'azure-openai' }` is the idiom ENV_SPEC already has for exactly that (`S3_BUCKET` and the two S3 keys use it), and it comes with the closed-value-set refusal and the never-echo-the-value guarantee for free. No new idiom was minted; the alternative would have required one.

That decision carries one shared-code-path change: **`resolveSpec`'s promotion now also drops any `hasFallback` claim.** Without it, a promoted `MODEL_API_BASE_URL` (which legitimately declares a fallback for the *default* dialect) would land in the soft `requiredOnFallback` bucket and the preflight would report PASS for a configuration `model-client.ts` refuses at the first request — the precise failure the preflight's own header calls worse than no preflight. No row that shipped before this phase declares both fields, so the change is inert for every pre-existing profile; a test pins that.

---

## Acceptance criteria

| # | Criterion | Result |
|---|---|---|
| 1 | Azure dialect proven on the wire — `api-key` header, **no** `Authorization`, `/openai/deployments/{deployment}/chat/completions`, `api-version` query | **PASS** — three WIRE tests in `src/lib/model-client.test.ts`, built from the captured request. Mutation-checked: corrupting the expected path turns the suite red (`not ok 11`), so the fixture is not self-consistent-and-vacuous. |
| 2 | Default path untouched; all seven original tests pass | **PASS** — `getModelApiBaseUrl()` still returns `https://openrouter.ai/api/v1`, the default dialect still sends `Authorization: Bearer` to `/chat/completions` with no `api-version` (asserted on the wire), and all seven original tests survive, adapted only for the rename. |
| 3 | Alias resolves both directions, warns on the old name | **PASS** — three new preflight tests: `MODEL_API_KEY` alone passes; `OPENROUTER_API_KEY` alone passes, sets `viaPriorEra`, and renders `OPENROUTER_API_KEY → rename to MODEL_API_KEY`; both set resolves canonical with no error. The DEFINED-not-truthy precedence is pinned on both sides so `preflight-env.mjs` and `model-client.ts` cannot disagree. |
| 4 | Every refusal typed, naming its variable, none reaching an upstream call | **PASS** — five typed refusals (missing key · unrecognized `MODEL_API_KIND` · azure without `MODEL_API_VERSION` · azure without `MODEL_API_BASE_URL` · `MODEL_API_AUTH` reserved-or-contradicting). Each names its variable and the fix; the "before any upstream call" half is proven by standing the fake server and asserting it received **zero** requests. |
| 5 | The riders changed exactly the intended output | **PASS** — see the line-by-line above plus the before/after report diff. |
| 6 | CI gate green, container still feedable | **PASS with one environment caveat on `build`** — see below. |

## Checks, pasted

```
$ npm ci
4 moderate severity vulnerabilities        # pre-existing, unchanged by this branch
```

```
$ npm test
1..861
# tests 894
# suites 10
# pass 894
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1294.145625
```
(872 at `89476b9` → 894; +22 net, no test deleted.)

```
$ node --test scripts/preflight-env.test.mjs
1..63
# tests 63
# suites 0
# pass 63
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 47.068625
```

```
$ npm run build            # in this sandboxed agent session
> Build error occurred
- binding to a port
- binding to a port

$ npx next build --webpack # same session, documented fallback
✓ Running next.config.ts took 10ms
✓ Compiled successfully in 2.2s
✓ Generating static pages using 9 workers (32/32) in 186ms
Route (app)                               Revalidate  Expire
[full route table emitted]
```

```
$ npm run typecheck
> civic-ai-tools-website@0.1.0 typecheck
> tsc --noEmit
exit=0
```

```
$ npm run lint
✖ 4 problems (0 errors, 4 warnings)
```
(The 4-warning baseline exactly; two warnings this branch briefly introduced were removed rather than absorbed.)

```
$ npm run check:compose-env
  PROFILE: db=node-postgres  blob=s3  executor=container  model=openai-compatible
  70 environment entries, 10 build arg(s), 70 applicable spec entr(ies)

  NOTE: 6 variable(s) passed through under a prior-era name. …
          - OPENROUTER_API_KEY → MODEL_API_KEY
          - EVIDENCE_SIGNING_KEY → PUBLISHER_SIGNING_KEY
          - EVIDENCE_KEY_ID → PUBLISHER_KEY_ID
          - EVIDENCE_TRUST_REGISTRY_CANONICAL_URL → PUBLISHER_TRUST_REGISTRY_CANONICAL_URL
          - EVIDENCE_TRUST_REGISTRY_LEGACY_URL → PUBLISHER_TRUST_REGISTRY_LEGACY_URL
          - EVIDENCE_PLATFORM_AGENT_URL → PUBLISHER_PLATFORM_AGENT_URL

  RESULT: PASS — every variable this profile reads can reach the container.
```

### The `build` caveat, scoped to where it was measured

`npm run build` (Turbopack) fails **in this sandboxed agent session** with `creating new process / binding to a port / Operation not permitted`, in Turbopack's PostCSS worker pool. This is the condition `CLAUDE.md` documents; per that rule I re-measured rather than assumed — it failed on two consecutive runs today, where the note records it succeeding on 2026-08-19, so the sandbox's behavior has changed since that measurement. `next build --webpack` skips the worker pool and compiles successfully in the same session, exercising the same TypeScript and the same route graph.

**Resolved on the real gate: CI's `build / test / lint / typecheck` job passed in 1m19s, unsandboxed, on Turbopack.** The local failure was the sandbox and nothing else.

## CI status on this branch

```
DCO                               pass  1s
Vercel                            pass        Deployment has completed
Vercel Preview Comments           pass
build / test / lint / typecheck   pass  1m19s
standalone build + asset check    pass  44s
```

All three required checks (`build / test / lint / typecheck`, `Vercel`, `DCO`) are green, plus the non-required `standalone.yml`.

---

## Premises that did not survive the check

1. **`missingRecommended` is at `:644`, not `:642`.** The contract and the G0 gate record both say `:642`; the G0 record specifically "corrected" the addendum's `:644` down to `:642`. The addendum was right. Measured at `89476b9` by grep: line 644. The finding itself was live as described.
2. **`requiredUnlessAllPresent` does not fit `MODEL_API_VERSION`.** Reported per the contract's instruction rather than forced — it demotes, this needed promotion. `requiredWhen` plus a fourth driver seam is the corrected fix-shape; see the design note above.
3. **`AzureOpenAI`'s SDK shape held.** Constructor parameters are `{ baseURL, apiKey, apiVersion, endpoint, deployment, azureADTokenProvider, dangerouslyAllowBrowser }`; api-version rides as `defaultQuery['api-version']`; the deployment name does come from the `model` body field. Two things the sketch did not mention and the implementation had to handle: `baseURL` defaults from `process.env.OPENAI_BASE_URL` and is mutually exclusive with `endpoint`; and the constructor's api-version error names `OPENAI_API_VERSION`, a variable no operator of this app sets.
4. **Everything else in the contract's §2 held**, verified at `89476b9`: `model-client.ts` at 126 lines with every named symbol at the stated line; the seven tests at `:43, :50, :57, :62, :70, :75, :82`; `ENV_SPEC` opening `:159` with `OPENROUTER_API_KEY:161` and `MODEL_API_BASE_URL:162`; `priorEraName` documented `:117` and resolved `:526-529` across thirteen `PUBLISHER_*` rows; `requiredUnlessAllPresent` documented `:132`, used `:227-228`, evaluated `:602`; `DB_DRIVER:174`; `CIVICAITOOLS_SESSION_TOKEN:337`; `CRON_SECRET:338`; compose model vars at `:268-269` with the comment at `:27`.

## Flagged, not fixed — all outside the blast zone

1. **`src/app/api/evidence/[slug]/publish/route.ts:174` reads `process.env.OPENROUTER_API_KEY` directly.** This is the one that has a user-visible consequence: an instance configured only with `MODEL_API_KEY` gets a `502 Evaluation unavailable` from the publish route even though the model layer is fully configured, because that read bypasses the alias. Every other call site goes through `createModelClient`. **This should be closed before the rename is documented to operators** — it belongs to P2 or P4 by path ownership, but it is a correctness gap, not a cosmetic one.
2. **`src/lib/streaming.ts:198` and `:200`** — the reader-facing copy for `model_not_configured` / `model_auth_rejected` still names `OPENROUTER_API_KEY` only. Deliberately untouched (P4's statements pass), and `src/lib/streaming.test.ts:137-138` plus `src/lib/openrouter-streaming.test.ts:77` pin that wording, so P4 moves the copy and its three assertions together.
3. **`docs/deploy.md:60`** (and the wider model-seam surface) now under-describes the seam — explicitly P4's, per the contract; not touched.
4. **`scripts/eval-models.mjs` — repointing it at `model-client.ts` is not a five-line change.** Asked and answered: it is a `.mjs` script run as bare `node`, so it cannot import a TypeScript module — the same barrier that makes `preflight-env.mjs` carry its own copy of the two-name rule. Teaching it the alias and the base-URL override alone is ~4 lines (`:38`, `:50-52`) plus an edit to `scripts/eval-models.test.mjs:22-30`, which pins the `OPENROUTER_API_KEY` refusal text; teaching it the Azure dialect would mean duplicating the dialect logic, not repointing it. Out of scope per the contract (civic#155) either way.
5. **The deprecation NOTE's parenthetical.** `preflight-env.mjs` renders "the prior-era one is removed at a future major version (2026-08-19 vocabulary settlement)" for every prior-era name, including `OPENROUTER_API_KEY`, whose rename comes from D4 rather than that settlement. The removal claim is true; the attribution is imprecise for that one row. Left alone to keep the output delta to the announced set.
6. **`src/lib/openrouter-streaming.test.ts:44`'s `ENV_KEYS` does not clear `MODEL_API_KEY` or `MODEL_API_KIND`.** Harmless in CI (neither is set); a developer who exports `MODEL_API_KEY` in their shell would see that file's missing-key test behave differently. A one-line hermeticity fix in a file this phase does not own.
7. **Pre-existing, unchanged:** `getModelApiBaseUrl()` uses `||`, so a whitespace-only `MODEL_API_BASE_URL` is truthy and reaches the SDK as a base URL under the default dialect. The azure branch trims and rejects it; the default branch keeps its prior behavior.

## `.env.example` — owner-run append

`.env*` files are outside the blast zone and reading one trips the global secret-read guard, so this block was composed from `ENV_SPEC` without opening the file. **Purely additive — do not remove the existing `OPENROUTER_API_KEY` line; the expand phase depends on it still working.** ADR-0024 §D applies: in an env file a bare `NAME=` line delivers the **empty string**, not absence, so the optional rows are commented out rather than left empty.

```
# --- Model endpoint (a wire dialect, not just a base URL) ---
# MODEL_API_KEY is the canonical name for the model API key.
# OPENROUTER_API_KEY above is its prior-era name and still works; set either.
MODEL_API_KEY=sk-replace-me-with-a-real-key
# Wire dialect: openai-compatible (default) or azure-openai.
# Leave commented for the default; an unrecognized value is refused, not ignored.
#MODEL_API_KIND=openai-compatible
# Chat-completions endpoint. Under azure-openai this is the RESOURCE ENDPOINT
# (the https:// origin, no path). Commented out = the built-in default.
#MODEL_API_BASE_URL=https://example-resource.example.net
# Required when MODEL_API_KIND=azure-openai, ignored otherwise. There is no
# safe default: an api-version gates which request and response fields exist.
#MODEL_API_VERSION=2026-01-01-preview
# Auth mode: bearer | api-key. Derived from MODEL_API_KIND when unset.
# 'entra' is reserved in the enum and refused — there is no code behind it.
#MODEL_API_AUTH=
```

---

## Status

Merge-ready pending CI. The IMPL does not merge, does not push tags, and does not deploy — ORCH routes the gate on evidence-pass. Nothing was bypassed: the global pre-push sensitivity hook ran and did not block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnJTLG4XsDp13Ys2v97YPc
