### PR TITLE
feat: one model catalog per instance, one resolver every call site uses (#30 P2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,6 +279,14 @@ services:
       MODEL_API_BASE_URL:
       MODEL_API_VERSION:
       MODEL_API_AUTH:
+      # The model catalog, in either delivery form. Both are bare
+      # pass-throughs and neither is pinned here: the app REFUSES both being
+      # set, so a compose file that supplied one would break the other. Unset
+      # under the built-in endpoint means the built-in model list; against any
+      # other endpoint one of these is required. MODEL_CATALOG_PATH names a
+      # path INSIDE the container, so the file has to be mounted there.
+      MODEL_CATALOG:
+      MODEL_CATALOG_PATH:
       SOCRATA_MCP_URL:
       SOCRATA_APP_TOKEN:
       DATA_COMMONS_MCP_URL:

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -153,6 +153,17 @@ export const DRIVER_SEAMS = {
  *     degrade" nag. Same no-nagging principle as `onlyWhen`; the entry stays
  *     listed so the operator can still see the option exists.
  *
+ * WHEN AN ENTRY CARRIES BOTH `requiredWhen` AND `requiredUnlessAllPresent`,
+ * the alternative wins: `resolveSpec` checks the alternative FIRST, so a driver
+ * that makes a NEED load-bearing does not make THIS variable load-bearing while
+ * a sibling already supplies it. The model catalog is the case that forced the
+ * question — MODEL_CATALOG and MODEL_CATALOG_PATH are two deliveries of one
+ * document, and the app REFUSES both being set, so a profile that promotes the
+ * need must promote at most the delivery that is still absent. Promotion-first
+ * would have failed a correctly-configured instance by demanding the variable
+ * it was refused for setting. Inert for every row that shipped before this:
+ * no other entry carries both fields.
+ *
  * CONSTRAINT: all three fields must leave the default profile untouched. With
  * no selector set (or every selector set to its default) and no alternative
  * set complete, the resolved spec is identical to the declared one, so the
@@ -196,6 +207,25 @@ export const ENV_SPEC = [
   // dialect, 'api-key' under azure-openai. 'entra' is RESERVED in the enum
   // with no code behind it — setting it is a typed refusal, not a fallback.
   { name: 'MODEL_API_AUTH', tier: 'optional', purpose: "Model auth mode — 'bearer' or 'api-key'; derived from MODEL_API_KIND when unset ('entra' is reserved, not implemented)", hasFallback: true },
+  // The model catalog — the models this instance offers, and the identity each
+  // one asserts in a signed record. Two delivery forms carrying ONE schema:
+  // MODEL_CATALOG holds the JSON document itself (a hosting platform's
+  // environment, or an `op run` injection), MODEL_CATALOG_PATH names a file
+  // holding the same document (a container that mounts configuration). Either
+  // satisfies the need and setting BOTH is refused by the app, which is why
+  // each row lists the other as its alternative rather than both promoting.
+  //
+  // ADR-0024 §C — ON THE EVIDENCE PATH, so absent-or-error off the built-in
+  // endpoint: an entry's `model` is the identity that lands under the signature
+  // in cost.model, environment.modelVersion and the PROV model agent (§C.1),
+  // and its `endpointModel` selects which deployment actually answers, an input
+  // to those same bytes (§C.3). The coded built-in list is admissible under the
+  // OpenRouter default alone, where the slug called IS the slug recorded, so it
+  // asserts nothing (§B). `hasFallback` is therefore true only in the default
+  // profile, and the promotion below drops it exactly as it does for
+  // MODEL_API_BASE_URL.
+  { name: 'MODEL_CATALOG', tier: 'optional', purpose: 'Model catalog as a JSON document — required unless this instance uses the built-in OpenRouter endpoint (MODEL_CATALOG_PATH is the file-delivered alternative; setting both is refused)', hasFallback: true, requiredWhen: { model: 'azure-openai' }, requiredUnlessAllPresent: ['MODEL_CATALOG_PATH'] },
+  { name: 'MODEL_CATALOG_PATH', tier: 'optional', purpose: 'Path to a file holding the model catalog — the container-friendly delivery of MODEL_CATALOG, same schema; setting both is refused', hasFallback: true, requiredWhen: { model: 'azure-openai' }, requiredUnlessAllPresent: ['MODEL_CATALOG'] },
   // No coded fallback (#258 C4): the fallback used to point at the reference
   // deployment's hosted endpoint, silently routing an unconfigured instance's
   // queries through infrastructure it does not operate. Absent, every data
@@ -646,6 +676,15 @@ export function resolveSpec(drivers, spec = ENV_SPEC, env = {}) {
       notApplicable.push(s);
       continue;
     }
+    // An alternative set already covers this variable's need — checked BEFORE
+    // promotion (see the both-fields note on ENV_SPEC). Demote rather than
+    // suppress, so the option stays visible without being nagged about.
+    const satisfiedByAlternative =
+      s.requiredUnlessAllPresent && allPresent(s.requiredUnlessAllPresent, env);
+    if (satisfiedByAlternative) {
+      applicable.push({ ...s, tier: 'optional' });
+      continue;
+    }
     const promoted = s.requiredWhen && conditionMet(s.requiredWhen, drivers);
     if (promoted) {
       // The promotion also drops any `hasFallback` claim. A driver that makes
@@ -662,10 +701,7 @@ export function resolveSpec(drivers, spec = ENV_SPEC, env = {}) {
       applicable.push(promotedEntry);
       continue;
     }
-    // An alternative set covers this variable's need: demote rather than
-    // suppress, so the option stays visible without being nagged about.
-    const demoted = s.requiredUnlessAllPresent && allPresent(s.requiredUnlessAllPresent, env);
-    applicable.push(demoted ? { ...s, tier: 'optional' } : s);
+    applicable.push(s);
   }
   return { applicable, notApplicable };
 }

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -305,30 +305,89 @@ test('the model seam is a declared driver seam whose default is the current beha
   assert.deepEqual(result.notApplicable, []);
 });
 
-test('MODEL_API_KIND=azure-openai promotes the version and the resource endpoint to HARD misses', () => {
+test('MODEL_API_KIND=azure-openai promotes the version, the resource endpoint and the catalog to HARD misses', () => {
   const env = { ...envWithAllRequired(), MODEL_API_KIND: 'azure-openai' };
   const result = evaluateEnv(env);
   assert.equal(result.ok, false);
   const missing = result.missingRequired.map((r) => r.name).sort();
-  assert.deepEqual(missing, ['MODEL_API_BASE_URL', 'MODEL_API_VERSION']);
+  // The catalog joins the promotion in website#30 P2: off the built-in
+  // endpoint the coded model list names slugs that may resolve to nothing, and
+  // the identity it would put in a signed record would be a guess.
+  assert.deepEqual(missing, [
+    'MODEL_API_BASE_URL',
+    'MODEL_API_VERSION',
+    'MODEL_CATALOG',
+    'MODEL_CATALOG_PATH',
+  ]);
   // MODEL_API_BASE_URL declares hasFallback for the DEFAULT dialect. The
   // promotion must drop that claim, or the row lands in the soft
   // `requiredOnFallback` bucket and the run PASSES a configuration
-  // src/lib/model-client.ts refuses at the first request.
-  assert.ok(!result.requiredOnFallback.some((r) => r.name === 'MODEL_API_BASE_URL'));
+  // src/lib/model-client.ts refuses at the first request. Same for the catalog.
+  for (const name of ['MODEL_API_BASE_URL', 'MODEL_CATALOG', 'MODEL_CATALOG_PATH']) {
+    assert.ok(!result.requiredOnFallback.some((r) => r.name === name), `${name} is a hard miss`);
+  }
 
   env.MODEL_API_BASE_URL = 'https://example-resource.example.net';
   env.MODEL_API_VERSION = '2099-01-01-preview';
+  env.MODEL_CATALOG = '[]';
   const configured = evaluateEnv(env);
   assert.equal(configured.ok, true);
   assert.match(renderReport(configured), /PROFILE:.*model=azure-openai/);
 });
 
-test('the promotion is inert for every row that shipped before the model seam', () => {
+test('either catalog delivery satisfies the azure promotion — the alternative blocks it', () => {
+  // The two forms carry one schema and the app REFUSES both being set, so a
+  // promotion that demanded both would fail a correctly-configured instance.
+  const base = {
+    ...envWithAllRequired(),
+    MODEL_API_KIND: 'azure-openai',
+    MODEL_API_BASE_URL: 'https://example-resource.example.net',
+    MODEL_API_VERSION: '2099-01-01-preview',
+  };
+  for (const delivered of ['MODEL_CATALOG', 'MODEL_CATALOG_PATH']) {
+    const result = evaluateEnv({ ...base, [delivered]: 'present' });
+    assert.equal(result.ok, true, `${delivered} alone should satisfy the promotion`);
+    assert.deepEqual(result.missingRequired.map((r) => r.name), []);
+  }
+  // Neither delivered: both are named, so the operator can see both options.
+  const neither = evaluateEnv(base);
+  assert.equal(neither.ok, false);
+  assert.deepEqual(neither.missingRequired.map((r) => r.name).sort(), [
+    'MODEL_CATALOG',
+    'MODEL_CATALOG_PATH',
+  ]);
+});
+
+test('REGRESSION: the catalog rows are inert in the default profile', () => {
+  // The CONSTRAINT on ENV_SPEC: with every selector at its default, resolveSpec
+  // is the identity transform, so neither the promotion nor its blocker fires.
+  const result = evaluateEnv(envWithAllRequired());
+  assert.equal(result.ok, true);
+  for (const name of ['MODEL_CATALOG', 'MODEL_CATALOG_PATH']) {
+    const row = result.rows.find((r) => r.name === name);
+    assert.equal(row.tier, 'optional', `${name} stays optional under the built-in endpoint`);
+    assert.equal(row.hasFallback, true, `${name} keeps its fallback claim there`);
+    assert.ok(!result.missingRequired.some((r) => r.name === name));
+    assert.ok(!result.missingRecommended.some((r) => r.name === name));
+  }
+});
+
+test('the promotion is inert for every row that does not declare both fields', () => {
   // The `hasFallback`-dropping promotion is a shared code path. It can only
-  // change a row that declares BOTH fields; MODEL_API_BASE_URL is the first.
+  // change a row that declares BOTH fields, and every such row belongs to the
+  // model seam this sprint added.
   const both = ENV_SPEC.filter((s) => s.requiredWhen && s.hasFallback).map((s) => s.name);
-  assert.deepEqual(both, ['MODEL_API_BASE_URL']);
+  assert.deepEqual(both, ['MODEL_API_BASE_URL', 'MODEL_CATALOG', 'MODEL_CATALOG_PATH']);
+});
+
+test('the catalog rows are declared as the two deliveries of one document', () => {
+  const inline = ENV_SPEC.find((s) => s.name === 'MODEL_CATALOG');
+  const file = ENV_SPEC.find((s) => s.name === 'MODEL_CATALOG_PATH');
+  assert.deepEqual(inline.requiredUnlessAllPresent, ['MODEL_CATALOG_PATH']);
+  assert.deepEqual(file.requiredUnlessAllPresent, ['MODEL_CATALOG']);
+  // Read by the server process, not at build time and not by an external tool.
+  assert.equal(inline.readBy, undefined);
+  assert.equal(file.readBy, undefined);
 });
 
 test('an unrecognized MODEL_API_KIND fails the run and is never echoed', () => {
@@ -666,9 +725,15 @@ test('every requiredUnlessAllPresent names variables the spec itself declares', 
     if (!s.requiredUnlessAllPresent) continue;
     assert.ok(Array.isArray(s.requiredUnlessAllPresent), `${s.name}.requiredUnlessAllPresent is a list`);
     assert.ok(s.requiredUnlessAllPresent.length > 0, `${s.name}.requiredUnlessAllPresent is non-empty`);
-    // Demotion only makes sense from 'required' — anything else is a no-op
-    // that would silently mislead a reader of the spec.
-    assert.equal(s.tier, 'required', `${s.name} declares 'required' so the demotion is meaningful`);
+    // Demotion has to be able to change something, or the field is decoration
+    // that misleads a reader of the spec. It can in two shapes: the declared
+    // tier is 'required' and the alternative lowers it (the sign-in
+    // providers), or a `requiredWhen` promotion exists for the alternative to
+    // block (the model catalog's two delivery forms, website#30 P2).
+    assert.ok(
+      s.tier === 'required' || s.requiredWhen,
+      `${s.name} declares 'required', or a requiredWhen the alternative can block, so the demotion is meaningful`,
+    );
     for (const name of s.requiredUnlessAllPresent) {
       assert.ok(declared.has(name), `${s.name} names a declared variable (${name})`);
     }

--- a/src/app/api/evidence/[slug]/publish/route.ts
+++ b/src/app/api/evidence/[slug]/publish/route.ts
@@ -17,6 +17,8 @@ import {
   evaluateUnsignedRecordPublishGate,
 } from '@/lib/evidence/unsigned-tier';
 import { fromDbValue, toDbValue } from '@/lib/evidence/visibility';
+import { resolveEvaluatorModel, resolveModel, ModelNotOfferedError } from '@/lib/model-resolver';
+import { getMissingModelCredentialError, ModelConfigurationError } from '@/lib/model-client';
 import { visibilityMatches } from '@/lib/evidence/visibility-sql';
 
 /**
@@ -31,7 +33,7 @@ import { visibilityMatches } from '@/lib/evidence/visibility-sql';
  *
  * Flow:
  *   1. Default-on adversarial eval (skippable via runEvaluation:false): the
- *      platform runs the six-criterion rubric with its own OpenRouter key and
+ *      platform runs the six-criterion rubric with its own model credential and
  *      emits a signed `attestation/evaluates/v1` node targeting the content
  *      node. The gate is PRESENCE-based — the eval and the publication record
  *      relate via the shared targetNodeId; `publishes/v1` stays at its
@@ -56,10 +58,11 @@ import { visibilityMatches } from '@/lib/evidence/visibility-sql';
  * withdrawal is a new attestation in the chain, not an unpublish.
  */
 
-// Default evaluator for the publication gate. Must differ from the analysis
-// model (evaluator independence); when they collide, the fallback is used.
-const DEFAULT_EVALUATOR_MODEL = 'anthropic/claude-sonnet-4-6';
-const FALLBACK_EVALUATOR_MODEL = 'openai/gpt-4o';
+// The evaluator for the publication gate comes from this instance's catalog
+// (`evaluator` ranks, civic-ai-tools-website#30 P2), not from two literals
+// here. Evaluator independence is unchanged: the gate walks the declared
+// preference order and takes the first candidate that is not the analysis
+// model.
 
 export async function POST(
   request: NextRequest,
@@ -171,8 +174,17 @@ export async function POST(
   // 1. Default-on adversarial evaluation (civic-ai-tools#72; Q25 (b)+(c)).
   let evaluationNodeId: string | undefined;
   if (runEvaluation) {
-    const platformKey = process.env.OPENROUTER_API_KEY;
-    if (!platformKey) {
+    // The platform credential is resolved by the endpoint layer, under either
+    // accepted name (MODEL_API_KEY, or its prior-era spelling
+    // OPENROUTER_API_KEY). This route used to read the prior-era variable from
+    // `process.env` directly, so an instance configured with MODEL_API_KEY
+    // alone was told "Evaluation unavailable" by the publication gate despite a
+    // fully configured model layer (flagged by #30 P1, closed here). It also
+    // stops this path from holding a credential as a string at all: the client
+    // resolves its own key, so nothing is threaded through.
+    const credentialError = getMissingModelCredentialError();
+    if (credentialError) {
+      console.error('[publish]', credentialError.message);
       return NextResponse.json(
         {
           error:
@@ -181,26 +193,57 @@ export async function POST(
         { status: 502 },
       );
     }
+
     // Evaluator independence: the evaluator model must differ from the model
     // that produced the analysis (same invariant as the interactive route).
-    // An explicit override that collides is the caller's error (400); the
-    // DEFAULT colliding silently falls back instead.
-    let evaluatorModel = evaluatorModelOverride ?? DEFAULT_EVALUATOR_MODEL;
-    if (evaluatorModelOverride && evaluatorModelOverride === pkg.cost.model) {
-      return NextResponse.json(
-        { error: 'Evaluator model must differ from the analysis model' },
-        { status: 400 },
-      );
-    }
-    if (evaluatorModel === pkg.cost.model) {
-      evaluatorModel = FALLBACK_EVALUATOR_MODEL;
+    // An explicit override that collides is the caller's error (400), as is an
+    // override this instance does not offer — refused here, before any upstream
+    // call, instead of being forwarded for the endpoint to reject.
+    let evaluatorModel: string;
+    try {
+      if (evaluatorModelOverride !== undefined) {
+        if (evaluatorModelOverride === pkg.cost.model) {
+          return NextResponse.json(
+            { error: 'Evaluator model must differ from the analysis model' },
+            { status: 400 },
+          );
+        }
+        evaluatorModel = resolveModel(evaluatorModelOverride).id;
+      } else {
+        const preferred = resolveEvaluatorModel(pkg.cost.model);
+        if (!preferred) {
+          // Every declared candidate IS the analysis model. Not a bad request
+          // and not retryable by the caller: the instance's catalog declares no
+          // second evaluator, which only an operator can change.
+          return NextResponse.json(
+            {
+              error:
+                'Evaluation unavailable (this instance declares no evaluator model other than the one that produced this analysis); retry with {"runEvaluation": false} to publish without an evaluation.',
+            },
+            { status: 502 },
+          );
+        }
+        evaluatorModel = preferred.id;
+      }
+    } catch (error) {
+      if (error instanceof ModelNotOfferedError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      if (error instanceof ModelConfigurationError) {
+        console.error('[publish]', error.message);
+        return NextResponse.json(
+          {
+            error:
+              'Evaluation unavailable (this instance has no usable model catalog); retry with {"runEvaluation": false} to publish without an evaluation.',
+          },
+          { status: 502 },
+        );
+      }
+      throw error;
     }
 
     try {
-      const parsed = await runAdversarialEval(pkg, {
-        apiKey: platformKey,
-        evaluatorModel,
-      });
+      const parsed = await runAdversarialEval(pkg, { evaluatorModel });
       if (!parsed.ok) {
         return NextResponse.json(
           {

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -1,8 +1,33 @@
 import { NextResponse } from 'next/server';
-import { availableModels } from '@/lib/mcp/tools';
+import { getOfferedModels } from '@/lib/model-resolver';
+import { ModelConfigurationError } from '@/lib/model-client';
 
+/**
+ * GET /api/models — the models this instance offers, for the selector.
+ *
+ * The response shape is unchanged (civic-ai-tools-website#283 pins it through
+ * `parseModelsResponse`); only its source moved, from a hardcoded array to the
+ * instance's catalog. Under the built-in endpoint with no catalog configured
+ * the body is byte-identical to the pre-catalog one — `model-catalog.test.ts`
+ * asserts that against a frozen literal.
+ *
+ * A catalog this instance cannot read is a 503, not an empty list: an empty
+ * `models` array is a valid body meaning "no models offered", and answering it
+ * would turn an operator's misconfiguration into a reader-facing silence.
+ */
 export async function GET() {
-  return NextResponse.json({
-    models: availableModels,
-  });
+  try {
+    return NextResponse.json({
+      models: getOfferedModels(),
+    });
+  } catch (error) {
+    if (error instanceof ModelConfigurationError) {
+      console.error('[api/models]', error.message);
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: 503 },
+      );
+    }
+    throw error;
+  }
 }

--- a/src/app/api/query-notebook/route.ts
+++ b/src/app/api/query-notebook/route.ts
@@ -25,6 +25,8 @@ import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-li
 import { mcpTools } from '@/lib/mcp/tools';
 import { callMcpTool, routeTool } from '@/lib/mcp/client';
 import { getMissingMcpRoutingError } from '@/lib/mcp/registry';
+import { getDefaultModel, resolveModel, ModelNotOfferedError } from '@/lib/model-resolver';
+import { ModelConfigurationError } from '@/lib/model-client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import {
   queryWithMcpStreaming,
@@ -43,7 +45,6 @@ import {
 import { executeNotebook, NotebookExecutionError } from '@/lib/sandbox';
 
 const DEFAULT_PORTAL = 'data.cityofnewyork.us';
-const DEFAULT_MODEL = 'anthropic/claude-sonnet-4-6';
 
 interface QueryNotebookRequest {
   query: string;
@@ -102,7 +103,36 @@ export async function POST(request: NextRequest) {
     );
   }
   const portal = body.portal || DEFAULT_PORTAL;
-  const model = body.model || DEFAULT_MODEL;
+
+  // The model comes from this instance's catalog, not from a literal in this
+  // file (civic-ai-tools-website#30 P2). Two things changed here:
+  //   - the default is the catalog's `default` entry rather than a slug
+  //     duplicated between this route and the publication gate;
+  //   - a caller-named id is RESOLVED. Before, an unknown id was forwarded and
+  //     the endpoint decided; now an id this instance does not offer is a 400
+  //     raised before any upstream call, so it is never billed and never
+  //     reaches a record's `cost.model`.
+  // A catalog the instance cannot read is 503 (operator) rather than 400
+  // (caller) — the two failures are not the same and do not share a status.
+  let model: string;
+  try {
+    model = body.model ? resolveModel(body.model).id : getDefaultModel().id;
+  } catch (error) {
+    if (error instanceof ModelNotOfferedError) {
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (error instanceof ModelConfigurationError) {
+      console.error('[query-notebook]', error.message);
+      return new Response(
+        JSON.stringify({ error: error.message, code: error.code }),
+        { status: 503, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    throw error;
+  }
 
   // Fail fast when no MCP endpoint is configured for the primary data source
   // (#258 C4): Phase A cannot discover datasets without one, and

--- a/src/lib/evidence/adversarial-eval.ts
+++ b/src/lib/evidence/adversarial-eval.ts
@@ -58,8 +58,15 @@ export * from './adversarial-eval-core.ts';
  */
 export async function runAdversarialEval(
   pkg: EvidencePackage,
-  opts: { apiKey: string; evaluatorModel: string },
+  opts: { apiKey?: string; evaluatorModel: string },
 ): Promise<ParsedEvaluation> {
+  // `apiKey` is OPTIONAL: omitted, `createModelClient` resolves the platform
+  // credential itself, under either accepted name (MODEL_API_KEY, or its
+  // prior-era spelling). The publication gate takes that path, which is why it
+  // no longer reads a variable out of `process.env` and hands it down as a
+  // string — one fewer code path holding a credential
+  // (civic-ai-tools-website#30 P1 flag, closed in P2). The parameter stays for
+  // a caller-supplied key; #30 P4 renames the wire field that carries one.
   const openrouter = createModelClient({ apiKey: opts.apiKey });
   const response = await openrouter.chat.completions.create({
     model: opts.evaluatorModel,

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -385,41 +385,8 @@ export const mcpTools: ChatCompletionTool[] = [
   ...bostonOpencontextMcpTools,
 ];
 
-// Model definitions for the model selector
-export interface ModelDefinition {
-  id: string;
-  name: string;
-  tag?: string; // short descriptor shown in dropdown only (e.g. "recommended")
-  provider: string;
-  supports_tools: boolean;
-  description?: string;
-  maxTokenBudget?: number; // per-model token limit override
-}
-
-export const availableModels: ModelDefinition[] = [
-  {
-    id: 'openai/gpt-4o',
-    name: 'GPT-4o',
-    tag: 'recommended',
-    provider: 'OpenAI',
-    supports_tools: true,
-    description: 'Best balance of quality and speed',
-  },
-  {
-    id: 'openai/gpt-5.4',
-    name: 'GPT-5.4',
-    tag: 'premium',
-    provider: 'OpenAI',
-    supports_tools: true,
-    description: 'Highest quality analysis, newest model',
-  },
-  {
-    id: 'google/gemini-3.5-flash-lite',
-    name: 'Gemini 3.5 Flash Lite',
-    tag: 'fastest',
-    provider: 'Google',
-    supports_tools: true,
-    description: 'Fast and budget-friendly',
-    maxTokenBudget: 150_000,
-  },
-];
+// Model definitions moved to src/lib/model-catalog.ts (civic-ai-tools-website#30
+// P2). `ModelDefinition`, the offered list, its pricing and its display names
+// were four tables in three files describing the same ids; they are now one
+// catalog with one resolver (src/lib/model-resolver.ts). Nothing about MCP
+// tooling lived in them, which is why they left this file rather than staying.

--- a/src/lib/model-catalog.test.ts
+++ b/src/lib/model-catalog.test.ts
@@ -1,0 +1,536 @@
+// Tests for the model catalog and its resolver (civic-ai-tools-website#30 P2).
+//
+// ENVIRONMENT OF VERIFICATION. Every claim below is checked in-process under
+// Node on macOS, against `process.env` and a real temp file — never against a
+// live model endpoint. No test here makes an upstream call, which is itself
+// half the point: the refusals this phase adds all fire BEFORE one. Test names
+// carry their scope so a later reader cannot mistake the scope for more than it
+// is:
+//   CATALOG:  pure schema/projection facts, no environment read at all.
+//   INSTANCE: resolved through `process.env` (and, for the file form, a real
+//             file on disk) with the module's memo reset between cases.
+//
+// Run with: npm test
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  BUILT_IN_CATALOG,
+  catalogDefaultEntry,
+  catalogEvaluatorOrder,
+  declaredModelIdentity,
+  selectableModels,
+  validateCatalog,
+  type CatalogEntry,
+} from './model-catalog.ts';
+import {
+  getDefaultModel,
+  getModelCatalog,
+  getOfferedModels,
+  resolveEvaluatorModel,
+  resolveModel,
+  ModelNotOfferedError,
+  _resetModelCatalogForTests,
+} from './model-resolver.ts';
+import {
+  ModelConfigurationError,
+  getMissingModelCredentialError,
+  createModelClient,
+  _resetDefaultModelClientForTests,
+} from './model-client.ts';
+
+/**
+ * The exact `/api/models` body this repo served at `b95c768`, the commit this
+ * phase branched from, captured by running `JSON.stringify` over the
+ * pre-catalog `availableModels`. Criterion 1 of the phase: the reference
+ * instance sees ZERO change. Not a snapshot to be regenerated — a frozen
+ * literal. If a change makes this fail, the change altered what the selector
+ * offers, which is civic-ai-tools-website#302's question and not this one's.
+ */
+const FROZEN_MODELS_BODY =
+  '{"models":[{"id":"openai/gpt-4o","name":"GPT-4o","tag":"recommended","provider":"OpenAI","supports_tools":true,"description":"Best balance of quality and speed"},{"id":"openai/gpt-5.4","name":"GPT-5.4","tag":"premium","provider":"OpenAI","supports_tools":true,"description":"Highest quality analysis, newest model"},{"id":"google/gemini-3.5-flash-lite","name":"Gemini 3.5 Flash Lite","tag":"fastest","provider":"Google","supports_tools":true,"description":"Fast and budget-friendly","maxTokenBudget":150000}]}';
+
+/** Every variable these tests touch, cleared before and after each one. */
+const ENV_KEYS = [
+  'MODEL_CATALOG',
+  'MODEL_CATALOG_PATH',
+  'MODEL_API_BASE_URL',
+  'MODEL_API_KIND',
+  'MODEL_API_VERSION',
+  'MODEL_API_AUTH',
+  'MODEL_API_KEY',
+  'OPENROUTER_API_KEY',
+];
+
+const saved: Record<string, string | undefined> = {};
+let tmp: string | null = null;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  _resetModelCatalogForTests();
+  _resetDefaultModelClientForTests();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+  _resetModelCatalogForTests();
+  _resetDefaultModelClientForTests();
+  if (tmp) {
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = null;
+  }
+});
+
+/** A minimal well-formed catalog, as an operator would write it. */
+function sampleCatalog(overrides: Partial<CatalogEntry>[] = []): unknown[] {
+  const base: unknown[] = [
+    {
+      id: 'fast',
+      name: 'Fast Model',
+      provider: 'Example Provider',
+      supports_tools: true,
+      endpointModel: 'example-fast-deployment',
+      model: 'vendor/model-fast-1',
+      default: true,
+      evaluator: 2,
+    },
+    {
+      id: 'careful',
+      name: 'Careful Model',
+      provider: 'Example Provider',
+      supports_tools: true,
+      endpointModel: 'example-careful-deployment',
+      model: 'vendor/model-careful-1',
+      evaluator: 1,
+    },
+  ];
+  return overrides.length === 0 ? base : overrides;
+}
+
+function refusalFrom(fn: () => unknown): ModelConfigurationError {
+  try {
+    fn();
+  } catch (error) {
+    assert.ok(
+      error instanceof ModelConfigurationError,
+      `expected a typed ModelConfigurationError, got ${String(error)}`,
+    );
+    return error as ModelConfigurationError;
+  }
+  assert.fail('expected a refusal, got a value');
+}
+
+// --- Criterion 1: the reference instance sees zero change -------------------
+
+test('INSTANCE: with no catalog and the default endpoint, /api/models is byte-identical to b95c768', () => {
+  assert.equal(JSON.stringify({ models: getOfferedModels() }), FROZEN_MODELS_BODY);
+});
+
+test('CATALOG: the projection omits absent optionals rather than emitting them', () => {
+  const served = selectableModels([
+    {
+      id: 'bare',
+      name: 'Bare',
+      provider: 'Example Provider',
+      supports_tools: false,
+      endpointModel: 'bare',
+    },
+  ]);
+  assert.deepEqual(Object.keys(served[0]), ['id', 'name', 'provider', 'supports_tools']);
+});
+
+test('CATALOG: `endpointModel` and `model` are never served — a deployment alias is internal', () => {
+  for (const served of selectableModels(BUILT_IN_CATALOG)) {
+    assert.ok(!('endpointModel' in served), 'endpointModel leaked into /api/models');
+    assert.ok(!('model' in served), 'model leaked into /api/models');
+    assert.ok(!('pricing' in served), 'pricing leaked into /api/models');
+    assert.ok(!('evaluator' in served), 'evaluator leaked into /api/models');
+    assert.ok(!('default' in served), 'default leaked into /api/models');
+    assert.ok(!('selectable' in served), 'selectable leaked into /api/models');
+  }
+});
+
+test('CATALOG: the built-in default and evaluator are resolvable but not served', () => {
+  const served = selectableModels(BUILT_IN_CATALOG).map((m) => m.id);
+  const defaultId = catalogDefaultEntry(BUILT_IN_CATALOG).id;
+  assert.ok(!served.includes(defaultId), 'the notebook default has never been in the selector');
+  assert.equal(defaultId, 'anthropic/claude-sonnet-4-6', 'the pre-catalog DEFAULT_MODEL, unchanged');
+});
+
+test('INSTANCE: the notebook default resolves by id even though it is not selectable', () => {
+  const entry = resolveModel('anthropic/claude-sonnet-4-6');
+  assert.equal(entry.id, 'anthropic/claude-sonnet-4-6');
+  assert.equal(getDefaultModel().id, 'anthropic/claude-sonnet-4-6');
+});
+
+test('CATALOG: the built-in evaluator order reproduces the two literals it replaced', () => {
+  const order = catalogEvaluatorOrder(BUILT_IN_CATALOG).map((e) => e.id);
+  assert.deepEqual(order, ['anthropic/claude-sonnet-4-6', 'openai/gpt-4o']);
+});
+
+test('INSTANCE: evaluator independence picks the same model the two literals did', () => {
+  // Pre-catalog: DEFAULT_EVALUATOR_MODEL unless it collides with the analysis
+  // model, in which case FALLBACK_EVALUATOR_MODEL.
+  assert.equal(resolveEvaluatorModel('openai/gpt-4o')?.id, 'anthropic/claude-sonnet-4-6');
+  assert.equal(resolveEvaluatorModel('anthropic/claude-sonnet-4-6')?.id, 'openai/gpt-4o');
+  assert.equal(resolveEvaluatorModel('openai/gpt-5.4')?.id, 'anthropic/claude-sonnet-4-6');
+});
+
+test('CATALOG: an omitted `model` under the default dialect declares the endpoint string', () => {
+  // Which is what makes the built-in list safe there: the slug called is the
+  // slug recorded. P3 consumes `model`; P2 only carries it.
+  //
+  // The third assertion is also the licence for this phase's call sites to keep
+  // sending `entry.id` on the wire rather than `entry.endpointModel`: under the
+  // built-in catalog they are the same string. A catalog where they differ
+  // needs P3's split of the wire parameter from the recorded identity first —
+  // see the note on model-resolver.ts. If this ever fails, that split is
+  // overdue, not this test.
+  for (const entry of BUILT_IN_CATALOG) {
+    assert.equal(entry.model, undefined);
+    assert.equal(declaredModelIdentity(entry), entry.id);
+    assert.equal(entry.endpointModel, entry.id);
+  }
+});
+
+// --- Criterion 2: both delivery forms, one schema, both together refuse -----
+
+test('INSTANCE: MODEL_CATALOG alone loads the declared catalog', () => {
+  process.env.MODEL_CATALOG = JSON.stringify(sampleCatalog());
+  const catalog = getModelCatalog();
+  assert.deepEqual(catalog.map((e) => e.id), ['fast', 'careful']);
+  assert.equal(getDefaultModel().id, 'fast');
+  assert.equal(resolveModel('careful').endpointModel, 'example-careful-deployment');
+});
+
+test('INSTANCE: MODEL_CATALOG_PATH alone loads the same catalog from a real file', () => {
+  tmp = mkdtempSync(join(tmpdir(), 'model-catalog-'));
+  const file = join(tmp, 'catalog.json');
+  writeFileSync(file, JSON.stringify(sampleCatalog()), 'utf8');
+
+  process.env.MODEL_CATALOG = JSON.stringify(sampleCatalog());
+  const viaEnv = getModelCatalog();
+
+  delete process.env.MODEL_CATALOG;
+  process.env.MODEL_CATALOG_PATH = file;
+  _resetModelCatalogForTests();
+  const viaFile = getModelCatalog();
+
+  assert.deepEqual(viaFile, viaEnv, 'one schema — the two delivery forms differ only in transport');
+});
+
+test('INSTANCE: both delivery variables set is a refusal naming both', () => {
+  tmp = mkdtempSync(join(tmpdir(), 'model-catalog-'));
+  const file = join(tmp, 'catalog.json');
+  writeFileSync(file, JSON.stringify(sampleCatalog()), 'utf8');
+  process.env.MODEL_CATALOG = JSON.stringify(sampleCatalog());
+  process.env.MODEL_CATALOG_PATH = file;
+
+  const err = refusalFrom(getModelCatalog);
+  assert.match(err.message, /MODEL_CATALOG\b/);
+  assert.match(err.message, /MODEL_CATALOG_PATH/);
+  assert.match(err.message, /refused|Unset one/i);
+});
+
+test('INSTANCE: a MODEL_CATALOG_PATH that cannot be read is a refusal naming the variable', () => {
+  process.env.MODEL_CATALOG_PATH = join(tmpdir(), 'no-such-model-catalog-file.json');
+  const err = refusalFrom(getModelCatalog);
+  assert.match(err.message, /MODEL_CATALOG_PATH/);
+});
+
+test('INSTANCE: a catalog that is not JSON is a refusal naming where it came from', () => {
+  process.env.MODEL_CATALOG = 'not json at all';
+  const err = refusalFrom(getModelCatalog);
+  assert.match(err.message, /MODEL_CATALOG/);
+  assert.match(err.message, /valid JSON/i);
+});
+
+// --- Criterion 3: the built-in retention rule, both directions --------------
+
+test('INSTANCE: the default base URL with no catalog keeps the built-in list', () => {
+  assert.deepEqual(getModelCatalog(), BUILT_IN_CATALOG);
+});
+
+test('INSTANCE: the default base URL set EXPLICITLY still keeps the built-in list', () => {
+  // D2 is written against the RESOLVED base URL, not against "the variable is
+  // unset" — an operator who pins the default endpoint by hand has the same
+  // endpoint and the same guarantee.
+  process.env.MODEL_API_BASE_URL = 'https://openrouter.ai/api/v1';
+  assert.deepEqual(getModelCatalog(), BUILT_IN_CATALOG);
+});
+
+test('INSTANCE: any other base URL with no catalog is a refusal naming MODEL_CATALOG', () => {
+  process.env.MODEL_API_BASE_URL = 'https://example-gateway.example.net/v1';
+  const err = refusalFrom(getModelCatalog);
+  assert.match(err.message, /MODEL_CATALOG/);
+  assert.match(err.message, /MODEL_CATALOG_PATH/, 'the file form is offered as the alternative');
+});
+
+test('INSTANCE: the azure dialect with no catalog is a refusal even before a base URL is set', () => {
+  // The built-in list names public slugs in another dialect; it can never be
+  // the right answer under azure-openai, whatever the URL resolves to.
+  process.env.MODEL_API_KIND = 'azure-openai';
+  const err = refusalFrom(getModelCatalog);
+  assert.match(err.message, /MODEL_CATALOG/);
+});
+
+test('INSTANCE: a declared catalog is used under a non-default endpoint', () => {
+  process.env.MODEL_API_BASE_URL = 'https://example-gateway.example.net/v1';
+  process.env.MODEL_CATALOG = JSON.stringify(sampleCatalog());
+  assert.deepEqual(getModelCatalog().map((e) => e.id), ['fast', 'careful']);
+});
+
+// --- Criterion 4: every refusal is typed and names what to fix --------------
+
+test('INSTANCE: an unknown model id is a typed not-offered error, raised before any upstream call', () => {
+  let thrown: unknown;
+  try {
+    resolveModel('vendor/model-nobody-offers');
+  } catch (error) {
+    thrown = error;
+  }
+  assert.ok(thrown instanceof ModelNotOfferedError, 'a caller error, not a configuration error');
+  const err = thrown as ModelNotOfferedError;
+  assert.equal(err.code, 'model_not_offered');
+  assert.equal(err.modelId, 'vendor/model-nobody-offers');
+  assert.match(err.message, /not offered by this instance/);
+  assert.match(err.message, /openai\/gpt-4o/, 'the message lists what IS offered');
+  assert.ok(
+    !(err instanceof ModelConfigurationError),
+    'a bad request must not be reported as a broken instance',
+  );
+});
+
+test('CATALOG: an invalid entry names the entry and the field', () => {
+  const result = validateCatalog(
+    [{ id: 'fast', name: 'Fast', provider: 'Example Provider', supports_tools: true }],
+    { source: 'MODEL_CATALOG', kind: 'openai-compatible' },
+  );
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /entry "fast"/);
+  assert.match((result as { message: string }).message, /"endpointModel"/);
+});
+
+test('CATALOG: an entry with no usable id is named by position', () => {
+  const result = validateCatalog([{ name: 'Nameless' }], {
+    source: 'MODEL_CATALOG',
+    kind: 'openai-compatible',
+  });
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /entry #1/);
+  assert.match((result as { message: string }).message, /"id"/);
+});
+
+test('CATALOG: duplicate ids are refused rather than resolved by position', () => {
+  const dup = [
+    { id: 'same', name: 'A', provider: 'P', supports_tools: true, endpointModel: 'a', default: true, evaluator: 1 },
+    { id: 'same', name: 'B', provider: 'P', supports_tools: true, endpointModel: 'b' },
+  ];
+  const result = validateCatalog(dup, { source: 'MODEL_CATALOG', kind: 'openai-compatible' });
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /"same"/);
+  assert.match((result as { message: string }).message, /more than one entry/);
+});
+
+test('CATALOG: zero default entries is a refusal', () => {
+  const none = [
+    { id: 'a', name: 'A', provider: 'P', supports_tools: true, endpointModel: 'a', evaluator: 1 },
+  ];
+  const result = validateCatalog(none, { source: 'MODEL_CATALOG', kind: 'openai-compatible' });
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /no default model/);
+});
+
+test('CATALOG: more than one default entry is a refusal naming both', () => {
+  const two = [
+    { id: 'a', name: 'A', provider: 'P', supports_tools: true, endpointModel: 'a', default: true, evaluator: 1 },
+    { id: 'b', name: 'B', provider: 'P', supports_tools: true, endpointModel: 'b', default: true },
+  ];
+  const result = validateCatalog(two, { source: 'MODEL_CATALOG', kind: 'openai-compatible' });
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /"a"/);
+  assert.match((result as { message: string }).message, /"b"/);
+});
+
+test('CATALOG: an evaluator preference that resolves to nothing is a refusal', () => {
+  const none = [
+    { id: 'a', name: 'A', provider: 'P', supports_tools: true, endpointModel: 'a', default: true },
+  ];
+  const result = validateCatalog(none, { source: 'MODEL_CATALOG', kind: 'openai-compatible' });
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /no evaluator/);
+});
+
+test('CATALOG: two entries claiming the same evaluator rank are refused', () => {
+  const tie = [
+    { id: 'a', name: 'A', provider: 'P', supports_tools: true, endpointModel: 'a', default: true, evaluator: 1 },
+    { id: 'b', name: 'B', provider: 'P', supports_tools: true, endpointModel: 'b', evaluator: 1 },
+  ];
+  const result = validateCatalog(tie, { source: 'MODEL_CATALOG', kind: 'openai-compatible' });
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /rank 1/);
+});
+
+test('CATALOG: under azure-openai an entry without `model` is refused, naming entry and field', () => {
+  const noIdentity = [
+    {
+      id: 'fast',
+      name: 'Fast',
+      provider: 'Example Provider',
+      supports_tools: true,
+      endpointModel: 'example-fast-deployment',
+      default: true,
+      evaluator: 1,
+    },
+  ];
+  const result = validateCatalog(noIdentity, { source: 'MODEL_CATALOG', kind: 'azure-openai' });
+  assert.equal(result.ok, false);
+  const message = (result as { message: string }).message;
+  assert.match(message, /entry "fast"/);
+  assert.match(message, /"model"/);
+  assert.match(message, /azure-openai/);
+  assert.match(message, /deployment name/, 'the message says WHY, not just what');
+});
+
+test('CATALOG: the same entry is accepted under openai-compatible, where omission is true', () => {
+  const noIdentity = [
+    {
+      id: 'fast',
+      name: 'Fast',
+      provider: 'Example Provider',
+      supports_tools: true,
+      endpointModel: 'vendor/model-fast-1',
+      default: true,
+      evaluator: 1,
+    },
+  ];
+  const result = validateCatalog(noIdentity, {
+    source: 'MODEL_CATALOG',
+    kind: 'openai-compatible',
+  });
+  assert.equal(result.ok, true);
+  assert.equal(
+    declaredModelIdentity((result as { catalog: CatalogEntry[] }).catalog[0]),
+    'vendor/model-fast-1',
+  );
+});
+
+test('INSTANCE: the azure rule fires through the resolver, not only the validator', () => {
+  process.env.MODEL_API_KIND = 'azure-openai';
+  process.env.MODEL_API_BASE_URL = 'https://example-resource.example.net';
+  process.env.MODEL_API_VERSION = '2026-01-01';
+  process.env.MODEL_CATALOG = JSON.stringify([
+    {
+      id: 'fast',
+      name: 'Fast',
+      provider: 'Example Provider',
+      supports_tools: true,
+      endpointModel: 'example-fast-deployment',
+      default: true,
+      evaluator: 1,
+    },
+  ]);
+  const err = refusalFrom(getModelCatalog);
+  assert.match(err.message, /entry "fast"/);
+  assert.match(err.message, /"model"/);
+});
+
+test('CATALOG: an unknown field is refused rather than ignored, so a typo cannot do nothing', () => {
+  const typo = [
+    {
+      id: 'a',
+      name: 'A',
+      provider: 'P',
+      supports_tools: true,
+      endpointModel: 'a',
+      default: true,
+      evaluator: 1,
+      endpointmodel: 'a',
+    },
+  ];
+  const result = validateCatalog(typo, { source: 'MODEL_CATALOG', kind: 'openai-compatible' });
+  assert.equal(result.ok, false);
+  assert.match((result as { message: string }).message, /"endpointmodel"/);
+});
+
+test('CATALOG: a document that is not an array, and an empty array, are both refused', () => {
+  for (const document of [{ models: [] }, 'a string', 42, null]) {
+    const result = validateCatalog(document, {
+      source: 'MODEL_CATALOG',
+      kind: 'openai-compatible',
+    });
+    assert.equal(result.ok, false, `expected a refusal for ${JSON.stringify(document)}`);
+    assert.match((result as { message: string }).message, /JSON array/);
+  }
+  const empty = validateCatalog([], { source: 'MODEL_CATALOG', kind: 'openai-compatible' });
+  assert.equal(empty.ok, false);
+  assert.match((empty as { message: string }).message, /empty array/);
+});
+
+test('CATALOG: malformed pricing is refused; absent pricing is fine', () => {
+  const bad = [
+    { id: 'a', name: 'A', provider: 'P', supports_tools: true, endpointModel: 'a', default: true, evaluator: 1, pricing: { input: 1 } },
+  ];
+  assert.equal(validateCatalog(bad, { source: 'MODEL_CATALOG', kind: 'openai-compatible' }).ok, false);
+
+  const none = [
+    { id: 'a', name: 'A', provider: 'P', supports_tools: true, endpointModel: 'a', default: true, evaluator: 1 },
+  ];
+  assert.equal(validateCatalog(none, { source: 'MODEL_CATALOG', kind: 'openai-compatible' }).ok, true);
+});
+
+// --- Criterion 5: the routed defect is closed ------------------------------
+
+test('INSTANCE: the publication gate credential check passes on MODEL_API_KEY alone', () => {
+  // The exact predicate the publish route now calls. Before this phase the
+  // route read the prior-era variable straight out of `process.env`, so this
+  // configuration produced 502 Evaluation unavailable from a fully configured
+  // instance (#30 P1's flag, routed to P2).
+  process.env.MODEL_API_KEY = 'obviously-fake-test-key';
+  assert.equal(getMissingModelCredentialError(), null);
+  // And the client the evaluator builds resolves that key without being handed
+  // one — which is why the route no longer threads a credential as a string.
+  assert.doesNotThrow(() => createModelClient({ apiKey: undefined }));
+});
+
+test('INSTANCE: the genuine no-credential case still refuses, naming both accepted names', () => {
+  const err = getMissingModelCredentialError();
+  assert.ok(err instanceof ModelConfigurationError);
+  assert.match(err!.message, /MODEL_API_KEY/);
+  assert.match(err!.message, /OPENROUTER_API_KEY/);
+});
+
+test('INSTANCE: the publish route holds no direct read of the prior-era key variable', () => {
+  // A mechanical guard for a defect defined by absence (ADR-0024 §E): review
+  // does not reliably see a variable read that bypasses the resolver, and this
+  // one survived a whole phase before being flagged.
+  const source = readFileSync(
+    new URL('../app/api/evidence/[slug]/publish/route.ts', import.meta.url),
+    'utf8',
+  );
+  assert.ok(
+    !/process\.env\.OPENROUTER_API_KEY/.test(source),
+    'the publication gate must resolve its credential through the endpoint layer',
+  );
+});
+
+// --- The five consolidated sites now have one home -------------------------
+
+test('CATALOG: every built-in entry carries pricing, so no offered model reports a null cost', () => {
+  // The #232 guard, kept: the roster and the pricing table used to be two maps
+  // synchronized by hand, and an id in one and not the other silently produced
+  // no cost estimate. They are now one record per model, which is what makes
+  // that class of drift unrepresentable rather than merely tested.
+  for (const entry of BUILT_IN_CATALOG) {
+    assert.ok(entry.pricing, `${entry.id} has no pricing`);
+  }
+});

--- a/src/lib/model-catalog.ts
+++ b/src/lib/model-catalog.ts
@@ -1,0 +1,528 @@
+import type { ModelApiKind } from './model-client.ts';
+
+/**
+ * The model catalog — the shape of one instance's model list, the built-in
+ * list the reference instance runs on, and the mechanical validation an
+ * operator-supplied list has to pass.
+ *
+ * WHY THIS MODULE EXISTS. Before it, five hardcoded tables described the same
+ * models and drifted independently: the offered list (`availableModels` in
+ * mcp/tools.ts), the pricing table and the display-name map (both in
+ * models.ts), the publication gate's two evaluator literals, and the notebook
+ * route's default. Each answered a different question about the same id and
+ * nothing kept them in agreement — #232 is that defect class already having
+ * happened once.
+ *
+ * WHY IT IS SPLIT IN TWO. This half is PURE: no `process.env`, no `node:fs`,
+ * no SDK. It has to be, because `models.ts` re-exports display and cost
+ * helpers into two client components (`ProvenanceChain`, `ChatNotebookOutput`),
+ * and a client bundle cannot reach a module that imports `node:fs`. Everything
+ * that reads the environment — the two delivery forms, the built-in retention
+ * rule, memoization — lives in `model-resolver.ts`, which is server-only. The
+ * one import here is type-only and erased at compile time.
+ *
+ * THE EVIDENCE-INTEGRITY RULE THIS ENCODES. An entry separates three strings
+ * that were one string before:
+ *
+ *   - `id`          — what a caller asks for and what `/api/models` serves.
+ *   - `endpointModel` — what goes on the wire as `model`. An OpenRouter slug
+ *     under the OpenAI-compatible dialect; an Azure DEPLOYMENT NAME under
+ *     `azure-openai`, which is an operator's private label for a resource and
+ *     asserts nothing about which model actually answered.
+ *   - `model`       — the operator-DECLARED identity that signed output will
+ *     assert. Consumed by website#30 P3; carried, not read, here.
+ *
+ * Under `openai-compatible` an entry may omit `model`: omission declares that
+ * the identity IS `endpointModel`, which is true because the slug called is
+ * the slug recorded. Under `azure-openai` that reasoning does not hold — a
+ * deployment name is not a model identity — so `model` is REQUIRED per entry
+ * and its absence is a refusal, not a default. That single asymmetry is the
+ * reason this phase exists (ADR-0024 §A: on the evidence path, configuration
+ * is absent-or-error, never defaulted).
+ *
+ * VALIDATION IS MECHANICAL (ADR-0024 §E). Every failure below names the entry
+ * and the field, and returns rather than throws, so the pure half stays
+ * testable without an environment and the server half owns the error type.
+ */
+
+/**
+ * The seven fields `/api/models` serves, in the order the response has always
+ * carried them. Unchanged from the pre-catalog `ModelDefinition` — the shape is
+ * a wire contract with `parseModelsResponse` (src/lib/model-list.ts, #283) and
+ * with `QueryForm`'s selector, and this phase does not touch it.
+ */
+export interface ModelDefinition {
+  id: string;
+  name: string;
+  tag?: string; // short descriptor shown in dropdown only (e.g. "recommended")
+  provider: string;
+  supports_tools: boolean;
+  description?: string;
+  maxTokenBudget?: number; // per-model token limit override
+}
+
+/** Per-1M-token prices in USD. */
+export interface ModelPricing {
+  input: number;
+  output: number;
+}
+
+/**
+ * One catalog entry: the served fields plus the four this phase adds.
+ *
+ * `selectable` exists because two of this instance's reachable models are not
+ * offered in the selector — the notebook route's default and the publication
+ * gate's preferred evaluator are the same id, and it has never appeared in
+ * `/api/models`. Suppressing it from the served list is what keeps that
+ * response byte-identical while the id stays resolvable.
+ */
+export interface CatalogEntry extends ModelDefinition {
+  /** The string sent as `model` on the wire (slug, or Azure deployment name). */
+  endpointModel: string;
+  /**
+   * The operator-declared model identity signed output asserts. Omitted under
+   * `openai-compatible` means "the same as `endpointModel`"; required under
+   * `azure-openai`. Read `declaredModelIdentity()` rather than this field.
+   */
+  model?: string;
+  /** False suppresses the entry from `/api/models`; it stays resolvable by id. */
+  selectable?: boolean;
+  /** Exactly one entry carries `true`: the notebook route's default model. */
+  default?: boolean;
+  /**
+   * Rank in the publication gate's evaluator preference order — lower is
+   * preferred. The gate walks this order and takes the first entry that is not
+   * the analysis model (evaluator independence).
+   */
+  evaluator?: number;
+  /** Per-1M-token prices. Absent means cost estimation returns null. */
+  pricing?: ModelPricing;
+}
+
+/**
+ * The list the reference instance runs on, kept ONLY while the resolved base
+ * URL is the OpenRouter default (website#30 G0 D2 — the retention rule is
+ * enforced in `model-resolver.ts`). Under that endpoint every `endpointModel`
+ * is a public OpenRouter slug identical to its `id`, so the list asserts
+ * nothing a record could get wrong: the slug called is the slug recorded, and
+ * `model` is correctly omitted throughout.
+ *
+ * The first three entries are `availableModels` verbatim, in order, with their
+ * pricing folded back in. The fourth was never in the selector and is not added
+ * to it: it is the notebook route's `DEFAULT_MODEL` and the publication gate's
+ * `DEFAULT_EVALUATOR_MODEL`, which were the same literal in two files.
+ *
+ * WHICH MODELS ARE OFFERED IS NOT THIS PHASE'S QUESTION (civic-ai-tools-website#302
+ * holds it). This phase changes only where the list comes from.
+ */
+export const BUILT_IN_CATALOG: readonly CatalogEntry[] = Object.freeze([
+  {
+    id: 'openai/gpt-4o',
+    name: 'GPT-4o',
+    tag: 'recommended',
+    provider: 'OpenAI',
+    supports_tools: true,
+    description: 'Best balance of quality and speed',
+    endpointModel: 'openai/gpt-4o',
+    pricing: { input: 2.5, output: 10.0 },
+    // The publication gate's FALLBACK_EVALUATOR_MODEL, at rank 2.
+    evaluator: 2,
+  },
+  {
+    id: 'openai/gpt-5.4',
+    name: 'GPT-5.4',
+    tag: 'premium',
+    provider: 'OpenAI',
+    supports_tools: true,
+    description: 'Highest quality analysis, newest model',
+    endpointModel: 'openai/gpt-5.4',
+    pricing: { input: 2.5, output: 15.0 },
+  },
+  {
+    id: 'google/gemini-3.5-flash-lite',
+    name: 'Gemini 3.5 Flash Lite',
+    tag: 'fastest',
+    provider: 'Google',
+    supports_tools: true,
+    description: 'Fast and budget-friendly',
+    maxTokenBudget: 150_000,
+    endpointModel: 'google/gemini-3.5-flash-lite',
+    pricing: { input: 0.3, output: 2.5 },
+  },
+  {
+    id: 'anthropic/claude-sonnet-4-6',
+    name: 'Claude Sonnet 4.6',
+    provider: 'Anthropic',
+    supports_tools: true,
+    // Never appeared in `/api/models`, and does not start now: this entry is
+    // the pre-catalog notebook default and preferred evaluator, and adding it
+    // to the selector would be a product change this phase is not making.
+    selectable: false,
+    endpointModel: 'anthropic/claude-sonnet-4-6',
+    pricing: { input: 3.0, output: 15.0 },
+    default: true,
+    evaluator: 1,
+  },
+]);
+
+/**
+ * Display names and prices for model ids this instance does NOT offer but whose
+ * bytes are already published.
+ *
+ * This is not a catalog and must not become one. `cost.model` inside a signed
+ * package is history: the record detail page, the provenance chain and the
+ * notebook output all render it long after the roster that produced it changed.
+ * Dropping these three ids would regress those surfaces from "Claude Opus 5"
+ * and a cost estimate to a raw slug and a blank — a reader-facing loss, and the
+ * wrong side of "user language not implementation language"
+ * (docs/design-principles.md).
+ *
+ * Pricing and display for a NON-OFFERED id is therefore deliberately not the
+ * catalog's business. It stays a built-in constant: never operator-supplied,
+ * never served, never resolvable by `resolveModel`. Adding a row here does not
+ * offer a model; it teaches the renderer a name for bytes that already exist.
+ */
+const HISTORICAL_MODELS: Readonly<Record<string, { name: string; pricing: ModelPricing }>> =
+  Object.freeze({
+    'anthropic/claude-sonnet-4': { name: 'Claude Sonnet 4', pricing: { input: 3.0, output: 15.0 } },
+    'anthropic/claude-opus-5': { name: 'Claude Opus 5', pricing: { input: 5.0, output: 25.0 } },
+    'anthropic/claude-haiku-4.5': { name: 'Claude Haiku 4.5', pricing: { input: 1.0, output: 5.0 } },
+  });
+
+/**
+ * The identity signed output asserts for this entry (website#30 P3 consumes
+ * this; nothing in P2 reads it). Under `openai-compatible` an omitted `model`
+ * resolves to `endpointModel`; under `azure-openai` validation guarantees
+ * `model` is present, so the fallback is unreachable there.
+ */
+export function declaredModelIdentity(entry: CatalogEntry): string {
+  return entry.model ?? entry.endpointModel;
+}
+
+/**
+ * Project one entry down to the seven served fields, in the response's
+ * historical key order, omitting absent optionals rather than emitting them.
+ * Key order is load-bearing: `/api/models` must stay byte-identical.
+ */
+export function projectServedModel(entry: CatalogEntry): ModelDefinition {
+  return {
+    id: entry.id,
+    name: entry.name,
+    ...(entry.tag !== undefined ? { tag: entry.tag } : {}),
+    provider: entry.provider,
+    supports_tools: entry.supports_tools,
+    ...(entry.description !== undefined ? { description: entry.description } : {}),
+    ...(entry.maxTokenBudget !== undefined ? { maxTokenBudget: entry.maxTokenBudget } : {}),
+  };
+}
+
+/** The catalog as `/api/models` serves it: selectable entries, catalog order. */
+export function selectableModels(catalog: readonly CatalogEntry[]): ModelDefinition[] {
+  return catalog.filter((e) => e.selectable !== false).map(projectServedModel);
+}
+
+/** The entry offered under `id`, or undefined. Selectability is not consulted. */
+export function findCatalogEntry(
+  catalog: readonly CatalogEntry[],
+  id: string,
+): CatalogEntry | undefined {
+  return catalog.find((e) => e.id === id);
+}
+
+/** The single `default: true` entry. Validation guarantees exactly one. */
+export function catalogDefaultEntry(catalog: readonly CatalogEntry[]): CatalogEntry {
+  const entry = catalog.find((e) => e.default === true);
+  if (!entry) {
+    // Unreachable through the resolver: `validateCatalog` refuses a catalog
+    // without exactly one default before it can be returned.
+    throw new Error('model catalog has no default entry');
+  }
+  return entry;
+}
+
+/** Evaluator candidates in preference order (lowest `evaluator` rank first). */
+export function catalogEvaluatorOrder(catalog: readonly CatalogEntry[]): CatalogEntry[] {
+  return catalog
+    .filter((e) => typeof e.evaluator === 'number')
+    .sort((a, b) => (a.evaluator as number) - (b.evaluator as number));
+}
+
+/**
+ * Human-readable name for a model id, for rendering a value that is already
+ * recorded. Consults the built-in catalog and then the historical table; falls
+ * back to the raw id, which is what an operator-configured catalog's ids reach
+ * (see the limitation noted in `models.ts`).
+ */
+export function builtInDisplayName(id: string): string | undefined {
+  const entry = findCatalogEntry(BUILT_IN_CATALOG, id);
+  if (entry) return entry.name;
+  return HISTORICAL_MODELS[id]?.name;
+}
+
+/** Prices for a model id, from the built-in catalog then the historical table. */
+export function builtInPricing(id: string): ModelPricing | undefined {
+  const entry = findCatalogEntry(BUILT_IN_CATALOG, id);
+  if (entry?.pricing) return entry.pricing;
+  return HISTORICAL_MODELS[id]?.pricing;
+}
+
+// --- Mechanical validation (ADR-0024 §E) ---
+
+export type CatalogValidation =
+  | { ok: true; catalog: CatalogEntry[] }
+  | { ok: false; message: string };
+
+/** Every key an entry may carry. An unknown key is a refusal, not an ignore. */
+const KNOWN_ENTRY_KEYS = new Set([
+  'id',
+  'name',
+  'tag',
+  'provider',
+  'supports_tools',
+  'description',
+  'maxTokenBudget',
+  'endpointModel',
+  'model',
+  'selectable',
+  'default',
+  'evaluator',
+  'pricing',
+]);
+
+/** How an entry is named in a refusal: by id when it has a usable one. */
+function entryLabel(raw: Record<string, unknown>, index: number): string {
+  const id = raw.id;
+  return typeof id === 'string' && id.trim() !== ''
+    ? `entry "${id}"`
+    : `entry #${index + 1}`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(
+  raw: Record<string, unknown>,
+  field: string,
+  label: string,
+  source: string,
+): string | { message: string } {
+  const value = raw[field];
+  if (typeof value !== 'string' || value.trim() === '') {
+    return {
+      message:
+        `${source} is invalid: ${label} has no usable "${field}". ` +
+        `Give every entry a non-empty string "${field}", then restart the server.`,
+    };
+  }
+  return value;
+}
+
+/**
+ * Validate a parsed catalog document against the schema, for one wire dialect.
+ *
+ * `kind` is a parameter rather than an environment read so this stays pure and
+ * so the azure-only rule can be tested without an Azure endpoint. `source` is
+ * the operator-facing name of where the document came from, and appears at the
+ * head of every message so a refusal says which variable to edit.
+ */
+export function validateCatalog(
+  document: unknown,
+  opts: { source: string; kind: ModelApiKind },
+): CatalogValidation {
+  const { source, kind } = opts;
+
+  if (!Array.isArray(document)) {
+    return {
+      ok: false,
+      message:
+        `${source} is not a JSON array. The catalog is a JSON array of model entries ` +
+        `(for example: [{"id":"my-model","name":"My Model","provider":"Example",` +
+        `"supports_tools":true,"endpointModel":"example-deployment","model":"vendor/model-1",` +
+        `"default":true,"evaluator":1}]). Fix it and restart the server.`,
+    };
+  }
+
+  if (document.length === 0) {
+    return {
+      ok: false,
+      message:
+        `${source} is an empty array, so this instance offers no models at all. ` +
+        `Declare at least one entry, exactly one of which carries "default": true, and restart the server.`,
+    };
+  }
+
+  const catalog: CatalogEntry[] = [];
+  const seenIds = new Set<string>();
+  const seenEvaluatorRanks = new Map<number, string>();
+  const defaults: string[] = [];
+
+  for (const [index, raw] of document.entries()) {
+    if (!isPlainObject(raw)) {
+      return {
+        ok: false,
+        message:
+          `${source} is invalid: entry #${index + 1} is not a JSON object. ` +
+          `Every element of the catalog array is an object describing one model. Fix it and restart the server.`,
+      };
+    }
+
+    const label = entryLabel(raw, index);
+
+    for (const key of Object.keys(raw)) {
+      if (!KNOWN_ENTRY_KEYS.has(key)) {
+        return {
+          ok: false,
+          message:
+            `${source} is invalid: ${label} carries an unknown field "${key}". ` +
+            `Accepted fields are: ${[...KNOWN_ENTRY_KEYS].join(', ')}. ` +
+            `Check the spelling (an unrecognized field is refused rather than ignored, so a typo cannot silently do nothing) and restart the server.`,
+        };
+      }
+    }
+
+    for (const field of ['id', 'name', 'provider', 'endpointModel'] as const) {
+      const value = requireString(raw, field, label, source);
+      if (typeof value !== 'string') return { ok: false, message: value.message };
+    }
+    const id = raw.id as string;
+    const endpointModel = raw.endpointModel as string;
+
+    if (seenIds.has(id)) {
+      return {
+        ok: false,
+        message:
+          `${source} is invalid: the id "${id}" appears on more than one entry. ` +
+          `An id selects exactly one model, so duplicates are refused rather than resolved by position. Remove one and restart the server.`,
+      };
+    }
+    seenIds.add(id);
+
+    if (typeof raw.supports_tools !== 'boolean') {
+      return {
+        ok: false,
+        message:
+          `${source} is invalid: ${label} has no usable "supports_tools". ` +
+          `Set it to true or false (this instance's query path needs tool calling; a model without it cannot answer a data question) and restart the server.`,
+      };
+    }
+
+    for (const field of ['tag', 'description'] as const) {
+      if (raw[field] !== undefined && typeof raw[field] !== 'string') {
+        return {
+          ok: false,
+          message: `${source} is invalid: ${label} has a non-string "${field}". Remove it or make it a string, then restart the server.`,
+        };
+      }
+    }
+
+    if (raw.maxTokenBudget !== undefined) {
+      const budget = raw.maxTokenBudget;
+      if (typeof budget !== 'number' || !Number.isInteger(budget) || budget <= 0) {
+        return {
+          ok: false,
+          message: `${source} is invalid: ${label} has a "maxTokenBudget" that is not a positive whole number. Fix it or remove it, then restart the server.`,
+        };
+      }
+    }
+
+    for (const field of ['selectable', 'default'] as const) {
+      if (raw[field] !== undefined && typeof raw[field] !== 'boolean') {
+        return {
+          ok: false,
+          message: `${source} is invalid: ${label} has a non-boolean "${field}". Set it to true or false, or remove it, then restart the server.`,
+        };
+      }
+    }
+
+    // THE RULE THIS PHASE EXISTS FOR. A deployment name is an operator's
+    // private label; it asserts nothing about which model answered, so under
+    // Azure the declared identity cannot be inferred from the wire string.
+    if (raw.model !== undefined && (typeof raw.model !== 'string' || raw.model.trim() === '')) {
+      return {
+        ok: false,
+        message: `${source} is invalid: ${label} has an empty or non-string "model". Give it the model identity this instance will assert in signed records, or remove it, then restart the server.`,
+      };
+    }
+    if (kind === 'azure-openai' && raw.model === undefined) {
+      return {
+        ok: false,
+        message:
+          `${source} is invalid: ${label} has no "model", which is required when MODEL_API_KIND=azure-openai. ` +
+          `Its "endpointModel" ("${endpointModel}") is a deployment name — an operator's label for a resource — so it cannot stand in for the model identity that signed records will assert. ` +
+          `Declare "model" on every entry and restart the server.`,
+      };
+    }
+
+    if (raw.default === true) defaults.push(id);
+
+    if (raw.evaluator !== undefined) {
+      const rank = raw.evaluator;
+      if (typeof rank !== 'number' || !Number.isInteger(rank) || rank <= 0) {
+        return {
+          ok: false,
+          message: `${source} is invalid: ${label} has an "evaluator" that is not a positive whole number. It is a preference rank (1 is tried first), not a flag. Fix it or remove it, then restart the server.`,
+        };
+      }
+      const clash = seenEvaluatorRanks.get(rank);
+      if (clash !== undefined) {
+        return {
+          ok: false,
+          message:
+            `${source} is invalid: entries "${clash}" and "${id}" both claim evaluator rank ${rank}. ` +
+            `The rank is a preference ORDER, so a tie has no defined answer. Give each candidate a distinct rank and restart the server.`,
+        };
+      }
+      seenEvaluatorRanks.set(rank, id);
+    }
+
+    if (raw.pricing !== undefined) {
+      const pricing = raw.pricing;
+      const valid =
+        isPlainObject(pricing) &&
+        typeof pricing.input === 'number' &&
+        Number.isFinite(pricing.input) &&
+        pricing.input >= 0 &&
+        typeof pricing.output === 'number' &&
+        Number.isFinite(pricing.output) &&
+        pricing.output >= 0;
+      if (!valid) {
+        return {
+          ok: false,
+          message: `${source} is invalid: ${label} has a "pricing" that is not {"input": <number>, "output": <number>} with both values zero or greater (USD per 1M tokens). Fix it or remove it — an entry without pricing simply reports no cost estimate — then restart the server.`,
+        };
+      }
+    }
+
+    catalog.push(raw as unknown as CatalogEntry);
+  }
+
+  if (defaults.length === 0) {
+    return {
+      ok: false,
+      message:
+        `${source} declares no default model: no entry carries "default": true. ` +
+        `The notebook route needs one when a caller names no model, and there is no safe guess. Mark exactly one entry and restart the server.`,
+    };
+  }
+  if (defaults.length > 1) {
+    return {
+      ok: false,
+      message:
+        `${source} declares more than one default model: ${defaults.map((d) => `"${d}"`).join(', ')} all carry "default": true. ` +
+        `Exactly one entry may. Mark one and restart the server.`,
+    };
+  }
+
+  if (seenEvaluatorRanks.size === 0) {
+    return {
+      ok: false,
+      message:
+        `${source} declares no evaluator: no entry carries an "evaluator" rank. ` +
+        `The publication gate runs an adversarial evaluation before a record goes public and has no candidate to run it with. ` +
+        `Give at least one entry "evaluator": 1 — two or more ranks let the gate pick a different model from the one under evaluation — and restart the server.`,
+    };
+  }
+
+  return { ok: true, catalog };
+}

--- a/src/lib/model-client.ts
+++ b/src/lib/model-client.ts
@@ -37,7 +37,15 @@ import type { ModelErrorCode } from './streaming.ts';
  * hang.
  */
 
-const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
+/**
+ * Exported so the built-in-catalog retention rule has ONE source of truth for
+ * "the default endpoint" (website#30 G0 D2, enforced in `model-resolver.ts`):
+ * the built-in model list is kept only while the RESOLVED base URL is this
+ * value. A second copy of the literal would let the two drift silently in the
+ * direction that matters — a catalog trusted against an endpoint it no longer
+ * describes.
+ */
+export const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
 
 /** The credential's canonical name, and the prior-era name still accepted. */
 const CANONICAL_KEY_NAME = 'MODEL_API_KEY';

--- a/src/lib/model-resolver.ts
+++ b/src/lib/model-resolver.ts
@@ -1,0 +1,216 @@
+import { readFileSync } from 'node:fs';
+import {
+  BUILT_IN_CATALOG,
+  catalogDefaultEntry,
+  catalogEvaluatorOrder,
+  findCatalogEntry,
+  selectableModels,
+  validateCatalog,
+  type CatalogEntry,
+  type ModelDefinition,
+} from './model-catalog.ts';
+import {
+  DEFAULT_BASE_URL,
+  ModelConfigurationError,
+  getModelApiBaseUrl,
+  getModelApiKind,
+} from './model-client.ts';
+
+/**
+ * The model resolver — the one lookup every call site uses, and the only place
+ * an instance's model catalog is read from its environment.
+ *
+ * DELIVERY (website#30 G0 D1 — both forms, one schema, env primary):
+ *
+ *   MODEL_CATALOG       — the catalog as a JSON document in the variable
+ *     itself. Works where a file cannot be mounted: a Vercel project's
+ *     environment, or an `op run` injection from a secret manager.
+ *   MODEL_CATALOG_PATH  — a path to the same JSON document on disk, for a
+ *     container that mounts config rather than passing a long value through
+ *     its environment.
+ *
+ * Both set is a REFUSAL, not a precedence rule. Two catalogs in one environment
+ * is an operator who believes something false about which models this instance
+ * offers, and silently picking one would leave that belief in place — while the
+ * bytes it produces go into signed records.
+ *
+ * BUILT-IN RETENTION (D2): the built-in catalog is the default ONLY while the
+ * resolved endpoint is the OpenRouter default. There, every `endpointModel` is
+ * a public slug identical to its id, so the built-in list asserts nothing a
+ * record could get wrong — the slug called is the slug recorded. Point the app
+ * at any other endpoint and that stops being true: the same slugs may name
+ * nothing, or name something else. Any other endpoint with no catalog is
+ * therefore refused by name, before any upstream call.
+ *
+ * MEMOIZATION mirrors `getModelClient()` in model-client.ts: resolved once per
+ * process, so a catalog change needs a restart. Every refusal below says so.
+ *
+ * WHAT THIS PHASE DELIBERATELY DOES NOT DO. Call sites resolve an id to an
+ * entry and still send `entry.id` on the wire, not `entry.endpointModel`. That
+ * is not an oversight: today every call site uses ONE string for two jobs — the
+ * wire parameter AND the identity that lands in `analysis.model`, in the
+ * notebook stamp, and in an evaluation attestation's methodology. Swapping in
+ * `endpointModel` here without splitting those two jobs would push a deployment
+ * name into signed output, which is the exact defect this sprint exists to
+ * prevent. The split belongs to website#30 P3, which owns the identity sites.
+ * Nothing is wrong in the meantime: under the built-in catalog every entry's
+ * `endpointModel` IS its `id` (pinned by a test), and a catalog where they
+ * differ only reaches an endpoint that P3 lands before P4 documents.
+ *
+ * WHY THIS FILE IS SEPARATE FROM `model-catalog.ts`: this one reaches
+ * `node:fs` and `process.env` and imports the SDK-bearing endpoint layer, so it
+ * is server-only. The schema, the built-in list and the projection live in the
+ * pure half, which two client components reach through `models.ts`.
+ */
+
+const CATALOG_ENV = 'MODEL_CATALOG';
+const CATALOG_PATH_ENV = 'MODEL_CATALOG_PATH';
+
+/**
+ * A caller named a model this instance does not offer.
+ *
+ * Distinct from `ModelConfigurationError` on purpose: that one says the
+ * operator's environment is wrong (an operability failure, 5xx), this one says
+ * the REQUEST is wrong (a caller failure, 4xx). Before this phase an unknown id
+ * was forwarded upstream and the endpoint decided — which meant an id this
+ * instance never offered could still reach a model, be billed, and land in a
+ * record's `cost.model`. It is now refused before any upstream call.
+ */
+export class ModelNotOfferedError extends Error {
+  readonly code = 'model_not_offered';
+  readonly modelId: string;
+
+  constructor(modelId: string, offered: string[]) {
+    super(
+      `The model "${modelId}" is not offered by this instance. ` +
+        `Choose one of: ${offered.join(', ')}.`,
+    );
+    this.name = 'ModelNotOfferedError';
+    this.modelId = modelId;
+  }
+}
+
+/** Trimmed environment read: unset, empty and whitespace-only are all absent. */
+function readSetting(name: string): string | undefined {
+  const raw = process.env[name];
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+/**
+ * True when this instance runs against the endpoint the built-in catalog
+ * describes. The dialect is checked as well as the URL: under `azure-openai`
+ * the resolved base URL is a resource endpoint, and `getModelApiBaseUrl()`
+ * would otherwise report the OpenRouter default for an Azure instance that has
+ * not set `MODEL_API_BASE_URL` — a configuration `resolveModelEndpointConfig()`
+ * refuses anyway, but this predicate must not depend on that ordering.
+ */
+function isBuiltInEndpoint(): boolean {
+  return getModelApiKind() === 'openai-compatible' && getModelApiBaseUrl() === DEFAULT_BASE_URL;
+}
+
+function readCatalogFile(path: string): string {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    // The path itself is not echoed: this message reaches server logs, and the
+    // operator knows what they set. Naming the variable is what makes it
+    // actionable (same discipline as the endpoint layer, which echoes no
+    // configured value).
+    throw new ModelConfigurationError(
+      `${CATALOG_PATH_ENV} names a file this server cannot read. ` +
+        `Check that the path is correct, that the file exists inside the container, and that the server process can read it; then restart the server.`,
+    );
+  }
+}
+
+function loadCatalog(): readonly CatalogEntry[] {
+  const inline = readSetting(CATALOG_ENV);
+  const path = readSetting(CATALOG_PATH_ENV);
+
+  if (inline !== undefined && path !== undefined) {
+    throw new ModelConfigurationError(
+      `${CATALOG_ENV} and ${CATALOG_PATH_ENV} are both set, and they are two ways to deliver the SAME catalog. ` +
+        `This is refused rather than resolved by precedence: whichever one lost would be a list of models an operator believes this instance offers and it does not. ` +
+        `Unset one of them and restart the server.`,
+    );
+  }
+
+  if (inline === undefined && path === undefined) {
+    if (isBuiltInEndpoint()) return BUILT_IN_CATALOG;
+    throw new ModelConfigurationError(
+      `${CATALOG_ENV} is required when this instance does not use the built-in model endpoint. ` +
+        `The built-in model list names public OpenRouter slugs; against any other endpoint those ids may name nothing, or name something else, and the identity they would put in a signed record would be a guess. ` +
+        `Declare this instance's models in ${CATALOG_ENV} (or in a file named by ${CATALOG_PATH_ENV}) and restart the server.`,
+    );
+  }
+
+  const source = inline !== undefined ? CATALOG_ENV : `${CATALOG_PATH_ENV} (the file it names)`;
+  const text = inline !== undefined ? inline : readCatalogFile(path as string);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new ModelConfigurationError(
+      `${source} does not contain valid JSON. The catalog is a JSON array of model entries. Fix it and restart the server.`,
+    );
+  }
+
+  const result = validateCatalog(parsed, { source, kind: getModelApiKind() });
+  if (!result.ok) throw new ModelConfigurationError(result.message);
+  return result.catalog;
+}
+
+let cachedCatalog: readonly CatalogEntry[] | null = null;
+
+/**
+ * This instance's model catalog. Throws a typed `ModelConfigurationError` when
+ * the environment cannot describe one — always before any upstream call.
+ */
+export function getModelCatalog(): readonly CatalogEntry[] {
+  if (!cachedCatalog) cachedCatalog = loadCatalog();
+  return cachedCatalog;
+}
+
+/** Test support: drop the memoized catalog so env changes take effect. */
+export function _resetModelCatalogForTests(): void {
+  cachedCatalog = null;
+}
+
+/**
+ * The entry this instance offers under `id`, or a typed not-offered error.
+ * Non-selectable entries resolve: `selectable` governs what `/api/models`
+ * lists, not what a caller may name.
+ */
+export function resolveModel(id: string): CatalogEntry {
+  const catalog = getModelCatalog();
+  const entry = findCatalogEntry(catalog, id);
+  if (!entry) throw new ModelNotOfferedError(id, catalog.map((e) => e.id));
+  return entry;
+}
+
+/** The models `/api/models` serves, in catalog order. */
+export function getOfferedModels(): ModelDefinition[] {
+  return selectableModels(getModelCatalog());
+}
+
+/** The entry a caller gets when it names no model. */
+export function getDefaultModel(): CatalogEntry {
+  return catalogDefaultEntry(getModelCatalog());
+}
+
+/**
+ * The publication gate's evaluator, given the model that produced the analysis.
+ *
+ * Evaluator independence (civic-ai-tools#72, Q26): the evaluator must differ
+ * from the analysis model, so the declared preference order is walked and the
+ * first candidate that is not the analysis model wins. Null when every declared
+ * candidate IS the analysis model — an instance-configuration answer the caller
+ * cannot fix by retrying, which the publish route reports as such.
+ */
+export function resolveEvaluatorModel(analysisModelId: string): CatalogEntry | null {
+  const candidates = catalogEvaluatorOrder(getModelCatalog());
+  return candidates.find((e) => e.id !== analysisModelId) ?? null;
+}

--- a/src/lib/models.test.ts
+++ b/src/lib/models.test.ts
@@ -1,36 +1,84 @@
-// Guards the model-roster/pricing-table coupling that caused #232: the UI
-// roster (`availableModels` in mcp/tools.ts) and the cost-estimation table
-// (`MODEL_PRICING` in this file) are two separate maps kept in sync by hand.
-// A model id present in one and missing from the other is exactly the defect
-// class from #232 — `estimateCostUsd` silently returns null for it. This test
-// turns that into a CI failure instead of a silent gap.
+// Guards the model-roster/pricing coupling that caused #232.
+//
+// The original defect: the UI roster (`availableModels`) and the cost table
+// (`MODEL_PRICING`) were two hand-synchronized maps, and an id present in one
+// and missing from the other made `estimateCostUsd` return null in silence.
+// civic-ai-tools-website#30 P2 folded both — and the display-name map, the
+// notebook default and the publication gate's evaluator literals — into one
+// catalog entry per model, so the two can no longer disagree by construction.
+// What is still worth pinning is the OUTPUT: this file asserts that the ids
+// this repo priced and named at `b95c768` still price and name identically, so
+// the consolidation cannot be a silent reader-facing regression on records
+// already published.
+//
+// The structural half of the guard (every offered entry carries pricing, the
+// default resolves, the evaluator order reproduces the two literals) lives in
+// model-catalog.test.ts.
 //
 // Run with: npm test
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { MODEL_PRICING } from './models.ts';
-import { availableModels } from './mcp/tools.ts';
+import { estimateCostUsd, formatModelName } from './models.ts';
+import { BUILT_IN_CATALOG, catalogDefaultEntry } from './model-catalog.ts';
 
-test('every availableModels id has a MODEL_PRICING entry', () => {
-  const missing = availableModels
-    .map((m) => m.id)
-    .filter((id) => !(id in MODEL_PRICING));
-  assert.deepEqual(
-    missing,
-    [],
-    `availableModels ids missing from MODEL_PRICING: ${missing.join(', ')}`,
-  );
+/**
+ * Display name and per-1M-token prices for every id this repo knew at
+ * `b95c768` — the three in the selector, the notebook/evaluator default, and
+ * the three that were priced and named but never selectable. A frozen literal,
+ * not a re-derivation: it is the pre-catalog `MODEL_PRICING` and
+ * `formatModelName` maps read off that commit.
+ */
+const FROZEN_MODEL_RENDERING: Record<string, { name: string; input: number; output: number }> = {
+  'openai/gpt-4o': { name: 'GPT-4o', input: 2.5, output: 10.0 },
+  'openai/gpt-5.4': { name: 'GPT-5.4', input: 2.5, output: 15.0 },
+  'google/gemini-3.5-flash-lite': { name: 'Gemini 3.5 Flash Lite', input: 0.3, output: 2.5 },
+  'anthropic/claude-sonnet-4': { name: 'Claude Sonnet 4', input: 3.0, output: 15.0 },
+  'anthropic/claude-sonnet-4-6': { name: 'Claude Sonnet 4.6', input: 3.0, output: 15.0 },
+  'anthropic/claude-opus-5': { name: 'Claude Opus 5', input: 5.0, output: 25.0 },
+  'anthropic/claude-haiku-4.5': { name: 'Claude Haiku 4.5', input: 1.0, output: 5.0 },
+};
+
+test('every id this repo priced at b95c768 still estimates the same cost', () => {
+  for (const [id, expected] of Object.entries(FROZEN_MODEL_RENDERING)) {
+    const cost = estimateCostUsd(id, 1_000_000, 1_000_000);
+    assert.equal(
+      cost,
+      expected.input + expected.output,
+      `cost estimation changed for "${id}" — a record already published renders through this`,
+    );
+  }
 });
 
-test('the notebook route default model has a MODEL_PRICING entry', () => {
-  // Mirrors DEFAULT_MODEL in src/app/api/query-notebook/route.ts. That file
-  // pulls in next/headers and next-auth, which aren't safe to import under
-  // node:test, so the id is duplicated here rather than imported — keep the
-  // two in sync by hand if the route's default model changes.
-  const NOTEBOOK_DEFAULT_MODEL = 'anthropic/claude-sonnet-4-6';
-  assert.ok(
-    NOTEBOOK_DEFAULT_MODEL in MODEL_PRICING,
-    `notebook route default model "${NOTEBOOK_DEFAULT_MODEL}" is missing from MODEL_PRICING`,
-  );
+test('every id this repo named at b95c768 still formats to the same display name', () => {
+  for (const [id, expected] of Object.entries(FROZEN_MODEL_RENDERING)) {
+    assert.equal(formatModelName(id), expected.name, `display name changed for "${id}"`);
+  }
+});
+
+test('an unknown id still falls back to the raw id and to no cost estimate', () => {
+  assert.equal(formatModelName('vendor/model-nobody-knows'), 'vendor/model-nobody-knows');
+  assert.equal(estimateCostUsd('vendor/model-nobody-knows', 1000, 1000), null);
+});
+
+test('every catalog entry has a display name and a cost estimate', () => {
+  // The #232 invariant, restated against the structure that replaced the two
+  // maps: an offered model is one record, so its name and its price cannot be
+  // in different states.
+  for (const entry of BUILT_IN_CATALOG) {
+    assert.equal(formatModelName(entry.id), entry.name);
+    assert.notEqual(
+      estimateCostUsd(entry.id, 1000, 1000),
+      null,
+      `estimateCostUsd is null for offered model "${entry.id}"`,
+    );
+  }
+});
+
+test('the notebook route default model is a catalog entry with pricing', () => {
+  // Replaces the hand-kept NOTEBOOK_DEFAULT_MODEL duplicate this file used to
+  // carry: the route no longer holds a slug to drift from, it asks the catalog.
+  const fallback = catalogDefaultEntry(BUILT_IN_CATALOG);
+  assert.ok(fallback.pricing, `default model "${fallback.id}" has no pricing`);
+  assert.equal(formatModelName(fallback.id), fallback.name);
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,31 +1,36 @@
 /**
- * Model pricing and display helpers.
+ * Model pricing and display helpers, for rendering a model id that is ALREADY
+ * RECORDED — `cost.model` inside a signed package, or the model name on an
+ * executed notebook. Both are history: the record outlives the roster.
  *
- * Prices per 1M tokens (USD) — current OpenRouter pricing as of 2026-08-11.
- * Update when OpenRouter pricing changes. Every id offered in `availableModels`
- * (src/lib/mcp/tools.ts) must have an entry here — see models.test.ts.
+ * The tables these read moved into `model-catalog.ts` (civic-ai-tools-website#30
+ * P2). Two of the three callers here are client components
+ * (`ProvenanceChain`, `ChatNotebookOutput`), which is why this file reaches the
+ * PURE half of the catalog and never the resolver — the resolver reads
+ * `node:fs` and cannot be bundled for a browser.
+ *
+ * LIMITATION, stated because it is invisible at the call site: these consult
+ * the BUILT-IN catalog and the historical table only. On an instance running a
+ * configured `MODEL_CATALOG`, its ids fall through to the honest fallbacks —
+ * the raw id, and no cost estimate — rather than to a wrong name or a wrong
+ * price. Routing a configured catalog's display data to the client would need a
+ * server-side projection through the record page; it is not this phase's, and
+ * it intersects P3's change to what `cost.model` holds.
  */
 
-export const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  'openai/gpt-4o':                  { input: 2.50, output: 10.00 },
-  'openai/gpt-5.4':                 { input: 2.50, output: 15.00 },
-  'google/gemini-3.5-flash-lite':   { input: 0.30, output: 2.50 },
-  'anthropic/claude-sonnet-4':      { input: 3.00, output: 15.00 },
-  'anthropic/claude-sonnet-4-6':    { input: 3.00, output: 15.00 },
-  'anthropic/claude-opus-5':        { input: 5.00, output: 25.00 },
-  'anthropic/claude-haiku-4.5':     { input: 1.00, output: 5.00 },
-};
+import { builtInDisplayName, builtInPricing } from './model-catalog.ts';
 
 /**
  * Estimate the USD cost of an LLM call given the model ID and token counts.
- * Returns null if the model isn't in the pricing table.
+ * Returns null when no pricing is known for the id — an honest blank rather
+ * than a guessed number.
  */
 export function estimateCostUsd(
   model: string,
   promptTokens: number,
   completionTokens: number,
 ): number | null {
-  const pricing = MODEL_PRICING[model];
+  const pricing = builtInPricing(model);
   if (!pricing) return null;
   return (
     (promptTokens / 1_000_000) * pricing.input +
@@ -34,18 +39,9 @@ export function estimateCostUsd(
 }
 
 /**
- * Format an OpenRouter model ID as a human-readable name.
+ * Format a model ID as a human-readable name.
  * Falls back to the raw ID if unknown.
  */
 export function formatModelName(id: string): string {
-  const map: Record<string, string> = {
-    'openai/gpt-4o':                  'GPT-4o',
-    'openai/gpt-5.4':                 'GPT-5.4',
-    'google/gemini-3.5-flash-lite':   'Gemini 3.5 Flash Lite',
-    'anthropic/claude-sonnet-4':      'Claude Sonnet 4',
-    'anthropic/claude-sonnet-4-6':    'Claude Sonnet 4.6',
-    'anthropic/claude-opus-5':        'Claude Opus 5',
-    'anthropic/claude-haiku-4.5':     'Claude Haiku 4.5',
-  };
-  return map[id] || id;
+  return builtInDisplayName(id) ?? id;
 }


### PR DESCRIPTION
## P2 — catalog + resolver

Branch `sprint-30/p2-catalog-resolver`, base `b95c768` (`rollback/pre-30-p2`). **IMPL model: Opus 5.**

Five hardcoded tables describing the same model ids become one catalog entry per model with one lookup. `/api/models` is byte-identical under the built-in endpoint.

### Blast zone

14 files, +1648/−135. Twelve of the fourteen are the contract's declared paths. **Two are declared extensions, both forced and both stated below** — `src/lib/model-client.ts` (one constant exported) and `docker-compose.yml` (two pass-through rows, without which `check:compose-env` fails).

| File | Why |
|---|---|
| `src/lib/model-catalog.ts` (new) | Pure half: schema, built-in list, historical display table, mechanical validation, the served projection |
| `src/lib/model-resolver.ts` (new) | Server half: the two delivery forms, D1/D2, memoization, `resolveModel` |
| `src/lib/model-catalog.test.ts` (new) | 36 tests, named by environment of verification |
| `src/lib/mcp/tools.ts` | `ModelDefinition` + `availableModels` removed |
| `src/lib/models.ts` | Pricing and display-name tables removed; delegates to the catalog |
| `src/lib/models.test.ts` | Re-pointed at the catalog; now pins output against `b95c768` |
| `src/app/api/models/route.ts` | Serves the catalog; 503 on an unreadable one |
| `src/app/api/query-notebook/route.ts` | `DEFAULT_MODEL` removed; caller ids resolved |
| `src/app/api/evidence/[slug]/publish/route.ts` | Evaluator literals removed; **the routed defect closed** |
| `src/lib/evidence/adversarial-eval.ts` | `apiKey` becomes optional |
| `scripts/preflight-env.mjs` | Two `ENV_SPEC` rows; `resolveSpec` checks the alternative before the promotion |
| `scripts/preflight-env.test.mjs` | Four new tests; three existing ones updated |
| `src/lib/model-client.ts` | **Extension.** `DEFAULT_BASE_URL` gains `export` — one word, no behavior change |
| `docker-compose.yml` | **Extension.** Two bare pass-throughs, forced by the compose guard |

### ADR-0024 §C classification for the two new variables

`MODEL_CATALOG` and `MODEL_CATALOG_PATH` are **on the evidence path**, both clauses:

- **§C.1 — under the signature.** An entry's `model` is the identity that lands in `cost.model`, `environment.modelVersion` and the PROV model agent.
- **§C.3 — changes an input to those bytes.** `endpointModel` selects which deployment actually answers.

So: absent-or-error off the built-in endpoint. Under the OpenRouter default the coded built-in list is admissible under **§B** — an honest default that asserts nothing, because the slug called is the slug recorded. Tier `optional` + `hasFallback` in the default profile; promoted to `required` under the `model` seam's `azure-openai` driver, where the promotion drops the fallback claim exactly as it does for `MODEL_API_BASE_URL`. `readBy` omitted (the server process reads them).

### The §2.1 asymmetry — decided deliberately

Seven ids were priced and named; three were selectable. The contract offered three options and asked which and why. **Measurement changed the question first:**

- `anthropic/claude-sonnet-4-6` is *not* an unreachable id. It is the notebook route's `DEFAULT_MODEL` **and** the publication gate's `DEFAULT_EVALUATOR_MODEL` — runtime-reachable on two paths, just never in the selector.
- All three consumers of `formatModelName`/`estimateCostUsd` render `pkg.cost.model` or `view.model` — the model recorded in an **already-published record**, not an offered one.

So the split is 4 reachable and 3 historical, not 3 and 4. The decision:

**The catalog holds exactly the ids this instance can call — four built-in entries.** The fourth carries `selectable: false`, which is what keeps `/api/models` byte-identical while the id stays resolvable. **Pricing and display for a non-offered id is not the catalog's business** (the contract's third option) — but it is not nothing either. It is historical-record rendering knowledge, so the remaining three ids stay a separate built-in constant, `HISTORICAL_MODELS`: never operator-supplied, never served, never resolvable by `resolveModel`. Dropping them would regress the record detail page and the provenance chain from "Claude Opus 5" plus a cost estimate to a raw slug and a blank — the wrong side of "user language not implementation language."

Nothing is added to the selector, so #302 keeps its question intact.

### Acceptance

| # | Criterion | Evidence |
|---|---|---|
| 1 | Reference instance sees zero change | `/api/models` pinned against a frozen literal captured at `b95c768`; `model-list.test.ts` untouched and green |
| 2 | Both delivery forms, both together refuse | Env form, real temp file, and a refusal naming both variables |
| 3 | D2 both directions | Default (unset **and** explicitly pinned) keeps the built-in; any other base URL, and `azure-openai`, refuse naming `MODEL_CATALOG` |
| 4 | Every refusal typed and named | Unknown id pre-upstream; entry+field; duplicate ids; zero/multiple defaults; evaluator resolving to nothing; azure missing `model`; unknown field |
| 5 | Routed defect closed | `getMissingModelCredentialError()` on `MODEL_API_KEY` alone; no-credential case still 502; plus a source-level guard that the direct read cannot come back |
| 6 | Five sites gone, CI green | All five removed; five checks pasted in the phase report |

`npm test` **936 pass / 0 fail** · `lint` **0 errors, 4 warnings** (baseline) · `typecheck` clean · `check:compose-env` **PASS** · build compiles (Turbopack is denied port binding in a sandboxed session — the documented behavior; CI's job is the gate).

### Two contract premises that did not survive

1. **Criterion 6's grep is broken twice over, and hid a sixth model table.** `grep -v test` drops every path containing the substring "test" — including `AttestationDialog.tsx`, because "At**test**ation" contains it. That silently hides `EVALUATOR_MODELS` at `AttestationDialog.tsx:125-131`, a five-entry model table. The regex also matches `'openai/resources/chat/completions'` SDK import paths, which can never go away, so "shows nothing" was unsatisfiable from the start.
2. **`ENV_SPEC` rows force a `docker-compose.yml` edit.** The compose guard demands every applicable row be deliverable; P1 hit the same and edited the file (its gate record's "check-compose-env.mjs untouched" refers to the script).

### Flagged, not fixed — all outside the blast zone

- **`generate-summary/route.ts:6`** — `SUMMARY_MODEL` is a **seventh** hardcoded id in a production route that calls `createModelClient()`. It sends a slug as the wire model, so it breaks under any non-default endpoint. The strongest of these flags.
- **`AttestationDialog.tsx:125-131`** — the sixth model table (the evaluator picker), stale against the roster and invisible to the contract's grep.
- **`endpointModel` is carried, not threaded.** Call sites still send `entry.id`. Deliberate: every call site uses one string for both the wire and the recorded identity, and swapping in `endpointModel` before P3 splits them would push a deployment name into signed output.
- `QueryForm.tsx:99`, `McpFlowDiagram.tsx:15`, `bpmn/traces.ts` (×4), `sampleExecutedNotebook.ts:46`, `project/page.tsx` (×3) — display, sample and fixture data. `project/page.tsx:52` names `anthropic/claude-opus-4-7`, an eighth id in no table at all.
- Configured-catalog display names do not reach the two client renderers.
- The preflight cannot express "required when a variable differs from its coded default", so an `openai-compatible` instance with a custom base URL and no catalog passes preflight and is refused by the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnJTLG4XsDp13Ys2v97YPc
