### PR TITLE
fix: close the cold read's six findings (#30 P6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ endpoint also means declaring its model list — see
 Publishing records
 additionally needs a database, object storage, sign-in, and a signing key —
 don't guess that set. The executable authority is the preflight, which checks
-the **presence** (never the value) of every variable the app reads and tiers
-each one against your instance's drivers:
+the **presence** of every variable the app reads — printing no value, ever —
+and tiers each one against your instance's drivers:
 
 ```bash
 node scripts/preflight-env.mjs

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -427,9 +427,9 @@ this reproduction into a different error than the one you came to see.
 
 The executable authority on the environment is
 [`scripts/preflight-env.mjs`](../scripts/preflight-env.mjs): it checks
-the **presence** (never the value) of every variable the app reads,
-resolves the three driver selectors first, and tiers every other
-variable against the resolved profile — so a self-hosted instance is
+the **presence** of every variable the app reads — and prints no
+value, ever — resolves the four driver selectors first, and tiers every
+other variable against the resolved profile — so a self-hosted instance is
 neither passed while unrunnable nor nagged about variables its profile
 never reads. It also warns when an **all-or-nothing variable group** is
 only partially set — the Vercel Sandbox auth trio, either sign-in
@@ -447,9 +447,14 @@ it cannot see what compose wires in** — the three driver selectors,
 a bare `node scripts/preflight-env.mjs` reports the *default managed
 profile* and fails demanding variables the compose path never uses
 (`BLOB_READ_WRITE_TOKEN` among them). To preflight a compose deployment,
-represent the compose profile explicitly. Presence is all that is
-checked, never values, so fixed stand-ins do for whatever compose
-supplies — and by the same token a PASS says nothing about the value:
+represent the compose profile explicitly. Presence is what is
+checked — no value is ever printed — so fixed stand-ins do for whatever
+compose supplies, with **one exception**: `MODEL_API_BASE_URL` is
+compared against the built-in default, because an endpoint that is not
+the default needs a `MODEL_CATALOG` and the app refuses the query
+without one. Give that variable its real value (or leave it unset for
+the built-in endpoint); a stand-in would tier the catalog rows wrongly.
+By the same token a PASS says nothing about the values it never read:
 `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` pass on a placeholder
 exactly as they pass on a real credential (see the tier notes below).
 From the checkout, with your own env-file values also in the

--- a/docs/instance-setup.md
+++ b/docs/instance-setup.md
@@ -228,7 +228,7 @@ never treated as the default.
 | --- | --- | --- | --- |
 | `MODEL_API_KEY` | The key the configured endpoint reads. Prior-era name `OPENROUTER_API_KEY`, still accepted — the canonical name wins whenever it is **defined**, empty string included. **Sensitive.** | always | **No.** A wrong value fails the request; it never reaches a byte a verifier reads. |
 | `MODEL_API_KIND` | `openai-compatible` (default) or `azure-openai`. | never — but see the rest of this table | **Yes (§C.1).** It derives `gen_ai.system` on the signed trace and the wording of the PROV model agent's description. |
-| `MODEL_API_BASE_URL` | The chat-completions endpoint. Under `azure-openai` this is the **resource endpoint** — the `https://` origin, no path. | `MODEL_API_KIND=azure-openai` | **Yes, indirectly (§C.3).** It never appears in a package — a public record must not carry your infrastructure hostnames — but it selects `gen_ai.system` and decides whether the built-in model list is trusted at all. |
+| `MODEL_API_BASE_URL` | The chat-completions endpoint. Under `azure-openai` this is the **resource endpoint** — the `https://` origin, no path. | `MODEL_API_KIND=azure-openai` | **Yes, indirectly (§C.3).** It never appears in a package — a public record must not carry your infrastructure hostnames — and it decides whether the built-in model list is trusted at all. It reaches `gen_ai.system` in two narrow cases only: the built-in default endpoint records `openrouter`, and OpenAI's own host records `openai`. Any other endpoint records the **dialect** you declared in `MODEL_API_KIND`, because naming a vendor your configuration never mentioned would be a guess printed under a signature. |
 | `MODEL_API_VERSION` | The api-version query parameter. There is no safe default: an api-version gates which request and response fields exist. | `MODEL_API_KIND=azure-openai` | **Yes, indirectly (§C.3).** It decides which response fields exist, and `gen_ai.response.model` — the endpoint's own report of what it ran, recorded under the signature — is read from the response body. |
 | `MODEL_API_AUTH` | `bearer` or `api-key`. Derived from the dialect when unset; a value contradicting the dialect is refused rather than ignored. `entra` is reserved in the enum and refused — there is no code behind it. | never | **No.** Authentication mechanics only. |
 | `MODEL_CATALOG` | This instance's model list, as a JSON document. | any endpoint other than the built-in one | **Yes (§C.1).** Each entry's `model` is the identity a signed record asserts. |
@@ -314,12 +314,24 @@ Field notes, all of them things the validator will tell you about anyway:
   `model` is required under `azure-openai`. `supports_tools` must be a boolean —
   this app's whole point is tool calls, so an entry that cannot make them is a
   configuration worth making explicit.
-- `tag` and `description` are shown in the picker. `maxTokenBudget` overrides
-  the per-request token ceiling for one model.
+- `tag` and `description` are shown in the picker. `maxTokenBudget` is
+  validated and served on `/api/models`, but **nothing reads it**: no code path
+  applies it as a ceiling. The per-request token budget is one module-level
+  constant for the whole instance — `TOKEN_LIMIT_PER_REQUEST` (default 200,000,
+  read in `src/lib/openrouter-streaming.ts`) — and there is no per-model route
+  to it. Setting the field is not an error; it just has no effect today.
 - `selectable: false` keeps an entry out of the picker while leaving it
   resolvable — the shape used above for a model that only fills a role.
-- `pricing` is per **1M** tokens, in USD, and is what a record's cost estimate is
-  computed from. Omit it and the estimate is omitted rather than guessed.
+- `pricing` is per **1M** tokens, in USD. **A configured catalog's `pricing` is
+  never read.** The cost estimate a record page renders consults the built-in
+  catalog and the historical price table only (`builtInPricing`,
+  `src/lib/model-catalog.ts`), and it looks a model up by the *declared*
+  identity recorded in `cost.model` while a catalog is keyed by `id` — so the
+  two do not even share a namespace. On an instance running its own catalog the
+  estimate is therefore **omitted rather than wrong**, which is the failure
+  direction to want; `src/lib/models.ts` states the same limitation at the
+  source. Whether the field should exist at all is
+  [#315](https://github.com/npstorey/civic-ai-tools-website/issues/315).
 - **An unknown field is refused, not ignored**, so a misspelling cannot silently
   do nothing.
 
@@ -328,7 +340,9 @@ Field notes, all of them things the validator will tell you about anyway:
 Bring the instance up and work outward from the cheapest check.
 
 ```bash
-# 1. Presence only — no values are read or printed.
+# 1. Presence — and one comparison. No value is ever printed; MODEL_API_BASE_URL
+#    is the sole value read, and only to ask whether it is the built-in default,
+#    because any other endpoint needs a MODEL_CATALOG.
 node scripts/preflight-env.mjs
 
 # 2. The catalog parsed, and the models this instance now offers.
@@ -345,7 +359,8 @@ What the failures mean:
 
 | What you see | What it is |
 | --- | --- |
-| `503` with `code: "model_not_configured"` | No key resolved. The message names the variable, and no upstream call was made. |
+| `400` naming the model you asked for | That id is not in this instance's catalog. Both comparison routes and `/api/query-notebook` refuse an id the catalog does not describe, before any upstream call — so a typo costs no tokens and reaches no record. (The refusal lists the ids it does accept, which includes any `selectable: false` entries `/api/models` does not show.) |
+| `503` with `code: "model_not_configured"` | The environment cannot describe a usable endpoint — no key, or a dialect missing a setting it requires. The message names the variable at fault, no upstream call was made, and nothing was charged against the day's request budget. |
 | `502` with `code: "model_auth_rejected"` | The endpoint refused the key — it exists and is wrong for this endpoint. |
 | `502` with `code: "model_rate_limited"` | The **endpoint** is rate-limiting this server. Not the app's own per-day limiter, which answers `429` with `Rate limit exceeded`. Under deployment routing, quota is per-model and per-region, so this points at one deployment's pool rather than at the whole resource. |
 | A `404`-ish or "deployment not found" error from the endpoint | `endpointModel` does not name a deployment on that resource. This is the failure mode nobody here has seen — see §5.5. |
@@ -448,6 +463,23 @@ Unverified against any real deployment-routed endpoint:
   cost estimate** — omitted rather than recorded as zero. If you measure which
   api-versions do admit it, that is the finding most likely to change this
   build's behavior.
+
+  **The other half of that parameter is no longer an unknown, and it is
+  recorded here because it was one.** Under `openai-compatible` the app *does*
+  send `stream_options`, including on the built-in default endpoint, and the
+  worry was that an endpoint rejecting the parameter answers 400 — which costs
+  the answer, not just the token count. On the built-in default it does
+  neither: OpenRouter's own usage-accounting documentation, read 2026-08-24,
+  says that `usage: { include: true }` and `stream_options: { include_usage:
+  true }` "are deprecated and have no effect" and that usage is "included in
+  the last SSE message for streaming responses … No additional parameters are
+  required." Accepted and ignored, in other words — and a live query run
+  against the reference deployment's production instance on 2026-08-24 (by the
+  project owner, not from a fixture) returned an answer. The parameter is still
+  sent, because `openai-compatible` is a dialect rather than one endpoint and
+  an endpoint that has not made the same change still has to be asked. What
+  remains genuinely unmeasured is the third case: an OpenAI-compatible endpoint
+  that *rejects* the parameter outright. If you run one, that is worth an issue.
 - **Error mapping under load.** Real 429s, content-filter refusals and quota
   exhaustion are mapped from synthetic statuses in tests. The mapping is
   structural — it reads the status, not the wording — which is the property most

--- a/scripts/check-compose-env.mjs
+++ b/scripts/check-compose-env.mjs
@@ -33,7 +33,13 @@
  *      settlement still delivers its values (a bare entry sets the variable
  *      only when the caller has it, so the pair is safe). A NOTE lists every
  *      prior-era name found: with a canonical twin present it is that
- *      deliberate pair; alone, it is a variable still to be renamed.
+ *      deliberate pair; alone, the entry still names the prior-era spelling
+ *      and the canonical one is the entry to move to. The NOTE says which
+ *      spelling is canonical and stops there (website#30 P6 F8): the two
+ *      renames sharing this mechanism have different lifetimes — the
+ *      publisher-identity set has a documented removal at a future major
+ *      version, MODEL_API_KEY's prior-era name has no removal scheduled — and
+ *      neither is the compose file's business.
  *   2. FORM — an `environment` entry written `${NAME:-}` is rejected. That
  *      form does NOT pass a variable through: it always sets the variable, to
  *      the empty string when the caller's environment has none. Empty is not
@@ -347,7 +353,7 @@ export function renderComposeReport(result, service = APP_SERVICE) {
     lines.push('        name. Both spellings reach the app, so this is not a failure. Where');
     lines.push('        the canonical twin is listed beside it, the pair is the deliberate');
     lines.push('        dual pass-through that keeps a pre-settlement env file working;');
-    lines.push('        where it stands alone, the entry is still to be renamed:');
+    lines.push('        where it stands alone, the canonical spelling is the one to move to:');
     for (const e of result.priorEraNamesInUse) {
       lines.push(`          - ${e.priorEraName} → ${e.name}`);
     }

--- a/scripts/preflight-env.mjs
+++ b/scripts/preflight-env.mjs
@@ -29,6 +29,15 @@
  * NAME alone. No unbounded input from the environment reaches the output,
  * which is what the "never echoed" test in the suite pins down.
  *
+ * ONE VARIABLE IS COMPARED WITHOUT BEING READ OUT: `MODEL_API_BASE_URL`, whose
+ * value `requiredWhenCustomized` (below) tests for equality against a coded
+ * default. The comparison yields a boolean and nothing else — the value is
+ * never printed, and the row it promotes is reported by NAME like every other.
+ * It is called out here rather than folded into the sentence above because
+ * "reads only presence" stopped being literally true of this script when the
+ * condition was added, and an endpoint URL is infrastructure even though it is
+ * not a credential.
+ *
  * `op run` is recommended for local use so the op:// references in
  * .env.local resolve into this process's environment:
  *
@@ -140,9 +149,35 @@ export const DRIVER_SEAMS = {
  *     output) and a preflight that disagreed with the app's own resolver would
  *     pass a configuration the app then refuses.
  *
- * A third conditional field expresses ALTERNATIVES rather than drivers — the
- * case where two variable sets satisfy the same need and an instance picks
- * one:
+ * A conditional field that is keyed by VARIABLE rather than by seam
+ * (website#30 P6 F2):
+ *   - `requiredWhenCustomized: { <VAR>: '<the app's coded default>' }` — tier
+ *     becomes 'required' when <VAR> is set to anything other than the coded
+ *     default named here. This is the "differs from its default" promotion,
+ *     and it exists because a driver seam cannot express it: a seam is a
+ *     closed set of enum literals, and a base URL is an open-valued setting
+ *     whose DEFAULT is what a coded fallback depends on.
+ *
+ *     THE CASE IT WAS MINTED FOR, measured. `src/lib/model-resolver.ts`
+ *     (`isBuiltInEndpoint`, `loadCatalog`) keeps the built-in model list only
+ *     while the dialect is `openai-compatible` AND the base URL is the coded
+ *     default; against ANY other endpoint, under EITHER dialect, a catalog is
+ *     required and the first request is refused by name without one. The seam
+ *     covered only the `azure-openai` half of that, so
+ *     `openai-compatible` + a custom `MODEL_API_BASE_URL` + no catalog passed
+ *     preflight and was then refused by the app — the exact failure a
+ *     preflight exists to prevent, on the check `docs/instance-setup.md` §5.3
+ *     makes step 1 of bringing an instance up.
+ *
+ *     THE COMPARISON MIRRORS THE APP'S OWN READ and is deliberately not
+ *     trimmed: `getModelApiBaseUrl()` is `process.env.MODEL_API_BASE_URL ||
+ *     DEFAULT_BASE_URL`, so empty falls back to the default and any other
+ *     string — whitespace included — is a custom endpoint. A trimming
+ *     comparison here would pass a configuration the app refuses, which is the
+ *     same failure mode the two-name precedence rule above is written to avoid.
+ *
+ * A field that expresses ALTERNATIVES rather than drivers — the case where two
+ * variable sets satisfy the same need and an instance picks one:
  *   - `requiredUnlessAllPresent: ['A', 'B', ...]` — the entry's declared
  *     'required' tier is DEMOTED TO 'optional' when every named variable is
  *     present. Used for the sign-in providers: an instance needs *a* provider,
@@ -153,21 +188,26 @@ export const DRIVER_SEAMS = {
  *     degrade" nag. Same no-nagging principle as `onlyWhen`; the entry stays
  *     listed so the operator can still see the option exists.
  *
- * WHEN AN ENTRY CARRIES BOTH `requiredWhen` AND `requiredUnlessAllPresent`,
- * the alternative wins: `resolveSpec` checks the alternative FIRST, so a driver
- * that makes a NEED load-bearing does not make THIS variable load-bearing while
- * a sibling already supplies it. The model catalog is the case that forced the
- * question — MODEL_CATALOG and MODEL_CATALOG_PATH are two deliveries of one
- * document, and the app REFUSES both being set, so a profile that promotes the
- * need must promote at most the delivery that is still absent. Promotion-first
- * would have failed a correctly-configured instance by demanding the variable
- * it was refused for setting. Inert for every row that shipped before this:
- * no other entry carries both fields.
+ * WHEN AN ENTRY CARRIES AN ALTERNATIVE AND EITHER PROMOTION, the alternative
+ * wins: `resolveSpec` checks `requiredUnlessAllPresent` FIRST, so a profile
+ * that makes a NEED load-bearing does not make THIS variable load-bearing
+ * while a sibling already supplies it. The model catalog is the case that
+ * forced the question — MODEL_CATALOG and MODEL_CATALOG_PATH are two
+ * deliveries of one document, and the app REFUSES both being set, so a profile
+ * that promotes the need must promote at most the delivery that is still
+ * absent. Promotion-first would have failed a correctly-configured instance by
+ * demanding the variable it was refused for setting. The two promotions are
+ * ORed: the catalog rows carry both (`azure-openai` under the seam, a custom
+ * base URL under the variable condition), which is exactly the app's own rule
+ * — built-in catalog only at the default endpoint in the default dialect.
+ * Inert for every row that shipped before the model seam: no other entry
+ * carries more than one of these fields.
  *
- * CONSTRAINT: all three fields must leave the default profile untouched. With
- * no selector set (or every selector set to its default) and no alternative
- * set complete, the resolved spec is identical to the declared one, so the
- * report is byte-identical to the pre-driver-awareness output. That is why the
+ * CONSTRAINT: all four fields must leave the default profile untouched. With
+ * no selector set (or every selector set to its default), no customized
+ * variable and no alternative set complete, the resolved spec is identical to
+ * the declared one, so the report is byte-identical to the
+ * pre-driver-awareness output — measured again for the new field. That is why the
  * S3_* knobs stay listed under the Vercel Blob profile rather than being
  * suppressed as not-applicable — the suppression only runs in the direction
  * that the frozen default output does not cover. The same holds for the
@@ -180,6 +220,22 @@ export const DRIVER_SEAMS = {
  * condition below is asserting. Named once so the two sides cannot drift.
  */
 export const OIDC_PROVIDER_SET = ['OIDC_ISSUER', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET'];
+
+/**
+ * The model endpoint the built-in catalog describes — the app's coded default
+ * for MODEL_API_BASE_URL, and the one value of it that leaves the built-in
+ * model list admissible.
+ *
+ * A DUPLICATED LITERAL, declared as one. `DEFAULT_BASE_URL` in
+ * `src/lib/model-client.ts` is the original; this script is `.mjs` and cannot
+ * import TypeScript, the same limitation that already forces a second copy of
+ * the two-name precedence rule. The hazard is real — a preflight comparing
+ * against a stale default would promote the catalog rows for an instance the
+ * app considers default, or fail to promote them for one it does not — so the
+ * test asserts this constant against that file's source rather than trusting
+ * the two to be kept in step by hand.
+ */
+export const BUILT_IN_MODEL_BASE_URL = 'https://openrouter.ai/api/v1';
 
 export const ENV_SPEC = [
   // --- Core query path (every demo query depends on these) ---
@@ -224,8 +280,14 @@ export const ENV_SPEC = [
   // asserts nothing (§B). `hasFallback` is therefore true only in the default
   // profile, and the promotion below drops it exactly as it does for
   // MODEL_API_BASE_URL.
-  { name: 'MODEL_CATALOG', tier: 'optional', purpose: 'Model catalog as a JSON document — required unless this instance uses the built-in OpenRouter endpoint (MODEL_CATALOG_PATH is the file-delivered alternative; setting both is refused)', hasFallback: true, requiredWhen: { model: 'azure-openai' }, requiredUnlessAllPresent: ['MODEL_CATALOG_PATH'] },
-  { name: 'MODEL_CATALOG_PATH', tier: 'optional', purpose: 'Path to a file holding the model catalog — the container-friendly delivery of MODEL_CATALOG, same schema; setting both is refused', hasFallback: true, requiredWhen: { model: 'azure-openai' }, requiredUnlessAllPresent: ['MODEL_CATALOG'] },
+  //
+  // TWO promotions, ORed, because the app's rule has two halves and the seam
+  // expresses only one (website#30 P6 F2): `azure-openai` promotes, and so does
+  // an endpoint that is not the built-in default under EITHER dialect. Without
+  // the second, `openai-compatible` + a custom MODEL_API_BASE_URL + no catalog
+  // PASSED here and was refused by the app at the first request.
+  { name: 'MODEL_CATALOG', tier: 'optional', purpose: 'Model catalog as a JSON document — required unless this instance uses the built-in OpenRouter endpoint (MODEL_CATALOG_PATH is the file-delivered alternative; setting both is refused)', hasFallback: true, requiredWhen: { model: 'azure-openai' }, requiredWhenCustomized: { MODEL_API_BASE_URL: BUILT_IN_MODEL_BASE_URL }, requiredUnlessAllPresent: ['MODEL_CATALOG_PATH'] },
+  { name: 'MODEL_CATALOG_PATH', tier: 'optional', purpose: 'Path to a file holding the model catalog — the container-friendly delivery of MODEL_CATALOG, same schema; setting both is refused', hasFallback: true, requiredWhen: { model: 'azure-openai' }, requiredWhenCustomized: { MODEL_API_BASE_URL: BUILT_IN_MODEL_BASE_URL }, requiredUnlessAllPresent: ['MODEL_CATALOG'] },
   // No coded fallback (#258 C4): the fallback used to point at the reference
   // deployment's hosted endpoint, silently routing an unconfigured instance's
   // queries through infrastructure it does not operate. Absent, every data
@@ -565,6 +627,27 @@ function conditionMet(condition, drivers) {
 }
 
 /**
+ * True when any variable named in a `requiredWhenCustomized` condition is set
+ * to something other than the coded default declared beside it.
+ *
+ * NOT TRIMMED, and not `isPresent`-based, on purpose — this mirrors the app's
+ * own read (`env.X || '<default>'`) exactly. Empty string falls back to the
+ * default there and so it does here; every other string, whitespace included,
+ * is a custom value there and so it is here. A preflight that resolved this
+ * differently from the app would pass a configuration the app then refuses,
+ * which is the whole failure this condition exists to close.
+ *
+ * The value is compared and discarded: only the boolean leaves this function.
+ */
+function customizedFromDefault(condition, env) {
+  return Object.entries(condition).some(([name, codedDefault]) => {
+    const raw = env[name];
+    if (typeof raw !== 'string' || raw === '') return false;
+    return raw !== codedDefault;
+  });
+}
+
+/**
  * THE presence test — non-empty after trim. Every check in this script
  * (tiers, alternatives, groups) uses this one boolean; no value is read
  * beyond it.
@@ -685,7 +768,9 @@ export function resolveSpec(drivers, spec = ENV_SPEC, env = {}) {
       applicable.push({ ...s, tier: 'optional' });
       continue;
     }
-    const promoted = s.requiredWhen && conditionMet(s.requiredWhen, drivers);
+    const promoted =
+      (s.requiredWhen && conditionMet(s.requiredWhen, drivers)) ||
+      (s.requiredWhenCustomized && customizedFromDefault(s.requiredWhenCustomized, env));
     if (promoted) {
       // The promotion also drops any `hasFallback` claim. A driver that makes
       // a variable load-bearing is by definition a driver the coded fallback
@@ -849,16 +934,31 @@ export function renderReport(result) {
   // not a WARN and never a failure: the value reached the app, the instance
   // works, and the rename is the operator's to schedule. It is reported at all
   // because the alternative — silence — leaves an operator to discover the new
-  // names from a release note, and because this list is exactly the work the
-  // eventual removal will require.
+  // names from a release note, and because this list is exactly the work a
+  // rename will require.
+  //
+  // TWO RENAMES SHARE THIS MECHANISM AND THEIR LIFETIMES DIFFER (website#30
+  // P6 F8), so the copy below states each rather than one promise covering
+  // both. The publisher-identity set has a documented removal at a future
+  // major version (docs/instance-setup.md §4, docs/key-rotation.md); the model
+  // credential's prior-era name has no removal scheduled anywhere in this
+  // repo — `src/lib/model-client.ts` says only that it keeps working, and a
+  // preflight that announced a removal date the project has not set would be
+  // telling operators to schedule work nobody has committed to. Not the same
+  // as calling it permanent, which is equally unsupported: the wire-field
+  // rename beside it (`openRouterApiKey` → `modelApiKey`,
+  // `src/lib/caller-model-key.ts`) IS classed alias-permanent, and that
+  // classification is about the request body, not about this variable.
   if (result.deprecatedNames && result.deprecatedNames.length > 0) {
     lines.push(
       `  NOTE: ${result.deprecatedNames.length} variable(s) supplied under a prior-era name.`,
     );
-    lines.push('        Both spellings work today; the prior-era one is removed at a future');
-    lines.push('        major version. The publisher-identity renames are the 2026-08-19');
-    lines.push('        vocabulary settlement; MODEL_API_KEY is a separate rename');
-    lines.push('        (civic-ai-tools-website#30) that reuses the same mechanism:');
+    lines.push('        Both spellings work today. The publisher-identity renames are the');
+    lines.push('        2026-08-19 vocabulary settlement, whose prior-era spellings are');
+    lines.push('        removed at a future major version (docs/instance-setup.md §4).');
+    lines.push('        MODEL_API_KEY is a SEPARATE rename (civic-ai-tools-website#30)');
+    lines.push('        reusing the same mechanism: OPENROUTER_API_KEY is still read and');
+    lines.push('        no removal is scheduled for it. Rename either way at your pace:');
     for (const r of result.deprecatedNames) {
       lines.push(`            - ${r.name} → rename to ${r.canonicalName}`);
     }

--- a/scripts/preflight-env.test.mjs
+++ b/scripts/preflight-env.test.mjs
@@ -7,7 +7,9 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import {
+  BUILT_IN_MODEL_BASE_URL,
   evaluateEnv,
   evaluateGroups,
   renderReport,
@@ -374,9 +376,12 @@ test('REGRESSION: the catalog rows are inert in the default profile', () => {
 
 test('the promotion is inert for every row that does not declare both fields', () => {
   // The `hasFallback`-dropping promotion is a shared code path. It can only
-  // change a row that declares BOTH fields, and every such row belongs to the
-  // model seam this sprint added.
-  const both = ENV_SPEC.filter((s) => s.requiredWhen && s.hasFallback).map((s) => s.name);
+  // change a row that declares a promotion AND a fallback claim, and every
+  // such row belongs to the model seam this sprint added. Both promotion
+  // fields are counted since website#30 P6 added the second one.
+  const both = ENV_SPEC.filter(
+    (s) => (s.requiredWhen || s.requiredWhenCustomized) && s.hasFallback,
+  ).map((s) => s.name);
   assert.deepEqual(both, ['MODEL_API_BASE_URL', 'MODEL_CATALOG', 'MODEL_CATALOG_PATH']);
 });
 
@@ -388,6 +393,127 @@ test('the catalog rows are declared as the two deliveries of one document', () =
   // Read by the server process, not at build time and not by an external tool.
   assert.equal(inline.readBy, undefined);
   assert.equal(file.readBy, undefined);
+});
+
+// --- website#30 P6 F2: preflight refuses what the app refuses -------------
+//
+// THE MEASURED DEFECT. The app requires a catalog for ANY endpoint that is not
+// the built-in default, under BOTH dialects (`isBuiltInEndpoint` and
+// `loadCatalog` in src/lib/model-resolver.ts). The seam expressed only the
+// azure half, and a seam is the only thing `conditionMet` can read — so
+// `openai-compatible` + a custom MODEL_API_BASE_URL + no catalog reported
+// `RESULT: PASS` here and was refused by the app at the first request, with
+// `MODEL_CATALOG is required…`. That is the exact failure a preflight exists
+// to prevent, on the check docs/instance-setup.md §5.3 makes step 1.
+
+const CUSTOM_ENDPOINT = 'https://gateway.example.net/v1';
+
+test('#30 P6 F2: a custom endpoint under the DEFAULT dialect promotes the catalog', () => {
+  const env = { ...envWithAllRequired(), MODEL_API_BASE_URL: CUSTOM_ENDPOINT };
+  const result = evaluateEnv(env);
+
+  // The run fails, which is the whole point: this configuration cannot answer
+  // a query, and the operator learns it here instead of at the first request.
+  assert.equal(result.ok, false);
+  for (const name of ['MODEL_CATALOG', 'MODEL_CATALOG_PATH']) {
+    assert.ok(
+      result.missingRequired.some((r) => r.name === name),
+      `${name} is a hard miss against an endpoint the built-in list does not describe`,
+    );
+    const row = result.rows.find((r) => r.canonicalName === name);
+    assert.equal(row.tier, 'required');
+    // The promotion drops the fallback claim exactly as the seam's does — the
+    // built-in catalog IS the fallback, and it is not admissible here. Left in
+    // place, the row lands in the soft `requiredOnFallback` bucket below and
+    // the run PASSES the configuration the app refuses.
+    assert.equal(row.hasFallback, false);
+    assert.ok(
+      !result.requiredOnFallback.some((r) => r.name === name),
+      `${name} must not land in the soft bucket, which would PASS the run`,
+    );
+  }
+
+  // The dialect is still the default one: this promotion is not a disguised
+  // driver change, and the profile line still reads openai-compatible.
+  assert.equal(result.profile.drivers.model, 'openai-compatible');
+
+  const report = renderReport(result);
+  assert.ok(report.includes('RESULT: FAIL'));
+  // SECRET HYGIENE. The condition is the one place this script reads a value
+  // other than a driver selector. It is compared and discarded: the endpoint
+  // must not appear anywhere in the output.
+  assert.ok(!report.includes(CUSTOM_ENDPOINT), 'the endpoint value is never echoed');
+  assert.ok(!report.includes('gateway.example.net'), 'not even its host');
+});
+
+test('#30 P6 F2: either catalog delivery satisfies the custom-endpoint promotion', () => {
+  for (const delivered of ['MODEL_CATALOG', 'MODEL_CATALOG_PATH']) {
+    const env = {
+      ...envWithAllRequired(),
+      MODEL_API_BASE_URL: CUSTOM_ENDPOINT,
+      [delivered]: delivered === 'MODEL_CATALOG' ? '[]' : '/etc/civicaitools/models.json',
+    };
+    const result = evaluateEnv(env);
+    assert.equal(result.ok, true, `${delivered} alone satisfies the need`);
+    // The sibling is demoted rather than demanded: the app REFUSES both being
+    // set, so promoting the absent one would fail a correct instance.
+    assert.ok(!result.missingRequired.some((r) => r.name.startsWith('MODEL_CATALOG')));
+  }
+});
+
+test('#30 P6 F2: the comparison agrees with the app’s own read of the variable', () => {
+  // `getModelApiBaseUrl()` is `process.env.MODEL_API_BASE_URL || DEFAULT`, so:
+  // unset and empty both mean the default, and every other string — the
+  // default written out, a trailing slash, whitespace — is read literally.
+  // A preflight that resolved any of these differently would pass a
+  // configuration the app refuses, or fail one it accepts.
+  const base = envWithAllRequired();
+  const promoted = (env) =>
+    evaluateEnv(env).rows.find((r) => r.canonicalName === 'MODEL_CATALOG').tier === 'required';
+
+  assert.equal(promoted({ ...base }), false, 'unset is the built-in endpoint');
+  assert.equal(promoted({ ...base, MODEL_API_BASE_URL: '' }), false, 'empty falls back');
+  assert.equal(
+    promoted({ ...base, MODEL_API_BASE_URL: BUILT_IN_MODEL_BASE_URL }),
+    false,
+    'the default written out explicitly is still the default',
+  );
+  assert.equal(
+    promoted({ ...base, MODEL_API_BASE_URL: `${BUILT_IN_MODEL_BASE_URL}/` }),
+    true,
+    'a trailing slash is a different string to the app, so it is one here',
+  );
+  assert.equal(promoted({ ...base, MODEL_API_BASE_URL: CUSTOM_ENDPOINT }), true);
+});
+
+test('#30 P6 F2: the coded default this script compares against is the app’s', () => {
+  // A DUPLICATED LITERAL — this script is .mjs and cannot import TypeScript.
+  // A stale copy would promote the catalog for an instance the app considers
+  // default, or fail to promote for one it does not, which is the same class
+  // of disagreement the two-name precedence rule is written to avoid. So it is
+  // asserted against the source of record rather than kept in step by hand.
+  const source = readFileSync(
+    new URL('../src/lib/model-client.ts', import.meta.url),
+    'utf8',
+  );
+  const match = source.match(/export const DEFAULT_BASE_URL = '([^']+)'/);
+  assert.ok(match, 'model-client.ts should declare DEFAULT_BASE_URL');
+  assert.equal(BUILT_IN_MODEL_BASE_URL, match[1]);
+});
+
+test('#30 P6 F2: the default profile is untouched by the new condition', () => {
+  // The standing constraint on every conditional field: with no selector set
+  // and nothing customized, the resolved spec is the declared one.
+  const { applicable, notApplicable } = resolveSpec(
+    resolveDrivers({}).drivers,
+    ENV_SPEC,
+    envWithAllRequired(),
+  );
+  assert.equal(notApplicable.length, 0);
+  assert.deepEqual(
+    applicable.map((s) => `${s.name}:${s.tier}:${s.hasFallback ?? false}`),
+    ENV_SPEC.map((s) => `${s.name}:${s.tier}:${s.hasFallback ?? false}`),
+  );
 });
 
 test('an unrecognized MODEL_API_KIND fails the run and is never echoed', () => {

--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -8,8 +8,9 @@ import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
 import { headers } from 'next/headers';
 import { encodeSSE, panelsForRun, type StreamErrorCode, type PanelType, type StreamEvent } from '@/lib/streaming';
-import { getMissingModelCredentialError } from '@/lib/model-client';
-import { modelIdentityForValue } from '@/lib/model-resolver';
+import { getMissingModelCredentialError, ModelConfigurationError } from '@/lib/model-client';
+import { resolveModelIdentity, ModelNotOfferedError } from '@/lib/model-resolver';
+import type { ModelIdentity } from '@/lib/model-catalog';
 import { getMissingMcpRoutingError, readMcpEnvFromProcess, skillRoutingTraceAttributes } from '@/lib/mcp/registry';
 import { TraceBuilder, hash, CIVICAITOOLS_TRACE_CONFIG } from '@/lib/evidence/trace';
 
@@ -62,11 +63,44 @@ export async function POST(request: NextRequest) {
     }
 
     // website#30 P3: the wire string and the recorded identity separate here.
-    // Resolved tolerantly rather than strictly — this route has never validated
-    // a caller's model id (the notebook route does), and adding a refusal is a
-    // product change, not this phase's. An id the catalog describes yields its
-    // pair; anything else is carried through on both sides exactly as before.
-    const model = modelIdentityForValue(modelId);
+    // P6 F1: resolved STRICTLY. Until this phase an unknown id was carried
+    // through on both sides, on the premise that this route records no
+    // identity. It does: `analysis.model` on the root span below, and
+    // `gen_ai.request.model` on every inference span — and the publish dialog
+    // carries this trace into a signed package. So a caller-supplied
+    // deployment alias became its own "declared identity" and was signed.
+    //
+    // The refusal is the one the notebook route already raises, in the same
+    // shape and with the same reader copy: a caller failure is 400, an
+    // operator's unreadable catalog is 503, and both are raised before any
+    // upstream call — before the skill fetch, before MCP init, before the
+    // model.
+    //
+    // WHAT THE UI SENDS, checked rather than assumed. `QueryForm` offers only
+    // ids from /api/models, which is this same catalog. `/explore` did NOT:
+    // it sent a module constant naming a historical, unresolvable id, and
+    // tolerant resolution was the only thing keeping that page working
+    // (#314). It now reads the offered list too, so "the UI sends an id this
+    // instance offers" is true by construction on both surfaces.
+    let model: ModelIdentity;
+    try {
+      model = resolveModelIdentity(modelId);
+    } catch (error) {
+      if (error instanceof ModelNotOfferedError) {
+        return new Response(
+          JSON.stringify({ error: error.message }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (error instanceof ModelConfigurationError) {
+        console.error('[compare-stream]', error.message);
+        return new Response(
+          JSON.stringify({ error: error.message, code: error.code }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      throw error;
+    }
 
     // Fail fast when the instance names no MCP endpoint for the primary data
     // source (#258 C4). SOCRATA_MCP_URL has no coded fallback — an

--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -7,7 +7,8 @@ import { callMcpTool } from '@/lib/mcp/client';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
 import { getMissingModelCredentialError, classifyModelError, ModelConfigurationError } from '@/lib/model-client';
-import { modelIdentityForValue } from '@/lib/model-resolver';
+import { resolveModelIdentity, ModelNotOfferedError } from '@/lib/model-resolver';
+import type { ModelIdentity } from '@/lib/model-catalog';
 import { streamErrorPayload } from '@/lib/streaming';
 import { getMissingMcpRoutingError } from '@/lib/mcp/registry';
 import { headers } from 'next/headers';
@@ -55,6 +56,37 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // website#30 P3 split the wire string from the recorded identity; P6 F1
+    // made the resolution STRICT and moved it here, above everything that
+    // costs anything. An id this instance does not offer is refused before the
+    // skill fetch, before rate limiting and before any model call — the same
+    // refusal, shape and reader copy the notebook route already raises (400
+    // for a caller's bad id, 503 for an operator's unreadable catalog).
+    //
+    // This route records no identity of its own, but it is one of a pair with
+    // /api/compare-stream, which does; a caller-supplied id that this route
+    // accepted and its twin signed would be the same defect with an extra
+    // step. The UI reaches neither refusal — `QueryForm` offers only ids from
+    // /api/models, and `/explore` reads the same list since #314; both were
+    // checked rather than assumed, because /explore's hardcoded id was
+    // precisely what tolerant resolution had been hiding.
+    let model: ModelIdentity;
+    try {
+      model = resolveModelIdentity(modelId);
+    } catch (error) {
+      if (error instanceof ModelNotOfferedError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      if (error instanceof ModelConfigurationError) {
+        console.error('[compare]', error.message);
+        return NextResponse.json(
+          { error: error.message, code: error.code },
+          { status: 503 }
+        );
+      }
+      throw error;
+    }
+
     // Get session and identifier for rate limiting
     const session = await getServerSession(authOptions);
     const headersList = await headers();
@@ -88,10 +120,6 @@ export async function POST(request: NextRequest) {
 When answering questions about civic data, government statistics, or local information,
 do your best to provide helpful information based on your training data.
 Be honest if you don't have access to current or real-time data.`;
-
-    // website#30 P3: same tolerant split as /api/compare-stream — the wire
-    // gets `endpointModel`, and nothing here records an identity.
-    const model = modelIdentityForValue(modelId);
 
     // Run both queries in parallel
     const [withoutMcpResult, withMcpResult] = await Promise.all([

--- a/src/app/api/model-refusal-ordering.test.ts
+++ b/src/app/api/model-refusal-ordering.test.ts
@@ -1,0 +1,249 @@
+// Where a query route refuses, and what it refuses with
+// (civic-ai-tools-website#30 P6, cold-read findings F1 and F3).
+//
+// TWO DEFECTS, ONE SHAPE. Both were failures of ORDER and of ATTRIBUTION on
+// the three routes that run a query:
+//
+//   F1 — `/api/compare` and `/api/compare-stream` resolved a caller's model id
+//        TOLERANTLY: an id the catalog did not describe was carried through on
+//        both sides of the wire/identity pair. That was justified on the
+//        premise that these routes record no identity. False for
+//        `/api/compare-stream`, which writes `analysis.model` onto the root
+//        span and `gen_ai.request.model` onto every inference span — and the
+//        publish dialog carries that trace into a signed package. A
+//        caller-supplied deployment alias therefore became its own "declared
+//        identity" and was signed. The byte-level half of this proof lives in
+//        `src/lib/model-identity.test.ts`; what is pinned HERE is that the
+//        routes take the strict path at all, and take it early.
+//
+//   F3 — `/api/query-notebook` never called `getMissingModelCredentialError()`,
+//        so a typed `ModelConfigurationError` naming (say) MODEL_API_VERSION
+//        was raised deep in the pipeline, classified to `model_not_configured`
+//        and rendered as that kind's copy: "no AI model API key configured …
+//        set MODEL_API_KEY". With a valid key present, that copy is false and
+//        points at the wrong variable. It also spent a reader's daily
+//        allowance to say it, because `incrementRateLimit` ran first.
+//
+// WHY THE ROUTES ARE READ AS SOURCE. They import `next/server`, `next-auth`
+// and `next/headers`, none of which loads under `node --test` — the same
+// constraint `rate-limit-split.test.ts` and `segment-alias.test.ts` work
+// under, and the same technique. Ordering is therefore asserted as the
+// relative position of the calls in the file, which is exactly what "before
+// any upstream call" means for a straight-line request handler. The BEHAVIOR
+// each ordering protects is asserted dynamically below and in the two library
+// suites, so neither half stands alone.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  _resetDefaultModelClientForTests,
+  getMissingModelCredentialError,
+} from '../../lib/model-client.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** The three routes that run a query against the model endpoint. */
+const QUERY_ROUTES = ['compare/route.ts', 'compare-stream/route.ts', 'query-notebook/route.ts'];
+
+/** The two routes F1 is about. */
+const COMPARE_ROUTES = ['compare/route.ts', 'compare-stream/route.ts'];
+
+function routeSource(relative: string): string {
+  return readFileSync(join(HERE, relative), 'utf8');
+}
+
+/** Position of a call in the file, asserted to exist. */
+function at(source: string, needle: string, route: string): number {
+  const index = source.indexOf(needle);
+  assert.ok(index > 0, `${route} should contain ${needle}`);
+  return index;
+}
+
+// --- F1: the compare routes refuse an unoffered id -------------------------
+
+test('#30 P6 F1: both compare routes resolve a caller id strictly', () => {
+  for (const route of COMPARE_ROUTES) {
+    const source = routeSource(route);
+    assert.ok(
+      source.includes('resolveModelIdentity(modelId)'),
+      `${route} resolves the caller's id against the catalog`,
+    );
+    // The tolerant helper is what carried an unknown id through. It has other,
+    // legitimate callers (POST /api/records, the evaluation preview) — but not
+    // these two, and a reintroduction here is the regression.
+    assert.ok(
+      !source.includes('modelIdentityForValue'),
+      `${route} must not carry an unresolved id through`,
+    );
+  }
+});
+
+test('#30 P6 F1: the refusal is the existing one — 400 for the caller, 503 for the operator', () => {
+  for (const route of COMPARE_ROUTES) {
+    const source = routeSource(route);
+    // Reused, not minted: the same typed error and the same two statuses the
+    // notebook route has raised since P2. No new reader copy was written for
+    // this, which is deliberate — the message already names the ids on offer.
+    assert.ok(
+      source.includes('error instanceof ModelNotOfferedError'),
+      `${route} handles the typed not-offered refusal`,
+    );
+    assert.ok(
+      source.includes('error instanceof ModelConfigurationError'),
+      `${route} keeps an unreadable catalog separate from a bad request`,
+    );
+    const notOffered = at(source, 'ModelNotOfferedError', route);
+    const status400 = source.indexOf('400', notOffered);
+    const status503 = source.indexOf('503', notOffered);
+    assert.ok(status400 > 0 && status503 > status400, `${route} answers 400 then 503`);
+  }
+});
+
+test('#30 P6 F1: the refusal precedes every upstream call and the rate limiter', () => {
+  for (const route of COMPARE_ROUTES) {
+    const source = routeSource(route);
+    const resolve = at(source, 'resolveModelIdentity(modelId)', route);
+
+    // `buildSystemPrompt` fetches skill guidance over the network: the first
+    // thing a request spends. `/api/compare` used to resolve the model AFTER
+    // it, and after the rate limiter too.
+    assert.ok(
+      resolve < at(source, 'buildSystemPrompt(portal)', route),
+      `${route} refuses before the skill fetch`,
+    );
+    // Nothing may be charged to a reader for a request that was never going to
+    // run. Same rule F3 restates for the notebook route.
+    assert.ok(
+      resolve < at(source, 'incrementRateLimit(', route),
+      `${route} refuses before spending the reader's daily allowance`,
+    );
+  }
+});
+
+// --- F3: the notebook route names the variable that is missing -------------
+
+test('#30 P6 F3: /api/query-notebook uses the shared endpoint guard, up front', () => {
+  const source = routeSource('query-notebook/route.ts');
+  assert.ok(
+    source.includes('getMissingModelCredentialError()'),
+    'the notebook route calls the same guard the compare routes do',
+  );
+  const guard = at(source, 'getMissingModelCredentialError()', 'query-notebook');
+
+  // Ahead of the catalog read: an endpoint that cannot be described is the
+  // more fundamental failure, and a catalog refusal raised first would send
+  // the operator after the wrong variable again.
+  assert.ok(
+    guard < at(source, 'resolveModel(body.model)', 'query-notebook'),
+    'the endpoint guard precedes the catalog read',
+  );
+  // …and ahead of the limiter, which is the second half of the finding.
+  assert.ok(
+    guard < at(source, 'incrementRateLimit(', 'query-notebook'),
+    'a misconfigured instance must not burn a reader’s allowance to fail',
+  );
+});
+
+test('#30 P6 F3: the guard reports the variable actually missing, not the key', () => {
+  // The exact configuration the cold read measured: a VALID key, the Azure
+  // dialect selected, and MODEL_API_VERSION absent. Before the fix the
+  // operator was told "no AI model API key configured … set MODEL_API_KEY".
+  const saved = {
+    MODEL_API_KEY: process.env.MODEL_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    MODEL_API_KIND: process.env.MODEL_API_KIND,
+    MODEL_API_BASE_URL: process.env.MODEL_API_BASE_URL,
+    MODEL_API_VERSION: process.env.MODEL_API_VERSION,
+    MODEL_API_AUTH: process.env.MODEL_API_AUTH,
+  };
+  try {
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.MODEL_API_VERSION;
+    delete process.env.MODEL_API_AUTH;
+    process.env.MODEL_API_KEY = 'obviously-fake-key-for-tests-do-not-use';
+    process.env.MODEL_API_KIND = 'azure-openai';
+    process.env.MODEL_API_BASE_URL = 'https://example-resource.example.net';
+    _resetDefaultModelClientForTests();
+
+    const error = getMissingModelCredentialError();
+    assert.ok(error, 'a missing api-version is a refusal');
+    assert.match(error!.message, /MODEL_API_VERSION/);
+    assert.doesNotMatch(
+      error!.message,
+      /No model API key is configured/,
+      'the key is present; saying otherwise sends the operator the wrong way',
+    );
+    // The kind is unchanged — `model_not_configured` still classifies it. What
+    // changed is that the TYPED message reaches the operator instead of being
+    // replaced by the kind's generic copy, which is why the route returns
+    // `error.message` rather than a classified payload.
+    assert.equal(error!.code, 'model_not_configured');
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    _resetDefaultModelClientForTests();
+  }
+});
+
+// --- The UI half of F1: what the clients actually send (#314) --------------
+//
+// F1's acceptance says the UI path still works "because the selector offers
+// only /api/models ids". Measured, that was true of `QueryForm` and false of
+// `/explore`: `McpFlowDiagram` had no selector at all, just a module constant
+// — `anthropic/claude-sonnet-4`, an id that lives in HISTORICAL_MODELS and is
+// deliberately never resolvable. Tolerant resolution was the only reason the
+// page worked; making the routes strict without this would have turned
+// /explore's headline feature into a 400 on every instance.
+
+test('#30 P6 F1 / #314: no query client names a model id in its own source', () => {
+  const clients = [
+    ['../../components/explore/McpFlowDiagram.tsx', '/explore’s live query'],
+    ['../../components/QueryForm.tsx', 'the home/ask query form'],
+  ] as const;
+  for (const [relative, what] of clients) {
+    const source = readFileSync(join(HERE, relative), 'utf8');
+    // Read from the instance, not asserted here.
+    assert.ok(source.includes("'/api/models'"), `${what} reads the offered list`);
+    assert.ok(source.includes('parseModelsResponse'), `${what} uses the shared parser`);
+    // A model id sent on the wire may not be a literal in a client. Comment
+    // prose naming an id is fine and both files have some; what must not
+    // appear is a literal in code, so the check is scoped to lines that are
+    // not comments.
+    const codeLines = source
+      .split('\n')
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line));
+    for (const line of codeLines) {
+      assert.ok(
+        !/'(anthropic|openai|google)\/[a-z0-9.\-]+'/.test(line),
+        `${what} must not name a model id in code: ${line.trim()}`,
+      );
+    }
+  }
+});
+
+// --- Both findings, stated as one standing rule ---------------------------
+
+test('#30 P6: no query route reaches the model before it has refused what it can', () => {
+  for (const route of QUERY_ROUTES) {
+    const source = routeSource(route);
+    // Every one of the three checks the endpoint configuration up front. This
+    // is the property that was asserted of all three at the P4 gate and was
+    // true of only two.
+    assert.ok(
+      source.includes('getMissingModelCredentialError()'),
+      `${route} checks the endpoint before running a query`,
+    );
+    assert.ok(
+      at(source, 'getMissingModelCredentialError()', route) <
+        at(source, 'incrementRateLimit(', route),
+      `${route} guards before it charges`,
+    );
+  }
+});

--- a/src/app/api/query-notebook/route.ts
+++ b/src/app/api/query-notebook/route.ts
@@ -26,7 +26,7 @@ import { mcpTools } from '@/lib/mcp/tools';
 import { callMcpTool, routeTool } from '@/lib/mcp/client';
 import { getMissingMcpRoutingError } from '@/lib/mcp/registry';
 import { getDefaultModel, resolveModel, ModelNotOfferedError } from '@/lib/model-resolver';
-import { ModelConfigurationError, getModelApiKind } from '@/lib/model-client';
+import { ModelConfigurationError, getMissingModelCredentialError, getModelApiKind } from '@/lib/model-client';
 import { modelAccessPhrase, modelIdentity, type ModelIdentity } from '@/lib/model-catalog';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import {
@@ -104,6 +104,38 @@ export async function POST(request: NextRequest) {
     );
   }
   const portal = body.portal || DEFAULT_PORTAL;
+
+  // Fail fast when the environment cannot describe a usable model endpoint
+  // (#178, and website#30 P6 F3). This is the guard /api/compare,
+  // /api/compare-stream and the publication gate have used since #178, and its
+  // absence here was a defect with two halves:
+  //
+  //   1. THE OPERATOR WAS TOLD THE WRONG VARIABLE. Without it, an endpoint
+  //      failure surfaced only when the pipeline reached the model, where the
+  //      typed ModelConfigurationError is classified to `model_not_configured`
+  //      and rendered as the kind's reader copy — "no AI model API key
+  //      configured … set MODEL_API_KEY". Measured with a valid key and
+  //      MODEL_API_VERSION absent, that copy is simply false: the key is
+  //      there, and the variable at fault is named nowhere the operator looks.
+  //      The typed message names the variable and the fix, and it survives
+  //      because it is returned from here rather than classified downstream.
+  //   2. IT BURNED QUOTA TO FAIL. `incrementRateLimit` below ran before
+  //      anything had established the endpoint was usable, so every attempt
+  //      against a misconfigured instance spent a day's allowance of a reader
+  //      who could never have got an answer. Guard first, then increment.
+  //
+  // Ahead of the catalog read for the same reason it is ahead of the limiter:
+  // the endpoint is the more fundamental configuration, and a catalog refusal
+  // raised first would send an operator after the wrong variable again. 503,
+  // not 400 — an operability failure, not a bad request.
+  const credentialError = getMissingModelCredentialError();
+  if (credentialError) {
+    console.error('[query-notebook]', credentialError.message);
+    return new Response(
+      JSON.stringify({ error: credentialError.message, code: credentialError.code }),
+      { status: 503, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
 
   // The model comes from this instance's catalog, not from a literal in this
   // file (civic-ai-tools-website#30 P2). Two things changed here:

--- a/src/components/explore/McpFlowDiagram.tsx
+++ b/src/components/explore/McpFlowDiagram.tsx
@@ -11,8 +11,8 @@ import { useTraceReplay } from '@/hooks/useTraceReplay';
 import { useLiveTrace } from '@/hooks/useLiveTrace';
 import type { ReplayState } from '@/lib/bpmn/animation';
 import { traceEventsToProgressData } from '@/lib/bpmn/trace-progress';
+import { parseModelsResponse } from '@/lib/model-list';
 
-const DEFAULT_MODEL = 'anthropic/claude-sonnet-4';
 const DEFAULT_PORTAL = 'data.cityofnewyork.us';
 
 export default function McpFlowDiagram() {
@@ -32,6 +32,58 @@ export default function McpFlowDiagram() {
 
   // Live trace
   const liveTrace = useLiveTrace();
+
+  /**
+   * The model this instance offers, for the live query (#314, closed as part
+   * of website#30 P6 F1).
+   *
+   * WHAT WAS HERE, AND WHY IT HAD TO GO. A module constant,
+   * `anthropic/claude-sonnet-4`, passed straight to `liveTrace.start` and out
+   * to `POST /api/compare-stream` as the `model` field — a WIRE VALUE, not a
+   * diagram label. That id is not in any catalog: website#30 P2 placed it in
+   * `HISTORICAL_MODELS`, the table that exists to render already-published
+   * records and is deliberately never resolvable. It survived only because the
+   * compare routes resolved a caller's id tolerantly, forwarding it upstream
+   * where the built-in endpoint happened to know the slug — so `/explore`'s
+   * live trace, which is publishable, asserted a model this instance does not
+   * offer. P6 makes those routes refuse an unoffered id, which turns a quiet
+   * wrong answer into a loud one; either way the constant was the defect.
+   *
+   * THE REPLACEMENT is the one `QueryForm` already uses since website#30 P4,
+   * which had the identical defect (a hardcoded initial model id): the first
+   * model `/api/models` offers, read from the instance rather than asserted
+   * here. Memoized in a ref so a reader who runs several queries fetches once,
+   * and warmed on mount so the click does not wait. An instance whose
+   * `/api/models` cannot answer yields the empty string, and the route's
+   * existing "Query and model are required" refusal surfaces in the live
+   * panel — an error the reader can see, rather than a button that does
+   * nothing.
+   *
+   * #314 asks a further question this does NOT answer: whether `/explore`
+   * should instead have its own catalog role, or reach the `default` entry
+   * (which is `selectable: false` and therefore absent from `/api/models`).
+   * That is a product decision; this only stops the page naming a model the
+   * instance never offered.
+   */
+  const offeredModelRef = useRef<Promise<string> | null>(null);
+  const offeredModel = useCallback((): Promise<string> => {
+    if (!offeredModelRef.current) {
+      offeredModelRef.current = fetch('/api/models')
+        .then((res) => res.json())
+        .then((data) => {
+          const parsed = parseModelsResponse(data);
+          return parsed && parsed.length > 0 ? parsed[0].id : '';
+        })
+        .catch((error) => {
+          console.error('Failed to fetch models:', error);
+          return '';
+        });
+    }
+    return offeredModelRef.current;
+  }, []);
+  useEffect(() => {
+    void offeredModel();
+  }, [offeredModel]);
 
   // Derive which state drives the viewer
   let activeState: ReplayState;
@@ -138,16 +190,20 @@ export default function McpFlowDiagram() {
     reset();
     viewerRef.current?.resetAll();
     // Auto-enter fullscreen on first live query
-    if (!isFullscreen) {
+    const enteringFullscreen = !isFullscreen;
+    if (enteringFullscreen) {
       setIsFullscreen(true);
       setHasPlayedOnce(true);
-      setTimeout(() => {
-        liveTrace.start(query, DEFAULT_MODEL, DEFAULT_PORTAL);
-      }, 400);
-    } else {
-      liveTrace.start(query, DEFAULT_MODEL, DEFAULT_PORTAL);
     }
-  }, [reset, liveTrace, isFullscreen]);
+    // The model is resolved before the query starts (#314). Usually already
+    // resolved: the fetch is warmed on mount and memoized, so this settles in
+    // a microtask and the 400ms fullscreen beat is unchanged.
+    void offeredModel().then((model) => {
+      const begin = () => liveTrace.start(query, model, DEFAULT_PORTAL);
+      if (enteringFullscreen) setTimeout(begin, 400);
+      else begin();
+    });
+  }, [reset, liveTrace, isFullscreen, offeredModel]);
 
   const handleLiveCancel = useCallback(() => {
     liveTrace.cancel();

--- a/src/lib/model-client.ts
+++ b/src/lib/model-client.ts
@@ -193,42 +193,108 @@ export function getModelApiBaseUrl(): string {
 }
 
 /**
+ * OpenAI's own chat-completions host. The ONE base URL for which `openai` is a
+ * statement about the configuration rather than a guess about it.
+ *
+ * Compared by hostname rather than by prefix so that a path, a trailing slash
+ * or a port cannot make a lookalike host match, and a legitimately-written
+ * `https://api.openai.com/v1` fails to.
+ */
+const OPENAI_OWN_HOST = 'api.openai.com';
+
+function isOpenAiOwnHost(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === OPENAI_OWN_HOST;
+  } catch {
+    // An unparseable base URL is certainly not OpenAI's host. It is not this
+    // function's job to refuse it — `createModelClient` does that.
+    return false;
+  }
+}
+
+/**
  * The OTel `gen_ai.system` value for the resolved endpoint — the trace
- * attribute naming which GenAI API answered (website#30 P3, E5).
+ * attribute naming which GenAI API answered (website#30 P3 E5, corrected in P6
+ * F4).
  *
- * MEASURED, not assumed. `CIVICAITOOLS_TRACE_CONFIG` (the harness's
- * `capture/trace.ts`, re-exported by `src/lib/evidence/trace.ts`) declares
- * `semconvVersion: '1.30.0'`, and every span this app writes carries that
- * version as `otel.semconv.version`. Read against the 1.30.0 attribute set:
- * `az.ai.openai` and `openai` are both REGISTERED values of `gen_ai.system`;
- * `openrouter` is NOT, and never has been — it was already the emitted value
- * before this phase.
+ * VERIFIED AGAINST THE DECLARED VERSION, not assumed. `CIVICAITOOLS_TRACE_CONFIG`
+ * (the harness's `capture/trace.ts`, re-exported by `src/lib/evidence/trace.ts`)
+ * declares `semconvVersion: '1.30.0'`, and every span this app writes carries
+ * that version as `otel.semconv.version`. Read against the v1.30.0 text of
+ * `docs/gen-ai/gen-ai-spans.md` (2026-08-24):
  *
- * So the mapping uses a registered value wherever one exists, and keeps the
- * unregistered one only where semconv itself has nothing to offer: for an
- * endpoint with no registered value the convention is the provider's name in
- * lowercase, which is exactly what `openrouter` is. Keeping it also means the
- * reference instance's traces do not silently change value in a phase whose
- * whole claim is that its bytes do not move — and replacing it with `openai`
- * would be a downgrade in honesty, since a router is not the OpenAI API.
+ *   - `gen_ai.system` is **Required**, so it is emitted on every inference
+ *     span. Omitting it where no listed value fits — the tempting move — is
+ *     not available: it would break conformance with the version the package
+ *     itself declares.
+ *   - Its well-known values are fourteen vendor names; `az.ai.openai` and
+ *     `openai` are among them, `openrouter` is not, and neither is `_OTHER`
+ *     (that value is in the table for `error.type`). What the same document
+ *     says instead is: "If one of them applies, then the respective value MUST
+ *     be used; otherwise, a custom value MAY be used", and, in the attribute's
+ *     own note, "For custom model, a custom friendly name SHOULD be used."
  *
- * `azure-openai` is the one dialect whose value this phase adds. Note what it
- * does NOT add: `server.address`. The resource hostname is the deployer's
- * infrastructure, and the trace is inside the signed package.
+ * WHY NOT DEFAULT TO `openai`. The note also says that where several systems
+ * are reachable through OpenAI client libraries the value "is set to `openai`
+ * based on the instrumentation's best knowledge", and that "the `server.address`
+ * attribute may help identify the actual system in use for `openai`". That
+ * disambiguation is exactly what this app does not offer: a resource hostname
+ * is the deployer's infrastructure and never enters a signed package (P3). So
+ * the reading that leans on `server.address` is the wrong reading HERE — it
+ * would put a vendor name nobody configured into a public trace with nothing
+ * beside it to correct the impression.
+ *
+ * WHAT IS EMITTED, and what each value is derived from:
+ *
+ *   azure-openai                      → `az.ai.openai`   (well-known)
+ *   openai-compatible @ the default   → `openrouter`     (custom, unchanged)
+ *   openai-compatible @ OpenAI's host → `openai`         (well-known)
+ *   openai-compatible @ anywhere else → `openai-compatible`, the CUSTOM value
+ *
+ * The last one is the correction. It is `MODEL_API_KIND` itself — declared
+ * configuration, not an inference about a URL — so the span says what the
+ * operator told this build and nothing more. It also agrees with the PROV model
+ * agent's description in the same package, which already says "an
+ * OpenAI-compatible chat-completions API" rather than naming a vendor.
+ *
+ * The built-in default keeps `openrouter`: semconv's escape for a system with
+ * no well-known value is a custom one, the provider's name in lowercase is what
+ * that convention produces, and the reference instance's traces therefore do
+ * not move on this attribute.
+ *
+ * Note what this still does NOT add: `server.address`. See above — the
+ * omission is deliberate and it is why the fallback had to change.
  */
 export function getGenAiSystem(): string {
-  if (getModelApiKind() === 'azure-openai') return 'az.ai.openai';
-  return getModelApiBaseUrl() === DEFAULT_BASE_URL ? 'openrouter' : 'openai';
+  const kind = getModelApiKind();
+  if (kind === 'azure-openai') return 'az.ai.openai';
+  const baseUrl = getModelApiBaseUrl();
+  if (baseUrl === DEFAULT_BASE_URL) return 'openrouter';
+  if (isOpenAiOwnHost(baseUrl)) return 'openai';
+  return kind;
 }
 
 /**
  * Whether a streaming request may ask the endpoint to report token usage.
  *
- * Usage is read only from the final chunk, and a streaming response carries no
- * `usage` object at all unless it is requested — which is why every streamed
- * answer this app has published recorded zero prompt and completion tokens
- * (website#30 P3, §2.5). `stream_options: { include_usage: true }` is the
- * OpenAI-dialect parameter that asks for it.
+ * Usage is read only from the final chunk, and under the OpenAI dialect a
+ * streaming response carries no `usage` object at all unless it is requested —
+ * which is why every streamed answer this app has published recorded zero
+ * prompt and completion tokens (website#30 P3, §2.5).
+ * `stream_options: { include_usage: true }` is the OpenAI-dialect parameter
+ * that asks for it.
+ *
+ * ON THE BUILT-IN DEFAULT ENDPOINT THE PARAMETER IS A NO-OP, and that is
+ * recorded rather than assumed (website#30 P6 F4/F7). OpenRouter's own
+ * usage-accounting documentation, read 2026-08-24, says: "The
+ * `usage: { include: true }` and `stream_options: { include_usage: true }`
+ * parameters are deprecated and have no effect. Full usage details are now
+ * always included automatically in every response" — "in the last SSE message
+ * for streaming responses". So on the reference instance the parameter is
+ * accepted and ignored, not a 400 waiting to happen; a live production query
+ * on 2026-08-24 confirmed the path answers. It is still sent, because this
+ * dialect is not one endpoint: an OpenAI-compatible endpoint that has not
+ * made the same change still needs to be asked.
  *
  * Asked only under `openai-compatible`. Under `azure-openai` the parameter's
  * availability is an api-version question — an api-version that does not know

--- a/src/lib/model-identity.test.ts
+++ b/src/lib/model-identity.test.ts
@@ -21,6 +21,7 @@
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
+import { readFileSync } from 'node:fs';
 import type { AddressInfo } from 'node:net';
 import canonicalize from 'canonicalize';
 import {
@@ -29,7 +30,13 @@ import {
   type StreamCallbacks,
 } from './openrouter-streaming.ts';
 import { modelIdentity } from './model-catalog.ts';
-import { resolveModel, _resetModelCatalogForTests } from './model-resolver.ts';
+import {
+  ModelNotOfferedError,
+  modelIdentityForValue,
+  resolveModel,
+  resolveModelIdentity,
+  _resetModelCatalogForTests,
+} from './model-resolver.ts';
 import { _resetDefaultModelClientForTests, getGenAiSystem } from './model-client.ts';
 import { TraceBuilder, CIVICAITOOLS_TRACE_CONFIG } from './evidence/trace.ts';
 import { buildEvidencePackage } from './evidence/packager.ts';
@@ -200,12 +207,8 @@ function silentCallbacks(): { callbacks: StreamCallbacks; errors: string[] } {
   };
 }
 
-/** Run one MCP-shaped query against the fake endpoint and return its trace. */
-async function runTracedQuery(baseUrl: string): Promise<{
-  trace: Record<string, unknown>;
-  warnings: unknown[][];
-  errors: string[];
-}> {
+/** Point this process at the fake endpoint with the azure-shaped catalog. */
+function configureFakeAzureInstance(baseUrl: string): void {
   process.env.MODEL_API_KIND = 'azure-openai';
   process.env.MODEL_API_BASE_URL = baseUrl;
   process.env.MODEL_API_VERSION = FAKE_API_VERSION;
@@ -213,9 +216,29 @@ async function runTracedQuery(baseUrl: string): Promise<{
   process.env.MODEL_CATALOG = AZURE_CATALOG;
   _resetDefaultModelClientForTests();
   _resetModelCatalogForTests();
+}
+
+/**
+ * Run one MCP-shaped query against the fake endpoint and return its trace.
+ *
+ * `identity` defaults to what the catalog resolves for the offered id — the
+ * correct path. It is a parameter so the P6 probe below can run the SAME
+ * pipeline with the identity the tolerant resolver used to produce, which is
+ * how the defect is reproduced rather than described.
+ */
+async function runTracedQuery(
+  baseUrl: string,
+  identity?: { endpointModel: string; declared: string },
+): Promise<{
+  trace: Record<string, unknown>;
+  warnings: unknown[][];
+  errors: string[];
+}> {
+  configureFakeAzureInstance(baseUrl);
+  const model = identity ?? modelIdentity(resolveModel('fast'));
 
   const builder = new TraceBuilder(CIVICAITOOLS_TRACE_CONFIG);
-  builder.startRoot('analysis', { 'analysis.model': DECLARED_MODEL });
+  builder.startRoot('analysis', { 'analysis.model': model.declared });
 
   const { callbacks, errors } = silentCallbacks();
   const warnings: unknown[][] = [];
@@ -226,7 +249,7 @@ async function runTracedQuery(baseUrl: string): Promise<{
   try {
     await queryWithMcpStreaming(
       'How many 311 noise complaints last year?',
-      modelIdentity(resolveModel('fast')),
+      model,
       [],
       async () => {
         assert.fail('no tools are offered in this fixture');
@@ -438,6 +461,132 @@ test('PACKAGE (local fake, Node): declared identity reaches all three sites, and
   }
 });
 
+// --- P6 F1: the cold read's probe, run both ways over canonical bytes ------
+//
+// WHAT WAS MEASURED, AND WHY IT IS RUN HERE. The cold read on the merged wave
+// pointed `/api/compare-stream` at an azure-shaped catalog and named the
+// DEPLOYMENT ALIAS as the request's `model`. The route resolved it tolerantly,
+// the alias became its own "declared identity", the deployment answered, and
+// the alias was signed: seven occurrences in the package's canonical JSON.
+//
+// The routes cannot be imported under `node --test` (they pull in
+// `next/server`), so this reproduces the defect at the seam the routes call:
+// the two resolvers. The tolerant one is what they used; the strict one is
+// what they use now. Both halves run the same pipeline against the same fake
+// endpoint and are asserted over the SERIALIZED canonical form, because a
+// field-by-field check only finds leaks in fields somebody thought to check.
+
+/** How many times a needle occurs in a string. Non-overlapping, exact. */
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+function packageFrom(trace: Record<string, unknown>, model: string): string {
+  const { pkg } = buildEvidencePackage({
+    trace,
+    prompt: 'How many 311 noise complaints last year?',
+    output: 'Around 400,000.',
+    toolCalls: [],
+    model,
+    portal: 'data.cityofnewyork.us',
+    tokenUsage: { promptTokens: 11, completionTokens: 3 },
+    promptVisibility: 'full_text',
+    title: 'Test',
+    summary: 'Test summary.',
+    contentProfile: 'datHere',
+  });
+  return canonicalize(pkg) as string;
+}
+
+test('#30 P6 F1: the tolerant resolver DID sign a caller-named deployment alias', async () => {
+  const server = await startFakeEndpoint();
+  try {
+    configureFakeAzureInstance(server.baseUrl);
+
+    // What the compare routes used to do with a caller's `model` field. The
+    // alias is not an offered id, so it was carried on BOTH sides — becoming
+    // the wire string (correct, by accident) and the recorded identity (the
+    // defect).
+    const tolerant = modelIdentityForValue(DEPLOYMENT_NAME);
+    assert.deepEqual(tolerant, {
+      endpointModel: DEPLOYMENT_NAME,
+      declared: DEPLOYMENT_NAME,
+    });
+
+    const { trace } = await runTracedQuery(server.baseUrl, tolerant);
+    assert.ok(server.requests.length >= 1, 'the deployment answered — the request succeeded');
+
+    const canonical = packageFrom(trace, tolerant.declared);
+    const occurrences = countOccurrences(canonical, DEPLOYMENT_NAME);
+    assert.ok(
+      occurrences > 0,
+      'this half exists to PIN the defect: the alias reaching canonical JSON',
+    );
+    // Named sites, so the count above is not the only thing standing between
+    // this test and a silent change of shape.
+    for (const marker of [
+      `"model":"${DEPLOYMENT_NAME}"`,
+      `"modelVersion":"${DEPLOYMENT_NAME}"`,
+      `"gen_ai.request.model"`,
+    ]) {
+      assert.ok(canonical.includes(marker), `expected ${marker} in the counterfactual bytes`);
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('#30 P6 F1: the strict resolver refuses it before any upstream call', async () => {
+  const server = await startFakeEndpoint();
+  try {
+    configureFakeAzureInstance(server.baseUrl);
+
+    // The same request, through the resolver both compare routes now use.
+    assert.throws(
+      () => resolveModelIdentity(DEPLOYMENT_NAME),
+      (error: unknown) => {
+        assert.ok(error instanceof ModelNotOfferedError);
+        // The refusal names what IS offered, which is what makes it usable
+        // without a second round trip. It does not echo an endpoint or a key.
+        assert.match((error as Error).message, /is not offered by this instance/);
+        assert.match((error as Error).message, /fast/);
+        return true;
+      },
+    );
+
+    // BEFORE ANY UPSTREAM CALL, measured rather than reasoned: the fake
+    // endpoint recorded nothing. No deployment answered, so nothing was
+    // billed, and there is no trace for a publish dialog to carry.
+    assert.equal(server.requests.length, 0, 'nothing reached the endpoint');
+
+    // And the offered id still resolves — the refusal is not a blanket one.
+    assert.deepEqual(resolveModelIdentity('fast'), {
+      endpointModel: DEPLOYMENT_NAME,
+      declared: DECLARED_MODEL,
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test('#30 P6 F1: what the fixed path signs contains the identity and not the alias', async () => {
+  const server = await startFakeEndpoint();
+  try {
+    // The positive control, over canonical bytes: a request naming the OFFERED
+    // id — which is all the UI can send, since its selector lists /api/models
+    // — carries the declared identity into the package and the alias into
+    // nothing.
+    const { trace } = await runTracedQuery(server.baseUrl);
+    const canonical = packageFrom(trace, DECLARED_MODEL);
+
+    assert.equal(countOccurrences(canonical, DEPLOYMENT_NAME), 0);
+    assert.ok(countOccurrences(canonical, DECLARED_MODEL) > 0);
+    assert.ok(canonical.includes(`"model":"${DECLARED_MODEL}"`));
+  } finally {
+    await server.close();
+  }
+});
+
 // --- Criterion 5: usage is requested, and absence stays absent -------------
 
 test('WIRE (local fake, Node): a streamed request under the OpenAI dialect asks for usage', async () => {
@@ -486,19 +635,145 @@ test('WIRE (local fake, Node): the azure dialect does NOT ask for usage — the 
 
 // --- The dialect → gen_ai.system mapping, measured against semconv 1.30.0 ---
 
-test('gen_ai.system uses a semconv-registered value where 1.30.0 has one', () => {
-  // Default dialect at the built-in endpoint: `openrouter`. NOT registered in
-  // 1.30.0 — and kept anyway, because semconv's own rule for a system with no
-  // registered value is the provider's name in lowercase, and calling a router
-  // `openai` would be less honest, not more. It is also the value emitted
-  // before this phase, so the reference instance's traces do not move.
+test('gen_ai.system uses a well-known value where 1.30.0 has one', () => {
+  // Default dialect at the built-in endpoint: `openrouter`. NOT one of the
+  // fourteen well-known values in 1.30.0 — and kept anyway, because the same
+  // document's rule for a system with no listed value is that "a custom value
+  // MAY be used", and the provider's name in lowercase is what that produces.
+  // It is also the value emitted before this phase, so the reference
+  // instance's traces do not move on this attribute.
   assert.equal(getGenAiSystem(), 'openrouter');
 
-  // Any other OpenAI-compatible endpoint: the registered `openai`.
-  process.env.MODEL_API_BASE_URL = 'https://gateway.example.net/v1';
+  // OpenAI's own host: the well-known `openai`, which here is a statement
+  // about the configuration rather than a guess about it.
+  process.env.MODEL_API_BASE_URL = 'https://api.openai.com/v1';
   assert.equal(getGenAiSystem(), 'openai');
 
-  // The azure dialect: the registered `az.ai.openai`.
+  // The azure dialect: the well-known `az.ai.openai`.
   process.env.MODEL_API_KIND = 'azure-openai';
   assert.equal(getGenAiSystem(), 'az.ai.openai');
+});
+
+// --- P6 F4: the correction, and the two premises behind it -----------------
+//
+// PREMISES, VERIFIED AGAINST THE DECLARED VERSION before this was written
+// (v1.30.0 of the semantic conventions, `docs/gen-ai/gen-ai-spans.md`, read
+// 2026-08-24 — the version `CIVICAITOOLS_TRACE_CONFIG` declares and every span
+// carries as `otel.semconv.version`):
+//
+//   1. `gen_ai.system` is **Required** in the `span.gen_ai.client` table.
+//      Omission — the first instinct, on the honest-omission precedent P3 set
+//      for the model-agent description — is therefore not available.
+//   2. Its well-known list is fourteen vendor names and does NOT include
+//      `_OTHER`; that value is in the table for `error.type`. The escape the
+//      document gives for this attribute is "otherwise, a custom value MAY be
+//      used", plus, in the attribute's own note, "For custom model, a custom
+//      friendly name SHOULD be used". (The note does also offer `_OTHER` as a
+//      last resort "if none of these options apply" — a friendly custom name
+//      applies here, so that last resort is not reached.)
+//
+// The defect: for ANY non-default OpenAI-compatible base URL the value was
+// `openai`, so a self-hosted gateway's signed public traces named a vendor
+// nobody configured. Semconv does sanction that reading for a client speaking
+// OpenAI's protocol — but it sanctions it alongside `server.address`, which
+// this app deliberately never records (a resource hostname is the deployer's
+// infrastructure). With the disambiguating attribute absent by design, the
+// vendor name stands alone and uncorrected, which is why the default-to-
+// `openai` reading is the wrong one HERE.
+
+test('#30 P6 F4: an unnameable endpoint gets the dialect, never a vendor', () => {
+  // A self-hosted OpenAI-compatible gateway: nothing about this configuration
+  // says OpenAI, so the span says what the operator declared — MODEL_API_KIND.
+  process.env.MODEL_API_BASE_URL = 'https://gateway.example.net/v1';
+  assert.equal(getGenAiSystem(), 'openai-compatible');
+  assert.notEqual(getGenAiSystem(), 'openai');
+  // Derived from configuration, not from an inference about the URL: the value
+  // IS the declared dialect.
+  assert.equal(getGenAiSystem(), process.env.MODEL_API_KIND ?? 'openai-compatible');
+
+  // A lookalike host does not buy the vendor name either.
+  process.env.MODEL_API_BASE_URL = 'https://api.openai.com.example.net/v1';
+  assert.equal(getGenAiSystem(), 'openai-compatible');
+
+  // …and neither does something unparseable as a URL.
+  process.env.MODEL_API_BASE_URL = 'not-a-url';
+  assert.equal(getGenAiSystem(), 'openai-compatible');
+});
+
+test('#30 P6 F4: `openai` survives exactly where the endpoint IS OpenAI', () => {
+  for (const base of [
+    'https://api.openai.com/v1',
+    'https://api.openai.com',
+    'https://API.OpenAI.com/v1/',
+  ]) {
+    process.env.MODEL_API_BASE_URL = base;
+    assert.equal(getGenAiSystem(), 'openai');
+  }
+});
+
+test('#30 P6 F4: the built-in default is unchanged, so reference bytes do not move', () => {
+  // No MODEL_API_BASE_URL and no MODEL_API_KIND — the reference instance's
+  // profile. This is the assertion that keeps F4 from being a bytes change on
+  // the one instance whose bytes this sprint promised not to move.
+  assert.equal(process.env.MODEL_API_BASE_URL, undefined);
+  assert.equal(getGenAiSystem(), 'openrouter');
+  process.env.MODEL_API_BASE_URL = 'https://openrouter.ai/api/v1';
+  assert.equal(getGenAiSystem(), 'openrouter', 'the default written out explicitly is still the default');
+});
+
+test('#30 P6 F4: every value emitted is non-empty and names no host', () => {
+  // `gen_ai.system` is Required, so whatever the configuration, a value must
+  // come out — and it must never be the base URL itself, which is how a
+  // resource hostname would reach a signed package by the back door.
+  const profiles: [string, Record<string, string | undefined>][] = [
+    ['built-in', {}],
+    ['openai', { MODEL_API_BASE_URL: 'https://api.openai.com/v1' }],
+    ['self-hosted', { MODEL_API_BASE_URL: 'https://gateway.example.net/v1' }],
+    ['azure', { MODEL_API_KIND: 'azure-openai', MODEL_API_BASE_URL: 'https://example-resource.example.net' }],
+  ];
+  for (const [label, env] of profiles) {
+    delete process.env.MODEL_API_KIND;
+    delete process.env.MODEL_API_BASE_URL;
+    for (const [k, v] of Object.entries(env)) if (v !== undefined) process.env[k] = v;
+    const value = getGenAiSystem();
+    assert.ok(value && value.trim() !== '', `${label}: a Required attribute needs a value`);
+    assert.ok(!value.includes('example.net'), `${label}: no hostname in the value`);
+    assert.ok(!value.includes('://'), `${label}: no URL in the value`);
+  }
+});
+
+// --- Criterion 4: `gen_ai.system` is on EVERY inference span ---------------
+
+test('#30 P6 F4: every inference span carries gen_ai.system (measured on a trace)', async () => {
+  const server = await startFakeEndpoint();
+  try {
+    const { trace } = await runTracedQuery(server.baseUrl);
+    const inferenceSpans = spans(trace).filter((s) => s.name === 'llm_inference');
+    assert.ok(inferenceSpans.length >= 1, 'the run should have produced an inference span');
+    for (const span of inferenceSpans) {
+      const value = attr(span, 'gen_ai.system');
+      assert.ok(value, 'gen_ai.system is Required in the declared semconv version');
+      assert.equal(value, 'az.ai.openai');
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('#30 P6 F4: no inference span is started without gen_ai.system', () => {
+  // The drift guard the trace test cannot give: a THIRD `llm_inference` span
+  // added later without the attribute would not show up in a fixture that
+  // never takes that branch. Both current sites are in this one file.
+  const source = readFileSync(
+    new URL('./openrouter-streaming.ts', import.meta.url),
+    'utf8',
+  );
+  const starts = [...source.matchAll(/startSpan\('llm_inference'[\s\S]{0,240}?\}\)/g)];
+  assert.ok(starts.length >= 2, 'both inference sites should be found');
+  for (const match of starts) {
+    assert.ok(
+      match[0].includes("'gen_ai.system': getGenAiSystem()"),
+      'an inference span without gen_ai.system breaks conformance with the declared version',
+    );
+  }
 });

--- a/src/lib/model-resolver.ts
+++ b/src/lib/model-resolver.ts
@@ -243,17 +243,29 @@ export function resolveModelIdentity(id: string): ModelIdentity {
  * An id the catalog describes resolves to its pair; anything else is carried
  * through on both sides, unchanged.
  *
- * Four call sites take this path and none of them is a model selection:
- * `POST /api/evidence`, whose `model` field an external publisher supplies for
- * an analysis this instance never ran; the evaluation preview, which runs a
+ * TWO call sites take this path, and neither of them selects a model for a run
+ * this instance is about to make: `POST /api/records` (served from
+ * `/api/evidence`), whose `model` field an external publisher supplies for an
+ * analysis this instance never ran, and the evaluation preview, which runs a
  * caller's own key against a model they named from a dialog whose list
- * website#30 P4 still owns; and the two comparison routes, which have never
- * validated a caller's model id. All four predate the catalog, so introducing
- * a refusal here would be a product change rather than this phase's split.
+ * website#30 P4 still owns. Both predate the catalog.
  *
- * A catalog this instance cannot read is the same case, deliberately: none of
- * those four depended on one, so a broken catalog must not be the thing that
- * turns them into failures. The paths that DO select a model
+ * THE TWO COMPARISON ROUTES USED TO BE HERE AND ARE NOT ANY MORE (website#30
+ * P6 F1). Leaving them tolerant was justified on the premise that they record
+ * no identity. That premise was false for `/api/compare-stream`: it writes
+ * `analysis.model` onto the root span and `gen_ai.request.model` onto every
+ * inference span, and the publish dialog carries that trace into a signed
+ * package — so a caller-supplied deployment alias was reaching canonical JSON
+ * as its own "declared identity". Both routes now call `resolveModelIdentity`
+ * and refuse an unoffered id before any upstream call.
+ *
+ * `POST /api/records`' own tolerance of `body.model` is a separate question
+ * with a separate history — it predates this sprint and is filed rather than
+ * folded in here.
+ *
+ * A catalog this instance cannot read is deliberately the same case: neither
+ * remaining caller depends on one, so a broken catalog must not be the thing
+ * that turns them into failures. The paths that DO select a model
  * (`resolveModelIdentity`, `getDefaultModel`, `getSummarizerModel`) refuse
  * loudly instead.
  */


### PR DESCRIPTION
## P6 — the cold read's six findings, closed

Base `6b52359`. Branch `sprint-30/p6-cold-read-fixes`. Model: **Opus 5** (`claude-opus-5[1m]`).
Isolated worktree; nothing uncommitted; `main` untouched.

Specification: the [cold-read record](https://github.com/npstorey/civic-ai-tools-website/issues/30#issuecomment-5399826924)
and the [close rulings](https://github.com/npstorey/civic-ai-tools-website/issues/30#issuecomment-5400228648).
Requirements 2 and 4 are what this phase closes.

```
 README.md                                 |   4 +-
 docs/deploy.md                            |  17 +-
 docs/instance-setup.md                    |  46 ++++-
 scripts/check-compose-env.mjs             |  10 +-
 scripts/preflight-env.mjs                 | 152 +++++++++++---
 scripts/preflight-env.test.mjs            | 132 +++++++++++-
 src/app/api/compare-stream/route.ts       |  48 ++++-
 src/app/api/compare/route.ts              |  38 +++-
 src/app/api/model-refusal-ordering.test.ts| 235 ++++++++++++++++++++++
 src/app/api/query-notebook/route.ts       |  34 +++-
 src/components/explore/McpFlowDiagram.tsx |  72 ++++++-
 src/lib/model-client.ts                   | 116 +++++++++--
 src/lib/model-identity.test.ts            | 311 +++++++++++++++++++++++++++--
 src/lib/model-resolver.ts                 |  30 ++-
 14 files changed, 1141 insertions(+), 120 deletions(-)
```

**Blast zone.** Every path the contract named, plus **three it did not**, each declared rather than
slipped in:

| Path | Why it is here |
|---|---|
| `src/components/explore/McpFlowDiagram.tsx` | **The zone was too small.** Acceptance 1 requires the UI path to still work. It rested on "the selector offers only `/api/models` ids", which is true of `QueryForm` and false of `/explore` — that page had no selector, only the hardcoded id of [#314](https://github.com/npstorey/civic-ai-tools-website/issues/314). Tolerant resolution was the *only* thing keeping it working, so F1 without this ships a 400 on `/explore`'s headline feature on every instance including production. Details and the decision it implies are in the report below. |
| `docs/deploy.md`, `README.md` | Statements pass: both said the preflight reads "the **presence** (never the value)" of every variable. F2 makes that literally false for one variable, so both sentences were corrected. `deploy.md` also said "the three driver selectors" where `resolveDrivers` has iterated four since P1 — pre-existing, corrected in the sentence being edited rather than left standing. |

`.env*` untouched. **No new environment variables** — nothing is owed to `.env.example`.

---

## The findings

### F1 — an unresolved id could reach signed output

Both compare routes now resolve through `resolveModelIdentity` and refuse before any upstream call,
reusing the notebook route's existing refusal (400 for a caller's bad id, 503 for an operator's
unreadable catalog). No new reader copy was minted.

The probe, reproduced over canonical bytes (`src/lib/model-identity.test.ts`), and measured
end-to-end against the fake azure endpoint:

```
TOLERANT (pre-P6): upstream requests = 1 | alias occurrences in canonical JSON = 8
   cost.model = example-deployment-alias
STRICT (P6):     upstream requests during resolution = 0 | refusal = ModelNotOfferedError
```

The cold read measured 7 through the route; this fixture measures 8 because its trace carries one
`analysis.model` root attribute plus one inference span rather than the route's span shape. The
number is the fixture's, the defect is the same one. Three tests hold it: the counterfactual (the
alias reaching canonical JSON), the refusal (typed, with **zero** requests reaching the endpoint),
and the positive control (an offered id: declared identity present, alias occurrences **0**).

### F1's UI half — #314, and why it could not stay a non-goal

`src/components/explore/McpFlowDiagram.tsx:15` held `const DEFAULT_MODEL = 'anthropic/claude-sonnet-4'`
and passed it to `POST /api/compare-stream`. That id is in `HISTORICAL_MODELS` — the table that
renders already-published records and is **deliberately never resolvable**. #314 says so explicitly,
including *why it has not been visible*: the tolerant resolution this phase removes.

It now reads the first model `/api/models` offers, exactly as `QueryForm` has since P4 (the same
defect shape, already fixed once in this wave). **This is #314's option 1 of three, chosen by
precedent rather than by ruling** — the gate should confirm or redirect. On the reference instance
`/explore`'s live query moves from `anthropic/claude-sonnet-4` (unoffered) to `openai/gpt-4o` (the
first offered), and records published from that page assert an identity the instance actually
declares. #314's real question — whether `/explore` deserves its own catalog role, or a surface
exposing the `default` entry — is untouched and still open.

### F3 — the notebook route named the wrong variable

`/api/query-notebook` now calls `getMissingModelCredentialError()` up front: ahead of the catalog
read (the endpoint is the more fundamental failure) and ahead of `incrementRateLimit`. Pinned
dynamically against the exact configuration the cold read measured — a valid key, `azure-openai`,
`MODEL_API_VERSION` absent — asserting the message matches `/MODEL_API_VERSION/` and does **not**
say the key is missing.

### F4 — `gen_ai.system`, and the two premises

Both premises were checked against the version the trace config declares before anything was
written. **One of them did not survive as stated** — see the report section below.

Emitted now: `azure-openai` → `az.ai.openai`; the built-in default → `openrouter` (**unchanged** —
the reference instance's traces do not move); OpenAI's own host → `openai`; anything else → the
declared dialect from `MODEL_API_KIND`. `server.address` is still not recorded.

### F2 — the preflight now refuses what the app refuses

One new `ENV_SPEC` condition, `requiredWhenCustomized`, expressing *required when this variable
differs from its coded default*. Measured, complete required environment plus a custom
`MODEL_API_BASE_URL` and no catalog:

```
BASE 6b52359 exit=0 :: RESULT: PASS — all required variables present.
             endpoint echoed in report: false
P6          exit=1 :: RESULT: FAIL — 2 required variable(s) missing:
             endpoint echoed in report: false
```

Default-profile output is byte-identical to the base script (`true` for both the complete-required
and empty-environment profiles). The comparison mirrors `env.X || DEFAULT` exactly — untrimmed — so
preflight and app agree on empty, on the default written out, and on a trailing slash.

### F5, F6, F7, F8 — operator-facing claims

- **F5/F6** — `pricing` and `maxTokenBudget` corrected in `docs/instance-setup.md`, both verified
  first (`builtInPricing` reads `BUILT_IN_CATALOG` then `HISTORICAL_MODELS`, keyed by the *declared*
  identity from `pkg.cost.model`; `maxTokenBudget` has no consumer anywhere). Nothing filed; #315
  linked as the open question.
- **F7** — §5.5 records the parameter as documented-ignored. The documentation claim was verified
  from the page source, not from memory: *"The `usage: { include: true }` and
  `stream_options: { include_usage: true }` parameters are deprecated and have no effect"*, usage
  *"included in the last SSE message for streaming responses"* — read 2026-08-24. The same fact is
  recorded beside `includeStreamUsage()`, which had asserted the opposite as a general rule.
- **F8** — the two renames sharing the prior-era-name mechanism have **different lifetimes**, so the
  copy states each. See the report: the contract's citation for this one did not survive.

---

## Checks — full output

`npm ci` first.

### `npm test`

```
1..971
# tests 1004
# suites 10
# pass 1004
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1394.378084
```

### `npm run build`

```
> civic-ai-tools-website@0.1.0 build
> next build

▲ Next.js 16.3.0 (Turbopack)
✓ Running next.config.ts took 42ms

  Creating an optimized production build ...
✓ Compiled successfully in 976ms
  Running TypeScript ...
  Finished TypeScript in 1584ms ...
  Collecting page data using 9 workers ...
✓ Generating static pages using 9 workers (32/32) in 188ms
```

Followed by the Route (app) table, unchanged in shape. Two pre-existing Turbopack warnings
(`src/lib/notebook-author/helpers/index.ts` dynamic filesystem access), neither from this diff.
**Re-measured in this sandboxed session: it builds, exit 0** — no `--webpack` fallback needed.

### `npm run typecheck`

```
> civic-ai-tools-website@0.1.0 typecheck
> tsc --noEmit

```

No output, exit 0. Run after `npm run build`.

### `npm run lint`

```
/…/scripts/eval-models.mjs
  388:7  warning  'TokenBudgetExceeded' is defined but never used  @typescript-eslint/no-unused-vars

/…/src/components/evidence/AttestationDialog.tsx
  8:7  warning  'EXPERT_RATINGS' is assigned a value but only used as a type  @typescript-eslint/no-unused-vars

/…/src/components/notebook/RenderingCellOutputs.tsx
  96:9  warning  Using `<img>` could result in slower LCP and higher bandwidth…  @next/next/no-img-element

/…/src/lib/bpmn/animation.ts
  8:10  warning  'mapEventToNodes' is defined but never used  @typescript-eslint/no-unused-vars

✖ 4 problems (0 errors, 4 warnings)
```

The documented baseline exactly. (It caught one real thing on the way: a test helper named
`useFakeAzureInstance` tripped `react-hooks/rules-of-hooks`; renamed.)

### `npm run check:compose-env`

```
  RESULT: PASS — every variable this profile reads can reach the container.
```

### `node --test scripts/preflight-env.test.mjs`

```
1..71
# tests 71
# suites 0
# pass 71
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 59.074542
```

---

Refs: #30 · #314 (closed in part) · #315 (linked, not implemented)
