### PR TITLE
fix: /explore's model-fetch cache never clears on failure (#30 P7)

### DIFF
--- a/src/app/api/model-refusal-ordering.test.ts
+++ b/src/app/api/model-refusal-ordering.test.ts
@@ -203,20 +203,33 @@ test('#30 P6 F3: the guard reports the variable actually missing, not the key', 
 // /explore's headline feature into a 400 on every instance.
 
 test('#30 P6 F1 / #314: no query client names a model id in its own source', () => {
+  // website#30 P7 extracted /explore's fetch+parse into a plain module
+  // (`offered-model.ts`) so its retry/caching policy is unit-testable by
+  // node:test — McpFlowDiagram.tsx is JSX, which the test runner's
+  // `--experimental-strip-types` cannot parse. So /explore's "client" for
+  // this check is McpFlowDiagram.tsx plus the module it delegates to;
+  // QueryForm still does its own fetch inline.
   const clients = [
-    ['../../components/explore/McpFlowDiagram.tsx', '/explore’s live query'],
-    ['../../components/QueryForm.tsx', 'the home/ask query form'],
+    [
+      ['../../components/explore/McpFlowDiagram.tsx', '../../lib/offered-model.ts'],
+      '/explore’s live query',
+    ],
+    [
+      ['../../components/QueryForm.tsx'],
+      'the home/ask query form',
+    ],
   ] as const;
-  for (const [relative, what] of clients) {
-    const source = readFileSync(join(HERE, relative), 'utf8');
+  for (const [relatives, what] of clients) {
+    const sources = relatives.map((relative) => readFileSync(join(HERE, relative), 'utf8'));
+    const combined = sources.join('\n');
     // Read from the instance, not asserted here.
-    assert.ok(source.includes("'/api/models'"), `${what} reads the offered list`);
-    assert.ok(source.includes('parseModelsResponse'), `${what} uses the shared parser`);
+    assert.ok(combined.includes("'/api/models'"), `${what} reads the offered list`);
+    assert.ok(combined.includes('parseModelsResponse'), `${what} uses the shared parser`);
     // A model id sent on the wire may not be a literal in a client. Comment
-    // prose naming an id is fine and both files have some; what must not
+    // prose naming an id is fine and these files have some; what must not
     // appear is a literal in code, so the check is scoped to lines that are
     // not comments.
-    const codeLines = source
+    const codeLines = combined
       .split('\n')
       .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line));
     for (const line of codeLines) {

--- a/src/components/QueryForm.tsx
+++ b/src/components/QueryForm.tsx
@@ -14,30 +14,12 @@ import {
   type QueryMode,
 } from '@/lib/query-presentation';
 import { parseModelsResponse, type Model } from '@/lib/model-list';
+import { MODELS_LOAD_ERROR } from '@/lib/streaming';
 import RateLimitBanner from './RateLimitBanner';
 
 // Re-exported for existing importers; the type itself lives in
 // src/lib/query-presentation.ts alongside the derivations that use it.
 export type { QueryMode };
-
-/**
- * Reader-facing copy for a `/api/models` load failure (#283) — covers both a
- * failed fetch/JSON parse and a 200 response whose body doesn't carry a
- * usable `models` array. Both are the same class of failure to the reader
- * (the model list didn't load), so both route through this one message
- * rather than a raw error or a silent render crash.
- *
- * It used to say "only the default model is available right now", which was
- * true while this form carried a hardcoded model id to fall back on. It no
- * longer does (website#30 P4): which models exist is instance configuration,
- * and a form that cannot read the list has nothing to substitute. So the
- * message now discloses a blocking state, because that is what it is — and
- * the send control is withdrawn rather than the picker being marked invalid,
- * per docs/design-principles.md Principle 3 and its corollary (a list that
- * failed to load is not a bad selection).
- */
-const MODELS_LOAD_ERROR =
-  "Couldn't load the list of AI models this site offers, so a query can't be sent right now. Refresh the page to try again.";
 
 /**
  * Sticky-per-session mode persistence (§10 Q7), on the shared

--- a/src/components/explore/McpFlowDiagram.tsx
+++ b/src/components/explore/McpFlowDiagram.tsx
@@ -11,7 +11,7 @@ import { useTraceReplay } from '@/hooks/useTraceReplay';
 import { useLiveTrace } from '@/hooks/useLiveTrace';
 import type { ReplayState } from '@/lib/bpmn/animation';
 import { traceEventsToProgressData } from '@/lib/bpmn/trace-progress';
-import { parseModelsResponse } from '@/lib/model-list';
+import { createOfferedModelResolver, type OfferedModelResolver } from '@/lib/offered-model';
 
 const DEFAULT_PORTAL = 'data.cityofnewyork.us';
 
@@ -45,19 +45,24 @@ export default function McpFlowDiagram() {
    * records and is deliberately never resolvable. It survived only because the
    * compare routes resolved a caller's id tolerantly, forwarding it upstream
    * where the built-in endpoint happened to know the slug — so `/explore`'s
-   * live trace, which is publishable, asserted a model this instance does not
-   * offer. P6 makes those routes refuse an unoffered id, which turns a quiet
-   * wrong answer into a loud one; either way the constant was the defect.
+   * live trace queried and billed a model this instance does not offer. That
+   * trace is recorded server-side (`analysis.model` and `gen_ai.request.model`
+   * in `compare-stream/route.ts`) but DISCARDED on this surface, not
+   * published: `useLiveTrace.ts` has no handler for the `trace` SSE event
+   * `compare-stream/route.ts` emits (it switches on `progress`/`token`/
+   * `complete`/`error` only), so `LiveResponsePanel` renders
+   * `McpResponseDisplay` with no `evidenceTrace` prop, and `canPublish` in
+   * `McpResponseDisplay.tsx` requires `!!evidenceTrace` — never true on this
+   * page. P6 makes the compare routes refuse an unoffered id, which turns a
+   * quiet wrong answer into a loud one; either way the constant was the
+   * defect. (Corrected here in P7: the previous version of this comment
+   * claimed the live trace "is publishable" — it verifiably is not, by the
+   * three facts above.)
    *
    * THE REPLACEMENT is the one `QueryForm` already uses since website#30 P4,
    * which had the identical defect (a hardcoded initial model id): the first
    * model `/api/models` offers, read from the instance rather than asserted
-   * here. Memoized in a ref so a reader who runs several queries fetches once,
-   * and warmed on mount so the click does not wait. An instance whose
-   * `/api/models` cannot answer yields the empty string, and the route's
-   * existing "Query and model are required" refusal surfaces in the live
-   * panel — an error the reader can see, rather than a button that does
-   * nothing.
+   * here. Warmed on mount so the click does not wait.
    *
    * #314 asks a further question this does NOT answer: whether `/explore`
    * should instead have its own catalog role, or reach the `default` entry
@@ -65,22 +70,43 @@ export default function McpFlowDiagram() {
    * That is a product decision; this only stops the page naming a model the
    * instance never offered.
    */
-  const offeredModelRef = useRef<Promise<string> | null>(null);
+  // Lazy `useState` initializer, not a ref read during render: the latter
+  // trips `react-hooks/refs` ("refs should only be accessed outside of
+  // render"), even for the read-then-lazily-assign-once idiom. `useState`'s
+  // initializer function is the sanctioned way to construct something once
+  // per mount; the setter is never called again, so this is otherwise
+  // identical to a ref holding a stable instance.
+  const [offeredModelResolver] = useState<OfferedModelResolver>(() => createOfferedModelResolver());
+
+  /**
+   * True once an `/api/models` attempt has settled without producing a
+   * usable id — a network failure, a malformed body, or an empty catalog
+   * (website#30 P7). Mirrors `QueryForm`'s identically-named flag (website#30
+   * P4, #283): it clears on a later success, and while it is set the
+   * live-query Run control is withdrawn (`TraceControls`) rather than left to
+   * invite a click.
+   *
+   * That click would otherwise reach `/api/compare-stream` with an empty
+   * `model` and hit its "Query and model are required" 400 — a refusal whose
+   * body carries no `code` field (`compare-stream/route.ts`), so
+   * `classifyStreamError` falls through to `generic` and the reader would see
+   * only "Something went wrong while running this query. Please try again in
+   * a moment." (Corrected here in P7: the previous version of this comment
+   * claimed that refusal "surfaces in the live panel — an error the reader
+   * can see," as if the generic fallback were informative. `handleLiveStart`
+   * below now checks for an empty id itself and never sends that request, so
+   * the reader sees the disclosure below instead of a round trip to a
+   * mismatched-code 400.)
+   */
+  const [modelsError, setModelsError] = useState(false);
+
   const offeredModel = useCallback((): Promise<string> => {
-    if (!offeredModelRef.current) {
-      offeredModelRef.current = fetch('/api/models')
-        .then((res) => res.json())
-        .then((data) => {
-          const parsed = parseModelsResponse(data);
-          return parsed && parsed.length > 0 ? parsed[0].id : '';
-        })
-        .catch((error) => {
-          console.error('Failed to fetch models:', error);
-          return '';
-        });
-    }
-    return offeredModelRef.current;
-  }, []);
+    return offeredModelResolver.resolve().then((id) => {
+      setModelsError(id === '');
+      return id;
+    });
+  }, [offeredModelResolver]);
+
   useEffect(() => {
     void offeredModel();
   }, [offeredModel]);
@@ -196,9 +222,21 @@ export default function McpFlowDiagram() {
       setHasPlayedOnce(true);
     }
     // The model is resolved before the query starts (#314). Usually already
-    // resolved: the fetch is warmed on mount and memoized, so this settles in
-    // a microtask and the 400ms fullscreen beat is unchanged.
+    // resolved: the fetch is warmed on mount, so this settles in a microtask
+    // and the 400ms fullscreen beat is unchanged. `TraceControls` withdraws
+    // the Run control while `modelsError` is set, so this form should not be
+    // submittable with an empty id — the guard below is defense against the
+    // narrow race where a click lands before the mount-warmed fetch has
+    // settled and that settlement turns out to be a failure. In that case
+    // back out of the fullscreen entry rather than opening it onto nothing.
     void offeredModel().then((model) => {
+      if (!model) {
+        if (enteringFullscreen) {
+          setIsFullscreen(false);
+          setHasPlayedOnce(false);
+        }
+        return;
+      }
       const begin = () => liveTrace.start(query, model, DEFAULT_PORTAL);
       if (enteringFullscreen) setTimeout(begin, 400);
       else begin();
@@ -332,6 +370,7 @@ export default function McpFlowDiagram() {
           liveError={liveTrace.error}
           liveElapsedMs={liveTrace.elapsedMs}
           liveSlowMessage={liveTrace.slowMessage}
+          modelsUnavailable={modelsError}
           onLiveStart={handleLiveStart}
           onLiveCancel={handleLiveCancel}
           onLiveReplay={handleLiveReplay}

--- a/src/components/explore/TraceControls.tsx
+++ b/src/components/explore/TraceControls.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { PreRecordedTrace } from '@/lib/bpmn/traces';
 import type { PlaybackSpeed, ReplayState } from '@/lib/bpmn/animation';
 import type { LiveTraceStatus, SlowQueryMessage } from '@/hooks/useLiveTrace';
+import { MODELS_LOAD_ERROR } from '@/lib/streaming';
 
 export type DiagramMode = 'examples' | 'live';
 
@@ -25,6 +26,17 @@ interface TraceControlsProps {
   liveError: string | null;
   liveElapsedMs: number;
   liveSlowMessage: SlowQueryMessage | null;
+  /**
+   * True when this instance's `/api/models` catalog could not be read
+   * (website#30 P7) — the live query has no id to send. Withdraws the Run
+   * control and shows `MODELS_LOAD_ERROR` in its place, rather than letting a
+   * click reach `/api/compare-stream` with an empty `model` and land on that
+   * route's generic-error fallback. Not a validation state on the query
+   * input: per docs/design-principles.md Principle 3's corollary, a list
+   * that failed to load is not a bad selection, so nothing here is marked
+   * invalid.
+   */
+  modelsUnavailable: boolean;
   onLiveStart: (query: string) => void;
   onLiveCancel: () => void;
   onLiveReplay: () => void;
@@ -85,6 +97,7 @@ export default function TraceControls({
   liveError,
   liveElapsedMs,
   liveSlowMessage,
+  modelsUnavailable,
   onLiveStart,
   onLiveCancel,
   onLiveReplay,
@@ -284,13 +297,13 @@ export default function TraceControls({
               />
               <button
                 type="submit"
-                disabled={!liveQuery.trim()}
+                disabled={!liveQuery.trim() || modelsUnavailable}
                 className="ui-button ui-button-primary"
                 style={{
                   padding: '8px 20px',
                   fontSize: '13px',
-                  opacity: liveQuery.trim() ? 1 : 0.5,
-                  cursor: liveQuery.trim() ? 'pointer' : 'not-allowed',
+                  opacity: liveQuery.trim() && !modelsUnavailable ? 1 : 0.5,
+                  cursor: liveQuery.trim() && !modelsUnavailable ? 'pointer' : 'not-allowed',
                 }}
               >
                 Run
@@ -298,7 +311,19 @@ export default function TraceControls({
             </form>
           )}
 
-          {liveStatus === 'idle' && !isReplayingCapture && (
+          {/* Model-catalog load failure (website#30 P7): disclosed in place
+              of the Run control's helper text, not painted onto the query
+              input — the input didn't fail, the background fetch did (see
+              docs/design-principles.md's corollary). */}
+          {modelsUnavailable
+            && (liveStatus === 'idle' || liveStatus === 'error' || liveStatus === 'cancelled')
+            && !isReplayingCapture && (
+            <div role="status" style={{ fontSize: '13px', color: 'var(--caution)' }}>
+              {MODELS_LOAD_ERROR}
+            </div>
+          )}
+
+          {liveStatus === 'idle' && !isReplayingCapture && !modelsUnavailable && (
             <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
               Uses one of your daily queries. Watch the diagram animate in real time.
             </div>

--- a/src/lib/offered-model.test.ts
+++ b/src/lib/offered-model.test.ts
@@ -1,0 +1,101 @@
+// Tests for the offered-model resolver's retry/caching policy (website#30
+// P7), extracted from McpFlowDiagram.tsx so node:test can exercise it
+// directly (that component is JSX, which `--experimental-strip-types`
+// cannot parse — see offered-model.ts's header comment).
+//
+// The defect this pins down: the version of this logic P6 shipped memoized
+// the fetch's own PROMISE in a ref, including a REJECTED one, so a single
+// failed or empty `/api/models` response at mount poisoned every later
+// `/explore` click until a full page reload. `createOfferedModelResolver`
+// must cache a success but never a failure.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createOfferedModelResolver } from './offered-model.ts';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+test('a failed fetch is not cached: a later call retries and succeeds once the endpoint recovers', async () => {
+  let calls = 0;
+  const fetchImpl = (async () => {
+    calls += 1;
+    if (calls === 1) throw new Error('network error');
+    return jsonResponse({ models: [{ id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'openai' }] });
+  }) as typeof fetch;
+
+  const resolver = createOfferedModelResolver(fetchImpl);
+
+  const first = await resolver.resolve();
+  assert.equal(first, '', 'a rejected fetch resolves to the empty string, not a thrown error');
+  assert.equal(calls, 1);
+
+  const second = await resolver.resolve();
+  assert.equal(second, 'openai/gpt-4o', 'the retry reaches the network again and returns a usable id');
+  assert.equal(calls, 2, 'the failed attempt was not cached — the second call issued a new request');
+});
+
+test('a malformed response body (no usable `models` array) is not cached either', async () => {
+  let calls = 0;
+  const fetchImpl = (async () => {
+    calls += 1;
+    if (calls === 1) return jsonResponse({ notModels: [] });
+    return jsonResponse({ models: [{ id: 'anthropic/claude-sonnet-4-6', name: 'Claude', provider: 'anthropic' }] });
+  }) as typeof fetch;
+
+  const resolver = createOfferedModelResolver(fetchImpl);
+
+  assert.equal(await resolver.resolve(), '');
+  assert.equal(await resolver.resolve(), 'anthropic/claude-sonnet-4-6');
+  assert.equal(calls, 2);
+});
+
+test('an empty catalog is not cached: a later call retries once the catalog is non-empty', async () => {
+  let calls = 0;
+  const fetchImpl = (async () => {
+    calls += 1;
+    if (calls === 1) return jsonResponse({ models: [] });
+    return jsonResponse({ models: [{ id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'openai' }] });
+  }) as typeof fetch;
+
+  const resolver = createOfferedModelResolver(fetchImpl);
+
+  assert.equal(await resolver.resolve(), '');
+  assert.equal(await resolver.resolve(), 'openai/gpt-4o');
+  assert.equal(calls, 2);
+});
+
+test('a successful resolution IS cached: a later call does not hit the network again', async () => {
+  let calls = 0;
+  const fetchImpl = (async () => {
+    calls += 1;
+    return jsonResponse({ models: [{ id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'openai' }] });
+  }) as typeof fetch;
+
+  const resolver = createOfferedModelResolver(fetchImpl);
+
+  assert.equal(await resolver.resolve(), 'openai/gpt-4o');
+  assert.equal(await resolver.resolve(), 'openai/gpt-4o');
+  assert.equal(calls, 1, 'the second call reused the cached id instead of refetching');
+});
+
+test('concurrent calls while a request is in flight share one fetch', async () => {
+  let calls = 0;
+  const fetchImpl = (async () => {
+    calls += 1;
+    return jsonResponse({ models: [{ id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'openai' }] });
+  }) as typeof fetch;
+
+  const resolver = createOfferedModelResolver(fetchImpl);
+
+  const [a, b] = await Promise.all([resolver.resolve(), resolver.resolve()]);
+  assert.equal(a, 'openai/gpt-4o');
+  assert.equal(b, 'openai/gpt-4o');
+  assert.equal(calls, 1, 'two calls made before the first settles share one in-flight request');
+});

--- a/src/lib/offered-model.ts
+++ b/src/lib/offered-model.ts
@@ -1,0 +1,65 @@
+import { parseModelsResponse } from './model-list.ts';
+
+/**
+ * Resolves the first model this instance's `/api/models` catalog offers —
+ * the id `McpFlowDiagram.tsx` hands to a live `/explore` query, which has no
+ * model picker of its own (#314, website#30 P6 F1).
+ *
+ * WHY A FACTORY, NOT A HOOK. `McpFlowDiagram.tsx` is a client component with
+ * JSX, which node:test's `--experimental-strip-types` runner cannot parse
+ * (the same reason `parseModelsResponse` was pulled out into `model-list.ts`
+ * in #283). This factory holds the retry/caching policy in a plain closure
+ * so the policy itself, not just the response-shape guard, is unit-testable.
+ *
+ * THE DEFECT THIS REPLACES (website#30 P7, found in P6's version of this
+ * code): the fetch used to be memoized in a ref holding the fetch's own
+ * PROMISE, including a rejected one — `.catch()` resolved it to `''` without
+ * ever clearing the ref. One failed or empty `/api/models` response at
+ * mount — a deploy in flight, a blip on first paint, an operator restart —
+ * then poisoned every later click for the rest of the page's life; only a
+ * full reload cleared it.
+ *
+ * This factory instead caches only a RESOLVED, non-empty id. A failure —
+ * network error, malformed body, or an empty catalog — leaves nothing
+ * cached, so the next call to `resolve()` retries the network request
+ * instead of replaying the old failure.
+ */
+export interface OfferedModelResolver {
+  resolve(): Promise<string>;
+}
+
+export function createOfferedModelResolver(
+  fetchImpl: typeof fetch = fetch,
+): OfferedModelResolver {
+  let cachedId: string | null = null;
+  let inFlight: Promise<string> | null = null;
+
+  function resolve(): Promise<string> {
+    if (cachedId !== null) return Promise.resolve(cachedId);
+    if (inFlight) return inFlight;
+
+    inFlight = fetchImpl('/api/models')
+      .then((res) => res.json())
+      .then((data) => {
+        const parsed = parseModelsResponse(data);
+        if (parsed === null) {
+          console.error('Failed to fetch models: response missing a `models` array');
+          return '';
+        }
+        const id = parsed.length > 0 ? parsed[0].id : '';
+        if (id) cachedId = id;
+        return id;
+      })
+      .catch((error) => {
+        console.error('Failed to fetch models:', error);
+        return '';
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+
+    return inFlight;
+  }
+
+  return { resolve };
+}

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -270,6 +270,26 @@ export function friendlyStreamError(input: unknown): string {
 }
 
 /**
+ * Reader-facing copy for a `/api/models` load failure (#283) — covers both a
+ * failed fetch/JSON parse and a 200 response whose body doesn't carry a
+ * usable `models` array. Both are the same class of failure to the reader
+ * (the model list didn't load), so both route through this one message
+ * rather than a raw error or a silent render crash.
+ *
+ * The send/run control is withdrawn rather than the model picker (where one
+ * exists) being marked invalid, per docs/design-principles.md Principle 3
+ * and its corollary (a list that failed to load is not a bad selection).
+ *
+ * Cross-cutting per this file's own rule (CLAUDE.md): shared by every surface
+ * that needs an offered model id to submit a query and has nothing to
+ * substitute when the catalog can't be read — `QueryForm` (#283, website#30
+ * P4) and `/explore`'s live-query form (website#30 P7, which found the
+ * identical defect: a cached failed fetch poisoning every later click).
+ */
+export const MODELS_LOAD_ERROR =
+  "Couldn't load the list of AI models this site offers, so a query can't be sent right now. Refresh the page to try again.";
+
+/**
  * Server-side: the sanitized `error`-event payload for an already-classified
  * failure. The message is the reader-facing copy and the code is the kind, so
  * the raw error text never leaves the server (#154) while the render side


### PR DESCRIPTION
## Summary

P7 of #30 (Wave N4, last phase) — closes two defects the scoped re-read found in P6's own new code in `src/components/explore/McpFlowDiagram.tsx`.

**(A) A poisoned model-fetch cache.** `offeredModelRef` cached the fetch's own promise, including a rejected one; `.catch()` resolved it to `''` without clearing the ref, so one failed or empty `/api/models` response at mount poisoned every later `/explore` live-query click until a full page reload. Replaced with `createOfferedModelResolver` (`src/lib/offered-model.ts`), a plain factory that caches only a resolved, non-empty id — a failure leaves nothing cached, so the next `resolve()` retries.

**(B) Two inaccurate comments from the previous phase**, corrected to what I verified rather than what was claimed:
- `/explore`'s live trace is **not publishable**: `McpResponseDisplay.tsx`'s `canPublish` requires `!!evidenceTrace`; `LiveResponsePanel` renders `McpResponseDisplay` without an `evidenceTrace` prop; `useLiveTrace.ts` has no case for the `trace` SSE event `compare-stream/route.ts` emits (only `progress`/`token`/`complete`/`error`). The trace is recorded server-side and discarded on this surface.
- The route's "Query and model are required" 400 does **not** surface as something the reader can read — that body carries no `code`, so `classifyStreamError` falls through to `generic` copy. This is now moot on this surface: the client bails before ever sending that request.

The accurate versions of both claims at `compare-stream/route.ts:69-71` and `model-resolver.ts:256-259` are untouched (`git diff` confirms zero changes to either file).

## What changed

- **`src/lib/offered-model.ts`** (new) — the retry/caching policy, extracted into a plain factory so it's unit-testable by `node:test` (McpFlowDiagram.tsx is JSX, which `--experimental-strip-types` can't parse — the same reason `parseModelsResponse` was extracted into `model-list.ts` in #283).
- **`src/lib/offered-model.test.ts`** (new) — 5 tests, including the required "a failed fetch is not cached" case.
- **`src/components/explore/McpFlowDiagram.tsx`** — uses the resolver; tracks a `modelsError` flag (mirrors QueryForm's identically-named flag, P4) that clears on success and stays set on durable failure; `handleLiveStart` now bails before calling `liveTrace.start` when the resolved id is empty; corrected the two comments.
- **`src/components/explore/TraceControls.tsx`** — new `modelsUnavailable` prop; withdraws the Run control and discloses `MODELS_LOAD_ERROR` while it's true, rather than inviting a click that can't work (design-principles.md Principle 3's corollary: a list that failed to load is not a bad selection — nothing here is marked invalid).
- **`src/lib/streaming.ts`** — `MODELS_LOAD_ERROR` moved here (exported) from QueryForm.tsx (was private), per this repo's own rule for cross-cutting reader copy now that it has a second caller.
- **`src/components/QueryForm.tsx`** — one-line change: imports `MODELS_LOAD_ERROR` from `streaming.ts` instead of declaring it locally. No behavior change.
- **`src/app/api/model-refusal-ordering.test.ts`** — updated to check `/explore`'s fetch+parser across `McpFlowDiagram.tsx` and its new `offered-model.ts` dependency, since the extraction moved the literal `'/api/models'`/`parseModelsResponse` calls out of the component file this pre-existing test reads as source. This was a mandatory adjacent fix — the test failed against my refactor before this update (the behavioral property it protects, "no client hardcodes a model id," still holds; the implementation location moved).

### Blast-zone note

The contract named `McpFlowDiagram.tsx`, its test, `LiveResponsePanel.tsx` (if needed — it wasn't), and `streaming.ts` (if reader copy belonged there — it does) as the expected zone, explicitly inviting a flagged expansion if the zone proved too small (as three earlier phases in this wave did). It was: withdrawing the Run control required touching `TraceControls.tsx` (that's where the control lives), deduplicating `MODELS_LOAD_ERROR` required a one-line touch to `QueryForm.tsx` (per the repo's own cross-cutting-copy rule), and the new `offered-model.ts`/`offered-model.test.ts` pair required a corresponding update to the pre-existing `model-refusal-ordering.test.ts`. All four are flagged here.

## Verified code facts (acceptance criterion 3)

- `canPublish` (`McpResponseDisplay.tsx:426`): `isComplete && !!content && !!evidenceTrace && toolsCalled.length > 0`.
- `LiveResponsePanel.tsx:162-173` calls `<McpResponseDisplay ... />` with no `evidenceTrace` prop.
- `useLiveTrace.ts` switches on `type === 'progress' | 'token' | 'complete' | 'error'` only (lines 330/383/389/410) — no `trace` case.
- `compare-stream/route.ts:251` emits `{ type: 'trace', panel: 'withMcp', data: traceJson }`; `useStreamingComparison.ts:501` (used by `QueryForm`/`/ask`, not `/explore`) is the only consumer with a `case 'trace'`.
- `compare-stream/route.ts:36-40`: the "Query and model are required" 400 body is `{ error: 'Query and model are required' }` — no `code` field.
- `compare-stream/route.ts:69-71` and `model-resolver.ts:256-259` (the accurate route-level claims) — confirmed unchanged in this diff.

## What the reader sees on a durable model-catalog-load failure

The "Try your own" live-query form stays visible (query text isn't discarded), but the Run button is disabled and a `role="status"` message appears in `--caution` color: *"Couldn't load the list of AI models this site offers, so a query can't be sent right now. Refresh the page to try again."* — the same copy QueryForm already shows for the identical failure class. Nothing is marked invalid (no red border on the query input); this is a background-load disclosure, not a validation error.

## Checks (model: Sonnet 5, isolated worktree)

Base: `eadd284` (`rollback/pre-30-p7`). `npm ci` run first.

**`npm run build`** — exit 0, `✓ Compiled successfully`.

**`npm run typecheck`** — exit 0, no output.

**`npm test`** — exit 0:
```
# tests 1009
# suites 10
# pass 1009
# fail 0
# cancelled 0
# skipped 0
# todo 0
```
(1004 pre-existing + 5 new in `offered-model.test.ts`; `model-refusal-ordering.test.ts`'s existing test was updated, not added, so the count above isn't 1004+6.)

**`npm run lint`** — exit 0:
```
✖ 4 problems (0 errors, 4 warnings)
```
Matches CLAUDE.md's documented baseline exactly; all 4 warnings are pre-existing and unrelated to this diff (`scripts/eval-models.mjs`, `AttestationDialog.tsx`, `RenderingCellOutputs.tsx`, `bpmn/animation.ts`).

**`npm run check:compose-env`** — exit 0:
```
RESULT: PASS — every variable this profile reads can reach the container.
```

## Flagged, not fixed

- Initial implementation of the lazy-init used `useRef` with a null-check-then-assign pattern (the idiom the `react-hooks/refs` lint rule's own error message recommends); ESLint's `react-hooks/refs` flagged it as "Cannot access refs during render" anyway. Switched to `useState(() => ...)` lazy initializer instead — functionally identical (constructed once, setter never called again), passes lint, no behavior change. Noting this in case the rule's stance on that documented idiom is worth a separate look; out of scope here.
- #314's product question (should `/explore` have its own catalog role, or reach the `default` entry) — unanswered, as directed.
- #312, #315, the three preflight/app disagreements, the harness source registry, `POST /api/records` tolerance, CLAUDE.md's stale test count, anything moving signed-package bytes — untouched, as directed.

## Premises checked

Every quoted line/behavior in the contract was verified against this worktree's HEAD (`eadd284`) before editing; all matched. No premise failed to survive the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
