### PR TITLE
fix: stop advertising Socrata tools the model cannot call (#325 P6)

### DIFF
--- a/src/lib/mcp/preamble-advertised-tools.test.ts
+++ b/src/lib/mcp/preamble-advertised-tools.test.ts
@@ -11,68 +11,53 @@
  * in the output (civic-ai-tools-website#323 — the preamble told the model it
  * had `search` and `fetch` Socrata tools; only `get_data` was ever wired up).
  *
- * This test does not hardcode the expected tool list. It reads the preamble
- * source text directly, extracts every `Tools: a, b, c.` list via regex, and
- * checks each extracted name against the real `mcpTools` export. Re-adding
- * any uncallable name to the preamble in the future — not just `search` or
- * `fetch` specifically — fails this test.
+ * This test does not hardcode the expected tool list. It imports the real
+ * `CROSS_SOURCE_PREAMBLE` constant, extracts every `Tools: a, b, c.` list
+ * out of it via regex, and checks each extracted name against the real
+ * `mcpTools` export. Re-adding any uncallable name to the preamble in the
+ * future — not just `search` or `fetch` specifically — fails this test.
+ *
+ * Composing the full system prompt (`composeSkillPrompt` /
+ * `buildSystemPrompt`) was considered and rejected here: the property under
+ * test is a relation between the preamble text and `mcpTools`, and building
+ * intro + preamble + stub source bodies + outro around it doesn't strengthen
+ * that assertion — it only reintroduces a stray-"Tools:" hazard from
+ * whatever stub text stands in for the other sources. Importing the
+ * constant directly and asserting on it is the whole test.
  */
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { CROSS_SOURCE_PREAMBLE } from './socrata-skill.ts';
 import { mcpTools } from './tools.ts';
-
-const HERE = fileURLToPath(import.meta.url);
-const MCP_ROOT = path.dirname(HERE);
-const SOCRATA_SKILL_SOURCE = path.join(MCP_ROOT, 'socrata-skill.ts');
-
-/**
- * Pulls the `CROSS_SOURCE_PREAMBLE` template literal's body out of the raw
- * source text. Scoping the search to just this declaration (rather than
- * scanning the whole file for "Tools:") keeps the extraction from picking up
- * an unrelated "Tools:" mention elsewhere in the module.
- */
-function extractCrossSourcePreamble(sourceText: string): string {
-  const match = sourceText.match(/const CROSS_SOURCE_PREAMBLE = `([\s\S]*?)`;/);
-  assert.ok(
-    match,
-    'Expected to find `const CROSS_SOURCE_PREAMBLE = `...`;` in socrata-skill.ts — has the declaration moved or been renamed?',
-  );
-  return match![1];
-}
 
 /**
  * Extracts every tool name out of every "Tools: a, b, c." list in the given
  * text. Tool names in this codebase never contain periods or commas, so a
  * comma-separated run up to the next period is a reliable list boundary.
  */
-function extractAdvertisedToolNames(preambleText: string): string[] {
-  const names: string[] = [];
+function extractAdvertisedToolLists(preambleText: string): string[][] {
+  const lists: string[][] = [];
   const listRegex = /Tools:\s*([^.\n]+)\./g;
   let listMatch: RegExpExecArray | null;
   while ((listMatch = listRegex.exec(preambleText)) !== null) {
-    for (const rawName of listMatch[1].split(',')) {
-      names.push(rawName.trim());
-    }
+    lists.push(listMatch[1].split(',').map((name) => name.trim()));
   }
-  return names;
+  return lists;
 }
 
 test('every tool name the cross-source preamble advertises exists in mcpTools', () => {
-  const sourceText = fs.readFileSync(SOCRATA_SKILL_SOURCE, 'utf8');
-  const preambleText = extractCrossSourcePreamble(sourceText);
-  const advertisedNames = extractAdvertisedToolNames(preambleText);
+  const advertisedLists = extractAdvertisedToolLists(CROSS_SOURCE_PREAMBLE);
 
-  // Sanity check on the extraction itself: the preamble names three source
-  // sections ("1.", "2.", "3."), each with its own "Tools:" list. If this
-  // count changes, the regex is no longer matching what the preamble says
-  // and the test below would pass vacuously.
-  assert.ok(
-    advertisedNames.length >= 3,
-    `Expected to extract at least 3 tool names from the preamble's "Tools:" lists, got ${advertisedNames.length}: ${JSON.stringify(advertisedNames)}`,
+  // Structural guard: the preamble describes exactly three sources (Socrata,
+  // Data Commons, Boston OpenContext), each with its own "Tools:" list. If
+  // this count changes — a source added, removed, or a list reworded past
+  // what the regex recognizes — that is a deliberate change this test
+  // should be updated for, not something it should silently pass through.
+  assert.equal(
+    advertisedLists.length,
+    3,
+    `Expected exactly 3 "Tools:" lists in CROSS_SOURCE_PREAMBLE (one per MCP source), found ${advertisedLists.length}: ${JSON.stringify(advertisedLists)}`,
   );
 
   const callableToolNames = new Set(
@@ -81,7 +66,7 @@ test('every tool name the cross-source preamble advertises exists in mcpTools', 
       .map((tool) => tool.function.name),
   );
 
-  for (const advertisedName of advertisedNames) {
+  for (const advertisedName of advertisedLists.flat()) {
     assert.ok(
       callableToolNames.has(advertisedName),
       `Preamble advertises tool "${advertisedName}" but it is not in mcpTools (src/lib/mcp/tools.ts) — the model will plan around a capability that does not exist.`,

--- a/src/lib/mcp/preamble-advertised-tools.test.ts
+++ b/src/lib/mcp/preamble-advertised-tools.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Guard: every tool name the cross-source preamble advertises to the model
+ * is actually callable — present in `mcpTools` (src/lib/mcp/tools.ts).
+ *
+ * `CROSS_SOURCE_PREAMBLE` (src/lib/mcp/socrata-skill.ts) tells the model, in
+ * plain English, which tools each MCP source offers. That text is decoupled
+ * from the tool schemas actually sent to the model — nothing enforces that a
+ * name mentioned in the preamble is one the model can call. A name that is
+ * advertised but not callable is not an error: the model plans around having
+ * a capability it does not have, and the resulting worse plan is invisible
+ * in the output (civic-ai-tools-website#323 — the preamble told the model it
+ * had `search` and `fetch` Socrata tools; only `get_data` was ever wired up).
+ *
+ * This test does not hardcode the expected tool list. It reads the preamble
+ * source text directly, extracts every `Tools: a, b, c.` list via regex, and
+ * checks each extracted name against the real `mcpTools` export. Re-adding
+ * any uncallable name to the preamble in the future — not just `search` or
+ * `fetch` specifically — fails this test.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mcpTools } from './tools.ts';
+
+const HERE = fileURLToPath(import.meta.url);
+const MCP_ROOT = path.dirname(HERE);
+const SOCRATA_SKILL_SOURCE = path.join(MCP_ROOT, 'socrata-skill.ts');
+
+/**
+ * Pulls the `CROSS_SOURCE_PREAMBLE` template literal's body out of the raw
+ * source text. Scoping the search to just this declaration (rather than
+ * scanning the whole file for "Tools:") keeps the extraction from picking up
+ * an unrelated "Tools:" mention elsewhere in the module.
+ */
+function extractCrossSourcePreamble(sourceText: string): string {
+  const match = sourceText.match(/const CROSS_SOURCE_PREAMBLE = `([\s\S]*?)`;/);
+  assert.ok(
+    match,
+    'Expected to find `const CROSS_SOURCE_PREAMBLE = `...`;` in socrata-skill.ts — has the declaration moved or been renamed?',
+  );
+  return match![1];
+}
+
+/**
+ * Extracts every tool name out of every "Tools: a, b, c." list in the given
+ * text. Tool names in this codebase never contain periods or commas, so a
+ * comma-separated run up to the next period is a reliable list boundary.
+ */
+function extractAdvertisedToolNames(preambleText: string): string[] {
+  const names: string[] = [];
+  const listRegex = /Tools:\s*([^.\n]+)\./g;
+  let listMatch: RegExpExecArray | null;
+  while ((listMatch = listRegex.exec(preambleText)) !== null) {
+    for (const rawName of listMatch[1].split(',')) {
+      names.push(rawName.trim());
+    }
+  }
+  return names;
+}
+
+test('every tool name the cross-source preamble advertises exists in mcpTools', () => {
+  const sourceText = fs.readFileSync(SOCRATA_SKILL_SOURCE, 'utf8');
+  const preambleText = extractCrossSourcePreamble(sourceText);
+  const advertisedNames = extractAdvertisedToolNames(preambleText);
+
+  // Sanity check on the extraction itself: the preamble names three source
+  // sections ("1.", "2.", "3."), each with its own "Tools:" list. If this
+  // count changes, the regex is no longer matching what the preamble says
+  // and the test below would pass vacuously.
+  assert.ok(
+    advertisedNames.length >= 3,
+    `Expected to extract at least 3 tool names from the preamble's "Tools:" lists, got ${advertisedNames.length}: ${JSON.stringify(advertisedNames)}`,
+  );
+
+  const callableToolNames = new Set(
+    mcpTools
+      .filter((tool): tool is Extract<typeof tool, { type: 'function' }> => tool.type === 'function')
+      .map((tool) => tool.function.name),
+  );
+
+  for (const advertisedName of advertisedNames) {
+    assert.ok(
+      callableToolNames.has(advertisedName),
+      `Preamble advertises tool "${advertisedName}" but it is not in mcpTools (src/lib/mcp/tools.ts) — the model will plan around a capability that does not exist.`,
+    );
+  }
+});

--- a/src/lib/mcp/socrata-skill.ts
+++ b/src/lib/mcp/socrata-skill.ts
@@ -480,7 +480,7 @@ export interface SkillEntry {
  */
 export type SkillRegistry = Partial<Record<SourceId, SkillEntry>>;
 
-const CROSS_SOURCE_PREAMBLE = `You have access to THREE MCP data sources through the tools below.
+export const CROSS_SOURCE_PREAMBLE = `You have access to THREE MCP data sources through the tools below.
 
 1. **Socrata open data portals** — city operational data such as 311 requests, building permits, inspections, crime, housing violations, payroll, and licenses. Covers NYC, Chicago, SF, Seattle, LA, and hundreds of other portals — but not Boston. Tools: get_data.
 2. **Google Data Commons** — authoritative federal and international statistical data from the U.S. Census Bureau (ACS, Decennial), BLS, CDC, Department of Education, EPA, and other official agencies. Tools: search_indicators, get_observations.

--- a/src/lib/mcp/socrata-skill.ts
+++ b/src/lib/mcp/socrata-skill.ts
@@ -482,7 +482,7 @@ export type SkillRegistry = Partial<Record<SourceId, SkillEntry>>;
 
 const CROSS_SOURCE_PREAMBLE = `You have access to THREE MCP data sources through the tools below.
 
-1. **Socrata open data portals** — city operational data such as 311 requests, building permits, inspections, crime, housing violations, payroll, and licenses. Covers NYC, Chicago, SF, Seattle, LA, and hundreds of other portals — but not Boston. Tools: get_data, search, fetch.
+1. **Socrata open data portals** — city operational data such as 311 requests, building permits, inspections, crime, housing violations, payroll, and licenses. Covers NYC, Chicago, SF, Seattle, LA, and hundreds of other portals — but not Boston. Tools: get_data.
 2. **Google Data Commons** — authoritative federal and international statistical data from the U.S. Census Bureau (ACS, Decennial), BLS, CDC, Department of Education, EPA, and other official agencies. Tools: search_indicators, get_observations.
 3. **Boston OpenContext** — the City of Boston's CKAN-native open-data MCP, fronting data.boston.gov. 311, permits, crime, inspections, property, elections, schools, parcels, and neighborhoods for Boston specifically. Tools: ckan__search_datasets, ckan__get_dataset, ckan__query_data, ckan__get_schema, ckan__execute_sql, ckan__aggregate_data.
 


### PR DESCRIPTION
Closes #323. Wave N6 phase P6.

## The defect

`CROSS_SOURCE_PREAMBLE` told the model it had three Socrata tools — `get_data`, `search` and `fetch`. Only `get_data` is ever added to `mcpTools`, so two of the three were uncallable.

This is not a visible failure. A model that believes it has a `search` tool plans around having one, and the resulting worse plan is invisible in the output — there is no error message to notice.

## The fix

The preamble now names `get_data` alone. `search` and `fetch` were **not** added to the tool list: `get_data` already covers catalog search, metadata, SoQL queries and metrics, so wiring them up would widen the analysis loop's decision surface with a redundant retrieval path on no measured demand. Adding them later is additive, and the new test keeps that honest whenever it happens.

`src/lib/mcp/registry.ts` is deliberately untouched. Its `SOCRATA_TOOLS` array is the *routing* registry — it builds `toolIndex` and `unconfiguredTools` so an instance with no Socrata endpoint refuses those names by naming the missing variable rather than routing to a default host. Removing names there would change refusal behaviour, which is a different concern.

## The guard

`src/lib/mcp/preamble-advertised-tools.test.ts` asserts that every tool name the preamble advertises is present in `mcpTools`. It derives the names from the preamble text itself rather than a copied list, so re-adding *any* uncallable name in future fails the test — not just these two. A structural assertion that exactly three `Tools:` lists are found means a fourth source forces a deliberate test update instead of silently passing through.

The test was demonstrated failing before it was accepted: temporarily restoring `search` to the preamble produces

```
not ok 1 - every tool name the cross-source preamble advertises exists in mcpTools
  error: 'Preamble advertises tool "search" but it is not in mcpTools ...'
```

## Diff

Two changed lines in `src/lib/mcp/socrata-skill.ts` — the Socrata bullet's tool list, and an `export` keyword so the test reads the live constant rather than a copy — plus one new test file.

```
 src/lib/mcp/preamble-advertised-tools.test.ts | 75 +++++++++++++++++++++++++++
 src/lib/mcp/socrata-skill.ts                  |  4 +-
```

## Checks

| Check | Result |
|---|---|
| `npm test` | 1010 tests, 1010 pass, 0 fail — +1 against the 1009 baseline, nothing moved |
| `npm run build` | Compiled successfully, route table printed |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | 4 problems, 0 errors, 4 warnings — the existing baseline, none introduced |
| `npm run check:compose-env` | PASS |

Every commit carries a DCO sign-off matching the author.

## Follow-up noted, not fixed here

`buildSystemPrompt(portal)` is the only production caller that assembles a prompt containing the real preamble, and it has no seam for substituting a registry — so its own wiring (which sources it activates, in what order, with which portal and preamble) is exercised only against the real network-calling registry. An optional defaulted registry parameter would close that gap. Additive, no caller changes required, and better filed as its own small test-infrastructure change than bundled here.
