### PR TITLE
fix: container build type-checks a file its context excludes, and CI cannot see it (#325 P1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,10 +41,33 @@ README.md
 # and whatever is lying here would otherwise be copied into the image.
 temp
 
+# Tests are repository material as well — and keeping them out is not a size
+# saving, it is what makes the build's type-check scope match the context
+# (#295). `next build` type-checks everything tsconfig.json's `**/*.ts` glob
+# matches, test files included, but this context is deliberately NOT the whole
+# repository. A test that imports a path filtered out below therefore fails
+# the IMAGE build while every host-run check stays green — which is how a test
+# importing `scripts/preflight-env.mjs` broke the documented
+# `docker compose up --build` bring-up with CI green throughout.
+#
+# Excluding them makes the two scopes agree by construction: the image build
+# type-checks application code; `npm run typecheck` and CI type-check
+# application code AND tests, on a host where the whole repository is present.
+# The superset still runs, so nothing loses coverage.
+**/*.test.ts
+**/*.test.tsx
+**/*.test.mts
+**/*.test.mjs
+
 # The build stage runs exactly one repository script — the standalone asset
 # check chained into `npm run build:standalone`. Admitting only that one keeps
 # the built stages from doubling as a place to run the rest of the repo's
 # tooling. A new build-time script must be added here explicitly; forgetting
 # fails the build loudly rather than silently enlarging the image.
+#
+# This allowlist is for scripts the BUILD runs, not for scripts a test
+# imports. Test files no longer reach the context at all (see above), so a
+# test import can neither justify an entry here nor break the image build;
+# application code importing a filtered path still fails loudly, as intended.
 scripts/*
 !scripts/check-standalone-assets.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,45 @@ jobs:
             exit 1
           fi
           echo "byte-identical (sha256 $(sha256sum "$SOURCE" | cut -d' ' -f1))"
+
+  # THE FILTERED-CONTEXT BUILD (#295). Every step in `verify` above runs on the
+  # runner, where the whole repository is present. `docker build` does not: the
+  # builder stage sees a `.dockerignore`-filtered context, and `next build`
+  # type-checks whatever tsconfig.json's globs match *within that context*. The
+  # two scopes can therefore disagree, and when they do, only the image build
+  # notices — which is exactly what happened: a test file's import of a filtered
+  # script broke the documented `docker compose up --build` bring-up for two
+  # days while `verify` and `standalone.yml` stayed green on every PR.
+  #
+  # Running `npm run build:standalone` on the runner cannot see that class of
+  # defect — standalone.yml's own header says so — because on the runner nothing
+  # is filtered. Only a build whose context is actually filtered can. So this
+  # job builds the real image, with the operator's own command shape.
+  #
+  # NO PATHS FILTER, deliberately. The trigger for this class is "any file the
+  # build type-checks changed", which is most of the repository — a paths filter
+  # would have to enumerate that, get it wrong, and go quiet. It lives in this
+  # workflow rather than the paths-filtered standalone.yml for the same reason:
+  # here, always-run is the file's existing property rather than a promise.
+  #
+  # Credential-free like the rest of this workflow: no `secrets.`, no `env:`,
+  # and no `--build-arg`. The image building with nothing passed in is part of
+  # the same tested invariant — an operator's first build supplies no config.
+  #
+  # If anonymous Docker Hub pulls ever rate-limit this job, the seam is the
+  # Dockerfile's NODE_IMAGE / DOCKER_CLI_IMAGE args, not a registry credential.
+  container-image:
+    name: container image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The default target (runner), not `--target builder`: it is what
+      # `docker compose up --build` builds, and it additionally exercises the
+      # standalone copy and the Dockerfile's sharp resolve-and-run smoke test,
+      # neither of which any other job covers. The runtime stage costs little
+      # on top of the builder stage — a cold `--no-cache` full build measured
+      # 41s on one developer machine with the base images already local. That
+      # is not a runner measurement; budget for the base-image pulls too.
+      - name: Build the application image (dockerignore-filtered context)
+        run: docker build --progress=plain -t civic-app:ci .

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,13 +1,23 @@
 name: Standalone
 
-# The empirical net for the standalone build (wave N5 P1, anchor #282).
+# The empirical net for the standalone build ON A HOST (wave N5 P1, anchor
+# #282; scope narrowed by #295).
 #
 # `npm run build:standalone` (BUILD_STANDALONE=1 next build, then
-# scripts/check-standalone-assets.mjs) otherwise runs only inside
-# `docker build` — which no workflow performs — so a change that breaks
-# standalone tracing of the runtime-read helper files would first surface in
-# an operator's image build. This leg runs the same command directly, on the
-# paths that can break it.
+# scripts/check-standalone-assets.mjs) runs in two environments that are not
+# interchangeable, and each needs its own leg:
+#
+#   host       — the whole repository present. This workflow, on the paths
+#                that can break standalone tracing of the runtime-read
+#                helper files.
+#   container  — a `.dockerignore`-filtered context. ci.yml's
+#                `container image build` job, always-run and unfiltered.
+#
+# This leg used to be the only one, and its own header said so: the command
+# "otherwise runs only inside `docker build` — which no workflow performs."
+# That was true and it was the gap. A defect visible only in the filtered
+# context passed here for two days (#295), because on this runner nothing is
+# filtered. Do not treat a green run here as evidence about an image build.
 #
 # Credential-free by construction, same charter as ci.yml: zero `secrets.`
 # references, no `env:` blocks of placeholder credentials, first-party


### PR DESCRIPTION
Closes #295. Wave N6 phase P1.

## The defect

`docker compose up --build` fails deterministically from a clean checkout, and no container comes up at all — not even the ones needing no image build of their own, because the invocation aborts before any is created.

The image build runs a whole-repo type-check over a context that is deliberately **not** the whole repo. `next build` type-checks everything `tsconfig.json`'s `**/*.ts` glob matches, test files included; the build context filters `scripts/*` down to a single allow-listed file. A test importing `scripts/preflight-env.mjs` therefore fails the image build while every host-run check stays green.

CI could not see it. `standalone.yml` runs `npm run build:standalone` **on the runner**, where nothing is filtered — its own header said the command "otherwise runs only inside `docker build` — which no workflow performs." That was true, and it was the gap: the defect passed CI for two days.

## The fix shape, and why this one

Test files are kept out of the build context (four patterns in `.dockerignore`), so the build's type-check scope matches the context by construction.

The defect is a scope/context mismatch, and there are only two ways to close one: make the scope match the context, or the context match the scope. This is the first. Against the three shapes the issue proposed:

- **Relocating what the test imports** is not available. `src/lib/publisher-env.test.ts:36-39` explains that the test exists to pin *two independent censuses* of one rule against each other; giving them a shared source makes it vacuous. That is unpinning, not fixing.
- **Allow-listing `scripts/preflight-env.mjs`** closes this instance and leaves the class open. It admits a non-build script into the builder *and* migrate stages to satisfy a **test** import, converting an allowlist for scripts the **build** runs into one for scripts a **test** imports — against that block's stated purpose. Measured: two test files already static-import into `scripts/`, and the second passes only because the script it reaches for happens to be allow-listed for an unrelated reason. The next test to import a script breaks the image build again.
- **A build-scoped tsconfig** gets the scope right but costs a second config to keep in sync, and still ships test files in the builder and migrate stages.

Nothing loses coverage: `npm run typecheck`, `npm test` and CI still see every test, on a host where the whole repository is present. Application code importing a filtered path still fails loudly, which is what the allowlist is for.

Structural proof the mechanism works, rather than just an exit code:

```
$ docker run --rm --entrypoint sh civic-p1-builder -c \
    'find /app -name "*.test.*" -not -path "*/node_modules/*" | wc -l; ls /app/scripts'
0
check-standalone-assets.mjs
```

Zero test files reach the builder stage, and `scripts/` there still holds exactly the one allow-listed build-time script — the existing invariant is preserved, not traded away.

## Closing the coverage gap

A new `container-image` job in `ci.yml` (check name `container image build`) runs `docker build --progress=plain -t civic-app:ci .`.

It lives in `ci.yml` rather than a new workflow because the property it needs is always-run and unfiltered, which is `ci.yml`'s existing structural property. `standalone.yml` is the cautionary case: its own header warns that a paths-filtered workflow must never become a required check, since it never reports on non-matching PRs.

It builds the **default target**, not `--target builder` — that is what `docker compose up --build` builds, and it additionally covers the standalone copy and the Dockerfile's image smoke test, which nothing in CI exercised.

Credential-free like the rest of the workflow: no `secrets.` reference, no `env:` block, no `--build-arg`, first-party actions only. The image building with nothing passed in is part of the same tested invariant.

`standalone.yml`'s header is corrected in the same commit: it asserted the gap as a live fact, and that claim is now false. Its host leg is kept and its scope stated explicitly, because host and container are genuinely different environments — which is the whole lesson of this defect.

## Evidence

| Check | Result |
|---|---|
| `docker build --target builder` | exit 0 |
| Same, with the fix scratch-reverted | exit 1, `TS2307: Cannot find module '../../scripts/preflight-env.mjs'` |
| CI leg's exact command, reverted tree | exit 1, same error |
| CI leg's exact command, fixed tree | exit 0 |
| `npm test` | 1009 tests, 1009 pass, 0 fail — identical to base; the diff touches no `.ts`/`.tsx`/`.mjs` |
| `npm run build` | Compiled successfully, route table printed |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | 4 problems, 0 errors, 4 warnings — existing baseline |
| `npm run check:compose-env` | PASS |

`--target migrate` and the default target also build clean. Both compose-built services use `context: .`, so the fix covers both.

## Scope of these measurements

Every docker measurement above is from one developer machine (Docker 29.4.0, darwin). **None of it is a claim about a GitHub runner** — the new job's first runner execution happens on this PR. That distinction is the defect's own subject matter, so it is stated rather than assumed.

For the same reason the new check is **not** added to any required set here. Suggested sequencing: merge unrequired, watch it green on several runners, then add the name to the ruleset. Two things to weigh: it has never run on a runner, and anonymous registry pull rate limits are a real flake mode for a required check.

## Flagged, not fixed

- `CLAUDE.md` now needs three edits, all outside this blast zone: the commands table's test count is stale; "CI runs the first five plus a `.well-known` check" no longer describes `ci.yml`, which gained a second job; and the `check:standalone` line is true but incomplete.
- `standalone.yml` is now largely redundant and is a retirement candidate — its only unique remaining coverage is proving the command works on a host with the whole repository present. Kept and documented rather than deleted on one phase's judgment.
- Residual hole, stated plainly: the exclusion keys off the `*.test.*` naming convention. A shared test-helper module not matching that pattern, importing a filtered path, would fail the image build the same way. Naming convention is the guard; nothing enforces it.
- `docker compose up --build` end to end was not run here — it needs configuration this phase is not permitted to touch. The leg #295 broke is proven; the remainder is neither confirmed nor refuted.
