### PR TITLE
DO NOT MERGE — #325 P1 negative check (auto-closed after the run)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,10 +41,33 @@ README.md
 # and whatever is lying here would otherwise be copied into the image.
 temp
 
+# Tests are repository material as well — and keeping them out is not a size
+# saving, it is what makes the build's type-check scope match the context
+# (#295). `next build` type-checks everything tsconfig.json's `**/*.ts` glob
+# matches, test files included, but this context is deliberately NOT the whole
+# repository. A test that imports a path filtered out below therefore fails
+# the IMAGE build while every host-run check stays green — which is how a test
+# importing `scripts/preflight-env.mjs` broke the documented
+# `docker compose up --build` bring-up with CI green throughout.
+#
+# Excluding them makes the two scopes agree by construction: the image build
+# type-checks application code; `npm run typecheck` and CI type-check
+# application code AND tests, on a host where the whole repository is present.
+# The superset still runs, so nothing loses coverage.
+**/*.test.ts
+**/*.test.tsx
+**/*.test.mts
+**/*.test.mjs
+
 # The build stage runs exactly one repository script — the standalone asset
 # check chained into `npm run build:standalone`. Admitting only that one keeps
 # the built stages from doubling as a place to run the rest of the repo's
 # tooling. A new build-time script must be added here explicitly; forgetting
 # fails the build loudly rather than silently enlarging the image.
+#
+# This allowlist is for scripts the BUILD runs, not for scripts a test
+# imports. Test files no longer reach the context at all (see above), so a
+# test import can neither justify an entry here nor break the image build;
+# application code importing a filtered path still fails loudly, as intended.
 scripts/*
 !scripts/check-standalone-assets.mjs

--- a/.dockerignore
+++ b/.dockerignore
@@ -41,33 +41,10 @@ README.md
 # and whatever is lying here would otherwise be copied into the image.
 temp
 
-# Tests are repository material as well — and keeping them out is not a size
-# saving, it is what makes the build's type-check scope match the context
-# (#295). `next build` type-checks everything tsconfig.json's `**/*.ts` glob
-# matches, test files included, but this context is deliberately NOT the whole
-# repository. A test that imports a path filtered out below therefore fails
-# the IMAGE build while every host-run check stays green — which is how a test
-# importing `scripts/preflight-env.mjs` broke the documented
-# `docker compose up --build` bring-up with CI green throughout.
-#
-# Excluding them makes the two scopes agree by construction: the image build
-# type-checks application code; `npm run typecheck` and CI type-check
-# application code AND tests, on a host where the whole repository is present.
-# The superset still runs, so nothing loses coverage.
-**/*.test.ts
-**/*.test.tsx
-**/*.test.mts
-**/*.test.mjs
-
 # The build stage runs exactly one repository script — the standalone asset
 # check chained into `npm run build:standalone`. Admitting only that one keeps
 # the built stages from doubling as a place to run the rest of the repo's
 # tooling. A new build-time script must be added here explicitly; forgetting
 # fails the build loudly rather than silently enlarging the image.
-#
-# This allowlist is for scripts the BUILD runs, not for scripts a test
-# imports. Test files no longer reach the context at all (see above), so a
-# test import can neither justify an entry here nor break the image build;
-# application code importing a filtered path still fails loudly, as intended.
 scripts/*
 !scripts/check-standalone-assets.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,45 @@ jobs:
             exit 1
           fi
           echo "byte-identical (sha256 $(sha256sum "$SOURCE" | cut -d' ' -f1))"
+
+  # THE FILTERED-CONTEXT BUILD (#295). Every step in `verify` above runs on the
+  # runner, where the whole repository is present. `docker build` does not: the
+  # builder stage sees a `.dockerignore`-filtered context, and `next build`
+  # type-checks whatever tsconfig.json's globs match *within that context*. The
+  # two scopes can therefore disagree, and when they do, only the image build
+  # notices — which is exactly what happened: a test file's import of a filtered
+  # script broke the documented `docker compose up --build` bring-up for two
+  # days while `verify` and `standalone.yml` stayed green on every PR.
+  #
+  # Running `npm run build:standalone` on the runner cannot see that class of
+  # defect — standalone.yml's own header says so — because on the runner nothing
+  # is filtered. Only a build whose context is actually filtered can. So this
+  # job builds the real image, with the operator's own command shape.
+  #
+  # NO PATHS FILTER, deliberately. The trigger for this class is "any file the
+  # build type-checks changed", which is most of the repository — a paths filter
+  # would have to enumerate that, get it wrong, and go quiet. It lives in this
+  # workflow rather than the paths-filtered standalone.yml for the same reason:
+  # here, always-run is the file's existing property rather than a promise.
+  #
+  # Credential-free like the rest of this workflow: no `secrets.`, no `env:`,
+  # and no `--build-arg`. The image building with nothing passed in is part of
+  # the same tested invariant — an operator's first build supplies no config.
+  #
+  # If anonymous Docker Hub pulls ever rate-limit this job, the seam is the
+  # Dockerfile's NODE_IMAGE / DOCKER_CLI_IMAGE args, not a registry credential.
+  container-image:
+    name: container image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The default target (runner), not `--target builder`: it is what
+      # `docker compose up --build` builds, and it additionally exercises the
+      # standalone copy and the Dockerfile's sharp resolve-and-run smoke test,
+      # neither of which any other job covers. The runtime stage costs little
+      # on top of the builder stage — a cold `--no-cache` full build measured
+      # 41s on one developer machine with the base images already local. That
+      # is not a runner measurement; budget for the base-image pulls too.
+      - name: Build the application image (dockerignore-filtered context)
+        run: docker build --progress=plain -t civic-app:ci .

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,13 +1,23 @@
 name: Standalone
 
-# The empirical net for the standalone build (wave N5 P1, anchor #282).
+# The empirical net for the standalone build ON A HOST (wave N5 P1, anchor
+# #282; scope narrowed by #295).
 #
 # `npm run build:standalone` (BUILD_STANDALONE=1 next build, then
-# scripts/check-standalone-assets.mjs) otherwise runs only inside
-# `docker build` — which no workflow performs — so a change that breaks
-# standalone tracing of the runtime-read helper files would first surface in
-# an operator's image build. This leg runs the same command directly, on the
-# paths that can break it.
+# scripts/check-standalone-assets.mjs) runs in two environments that are not
+# interchangeable, and each needs its own leg:
+#
+#   host       — the whole repository present. This workflow, on the paths
+#                that can break standalone tracing of the runtime-read
+#                helper files.
+#   container  — a `.dockerignore`-filtered context. ci.yml's
+#                `container image build` job, always-run and unfiltered.
+#
+# This leg used to be the only one, and its own header said so: the command
+# "otherwise runs only inside `docker build` — which no workflow performs."
+# That was true and it was the gap. A defect visible only in the filtered
+# context passed here for two days (#295), because on this runner nothing is
+# filtered. Do not treat a green run here as evidence about an image build.
 #
 # Credential-free by construction, same charter as ci.yml: zero `secrets.`
 # references, no `env:` blocks of placeholder credentials, first-party

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -1170,3 +1170,5 @@ export function encodeSSE(event: StreamEvent): string {
 export function panelsForRun(mcpOnly: boolean): PanelType[] {
   return mcpOnly ? ['withMcp'] : ['withoutMcp', 'withMcp'];
 }
+
+// #325 P1 negative check — throwaway branch, never merged.


### PR DESCRIPTION
Throwaway. Proves the new `container image build` job actually fails on a filtered-context break, on a GitHub runner — the half that PR #327 could only demonstrate on a developer machine.

Reverts `.dockerignore` to its `3464eb7` state and touches one unrelated `src/` file.

Expected: `container image build` FAILS, `build / test / lint / typecheck` passes, `standalone build + asset check` absent by path filter. Closed and deleted as soon as the run reports.