### PR TITLE
fix: every Data Commons cell is invalid Python (keyword argument repeated) (#325 P5)

### DIFF
--- a/src/lib/notebook-author/tool-to-cell.test.ts
+++ b/src/lib/notebook-author/tool-to-cell.test.ts
@@ -1,0 +1,175 @@
+// Renderer syntax + kwargs-collision tests (Wave N6 P5, #320).
+//
+// pyKwargs appends every arg a renderer did not enumerate by hand. The Data
+// Commons renderer hand-writes variable_dcid and place_dcid, then also
+// passes call.args through pyKwargs — so both landed twice and every
+// generated Data Commons cell was a Python SyntaxError: keyword argument
+// repeated. This is the first test file for tool-to-cell.ts. It:
+//
+//   - parses every generated code cell as Python via a real python3
+//     subprocess, across every cell-producing renderer in the file — not
+//     just the Data Commons one, so a repeat-kwargs regression anywhere
+//     here trips it;
+//   - pins that a Data Commons call carrying date/child_place_type renders
+//     each kwarg exactly once;
+//   - pins the Socrata renderer's output as byte-for-byte unchanged.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import type { NotebookCell } from './cells.ts';
+import { renderFetchToolCell, type PhaseAToolCall } from './tool-to-cell.ts';
+
+const CTX = { dataFrameIndex: 1, defaultPortal: 'data.cityofnewyork.us' };
+
+/**
+ * Parse a Jupyter code cell's source as Python via a real `python3`
+ * subprocess — the same syntax check `nbconvert`/the sandbox execution
+ * path would trip over first.
+ *
+ * Uses `compile()`, not bare `ast.parse()`: measured locally, `ast.parse()`
+ * accepts a repeated keyword argument (e.g. `f(x=1, x=2)`) without error —
+ * that check runs during compilation, not grammar parsing — so it would
+ * pass on the pre-fix #320 renderer output and never demonstrate the
+ * failure this test exists to catch. `compile(..., 'exec')` is a superset
+ * of `ast.parse()`'s syntax checking and also raises
+ * `SyntaxError: keyword argument repeated` for that case.
+ */
+function assertParsesAsPython(cell: NotebookCell, label: string): void {
+  assert.equal(cell.cell_type, 'code', `${label}: expected a code cell`);
+  const source = cell.source.join('');
+  const result = spawnSync(
+    'python3',
+    ['-c', "import sys; compile(sys.stdin.read(), '<cell>', 'exec')"],
+    { input: source, encoding: 'utf-8' },
+  );
+  assert.equal(
+    result.status,
+    0,
+    `${label}: generated cell is not valid Python (exit ${result.status})\n` +
+      `--- source ---\n${source}\n--- stderr ---\n${result.stderr}`,
+  );
+}
+
+function codeCells(call: PhaseAToolCall): NotebookCell[] {
+  const out = renderFetchToolCell(call, CTX);
+  assert.ok(out, `renderFetchToolCell returned null for ${call.name}`);
+  return out!.cells.filter(c => c.cell_type === 'code');
+}
+
+// --- Socrata query -----------------------------------------------------
+
+const SOCRATA_CALL: PhaseAToolCall = {
+  name: 'get_data',
+  operationType: 'query',
+  args: {
+    type: 'query',
+    portal: 'data.cityofnewyork.us',
+    dataset_id: 'erm2-nwe9',
+    select: 'complaint_type, count(*) as count',
+    where: 'complaint_type IS NOT NULL',
+    group: 'complaint_type',
+    order: 'count DESC',
+    limit: 5,
+  },
+  reason: 'to aggregate by complaint_type',
+  resultSummary: { rows: 5, columns: 2 },
+};
+
+// --- Data Commons observations ------------------------------------------
+
+const DC_CALL_MINIMAL: PhaseAToolCall = {
+  name: 'get_observations',
+  args: {
+    variable_dcid: 'Count_Person',
+    place_dcid: 'geoId/06',
+  },
+  resultSummary: { rows: 12, columns: 2 },
+};
+
+const DC_CALL_WITH_OPTIONALS: PhaseAToolCall = {
+  name: 'get_observations',
+  args: {
+    variable_dcid: 'Count_Person',
+    place_dcid: 'geoId/06',
+    date: '2020',
+    child_place_type: 'County',
+  },
+  resultSummary: { rows: 58, columns: 2 },
+};
+
+// --- Boston OpenContext ---------------------------------------------------
+
+const OPENCONTEXT_SQL_CALL: PhaseAToolCall = {
+  name: 'ckan__execute_sql',
+  args: { sql: 'SELECT * FROM "abc123" LIMIT 10' },
+};
+
+const OPENCONTEXT_QUERY_CALL: PhaseAToolCall = {
+  name: 'ckan__query_data',
+  args: { resource_id: 'abc123', filters: { status: 'open' }, limit: 25 },
+  resultSummary: { rows: 25, columns: 4 },
+};
+
+const ALL_FIXTURES: Array<[string, PhaseAToolCall]> = [
+  ['socrata get_data (query)', SOCRATA_CALL],
+  ['data commons get_observations (minimal)', DC_CALL_MINIMAL],
+  ['data commons get_observations (date + child_place_type)', DC_CALL_WITH_OPTIONALS],
+  ['opencontext ckan__execute_sql', OPENCONTEXT_SQL_CALL],
+  ['opencontext ckan__query_data', OPENCONTEXT_QUERY_CALL],
+];
+
+test('every renderer emits code cells that parse as Python', () => {
+  for (const [label, call] of ALL_FIXTURES) {
+    for (const cell of codeCells(call)) {
+      assertParsesAsPython(cell, label);
+    }
+  }
+});
+
+test('data commons: date and child_place_type each render exactly once when present', () => {
+  const [cell] = codeCells(DC_CALL_WITH_OPTIONALS);
+  assertParsesAsPython(cell, 'data commons (date + child_place_type)');
+  const source = cell.source.join('');
+  for (const key of ['variable_dcid', 'place_dcid', 'date', 'child_place_type']) {
+    const occurrences = source.split(`${key}=`).length - 1;
+    assert.equal(occurrences, 1, `${key}= should appear exactly once in:\n${source}`);
+  }
+});
+
+test('data commons: variable_dcid and place_dcid render exactly once even without date/child_place_type', () => {
+  const [cell] = codeCells(DC_CALL_MINIMAL);
+  const source = cell.source.join('');
+  for (const key of ['variable_dcid', 'place_dcid']) {
+    const occurrences = source.split(`${key}=`).length - 1;
+    assert.equal(occurrences, 1, `${key}= should appear exactly once in:\n${source}`);
+  }
+  assert.doesNotMatch(source, /\bdate=/);
+  assert.doesNotMatch(source, /child_place_type=/);
+});
+
+test('socrata: rendered cell output is unchanged (portal/dataset_id hand-written once, type never emitted)', () => {
+  const [cell] = codeCells(SOCRATA_CALL);
+  const source = cell.source.join('');
+  const expected = [
+    'df1 = fetch_socrata(',
+    '    portal="data.cityofnewyork.us",',
+    '    dataset_id="erm2-nwe9",',
+    '    select="complaint_type, count(*) as count",',
+    '    where="complaint_type IS NOT NULL",',
+    '    group="complaint_type",',
+    '    order="count DESC",',
+    '    limit=5,',
+    ')',
+    'df1',
+  ].join('\n');
+  assert.equal(source, expected);
+  // The type= call-routing discriminator never appears in the rendered
+  // Python, and portal/dataset_id are emitted exactly once each — the
+  // same invariant #320 broke for Data Commons.
+  assert.doesNotMatch(source, /\btype=/);
+  assert.equal(source.split('portal=').length - 1, 1);
+  assert.equal(source.split('dataset_id=').length - 1, 1);
+});

--- a/src/lib/notebook-author/tool-to-cell.ts
+++ b/src/lib/notebook-author/tool-to-cell.ts
@@ -43,9 +43,27 @@ function pyRepr(value: unknown, indent = ''): string {
   return JSON.stringify(value);
 }
 
-function pyKwargs(args: Record<string, unknown>, order: readonly string[]): string {
+/**
+ * Render `args` as Python keyword-argument lines: `order` first (in that
+ * order), then every remaining arg the caller did not enumerate, so a field
+ * this renderer doesn't know about yet is still emitted instead of silently
+ * dropped.
+ *
+ * `handledKeys` lists args the caller has already accounted for elsewhere in
+ * the generated cell — rendered by hand as explicit kwargs (e.g.
+ * `portal=...`), or consumed only as call-routing metadata that never
+ * appears in the rendered Python at all (e.g. `type`, which selects which
+ * renderer runs and is not itself a `fetch_*` parameter). Either way,
+ * `pyKwargs` must not append them a second time — the caller, not a
+ * hard-coded list here, owns which keys those are.
+ */
+function pyKwargs(
+  args: Record<string, unknown>,
+  order: readonly string[],
+  handledKeys: readonly string[] = [],
+): string {
   const lines: string[] = [];
-  const seen = new Set<string>();
+  const seen = new Set<string>(handledKeys);
   for (const key of order) {
     if (args[key] === undefined || args[key] === null) continue;
     lines.push(`    ${key}=${pyRepr(args[key], '    ')},`);
@@ -55,7 +73,6 @@ function pyKwargs(args: Record<string, unknown>, order: readonly string[]): stri
   for (const [key, value] of Object.entries(args)) {
     if (seen.has(key)) continue;
     if (value === undefined || value === null) continue;
-    if (key === 'type' || key === 'portal' || key === 'dataset_id') continue; // already positional-ish
     lines.push(`    ${key}=${pyRepr(value, '    ')},`);
   }
   return lines.join('\n');
@@ -106,7 +123,7 @@ function renderSocrataQueryCell(
     `${dfVar} = fetch_socrata(`,
     `    portal=${JSON.stringify(portal)},`,
     `    dataset_id=${JSON.stringify(datasetId)},`,
-    pyKwargs(call.args, SOCRATA_QUERY_KWARGS),
+    pyKwargs(call.args, SOCRATA_QUERY_KWARGS, ['portal', 'dataset_id', 'type']),
     ')',
     dfVar,
   ].filter(Boolean).join('\n');
@@ -137,7 +154,7 @@ function renderDataCommonsObsCell(
     `${dfVar} = fetch_data_commons(`,
     `    variable_dcid=${JSON.stringify(variable)},`,
     `    place_dcid=${JSON.stringify(place)},`,
-    pyKwargs(call.args, DC_OBS_KWARGS),
+    pyKwargs(call.args, DC_OBS_KWARGS, ['variable_dcid', 'place_dcid']),
     ')',
     dfVar,
   ].filter(Boolean).join('\n');


### PR DESCRIPTION
Closes #320. Wave N6 phase P5.

## The defect

`pyKwargs` appends every argument the caller did not enumerate. The Data Commons renderer emits `variable_dcid` and `place_dcid` by hand **and** lets `pyKwargs` append them again, so both land twice and the cell is a `SyntaxError: keyword argument repeated`.

Not one failing notebook — **every** notebook containing a Data Commons fetch, since the renderer was written.

The Socrata renderer escaped only by accident: it hand-writes `portal` and `dataset_id`, and those two happened to be in a hard-coded skip list inside `pyKwargs`. That list was a stand-in for the mechanism this change actually builds — the renderer and `pyKwargs` each believed they owned the argument list, and one pair of keys happened to be covered while the other was not.

## The fix

`pyKwargs` gains a `handledKeys` parameter that seeds its `seen` set. Each caller declares what it has already rendered:

- `renderSocrataQueryCell` → `['portal', 'dataset_id', 'type']`
- `renderDataCommonsObsCell` → `['variable_dcid', 'place_dcid']`

The hard-coded skip list is **removed**, not widened — the caller now owns the declaration, which is the point. `type` is a call-routing discriminator that selects which renderer runs and is never itself a rendered kwarg; it is declared by the one caller that carries it rather than given a second "never a kwarg anywhere" concept.

"Append everything the caller did not enumerate" is preserved for every renderer, so a field a renderer does not know about yet is still emitted rather than silently dropped.

## The guard, and why it is not `ast.parse`

Every generated cell, across every renderer, is now compiled as Python by a test that shells out via `spawnSync`.

The obvious implementation — `ast.parse()` — **cannot detect this defect**:

```
$ python3 -c "import ast; ast.parse('f(x=1, x=2)')"     # no error
$ python3 -c "compile('f(x=1, x=2)', '<c>', 'exec')"    # SyntaxError: keyword argument repeated: x
```

Duplicate-keyword detection happens during `compile()`, not during grammar-level parsing. A parse test written the obvious way would have passed against the broken renderer and been indistinguishable from a working guard. The test uses `compile()` — a strict superset of `ast.parse()`'s syntax checking — and says why in its own docstring.

That distinction was found by measurement, not by reading: the test was demonstrated **red** against the pre-fix renderer before it was accepted.

```
not ok 1 - every renderer emits code cells that parse as Python
    SyntaxError: keyword argument repeated: variable_dcid
not ok 2 - data commons: date and child_place_type each render exactly once when present
not ok 3 - data commons: variable_dcid and place_dcid render exactly once even without date/child_place_type
ok 4 - socrata: rendered cell output is unchanged        <- Socrata never had this bug
```

The Socrata case staying green in that run is itself evidence the fix is targeted: it proves the test distinguishes the broken renderer from the working one rather than failing everything indiscriminately.

## Checks

| Check | Result |
|---|---|
| `npm test` | 1014 tests, 1014 pass, 0 fail — 1010 baseline + 4 new, none moved or removed |
| `npm run build` | Compiled successfully, route table printed |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | 4 problems, 0 errors, 4 warnings — existing baseline |
| `npm run check:compose-env` | PASS |

Socrata's rendered cell is asserted unchanged by exact string equality, not merely by absence of a visible diff.

## Coordination note

This file is also P3's blast zone (#321 adds failure fields to `PhaseAToolCall` and changes rejected-call rendering). The diff is kept tight and local to the kwargs mechanism so P3 composes onto it rather than conflicting. P5 merges before P3 is cut.
