### PR TITLE
fix: resultSummary is never populated for Socrata calls (#325 P2)

### DIFF
--- a/src/lib/openrouter-streaming.test.ts
+++ b/src/lib/openrouter-streaming.test.ts
@@ -14,7 +14,7 @@ import type { AddressInfo } from 'node:net';
 import { queryWithoutMcpStreaming, queryWithMcpStreaming, type StreamCallbacks, type CompletionResult } from './openrouter-streaming.ts';
 import { carriedModelIdentity } from './model-catalog.ts';
 import { _resetDefaultModelClientForTests } from './model-client.ts';
-import { streamErrorPayload, type StreamErrorCode, type PanelType, type ProgressPhase } from './streaming.ts';
+import { streamErrorPayload, buildStatsSummary, buildProvenanceLine, type StreamErrorCode, type PanelType, type ProgressPhase } from './streaming.ts';
 
 const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
 
@@ -372,4 +372,143 @@ test('queryWithMcpStreaming: an envelope without a data array leaves resultSumma
   assert.equal(result.tools_called?.length, 1);
   assert.equal(result.tools_called?.[0].resultSummary, undefined);
   assert.equal(toolResultNarration(progress), 'Query to 311 Service Requests complete');
+});
+
+// --- Case 4: the rollups downstream of resultSummary (#322 follow-up) -------
+//
+// `resultSummary.rows` has two more readers beyond `formatToolResult`, both in
+// streaming.ts and both reached from the primary answer surface via
+// McpResponseDisplay.tsx (CLAUDE.md's canonical shared component, imported by
+// both ResponsePanel and LiveResponsePanel): `buildStatsSummary`'s "N records
+// analyzed" and `buildProvenanceLine`'s "N rows returned". Both `reduce` over
+// `resultSummary?.rows` across every tool call. Before this phase's fix they
+// summed to zero for every Socrata call, because resultSummary was always
+// null; after it they carry a real number onto the reader-facing answer. That
+// is a newly-activated provenance claim, and it rests on the same
+// rows-means-data.length-not-total_rows judgment call as the parse itself: if
+// that judgment is ever reversed, this is the test that says why not, by
+// making a mismatched, materially wrong total (300) visibly different from
+// the correct one (5).
+
+function startMultiToolCallModelServer(
+  toolName: string,
+  toolArgsList: Record<string, unknown>[],
+): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    let callCount = 0;
+    const server = createServer((_req, res) => {
+      callCount++;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (callCount === 1) {
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test-multi-tool-call',
+          object: 'chat.completion',
+          created: Math.floor(Date.now() / 1000),
+          model: 'fake/model',
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: toolArgsList.map((args, i) => ({
+                id: `call_${i + 1}`,
+                type: 'function',
+                function: { name: toolName, arguments: JSON.stringify(args) },
+              })),
+            },
+            finish_reason: 'tool_calls',
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        }));
+      } else {
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test-final',
+          object: 'chat.completion',
+          created: Math.floor(Date.now() / 1000),
+          model: 'fake/model',
+          choices: [{
+            index: 0,
+            message: { role: 'assistant', content: 'Final answer.' },
+            finish_reason: 'stop',
+          }],
+          usage: { prompt_tokens: 20, completion_tokens: 8, total_tokens: 28 },
+        }));
+      }
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/v1` });
+    });
+  });
+}
+
+test('queryWithMcpStreaming: buildStatsSummary and buildProvenanceLine sum data.length (5) across calls, never total_rows (300) and never 0', async () => {
+  const call1Args = { type: 'query', dataset_id: 'erm2-nwe9', portal: 'data.cityofnewyork.us' };
+  const call2Args = { type: 'query', dataset_id: '43nn-pn8j', portal: 'data.cityofnewyork.us' };
+
+  // Both envelopes carry a total_rows far larger than data.length - a capped
+  // page, same as production Socrata pagination - so summing the wrong field
+  // would produce a visibly different (and false) total.
+  const envelope1 = JSON.stringify({
+    data: [
+      { unique_key: '1', complaint_type: 'Noise' },
+      { unique_key: '2', complaint_type: 'Illegal Parking' },
+    ],
+    total_rows: 100,
+  });
+  const envelope2 = JSON.stringify({
+    data: [
+      { camis: 'a', dba: 'Restaurant A' },
+      { camis: 'b', dba: 'Restaurant B' },
+      { camis: 'c', dba: 'Restaurant C' },
+    ],
+    total_rows: 200,
+  });
+
+  const { server, url } = await startMultiToolCallModelServer('get_data', [call1Args, call2Args]);
+  try {
+    process.env.OPENROUTER_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    let result: CompletionResult | undefined;
+
+    await queryWithMcpStreaming(
+      'test question',
+      FAKE_MODEL,
+      [],
+      async (_name, args) => (args.dataset_id === 'erm2-nwe9' ? envelope1 : envelope2),
+      undefined,
+      {
+        onProgress: () => {},
+        onToken: () => {},
+        onComplete: (_panel, completion) => {
+          result = completion;
+        },
+        onError: (_panel, message) => {
+          assert.fail(`unexpected onError: ${message}`);
+        },
+      },
+    );
+
+    assert.ok(result, 'onComplete must fire');
+    const toolsCalled = result!.tools_called ?? [];
+    assert.equal(toolsCalled.length, 2);
+    assert.deepEqual(toolsCalled.map((t) => t.resultSummary), [
+      { rows: 2, columns: 2 },
+      { rows: 3, columns: 2 },
+    ]);
+
+    const stats = buildStatsSummary(toolsCalled, result!.duration_ms);
+    assert.match(stats, /\b5 records analyzed\b/);
+    assert.doesNotMatch(stats, /\b300\b/);
+    assert.doesNotMatch(stats, /\b0 records analyzed\b/);
+
+    const provenance = buildProvenanceLine(toolsCalled);
+    assert.ok(provenance, 'buildProvenanceLine must return a line for query-type tool calls');
+    assert.match(provenance!, /\b5 rows returned\b/);
+    assert.doesNotMatch(provenance!, /\b300\b/);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
 });

--- a/src/lib/openrouter-streaming.test.ts
+++ b/src/lib/openrouter-streaming.test.ts
@@ -11,10 +11,10 @@ import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { queryWithoutMcpStreaming, queryWithMcpStreaming, type StreamCallbacks } from './openrouter-streaming.ts';
+import { queryWithoutMcpStreaming, queryWithMcpStreaming, type StreamCallbacks, type CompletionResult } from './openrouter-streaming.ts';
 import { carriedModelIdentity } from './model-catalog.ts';
 import { _resetDefaultModelClientForTests } from './model-client.ts';
-import { streamErrorPayload, type StreamErrorCode, type PanelType } from './streaming.ts';
+import { streamErrorPayload, type StreamErrorCode, type PanelType, type ProgressPhase } from './streaming.ts';
 
 const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
 
@@ -173,4 +173,203 @@ test('queryWithMcpStreaming: upstream 401 yields typed model_auth_rejected onErr
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+});
+
+// --- Case 3: resultSummary from a real tool-call round trip (#322, website#325 P2) ---
+//
+// `executeToolCall` is an injected parameter (not an import), so these fixtures
+// drive the real tool-calling loop in `queryWithMcpStreaming` end to end with no
+// network call to any MCP server and no credential — only a local mock model
+// server standing in for the chat-completions endpoint, following the idiom of
+// `startAuthRejectingServer` above. The model server always answers with one
+// tool call on its first reply and a content-only final answer on its second,
+// which is the minimal shape that drives the tool-result parse block at
+// `openrouter-streaming.ts` and its narration consumer, `formatToolResult` in
+// `streaming.ts` — the two surfaces the anchor calls out.
+
+interface RecordedProgress {
+  panel: PanelType;
+  message: string;
+  phase?: ProgressPhase;
+}
+
+function startToolCallModelServer(toolName: string, toolArgs: Record<string, unknown>): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    let callCount = 0;
+    const server = createServer((_req, res) => {
+      callCount++;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      if (callCount === 1) {
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test-tool-call',
+          object: 'chat.completion',
+          created: Math.floor(Date.now() / 1000),
+          model: 'fake/model',
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [{
+                id: 'call_1',
+                type: 'function',
+                function: { name: toolName, arguments: JSON.stringify(toolArgs) },
+              }],
+            },
+            finish_reason: 'tool_calls',
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        }));
+      } else {
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test-final',
+          object: 'chat.completion',
+          created: Math.floor(Date.now() / 1000),
+          model: 'fake/model',
+          choices: [{
+            index: 0,
+            message: { role: 'assistant', content: 'Final answer.' },
+            finish_reason: 'stop',
+          }],
+          usage: { prompt_tokens: 20, completion_tokens: 8, total_tokens: 28 },
+        }));
+      }
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/v1` });
+    });
+  });
+}
+
+/**
+ * Runs one full tool-call round trip against a local mock model server, with
+ * `toolResult` handed back verbatim by the injected `executeToolCall` — the
+ * exact string `queryWithMcpStreaming` parses at the site this phase fixes.
+ * Returns the completed result and every progress event, so a test can assert
+ * both surfaces: the parsed `resultSummary` (`CompletionResult.tools_called`)
+ * and the narration line `formatToolResult` produces from it (the
+ * `phase: 'tool_result'` progress event).
+ */
+async function runToolCallRoundTrip(
+  toolArgs: Record<string, unknown>,
+  toolResult: string,
+): Promise<{ result: CompletionResult; progress: RecordedProgress[] }> {
+  const { server, url } = await startToolCallModelServer('get_data', toolArgs);
+  try {
+    process.env.OPENROUTER_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    const progress: RecordedProgress[] = [];
+    let result: CompletionResult | undefined;
+
+    await queryWithMcpStreaming(
+      'test question',
+      FAKE_MODEL,
+      [],
+      async () => toolResult,
+      undefined,
+      {
+        onProgress: (panel, message, opts) => {
+          progress.push({ panel, message, phase: opts?.phase });
+        },
+        onToken: () => {},
+        onComplete: (_panel, completion) => {
+          result = completion;
+        },
+        onError: (_panel, message) => {
+          assert.fail(`unexpected onError: ${message}`);
+        },
+      },
+    );
+
+    assert.ok(result, 'onComplete must fire');
+    return { result: result!, progress };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function toolResultNarration(progress: RecordedProgress[]): string | undefined {
+  return progress.find((p) => p.phase === 'tool_result')?.message;
+}
+
+test('queryWithMcpStreaming: a Socrata envelope ({data, total_rows}) populates resultSummary from data.length, not total_rows', async () => {
+  // total_rows (100) disagrees with data.length (2) - a capped page. rows
+  // must reflect what this call actually delivered, since that is what every
+  // downstream reader (narration, the "records analyzed" rollups in
+  // streaming.ts) means by "rows".
+  const envelope = JSON.stringify({
+    data: [
+      { unique_key: '1', complaint_type: 'Noise' },
+      { unique_key: '2', complaint_type: 'Illegal Parking' },
+    ],
+    total_rows: 100,
+  });
+
+  const { result, progress } = await runToolCallRoundTrip(
+    { type: 'query', dataset_id: 'erm2-nwe9' },
+    envelope,
+  );
+
+  assert.equal(result.tools_called?.length, 1);
+  assert.deepEqual(result.tools_called?.[0].resultSummary, { rows: 2, columns: 2 });
+
+  // Second surface: the live-panel narration, `formatToolResult` at
+  // openrouter-streaming.ts:339, keyed off the same resultSummary.
+  assert.equal(toolResultNarration(progress), 'Retrieved 2 records from 311 Service Requests');
+});
+
+test('queryWithMcpStreaming: a bare JSON array still populates resultSummary (no regression)', async () => {
+  const bareArray = JSON.stringify([
+    { id: 'abcd-1234', name: 'Restaurant Inspections' },
+    { id: 'wvxf-dwi5', name: 'Housing Violations' },
+    { id: 'vw6y-z8j6', name: '311 Cases' },
+  ]);
+
+  const { result, progress } = await runToolCallRoundTrip(
+    { type: 'catalog', query: 'inspections' },
+    bareArray,
+  );
+
+  assert.equal(result.tools_called?.length, 1);
+  assert.deepEqual(result.tools_called?.[0].resultSummary, { rows: 3, columns: 2 });
+  assert.equal(toolResultNarration(progress), 'Found 3 datasets matching the search');
+});
+
+test('queryWithMcpStreaming: a zero-row envelope yields resultSummary {rows: 0, columns: 0}, not null', async () => {
+  // Deliberate: a query that legitimately matched nothing is a real, valid
+  // answer ("no matching records"), distinct from a result this app could not
+  // parse at all. Collapsing both to `resultSummary: undefined` is exactly
+  // the always-null failure mode #322 reports - a diagnostic that never fires
+  // is worse than one that is simply absent, because P3's replay work reads
+  // this field as a failure signal.
+  const emptyEnvelope = JSON.stringify({ data: [], total_rows: 0 });
+
+  const { result, progress } = await runToolCallRoundTrip(
+    { type: 'query', dataset_id: 'erm2-nwe9' },
+    emptyEnvelope,
+  );
+
+  assert.equal(result.tools_called?.length, 1);
+  assert.deepEqual(result.tools_called?.[0].resultSummary, { rows: 0, columns: 0 });
+  assert.equal(toolResultNarration(progress), 'Retrieved 0 records from 311 Service Requests');
+});
+
+test('queryWithMcpStreaming: an envelope without a data array leaves resultSummary unset', async () => {
+  // Not every Socrata response is a row envelope (metadata/metrics payloads
+  // are objects with no `data` array at all). Absent a `data` array to count,
+  // resultSummary must stay unset rather than guess - the same "skip" outcome
+  // as the pre-existing not-JSON / not-an-array case.
+  const notARowEnvelope = JSON.stringify({ total_rows: 5, note: 'no data field' });
+
+  const { result, progress } = await runToolCallRoundTrip(
+    { type: 'query', dataset_id: 'erm2-nwe9' },
+    notARowEnvelope,
+  );
+
+  assert.equal(result.tools_called?.length, 1);
+  assert.equal(result.tools_called?.[0].resultSummary, undefined);
+  assert.equal(toolResultNarration(progress), 'Query to 311 Service Requests complete');
 });

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -309,17 +309,53 @@ export async function queryWithMcpStreaming(
             const toolDuration = Date.now() - toolStartTime;
             toolEntry.duration_ms = toolDuration;
 
-            // Parse result to extract row/column counts
+            // Parse result to extract row/column counts. Socrata (and any MCP
+            // server that paginates) answers with an envelope —
+            // { data: [...], total_rows: N, ... } — not a bare array, so the
+            // bare-array-only check below always missed it and `resultSummary`
+            // was silently null for every Socrata call (#322).
+            //
+            // `rows` is what THIS CALL actually delivered — `data.length` —
+            // never `total_rows`. `total_rows` is the size of the matching set
+            // upstream; a capped page can return far fewer rows than that, and
+            // every downstream reader of `resultSummary.rows` (the narration
+            // copy below, and the "records analyzed" / "rows returned" rollups
+            // in buildNarrativeSummary/buildProvenanceLine in streaming.ts)
+            // means "how much data flowed through this call," not "how large
+            // is the source dataset." Reporting `total_rows` there would claim
+            // the model analyzed rows it never saw.
             try {
-              const parsed = JSON.parse(result);
-              if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === 'object') {
-                toolEntry.resultSummary = {
-                  rows: parsed.length,
-                  columns: Object.keys(parsed[0]).length,
-                };
+              const parsed: unknown = JSON.parse(result);
+              const rows: unknown[] | undefined = Array.isArray(parsed)
+                ? parsed
+                : parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>).data)
+                  ? (parsed as Record<string, unknown>).data as unknown[]
+                  : undefined;
+
+              if (rows) {
+                const firstRow = rows[0];
+                if (rows.length === 0) {
+                  // A valid, empty result set is a real answer ("no matching
+                  // records"), not a parse failure — worth distinguishing from
+                  // the silent-skip cases below so a zero-row response is
+                  // diagnosable rather than indistinguishable from "did not
+                  // parse."
+                  toolEntry.resultSummary = { rows: 0, columns: 0 };
+                } else if (typeof firstRow === 'object' && firstRow !== null) {
+                  toolEntry.resultSummary = {
+                    rows: rows.length,
+                    columns: Object.keys(firstRow).length,
+                  };
+                }
+                // else: a non-empty array whose elements are not objects
+                // (e.g. an array of strings) - not tabular, skip, matching
+                // the prior bare-array behavior.
               }
+              // else: not JSON-parseable as a bare array or a { data: [...] }
+              // envelope (e.g. a metadata/metrics payload, or an envelope with
+              // no `data` field) - skip, `resultSummary` stays unset.
             } catch {
-              // Not JSON or not an array - skip
+              // Not JSON - skip
             }
 
             // Trace: end tool call span with response metadata


### PR DESCRIPTION
Closes #322. Wave N6 phase P2.

## The defect

`resultSummary` was populated only when the MCP result parsed as a bare JSON array. Socrata answers with an envelope — `{"data": [...], "total_rows": N, ...}` — so the field was **always null for Socrata**.

Two consequences, and the second is why this matters beyond cosmetics:

1. The notebook line *"Original execution returned N rows × M columns"* has never appeared in any notebook. The feature has been dead since it shipped.
2. A diagnostic that is silently always-null is worse than one that is absent, because other code gets written assuming it works. The rejected-call-replay work needed this as a failure signal and could not use it.

## The fix

The parse now recognises the envelope **in addition to** the bare array. Both shapes work; neither replaced the other.

### `rows` means what this call delivered, never `total_rows`

`rows` is `data.length`. `total_rows` is the size of the matching set upstream, and a capped page can return far fewer rows than that.

This is not a style preference — it is a provenance decision, because two functions in `streaming.ts` reduce `resultSummary.rows` into reader-facing totals: `buildStatsSummary` (`:1083`, "N records analyzed") and `buildProvenanceLine` (`:1150`, "N rows returned"). Both are consumed by `src/components/shared/McpResponseDisplay.tsx`, the shared component that both the home/ask and explore response panels delegate to. Summing `total_rows` there would tell a reader the model analyzed rows it never saw.

A regression test pins exactly that: two calls whose envelopes carry `total_rows` 100 and 200 while delivering 2 and 3 rows must roll up to **5** — never 300, never 0.

### Zero rows is now a real answer, not a silence

A zero-row envelope and a zero-length bare array both yield `{rows: 0, columns: 0}` instead of leaving the field unset.

The issue's own framing is that an always-null diagnostic is worse than an absent one. Collapsing "matched nothing" into the same `undefined` as "could not parse" reproduces that failure for the empty case — and the next phase needs to distinguish them. `columns: 0` is the observed count for a response containing no rows; deriving it from some other envelope field would mean trusting a field this codebase does not read or validate anywhere.

An envelope with **no** `data` array still leaves the field unset, as before.

## Surfaces asserted

The issue named two. Measured, there are four consumers of `resultSummary.rows`; three are in this phase's reach and all three are now under test:

| Surface | |
|---|---|
| `formatToolResult` — live-panel narration | asserted |
| `buildStatsSummary` — "N records analyzed" | asserted |
| `buildProvenanceLine` — "N rows returned" | asserted |
| notebook line — `tool-to-cell.ts` | belongs to the rejected-call phase |

Every test drives the **real** loop through the injected `executeToolCall` seam, so the fixtures exercise the production parse rather than a hand-built summary object. No network and no credential is involved.

## Checks

| Check | Result |
|---|---|
| `npm test` | 1015 tests, 1015 pass, 0 fail — 1010 baseline + 5 new, none moved or removed |
| `npm run build` | Compiled successfully, route table printed |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | 4 problems, 0 errors, 4 warnings — existing baseline |
| `npm run check:compose-env` | PASS |

## Measured and deliberately not fixed here

`truncateToolResult` (`openrouter-streaming.ts:144-160`) carries the **same** bare-array assumption. Measured with a 2,000-row envelope fixture: 296,028 chars in, 50,042 out, cut mid-record, and the result **is not valid JSON** (`Bad control character in string literal at position 50000`). An oversized Socrata result is therefore fed back to the model malformed.

Left unfixed on purpose. It is a context-management change that lands on the same file the token-limit work will rewrite, and this wave serializes those changes deliberately. Filed separately rather than smuggled in here.
