### PR TITLE
fix: notebook author replays tool calls the server rejected (#325 P3)

### DIFF
--- a/src/lib/notebook-author/synthesize.test.ts
+++ b/src/lib/notebook-author/synthesize.test.ts
@@ -6,7 +6,9 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { synthesizeNotebook } from './synthesize.ts';
+import type { PhaseAToolCall } from './tool-to-cell.ts';
 import {
   NOTEBOOK_EXTENSION_KEY,
   PYTHON_RUNTIME_VERSION,
@@ -239,4 +241,97 @@ test('synthesizeNotebook: the reproducibility stamp names the declared model and
     /- \*\*Author model:\*\* vendor\/model-1, reached over a deployment-routed chat-completions API\./,
   );
   assert.equal(/azure/i.test(azureFooter), false);
+});
+
+// --- #321: a whole notebook containing a rejected call ----------------------
+//
+// The tool-to-cell tests pin one renderer at a time. This pins the assembled
+// document — the artifact a reader actually opens — for the anchor's "the
+// notebook still executes end to end", static half: every code cell compiles,
+// and the rejected call contributes none.
+
+/** The fixture, with a REJECTED query call inserted before the good one. */
+const FIXTURE_WITH_REJECTED_CALL = {
+  ...BROOKLYN_311_FIXTURE,
+  toolCalls: [
+    BROOKLYN_311_FIXTURE.toolCalls[0],
+    BROOKLYN_311_FIXTURE.toolCalls[1],
+    {
+      name: 'get_data',
+      operationType: 'query',
+      args: {
+        type: 'query',
+        portal: 'data.cityofnewyork.us',
+        dataset_id: 'w7w3-xahh',
+        select: 'complaint_type, count(*) as count',
+      },
+      reason: 'to aggregate the legacy 311 archive by complaint_type',
+      failed: true,
+      failureKind: 'unavailable',
+    },
+    BROOKLYN_311_FIXTURE.toolCalls[2],
+  ] as readonly PhaseAToolCall[],
+};
+
+test('#321: a rejected call adds no code cell to the assembled notebook, and every cell still compiles', () => {
+  const out = synthesizeNotebook({ ...FIXTURE_WITH_REJECTED_CALL });
+  const codeCells = out.notebook.cells.filter(c => c.cell_type === 'code');
+
+  // Same six code cells as the all-succeeding fixture: env, imports, helpers,
+  // ONE fetch, metric capture, synthesis. The rejected call added none.
+  assert.equal(
+    codeCells.length,
+    6,
+    `rejected call must add no code cell:\n${codeCells.map(c => c.source.join('')).join('\n---\n')}`,
+  );
+  // Its dataset id appears nowhere in any executable cell.
+  for (const cell of codeCells) {
+    assert.doesNotMatch(cell.source.join(''), /w7w3-xahh/);
+  }
+  // It IS disclosed, in markdown, saying what was attempted and why nothing
+  // came back — the reader is told, just not handed a cell that throws.
+  const markdown = out.notebook.cells.filter(c => c.cell_type === 'markdown').map(c => c.source.join('')).join('\n');
+  assert.match(markdown, /Not reproduced/);
+  assert.match(markdown, /w7w3-xahh/);
+  assert.match(markdown, /could not be reached/);
+
+  // Every code cell in the assembled notebook is valid Python.
+  for (const [i, cell] of codeCells.entries()) {
+    const source = cell.source.join('');
+    const result = spawnSync(
+      'python3',
+      ['-c', "import sys; compile(sys.stdin.read(), '<cell>', 'exec')"],
+      { input: source, encoding: 'utf-8' },
+    );
+    assert.equal(result.status, 0, `code cell ${i} is not valid Python:\n${source}\n${result.stderr}`);
+  }
+});
+
+test('#321: a rejected call does not consume a step number', () => {
+  // `dataFrameIndex` advances only on a call that produced a DataFrame. Before
+  // that gate the surviving fetch here would have been numbered "Step 2" with
+  // no Step 1 anywhere in the notebook, and its variable would have been df2.
+  const out = synthesizeNotebook({ ...FIXTURE_WITH_REJECTED_CALL });
+  assert.deepEqual(out.dataFrameVariables, ['df1']);
+
+  const allText = out.notebook.cells.map(c => c.source.join('')).join('\n');
+  assert.match(allText, /### Step 1: Query `erm2-nwe9`/);
+  assert.doesNotMatch(allText, /### Step 2:/);
+
+  // The surviving fetch is still guarded and still the good dataset.
+  const fetchCell = out.notebook.cells.filter(c => c.cell_type === 'code')[3].source.join('');
+  assert.match(fetchCell, /^try:/m);
+  assert.match(fetchCell, /df1 = fetch_socrata\(/);
+  assert.match(fetchCell, /dataset_id="erm2-nwe9"/);
+});
+
+test('#321: a rejected call is not listed among the discovery steps of a full notebook', () => {
+  const out = synthesizeNotebook({ ...FIXTURE_WITH_REJECTED_CALL });
+  const discovery = out.notebook.cells
+    .map(c => c.source.join(''))
+    .find(t => t.startsWith('### Discovery'));
+  assert.ok(discovery, 'the two genuine discovery calls still produce a summary');
+  // The two real discovery calls are listed; the rejected query call is not.
+  assert.equal(discovery!.split('\n').filter(l => l.startsWith('- `')).length, 2);
+  assert.doesNotMatch(discovery!, /w7w3-xahh/);
 });

--- a/src/lib/notebook-author/synthesize.ts
+++ b/src/lib/notebook-author/synthesize.ts
@@ -138,7 +138,12 @@ export function synthesizeNotebook(inputs: PhaseAOutputs): SynthesisOutputs {
     if (rendered.citation) {
       citationMap.set(rendered.citation.id, rendered.citation);
     }
-    dataFrameIndex += 1;
+    // Only a call that actually produced a DataFrame consumes a step number.
+    // Since #321 a rendered call is no longer necessarily a fetching one — a
+    // failed call renders a markdown note and no DataFrame — and advancing on
+    // it would number the following fetch "Step 2" with no Step 1 in the
+    // notebook, or leave a gap mid-sequence.
+    if (rendered.producedDataFrame) dataFrameIndex += 1;
   }
 
   // Metric capture — prints a single `_civic_capture=…` line that Phase D

--- a/src/lib/notebook-author/tool-to-cell.test.ts
+++ b/src/lib/notebook-author/tool-to-cell.test.ts
@@ -20,7 +20,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import type { NotebookCell } from './cells.ts';
-import { renderFetchToolCell, type PhaseAToolCall } from './tool-to-cell.ts';
+import {
+  renderDiscoverySummaryCell,
+  renderFetchToolCell,
+  TOOL_FAILURE_KINDS,
+  type PhaseAToolCall,
+} from './tool-to-cell.ts';
 
 const CTX = { dataFrameIndex: 1, defaultPortal: 'data.cityofnewyork.us' };
 
@@ -51,6 +56,74 @@ function assertParsesAsPython(cell: NotebookCell, label: string): void {
     `${label}: generated cell is not valid Python (exit ${result.status})\n` +
       `--- source ---\n${source}\n--- stderr ---\n${result.stderr}`,
   );
+}
+
+/**
+ * Python source that reports every `fetch_*(...)` call in a cell together with
+ * how many `try` BODIES enclose it, as JSON `[[name, depth], …]`.
+ *
+ * A structural AST walk, not a string match on `"try:"` (website#325 P3,
+ * #321). A cell containing the characters `try:` anywhere — in a comment, in a
+ * SQL string literal, in a `try` around some other statement — would satisfy a
+ * text search while leaving the fetch itself unguarded, so the check would
+ * pass on exactly the code it exists to reject. Enclosure is a fact about the
+ * tree; only the tree can be asked.
+ *
+ * `visit_Try` walks `node.body` at depth+1 and the handler/else/finally
+ * branches at the SAME depth: a fetch inside an `except` block is not
+ * protected by the `try` it belongs to, and counting it as protected would
+ * re-open the same hole one level down.
+ */
+const FETCH_DEPTH_PROBE = [
+  'import ast, json, sys',
+  'tree = ast.parse(sys.stdin.read())',
+  'found = []',
+  'class V(ast.NodeVisitor):',
+  '    def __init__(self):',
+  '        self.depth = 0',
+  '    def visit_Try(self, node):',
+  '        self.depth += 1',
+  '        for s in node.body: self.visit(s)',
+  '        self.depth -= 1',
+  '        for h in node.handlers: self.visit(h)',
+  '        for s in node.orelse: self.visit(s)',
+  '        for s in node.finalbody: self.visit(s)',
+  '    def visit_Call(self, node):',
+  '        f = node.func',
+  "        if isinstance(f, ast.Name) and f.id.startswith('fetch_'):",
+  '            found.append([f.id, self.depth])',
+  '        self.generic_visit(node)',
+  'V().visit(tree)',
+  'print(json.dumps(found))',
+].join('\n');
+
+/**
+ * Assert that every `fetch_*` call in a code cell sits inside a `try` body
+ * (#321, part 3).
+ *
+ * Civic data is live: a fetch that worked when the analysis ran can fail at
+ * re-execution time for reasons unrelated to this notebook. Unguarded, the
+ * first such failure raises and every later cell — the analysis, the synthesis,
+ * the comparison — never runs. Also asserts at least one fetch was FOUND, so a
+ * renderer that stopped emitting one can't pass this vacuously.
+ */
+function assertFetchIsGuarded(cell: NotebookCell, label: string): void {
+  assert.equal(cell.cell_type, 'code', `${label}: expected a code cell`);
+  const source = cell.source.join('');
+  const result = spawnSync('python3', ['-c', FETCH_DEPTH_PROBE], { input: source, encoding: 'utf-8' });
+  assert.equal(result.status, 0, `${label}: AST probe failed\n${result.stderr}`);
+  const found = JSON.parse(result.stdout) as [string, number][];
+  assert.ok(
+    found.length > 0,
+    `${label}: no fetch_* call found in the cell at all — the probe would pass vacuously:\n${source}`,
+  );
+  for (const [name, depth] of found) {
+    assert.ok(
+      depth >= 1,
+      `${label}: ${name}() is not inside a try body (depth ${depth}). One dead endpoint ` +
+        `would abort every later cell:\n--- source ---\n${source}`,
+    );
+  }
 }
 
 function codeCells(call: PhaseAToolCall): NotebookCell[] {
@@ -153,16 +226,24 @@ test('data commons: variable_dcid and place_dcid render exactly once even withou
 test('socrata: rendered cell output is unchanged (portal/dataset_id hand-written once, type never emitted)', () => {
   const [cell] = codeCells(SOCRATA_CALL);
   const source = cell.source.join('');
+  // Updated for the try/except guard (website#325 P3, #321): the fetch is
+  // indented one level into a try body and a print/empty-DataFrame fallback
+  // follows. The kwargs invariants this test was written for (#320) are
+  // unchanged and still asserted below.
   const expected = [
-    'df1 = fetch_socrata(',
-    '    portal="data.cityofnewyork.us",',
-    '    dataset_id="erm2-nwe9",',
-    '    select="complaint_type, count(*) as count",',
-    '    where="complaint_type IS NOT NULL",',
-    '    group="complaint_type",',
-    '    order="count DESC",',
-    '    limit=5,',
-    ')',
+    'try:',
+    '    df1 = fetch_socrata(',
+    '        portal="data.cityofnewyork.us",',
+    '        dataset_id="erm2-nwe9",',
+    '        select="complaint_type, count(*) as count",',
+    '        where="complaint_type IS NOT NULL",',
+    '        group="complaint_type",',
+    '        order="count DESC",',
+    '        limit=5,',
+    '    )',
+    'except Exception as _err:',
+    '    df1 = pd.DataFrame()',
+    '    print(f"Step 1: live data could not be fetched ({type(_err).__name__}); continuing with an empty table.")',
     'df1',
   ].join('\n');
   assert.equal(source, expected);
@@ -172,4 +253,238 @@ test('socrata: rendered cell output is unchanged (portal/dataset_id hand-written
   assert.doesNotMatch(source, /\btype=/);
   assert.equal(source.split('portal=').length - 1, 1);
   assert.equal(source.split('dataset_id=').length - 1, 1);
+});
+
+// --- #321: a call the data source did not answer ---------------------------
+//
+// Wave N6 P3. A tool call that failed during Phase A was still rendered as an
+// executable fetch cell, which then threw on execution — in a notebook whose
+// own cover text tells the reader it is reproducible. Each test below names
+// the change that makes it red.
+
+const FAILED_SOCRATA_CALL: PhaseAToolCall = {
+  name: 'get_data',
+  operationType: 'query',
+  args: {
+    type: 'query',
+    portal: 'data.cityofnewyork.us',
+    dataset_id: 'erm2-nwe9',
+    select: 'complaint_type, count(*) as count',
+  },
+  reason: 'to aggregate by complaint_type',
+  failed: true,
+  failureKind: 'timeout',
+  // No resultSummary: the call never produced one. See the zero-row test at
+  // the bottom for why that absence is NOT what marks it failed.
+};
+
+test('#321: a failed call renders as markdown and never as a code cell', () => {
+  // RED: keep the type change, revert the failed branch in renderFetchToolCell
+  // — a code cell reappears and this fails.
+  const out = renderFetchToolCell(FAILED_SOCRATA_CALL, CTX);
+  assert.ok(out, 'a failed call must not return null — see the discovery test below');
+
+  const code = out!.cells.filter(c => c.cell_type === 'code');
+  assert.equal(
+    code.length,
+    0,
+    `a failed call must contribute no executable cell; got ${code.length}:\n` +
+      code.map(c => c.source.join('')).join('\n---\n'),
+  );
+  assert.equal(out!.cells.length, 1);
+  assert.equal(out!.cells[0].cell_type, 'markdown');
+  assert.equal(out!.producedDataFrame, false);
+  assert.equal(out!.dataFrameVariable, null);
+  // Nothing was retrieved, so nothing may be cited as retrieved.
+  assert.equal(out!.citation, null);
+
+  const md = out!.cells[0].source.join('');
+  // Says WHAT was attempted…
+  assert.match(md, /get_data/);
+  assert.match(md, /erm2-nwe9/);
+  assert.match(md, /data\.cityofnewyork\.us/);
+  assert.match(md, /to aggregate by complaint_type/);
+  // …and WHY it produced nothing.
+  assert.match(md, /did not respond in time/);
+  assert.match(md, /returned no data/);
+});
+
+test('#321: the failure note carries no raw error text, status codes or host detail', () => {
+  // CLAUDE.md: reader-facing failure text never carries raw error strings. The
+  // copy is static per kind and takes no message parameter, so this holds by
+  // construction — asserted anyway, because a constructive guarantee is one
+  // refactor away from being a convention.
+  for (const kind of TOOL_FAILURE_KINDS) {
+    const out = renderFetchToolCell({ ...FAILED_SOCRATA_CALL, failureKind: kind }, CTX);
+    const md = out!.cells[0].source.join('');
+    assert.doesNotMatch(md, /\b(?:4\d{2}|5\d{2})\b/, `${kind}: no HTTP status codes`);
+    assert.doesNotMatch(md, /Error:|Traceback|ECONNREFUSED|ENOTFOUND|stack/i, `${kind}: no raw error text`);
+    // "MCP server" is implementation language (design-principles.md P9).
+    assert.doesNotMatch(md, /MCP/i, `${kind}: user language, not implementation language`);
+  }
+});
+
+test('#321: a failed call is never counted as a discovery step', () => {
+  // The trap. `renderDiscoverySummaryCell` selects discovery calls by
+  // `renderFetchToolCell(...) === null`, so a failed call that returned null
+  // would be swept in here and described to the reader as something the
+  // analysis "ran … before fetching data" — a worse claim than the bug being
+  // fixed, and one a test asserting only "no code cell" would not catch.
+  //
+  // RED: make the failed branch in renderFetchToolCell return null.
+  const realDiscoveryCall: PhaseAToolCall = {
+    name: 'get_data',
+    args: { type: 'catalog', query: 'noise complaints' },
+    operationType: 'catalog',
+  };
+  const cell = renderDiscoverySummaryCell([FAILED_SOCRATA_CALL, realDiscoveryCall]);
+  assert.ok(cell, 'the genuine catalog call must still produce a discovery summary');
+  const md = cell!.source.join('');
+
+  assert.match(md, /catalog/, 'the genuine discovery call is still listed');
+  // The failed call's distinctive `reason` is what a swept-in bullet would
+  // carry (`- \`get_data\` (query) — to aggregate by complaint_type`), so this
+  // is the assertion that names the defect directly.
+  assert.doesNotMatch(
+    md,
+    /to aggregate by complaint_type/,
+    `the failed call was swept into the discovery summary and described as a ` +
+      `completed discovery step:\n${md}`,
+  );
+  // And exactly one bullet — the genuine discovery call.
+  assert.equal(
+    md.split('\n').filter(l => l.startsWith('- `')).length,
+    1,
+    `expected only the genuine discovery call to be listed:\n${md}`,
+  );
+});
+
+test('#321: a failed DISCOVERY call is also excluded, not silently listed as completed', () => {
+  // A discovery call renders no code cell either way, so the executable-cell
+  // bug does not apply to it — but listing a call that never completed among
+  // the steps "the original analysis ran" is its own false claim.
+  const failedDiscovery: PhaseAToolCall = {
+    name: 'ckan__search_datasets',
+    args: { query: 'potholes' },
+    operationType: 'catalog',
+    failed: true,
+    failureKind: 'unavailable',
+  };
+  assert.equal(renderDiscoverySummaryCell([failedDiscovery]), null);
+
+  const out = renderFetchToolCell(failedDiscovery, CTX);
+  assert.ok(out, 'a failed discovery call gets a note of its own');
+  assert.equal(out!.cells.filter(c => c.cell_type === 'code').length, 0);
+  assert.match(out!.cells[0].source.join(''), /ckan__search_datasets/);
+  assert.match(out!.cells[0].source.join(''), /could not be reached/);
+});
+
+test('#321: every surviving fetch cell wraps its fetch_* call in a try body', () => {
+  // RED: drop the try/except from guardedFetch — every fixture reports depth 0.
+  for (const [label, call] of ALL_FIXTURES) {
+    for (const cell of codeCells(call)) {
+      assertFetchIsGuarded(cell, label);
+      // Still valid Python after the wrapping.
+      assertParsesAsPython(cell, label);
+    }
+  }
+});
+
+test('#321: the guard probe is structural — a cell that merely CONTAINS "try:" fails it', () => {
+  // A meta-test on the check itself. An acceptance check that cannot fail is
+  // worse than no check, because it reads as passing evidence. This cell would
+  // satisfy any `source.includes('try:')` search — the characters appear in a
+  // comment, in a SQL string literal, and in a real `try` around an unrelated
+  // statement — while `fetch_opencontext` sits outside every try body. The AST
+  // probe must reject it, and its rejection is what proves the probe is
+  // measuring enclosure rather than the presence of six characters.
+  const decoy = [
+    '# try: the fetch below is deliberately NOT wrapped',
+    '_sql = "SELECT \'try:\' FROM some_table"',
+    'df1 = fetch_opencontext(sql=_sql)',
+    'try:',
+    '    _unrelated = 1',
+    'except Exception:',
+    '    _unrelated = 0',
+    'df1',
+  ].join('\n');
+  assert.ok(decoy.includes('try:'), 'the decoy does contain the literal a text search looks for');
+
+  const cell: NotebookCell = {
+    cell_type: 'code',
+    id: 'decoy',
+    metadata: {},
+    source: decoy.split('\n').map((l, i, a) => (i < a.length - 1 ? l + '\n' : l)),
+  };
+  assert.throws(
+    () => assertFetchIsGuarded(cell, 'decoy'),
+    /is not inside a try body \(depth 0\)/,
+    'the probe must reject an unguarded fetch even when "try:" appears in the cell',
+  );
+});
+
+test('#321: the guard falls back to an empty DataFrame and says so out loud', () => {
+  // An empty table that reads as a real zero is the false precision
+  // design-principles.md Principle 3 forbids, so the failure is printed into
+  // the executed output rather than swallowed.
+  const [cell] = codeCells(SOCRATA_CALL);
+  const source = cell.source.join('');
+  assert.match(source, /except Exception as _err:/);
+  assert.match(source, /df1 = pd\.DataFrame\(\)/);
+  assert.match(source, /print\(f"Step 1: live data could not be fetched/);
+  // The exception TYPE, never str(_err) — this notebook's outputs are captured
+  // into a published record, so its printed text is a reader-facing surface.
+  assert.match(source, /\{type\(_err\)\.__name__\}/);
+  assert.doesNotMatch(source, /str\(_err\)/);
+  // The trailing bare `df1` stays outside the try so the cell renders its
+  // table on both paths.
+  assert.ok(source.endsWith('\ndf1'), `cell must end with the bare df1 display:\n${source}`);
+});
+
+test('#321: a zero-row SUCCESS is not a failure — only `failed` marks one', () => {
+  // Pins the distinction website#325 P2 made possible. Before P2, Socrata
+  // resultSummary was always absent, so "no summary" looked like a plausible
+  // failure signal. It never was: since P2 a zero-row success carries
+  // {rows: 0, columns: 0}, and a query can legitimately match nothing.
+  //
+  // RED: any implementation that infers failure from a missing or zero
+  // summary. Both calls below have no rows; only one of them failed.
+  const zeroRowSuccess: PhaseAToolCall = {
+    name: 'get_data',
+    args: {
+      type: 'query',
+      portal: 'data.cityofnewyork.us',
+      dataset_id: 'erm2-nwe9',
+      where: "complaint_type = 'Nonexistent'",
+    },
+    resultSummary: { rows: 0, columns: 0 },
+  };
+  const successOut = renderFetchToolCell(zeroRowSuccess, CTX);
+  const successCode = successOut!.cells.filter(c => c.cell_type === 'code');
+  assert.equal(successCode.length, 1, 'a zero-row success is still reproducible and still gets a cell');
+  assert.equal(successOut!.producedDataFrame, true);
+  assertParsesAsPython(successCode[0], 'zero-row success');
+  assertFetchIsGuarded(successCode[0], 'zero-row success');
+
+  // Same absence of rows, opposite outcome — and the only thing that differs
+  // is the explicit `failed` flag.
+  const failedNoSummary = renderFetchToolCell(FAILED_SOCRATA_CALL, CTX);
+  assert.equal(failedNoSummary!.cells.filter(c => c.cell_type === 'code').length, 0);
+
+  // And a call that failed but DID carry a summary is still a failure: having
+  // a summary is not evidence a call did not fail.
+  const failedWithSummary = renderFetchToolCell(
+    { ...FAILED_SOCRATA_CALL, resultSummary: { rows: 0, columns: 0 } },
+    CTX,
+  );
+  assert.equal(failedWithSummary!.cells.filter(c => c.cell_type === 'code').length, 0);
+});
+
+test('#321: a failed call with no failureKind still renders, reading as `unknown`', () => {
+  // Defensive: `failed` without a kind must not throw or emit "undefined".
+  const out = renderFetchToolCell({ ...FAILED_SOCRATA_CALL, failureKind: undefined }, CTX);
+  const md = out!.cells[0].source.join('');
+  assert.equal(out!.cells.filter(c => c.cell_type === 'code').length, 0);
+  assert.match(md, /could not be completed/);
+  assert.doesNotMatch(md, /undefined/);
 });

--- a/src/lib/notebook-author/tool-to-cell.ts
+++ b/src/lib/notebook-author/tool-to-cell.ts
@@ -12,6 +12,32 @@
 import type { NotebookCell } from './cells.ts';
 import { codeCell, markdownCell } from './cells.ts';
 
+/**
+ * Why a tool call returned no data, as a closed set (#321).
+ *
+ * Deliberately narrower than `StreamErrorKind` (src/lib/streaming.ts), which
+ * classifies whole-query failures across ten kinds — six of them (this app's
+ * own rate limit, the model credential kinds, notebook execution) cannot
+ * describe a single tool call and would be nonsense in this position. These
+ * four are the ones a caller can actually derive from a failed tool call AND
+ * that change what a notebook reader should conclude:
+ *
+ *   - `timeout`         — the source was reached but did not answer in time.
+ *   - `unavailable`     — the source could not be reached at all.
+ *   - `not_configured`  — this instance has no live source for that request.
+ *   - `unknown`         — it failed and we cannot honestly say more.
+ *
+ * `unknown` is a real member, not a placeholder: claiming a specific cause we
+ * did not measure is exactly the false precision docs/design-principles.md
+ * Principle 3 forbids. Note in particular that "the source refused this
+ * request" (a 4xx on malformed SoQL) is NOT separable today — the classifier
+ * has no branch for it — so such a call lands in `unknown` rather than being
+ * asserted as a refusal.
+ */
+export const TOOL_FAILURE_KINDS = ['timeout', 'unavailable', 'not_configured', 'unknown'] as const;
+
+export type ToolFailureKind = (typeof TOOL_FAILURE_KINDS)[number];
+
 export interface PhaseAToolCall {
   name: string;
   args: Record<string, unknown>;
@@ -19,6 +45,19 @@ export interface PhaseAToolCall {
   duration_ms?: number;
   operationType?: string;
   reason?: string;
+  /**
+   * True when the tool call threw during Phase A — set at the catch site in
+   * `openrouter-streaming.ts`, where the rejection is already known (#321).
+   *
+   * This is a distinct signal from `resultSummary`, and must stay distinct:
+   * since website#325 P2 a zero-row SUCCESS carries `{rows: 0, columns: 0}`,
+   * so "no rows" and "no summary" are both legitimate outcomes of a call that
+   * worked. Having a summary is not evidence a call did not fail, and lacking
+   * one is not evidence that it did.
+   */
+  failed?: boolean;
+  /** Why it failed, when `failed` is true. Absent is read as `unknown`. */
+  failureKind?: ToolFailureKind;
 }
 
 /** Python-literal rendering for the JSON-safe values we get from MCP tool args. */
@@ -103,6 +142,54 @@ function socrataDatasetUrl(portal: string, datasetId: string): string {
   return `https://${portal}/d/${datasetId}`;
 }
 
+/** Indent every non-empty line of a code block by one Python level. */
+function indentBlock(code: string): string {
+  return code
+    .split('\n')
+    .map(line => (line.length > 0 ? `    ${line}` : line))
+    .join('\n');
+}
+
+/**
+ * Wrap a fetch statement in `try`/`except` so one upstream failure at
+ * re-execution time does not abort the rest of the notebook (#321).
+ *
+ * This matters independently of the rejected-call bug: civic data is live.
+ * A fetch that succeeded when the analysis ran can fail months later for
+ * reasons that have nothing to do with this notebook — a dataset reassigned
+ * a new id, a portal rate-limiting an anonymous caller, an outage. Unguarded,
+ * the first such failure raises and every later cell — including the analysis
+ * and the synthesis — never runs, so a reader loses the whole document to one
+ * dead endpoint.
+ *
+ * Three deliberate choices:
+ *
+ *   - The fallback is an EMPTY DataFrame, not an unset name, so later cells
+ *     get a well-typed empty table instead of `NameError`.
+ *   - The failure is PRINTED, so it is visible in the executed output rather
+ *     than silently becoming a zero. An empty table that looks like a real
+ *     zero is the false-precision failure of design-principles.md Principle 3.
+ *   - Only the exception's TYPE is printed, never `str(_err)`. This notebook's
+ *     outputs are captured into a published record, so its printed text is a
+ *     reader-facing surface and gets the same treatment CLAUDE.md requires of
+ *     streaming errors: no raw message text, no status codes, no host names.
+ *     The type name is enough to tell a timeout from an HTTP error.
+ *
+ * `except Exception` (not `BaseException`) so KeyboardInterrupt still
+ * interrupts. The bare `dfVar` trailing expression stays OUTSIDE the try, so
+ * the cell renders its table on both paths.
+ */
+function guardedFetch(dfVar: string, stepLabel: string, fetchCode: string): string {
+  return [
+    'try:',
+    indentBlock(fetchCode),
+    'except Exception as _err:',
+    `    ${dfVar} = pd.DataFrame()`,
+    `    print(f"${stepLabel}: live data could not be fetched ({type(_err).__name__}); continuing with an empty table.")`,
+    dfVar,
+  ].join('\n');
+}
+
 function renderSocrataQueryCell(
   call: PhaseAToolCall,
   ctx: ToolCellContext,
@@ -119,14 +206,13 @@ function renderSocrataQueryCell(
       ? `Original execution returned ${call.resultSummary.rows} rows × ${call.resultSummary.columns} columns.`
       : '',
   ].filter(Boolean).join('\n');
-  const code = [
+  const code = guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, [
     `${dfVar} = fetch_socrata(`,
     `    portal=${JSON.stringify(portal)},`,
     `    dataset_id=${JSON.stringify(datasetId)},`,
     pyKwargs(call.args, SOCRATA_QUERY_KWARGS, ['portal', 'dataset_id', 'type']),
     ')',
-    dfVar,
-  ].filter(Boolean).join('\n');
+  ].filter(Boolean).join('\n'));
   return {
     cells: [markdownCell(md), codeCell(code)],
     producedDataFrame: true,
@@ -150,14 +236,13 @@ function renderDataCommonsObsCell(
       ? `Original execution returned ${call.resultSummary.rows} observation rows.`
       : '',
   ].filter(Boolean).join('\n');
-  const code = [
+  const code = guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, [
     `${dfVar} = fetch_data_commons(`,
     `    variable_dcid=${JSON.stringify(variable)},`,
     `    place_dcid=${JSON.stringify(place)},`,
     pyKwargs(call.args, DC_OBS_KWARGS, ['variable_dcid', 'place_dcid']),
     ')',
-    dfVar,
-  ].filter(Boolean).join('\n');
+  ].filter(Boolean).join('\n'));
   return {
     cells: [markdownCell(md), codeCell(code)],
     producedDataFrame: true,
@@ -177,10 +262,12 @@ function renderOpenContextSqlCell(
     '',
     'We run the analyst-authored SELECT below against the Boston OpenContext DataStore.',
   ].join('\n');
+  // `_sql = …` stays outside the guard: a string literal cannot fail, and
+  // keeping it out means the statement is still readable in the notebook when
+  // the fetch below did not succeed.
   const code = [
     `_sql = ${JSON.stringify(sql)}`,
-    `${dfVar} = fetch_opencontext(sql=_sql)`,
-    dfVar,
+    guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, `${dfVar} = fetch_opencontext(sql=_sql)`),
   ].join('\n');
   return {
     cells: [markdownCell(md), codeCell(code)],
@@ -215,12 +302,99 @@ function renderOpenContextQueryCell(
   }
   codeLines.push(`    limit=${limit},`);
   codeLines.push(')');
-  codeLines.push(dfVar);
+  const code = guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, codeLines.join('\n'));
   return {
-    cells: [markdownCell(md), codeCell(codeLines.join('\n'))],
+    cells: [markdownCell(md), codeCell(code)],
     producedDataFrame: true,
     dataFrameVariable: dfVar,
     citation: { id: resourceId, label: `data.boston.gov: ${resourceId}`, url: `https://data.boston.gov/dataset/${resourceId}` },
+  };
+}
+
+/**
+ * Reader-facing copy for each failure kind. Static per kind and parameterless
+ * by construction, so no raw error text, status code or host name can reach a
+ * reader through this path — the same discipline `friendlyStreamError()` and
+ * `notebookExecutionErrorMessage()` enforce in src/lib/streaming.ts, applied
+ * to the notebook surface. "Data source", not "MCP server"
+ * (design-principles.md Principle 9).
+ */
+const FAILURE_REASON: Record<ToolFailureKind, string> = {
+  timeout: 'The data source did not respond in time, so the request returned no data.',
+  unavailable: 'The data source could not be reached, so the request returned no data.',
+  not_configured: 'No live data source was configured for this request, so it returned no data.',
+  unknown: 'The request could not be completed, so it returned no data.',
+};
+
+/**
+ * Plain-language description of what the call was trying to fetch, built from
+ * the same args the matching renderer would have used. Falls back to the tool
+ * name for a call with no dedicated renderer (a discovery call that failed),
+ * which is still more than the reader had before.
+ */
+function describeAttempt(call: PhaseAToolCall, ctx: ToolCellContext): string {
+  if (call.name === 'get_data') {
+    const portal = (call.args.portal as string) || ctx.defaultPortal;
+    const datasetId = (call.args.dataset_id as string) || 'unknown';
+    return `query the \`${datasetId}\` dataset on \`${portal}\``;
+  }
+  if (call.name === 'get_observations') {
+    const variable = (call.args.variable_dcid as string) || 'unknown';
+    const place = (call.args.place_dcid as string) || 'unknown';
+    return `fetch \`${variable}\` for \`${place}\` from Google Data Commons`;
+  }
+  if (call.name === 'ckan__execute_sql') {
+    return 'run the analyst-authored SQL statement against the Boston open-data store';
+  }
+  if (call.name === 'ckan__query_data') {
+    const resourceId = (call.args.resource_id as string) || 'unknown';
+    return `fetch records from Boston open-data resource \`${resourceId}\``;
+  }
+  return `run the \`${call.name}\` request`;
+}
+
+/**
+ * Render a tool call that returned no data as MARKDOWN, never as a code cell
+ * (#321).
+ *
+ * The bug this closes: a call the data source rejected during discovery was
+ * still rendered as an executable fetch cell, which then threw on execution —
+ * inside a notebook whose own cover text tells the reader it is reproducible.
+ * An honest note about what was attempted teaches the reader more than a cell
+ * that throws, and it does not put a broken step in a document that claims to
+ * run.
+ *
+ * Returning a non-null `ToolCellOutput` here is load-bearing beyond producing
+ * the note. `renderDiscoverySummaryCell` below selects discovery calls by
+ * `renderFetchToolCell(...) === null`, so a failed call that returned `null`
+ * would be swept into the discovery summary and reported to the reader as a
+ * completed discovery step — a worse claim than the bug being fixed, and one
+ * that would still pass a test asserting only "no code cell was emitted."
+ * That exclusion is pinned by a test in tool-to-cell.test.ts.
+ */
+function renderFailedToolCell(
+  call: PhaseAToolCall,
+  ctx: ToolCellContext,
+): ToolCellOutput {
+  const reason = call.reason ? ` ${call.reason}` : '';
+  const md = [
+    `#### Not reproduced: \`${call.name}\``,
+    '',
+    `The original analysis tried to ${describeAttempt(call, ctx)}${reason}. ` +
+      `${FAILURE_REASON[call.failureKind ?? 'unknown']}`,
+    '',
+    'No code cell is generated for it — a request that returned no data cannot be ' +
+      'reproduced. The steps below rest only on the requests that did return data.',
+  ].join('\n');
+  return {
+    // Markdown only. No executable cell, by construction rather than by a
+    // caller remembering to skip one.
+    cells: [markdownCell(md)],
+    producedDataFrame: false,
+    dataFrameVariable: null,
+    // No citation: nothing was retrieved from this source on this call, and
+    // listing it in the footer would credit a fetch that never happened.
+    citation: null,
   };
 }
 
@@ -229,11 +403,18 @@ function renderOpenContextQueryCell(
  * discovery-only calls that do not produce a DataFrame (catalog search,
  * metadata, schema lookups); those are summarized once in a single
  * discovery markdown cell instead of one cell per call.
+ *
+ * A call that FAILED never returns `null` and never returns a code cell — see
+ * `renderFailedToolCell`.
  */
 export function renderFetchToolCell(
   call: PhaseAToolCall,
   ctx: ToolCellContext,
 ): ToolCellOutput | null {
+  // Checked before the name dispatch, so this covers a failed discovery call
+  // too: a discovery step that did not complete is not a discovery step that
+  // did, and the summary below must not list it as one.
+  if (call.failed) return renderFailedToolCell(call, ctx);
   // Socrata: get_data with type=query is the only fetching variant.
   if (call.name === 'get_data') {
     const type = call.args.type as string | undefined;
@@ -255,6 +436,15 @@ export function renderFetchToolCell(
 /**
  * Summarize the discovery-only tool calls in a single markdown cell.
  * Returns null when there were no discovery calls to summarize.
+ *
+ * The filter reads "produced no cells of its own", and `null` is the ONLY
+ * value that means that. A failed call is deliberately not excluded by a
+ * second `!c.failed` guard here: `renderFetchToolCell` already answers
+ * non-null for one, and one mechanism that a test pins beats two that can
+ * drift apart. If a future change makes the failed branch return `null`
+ * again, every failed call silently reappears in this list — described as
+ * something the analysis "ran … before fetching data" — which is why that
+ * exact regression is what the test in tool-to-cell.test.ts drives.
  */
 export function renderDiscoverySummaryCell(
   calls: readonly PhaseAToolCall[],

--- a/src/lib/openrouter-streaming.test.ts
+++ b/src/lib/openrouter-streaming.test.ts
@@ -512,3 +512,113 @@ test('queryWithMcpStreaming: buildStatsSummary and buildProvenanceLine sum data.
     await new Promise((resolve) => server.close(resolve));
   }
 });
+
+// --- Case 5: a tool call the data source did not answer (#321, website#325 P3) ---
+//
+// The recorded tool-call entry must carry `failed` + `failureKind`, set at the
+// catch site where the rejection is already known. Nothing downstream can
+// recover the fact: `toolEntry` is pushed into `toolsCalled` BEFORE the await,
+// so without this the notebook synthesizer saw a call indistinguishable from a
+// successful one and rendered it as an executable fetch cell that then threw.
+//
+// Same harness as Case 3 — `executeToolCall` is an injected parameter, so
+// these drive the real loop in `queryWithMcpStreaming` with no MCP server and
+// no credential. The injected function THROWS instead of returning a payload,
+// which is the one difference.
+
+/**
+ * One full tool-call round trip whose tool execution throws `error`. The loop
+ * is expected to survive it: the catch feeds the model neutral guidance and
+ * the run completes with a final answer, so `onError` must never fire.
+ */
+async function runFailingToolCallRoundTrip(
+  toolArgs: Record<string, unknown>,
+  error: unknown,
+): Promise<CompletionResult> {
+  const { server, url } = await startToolCallModelServer('get_data', toolArgs);
+  try {
+    process.env.OPENROUTER_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    let result: CompletionResult | undefined;
+    await queryWithMcpStreaming(
+      'test question',
+      FAKE_MODEL,
+      [],
+      async () => {
+        throw error;
+      },
+      undefined,
+      {
+        onProgress: () => {},
+        onToken: () => {},
+        onComplete: (_panel, completion) => {
+          result = completion;
+        },
+        onError: (_panel, message) => {
+          assert.fail(`a failed tool call must not fail the whole query: ${message}`);
+        },
+      },
+    );
+
+    assert.ok(result, 'onComplete must fire — one dead tool call is not a dead query');
+    return result!;
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test('#321: a tool call that throws is recorded with failed + failureKind', async () => {
+  // RED: revert the two lines in the catch block of openrouter-streaming.ts —
+  // `failed` is undefined and this fails.
+  const result = await runFailingToolCallRoundTrip(
+    { type: 'query', dataset_id: 'erm2-nwe9', portal: 'data.cityofnewyork.us' },
+    new Error('Request to the data source timed out after 60000ms'),
+  );
+
+  assert.equal(result.tools_called?.length, 1, 'the call is still recorded — it was attempted');
+  const call = result.tools_called![0];
+  assert.equal(call.failed, true);
+  assert.equal(call.failureKind, 'timeout');
+  // The distinction #321 turns on: no summary, but that is NOT what says it
+  // failed. A zero-row success has no rows either (see the Case 3 test above).
+  assert.equal(call.resultSummary, undefined);
+  // The arguments survive, so the notebook's failure note can say what was
+  // attempted rather than just that something was.
+  assert.equal(call.args.dataset_id, 'erm2-nwe9');
+});
+
+test('#321: failureKind narrows honestly — an unreachable source is `unavailable`', async () => {
+  const result = await runFailingToolCallRoundTrip(
+    { type: 'query', dataset_id: 'erm2-nwe9' },
+    new Error('fetch failed'),
+  );
+  assert.equal(result.tools_called?.[0].failed, true);
+  assert.equal(result.tools_called?.[0].failureKind, 'unavailable');
+});
+
+test('#321: an unclassifiable failure is `unknown`, never a guessed cause', async () => {
+  // design-principles.md Principle 3: an error we cannot classify must not be
+  // asserted as a timeout or a refusal. `unknown` is a real member of the
+  // vocabulary, not a placeholder.
+  const result = await runFailingToolCallRoundTrip(
+    { type: 'query', dataset_id: 'erm2-nwe9' },
+    new Error('something we have no branch for'),
+  );
+  assert.equal(result.tools_called?.[0].failed, true);
+  assert.equal(result.tools_called?.[0].failureKind, 'unknown');
+});
+
+test('#321: a SUCCESSFUL tool call is not marked failed', async () => {
+  // The control. Without it, an implementation that sets `failed` on every
+  // call would pass every test above — and would suppress the code cell for
+  // every fetch in the notebook.
+  const { result } = await runToolCallRoundTrip(
+    { type: 'query', dataset_id: 'erm2-nwe9' },
+    JSON.stringify({ data: [{ unique_key: '1', complaint_type: 'Noise' }], total_rows: 1 }),
+  );
+  assert.equal(result.tools_called?.[0].failed, undefined);
+  assert.equal(result.tools_called?.[0].failureKind, undefined);
+  assert.deepEqual(result.tools_called?.[0].resultSummary, { rows: 1, columns: 2 });
+});

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -5,6 +5,7 @@ import { formatToolProgress, formatToolResult, generateToolReason, describeToolF
 import type { TraceBuilder } from './evidence/trace.ts';
 import { hash as traceHash } from './evidence/trace.ts';
 import { deriveOperationType } from './mcp/operation-types.ts';
+import type { ToolFailureKind } from './notebook-author/tool-to-cell.ts';
 
 export interface TraceContext {
   builder: TraceBuilder;
@@ -100,7 +101,40 @@ export interface CompletionResult {
     duration_ms?: number;
     operationType?: string;
     reason?: string;
+    /** Set when the tool call threw; see the catch block below (#321). */
+    failed?: boolean;
+    failureKind?: ToolFailureKind;
   }[];
+}
+
+/**
+ * Map a thrown tool-call error onto the notebook's failure vocabulary (#321).
+ *
+ * `classifyStreamError` is already this file's classifier for the same error
+ * shapes (`reportStreamFailure` uses it), so failure is classified ONCE, in
+ * one place, rather than re-derived downstream from prose. The mapping is
+ * narrowing and deliberately lossy: `ToolFailureKind` describes what a
+ * notebook reader needs to know about ONE request, so the six kinds that
+ * describe a whole query rather than a single tool call — this app's own rate
+ * limit, the two model-credential kinds, notebook execution — collapse into
+ * `unknown` rather than being asserted as something more specific than was
+ * measured (design-principles.md Principle 3).
+ *
+ * `connection` joins `mcp_unavailable`: to a reader deciding whether to re-run
+ * the notebook, "the source could not be reached" is the same fact either way.
+ */
+function toolFailureKindOf(error: unknown): ToolFailureKind {
+  switch (classifyStreamError(error)) {
+    case 'mcp_timeout':
+      return 'timeout';
+    case 'mcp_unavailable':
+    case 'connection':
+      return 'unavailable';
+    case 'mcp_not_configured':
+      return 'not_configured';
+    default:
+      return 'unknown';
+  }
 }
 
 // Token safety limits (configurable via env vars)
@@ -227,7 +261,7 @@ export async function queryWithMcpStreaming(
 ): Promise<void> {
   const startTime = Date.now();
   const panel: PanelType = 'withMcp';
-  const toolsCalled: { name: string; args: Record<string, unknown>; resultSummary?: { rows: number; columns: number }; duration_ms?: number; operationType?: string; reason?: string }[] = [];
+  const toolsCalled: { name: string; args: Record<string, unknown>; resultSummary?: { rows: number; columns: number }; duration_ms?: number; operationType?: string; reason?: string; failed?: boolean; failureKind?: ToolFailureKind }[] = [];
 
   try {
     callbacks.onProgress(panel, 'Reading your question...', { phase: 'analyze' });
@@ -386,6 +420,16 @@ export async function queryWithMcpStreaming(
               content: truncatedResult,
             });
           } catch (error) {
+            // #321: record the rejection ON the tool-call entry, here, where
+            // it is already known. `toolEntry` was pushed into `toolsCalled`
+            // before the await, so this mutation reaches every consumer of
+            // `CompletionResult.tools_called` — including the notebook
+            // synthesizer, which was rendering this call as an executable
+            // fetch cell that then threw on execution. Nothing downstream can
+            // recover this fact: a failed call is not distinguishable from a
+            // successful zero-row one by its `resultSummary`.
+            toolEntry.failed = true;
+            toolEntry.failureKind = toolFailureKindOf(error);
             if (toolTraceSpanId) {
               trace!.builder.endSpan(toolTraceSpanId, {
                 'error': true,


### PR DESCRIPTION
Closes #321. Wave N6 phase P3.

## The defect

A tool call the MCP server rejected during discovery was still rendered as a data-fetch cell in the generated notebook. The cell then failed on execution, in a notebook the reader is told is reproducible.

`PhaseAToolCall` carried no error field, so by the time the notebook was authored there was no record that the call had failed.

## The fix

Three parts, together:

1. **`failed` + `failureKind` on the tool-call record**, set in the catch block where the rejection is already known.
2. **A rejected call renders as markdown** — an honest note naming what was attempted and why it was refused — never as an executable cell.
3. **Every surviving fetch cell is `try`/`except`-wrapped**, falling back to an empty DataFrame and saying so out loud. This matters independently: civic data is live, so a fetch that worked at authoring time can fail at re-execution time for unrelated reasons.

## Three things measurement changed

**The field had to be added in three places, not one.** `tools_called` is not typed as `PhaseAToolCall` — `openrouter-streaming.ts:230` declares an inline structural literal and `CompletionResult.tools_called` (`:96`) a second copy, bridged by a cast. The vocabulary is declared once in `tool-to-cell.ts` and reaches the streaming file as `import type`, verified erased across all built server chunks so it adds no runtime module edge.

**`route.ts` needs no change**, measured rather than assumed: `synthesizeNotebook` receives the same objects `tools_called` holds, so the fields reach the notebook without passing through the SSE layer.

**`synthesize.ts` did need one.** `dataFrameIndex += 1` ran for every non-null render, so a failed call consumed a step number and the surviving fetch became "Step 2" with no Step 1.

## The trap, handled structurally

`renderDiscoverySummaryCell` selects discovery calls by `renderFetchToolCell(...) === null`. Had a failed call returned `null`, it would have been silently swept into the discovery summary and reported to the reader as a discovery step rather than a refusal — worse than the original bug, and invisible to any test that only checks "no code cell was emitted."

A failed call returns a non-null `ToolCellOutput`, so the filter excludes it by construction. No belt-and-braces `!c.failed` guard was added on purpose: it would make the regression test for this unable to fail, and the test is the guard.

## Every criterion was shown red before it was accepted

| Mutation | Result |
|---|---|
| Remove the two catch-block lines | 3 fail — `failed` undefined; control test passed, so the assertions are not trivially coupled |
| Revert the renderer branch, keep the type | 6 fail — output prints the offending executable cell, reproducing #321 verbatim |
| Failed branch returns `null` | 6 fail — output shows the rejected call listed under "the original analysis ran the following discovery calls" |
| Remove the `try`/`except` | 4 fail — `fetch_socrata() is not inside a try body (depth 0)` |
| Infer failure from `resultSummary` | 2 fail — a legitimate zero-row success loses its code cell |

**The guard probe is itself tested.** It walks the Python AST with a `visit_Try` visitor rather than searching for the string `"try:"`, and a meta-test feeds it a decoy containing `try:` in a comment, inside a SQL literal, and in a real `try` around an unrelated statement, with the fetch left unguarded. A text search passes that decoy; the probe must reject it. That is what makes the criterion non-vacuous.

## `failureKind` vocabulary, and an honest limit

`timeout` · `unavailable` · `not_configured` · `unknown`, narrowed from `StreamErrorKind` by a local mapper. Not `StreamErrorKind` itself: six of its ten kinds describe a whole query rather than one tool call, and its copy is written for a different surface.

**`unknown` is a real member, not a placeholder — and it currently absorbs the case this issue's title names.** A 4xx refusal (malformed SoQL, say) is not separable today because `classifyStreamError` has no 4xx branch. Rather than assert a refusal that was not measured, such calls land in `unknown`. `failed: true` is still set, and the reader still gets an honest note; only the classification is coarse. Adding that branch means touching `streaming.ts`, outside this blast zone. Flagged, not fixed.

## Checks

| Check | Result |
|---|---|
| `npm test` | 1035 tests, 1035 pass, 0 fail — 1019 baseline + 16 new, none moved |
| `npm run build` | Compiled successfully, route table printed |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | 4 problems, 0 errors, 4 warnings — existing baseline |
| `npm run check:compose-env` | PASS |

The reader-facing failure note is asserted to carry **no raw error text, status codes, or host detail**, per the repo rule that reader-facing errors never render a raw `err.message`.

## What was proved, and what was not

**The static half of "executes end to end":** every generated code cell — across all four renderers *and* in a fully assembled notebook containing a rejected call — compiles under a real `python3` `compile()` subprocess, and a rejected call contributes zero executable cells.

**Not proved here:** actual execution against a live portal. That is a later owner-run measurement; it confirms these fixtures rather than first-measuring them.

## Flagged, not fixed

- 4xx refusals are not separable from `unknown` — needs a classifier branch in `streaming.ts`.
- Failure does not reach the client: the SSE `phase_a_tool_call` event does not carry `failed`/`failureKind`, so the live progress panel still shows a rejected call like any other. Notebook-correct, display-incomplete.
- `duration_ms` is unset on failure — set only after the await returns. A failed call's elapsed time is measurable and currently discarded. Left alone to keep the catch-block diff tight for the phase that follows on this file.
- `uniquePortals` and `helpersForToolNames` still count failed calls, so a notebook can name a portal it never successfully queried. Judgment call rather than a clear defect — the analysis did attempt that portal, and the failure note names it.
- #331 untouched, per non-goals.
