### PR TITLE
fix: a mid-plan assistant turn is published as the final answer (#325 P4)

### DIFF
--- a/src/lib/openrouter-streaming.test.ts
+++ b/src/lib/openrouter-streaming.test.ts
@@ -11,7 +11,7 @@ import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { queryWithoutMcpStreaming, queryWithMcpStreaming, type StreamCallbacks, type CompletionResult } from './openrouter-streaming.ts';
+import { queryWithoutMcpStreaming, queryWithMcpStreaming, announcesUnrunWork, type StreamCallbacks, type CompletionResult } from './openrouter-streaming.ts';
 import { carriedModelIdentity } from './model-catalog.ts';
 import { _resetDefaultModelClientForTests } from './model-client.ts';
 import { streamErrorPayload, buildStatsSummary, buildProvenanceLine, type StreamErrorCode, type PanelType, type ProgressPhase } from './streaming.ts';
@@ -621,4 +621,334 @@ test('#321: a SUCCESSFUL tool call is not marked failed', async () => {
   assert.equal(result.tools_called?.[0].failed, undefined);
   assert.equal(result.tools_called?.[0].failureKind, undefined);
   assert.deepEqual(result.tools_called?.[0].resultSummary, { rows: 1, columns: 2 });
+});
+
+// --- #319: a final answering turn, and what counts as an answer ------------
+//
+// The defect, measured on a live portal: eight tool calls completed, then a
+// 235-character "answer" ending "...I'll query the fraction of records that
+// close within 14 and 30 days per type". It validated. It was publishable. The
+// loop had treated the first message carrying no `tool_calls` as the final
+// answer, so a statement of intent to run a query that was never run was
+// published under the same signature and the same visual treatment as a real
+// finding.
+//
+// These cases drive the REAL loop against a scripted model server, so the
+// number of requests that server receives is itself an assertion: it is how
+// "no extra model call on a good answer" and "at most one extra answering
+// turn" are pinned, neither of which is visible from the completion alone.
+
+interface ScriptedReply {
+  content?: string | null;
+  toolCalls?: { id: string; name: string; args: Record<string, unknown> }[];
+  totalTokens?: number;
+}
+
+/**
+ * A model server that answers from a script. Reply N serves request N; the
+ * LAST reply repeats for every request beyond the script, which is what makes
+ * an unbounded re-ask observable — a loop would keep drawing the same
+ * unsatisfying answer and the request count would climb past the bound.
+ *
+ * Unlike `startToolCallModelServer` above it reads the request body, so it can
+ * answer `stream: true` with real SSE (the answering turn streams) and record
+ * what was actually sent (tools omitted, contract restated, transcript intact).
+ */
+function startScriptedModelServer(replies: ScriptedReply[]): Promise<{
+  server: Server;
+  url: string;
+  requests: Record<string, unknown>[];
+}> {
+  const requests: Record<string, unknown>[] = [];
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+        requests.push(body);
+        const reply = replies[Math.min(requests.length - 1, replies.length - 1)];
+        const usage = {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: reply.totalTokens ?? 15,
+        };
+
+        if (body.stream === true) {
+          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+          const frame = (payload: Record<string, unknown>) =>
+            `data: ${JSON.stringify({
+              id: 'chatcmpl-test-scripted',
+              object: 'chat.completion.chunk',
+              created: 1,
+              model: 'fake/model',
+              ...payload,
+            })}\n\n`;
+          res.write(frame({
+            choices: [{ index: 0, delta: { content: reply.content ?? '' }, finish_reason: null }],
+          }));
+          res.write(frame({ choices: [], usage }));
+          res.write('data: [DONE]\n\n');
+          res.end();
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test-scripted',
+          object: 'chat.completion',
+          created: 1,
+          model: 'fake/model',
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: reply.content ?? null,
+              ...(reply.toolCalls
+                ? {
+                    tool_calls: reply.toolCalls.map((tc) => ({
+                      id: tc.id,
+                      type: 'function',
+                      function: { name: tc.name, arguments: JSON.stringify(tc.args) },
+                    })),
+                  }
+                : {}),
+            },
+            finish_reason: reply.toolCalls ? 'tool_calls' : 'stop',
+          }],
+          usage,
+        }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/v1`, requests });
+    });
+  });
+}
+
+async function runScripted(replies: ScriptedReply[]): Promise<{
+  result: CompletionResult;
+  requests: Record<string, unknown>[];
+}> {
+  const { server, url, requests } = await startScriptedModelServer(replies);
+  try {
+    process.env.OPENROUTER_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    let result: CompletionResult | undefined;
+    await queryWithMcpStreaming(
+      'How long do these requests take to close?',
+      FAKE_MODEL,
+      [],
+      async () => JSON.stringify({ data: [{ request_type: 'A', days_to_close: 9 }], total_rows: 1 }),
+      undefined,
+      {
+        onProgress: () => {},
+        onToken: () => {},
+        onComplete: (_panel, completion) => {
+          result = completion;
+        },
+        onError: (_panel, message) => {
+          assert.fail(`unexpected onError: ${message}`);
+        },
+      },
+    );
+    assert.ok(result, 'onComplete must fire');
+    return { result: result!, requests };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+const FETCH_CALL: ScriptedReply = {
+  toolCalls: [{ id: 'call_1', name: 'get_data', args: { type: 'query', dataset_id: 'abcd-1234' } }],
+};
+
+/**
+ * The measured shape of #319, in neutral fixture wording: work reported, then
+ * a query announced rather than run.
+ */
+const NARRATION =
+  "I now have the counts by request type for both years. Next, I'll query the fraction of " +
+  'records that close within 14 and 30 days per type.';
+
+const REAL_ANSWER =
+  'Across both years the portal recorded 4,812 requests of this type. The median time to close ' +
+  'was 9 days, and 71% closed within 14 days (dataset abcd-1234).';
+
+// --- Criterion 1: a mid-plan narration does not become the answer ----------
+
+test('#319: a tool_calls-free message that ANNOUNCES the next query is not published as the answer', async () => {
+  const { result, requests } = await runScripted([FETCH_CALL, { content: NARRATION }, { content: REAL_ANSWER }]);
+
+  // The whole point. Before the fix this assertion fails: `result.content` IS
+  // the narration, because the loop ended on the first message with no
+  // `tool_calls` and the content branch shipped it verbatim.
+  assert.notEqual(result.content, NARRATION);
+  assert.ok(
+    !result.content.includes("I'll query"),
+    `the announcement reached the published answer:\n${result.content}`,
+  );
+  assert.equal(result.content, REAL_ANSWER);
+
+  // Three requests: the opening call, the post-tool call that narrated, and
+  // exactly one answering turn.
+  assert.equal(requests.length, 3, 'one answering turn, no more');
+});
+
+// --- Criterion 2: a genuine answer passes through, at no extra cost --------
+
+test('#319: a genuine answer is published untouched, with NO extra model call', async () => {
+  const { result, requests } = await runScripted([FETCH_CALL, { content: REAL_ANSWER }]);
+
+  assert.equal(result.content, REAL_ANSWER);
+  // The counterweight to criterion 1, and it matters as much: a check that
+  // fires on a good answer would put a model call on the front of every query
+  // and rewrite answers that were already correct. Two requests, not three.
+  assert.equal(requests.length, 2, 'a good answer must not be re-asked');
+});
+
+// --- Criterion 3: the re-ask is bounded ------------------------------------
+
+test('#319: at most ONE answering turn — a second unsatisfying answer is not re-asked forever', async () => {
+  // The scripted server repeats its last reply, so a model that keeps
+  // announcing keeps announcing. An unbounded implementation never stops.
+  const { result, requests } = await runScripted([
+    FETCH_CALL,
+    { content: NARRATION },
+    { content: "Let me first compute the 30-day closure rates, then I'll summarize." },
+  ]);
+
+  assert.equal(requests.length, 3, `expected exactly one answering turn, saw ${requests.length - 2}`);
+  // Documented limitation, asserted so it stays deliberate: the second turn is
+  // taken at its word. Streamed tokens have already reached the reader by the
+  // time it can be judged, so they cannot be retracted — only appended to.
+  assert.match(result.content, /Let me first compute/);
+});
+
+// --- Criterion 4: the `!lastMessage?.content` guard ------------------------
+
+test('#319: a token-limit-exceeded run with content asks for a summary instead of shipping that content', async () => {
+  // Deliberately NOT an announcement: this content is plain working notes, so
+  // the only thing that can route it into an answering turn is the guard fix,
+  // not the announcement rule. The two halves of this phase stay separable.
+  const MID_RUN_NOTES =
+    'Working notes so far: 4,812 rows returned across the two years, and the request-type ' +
+    'column has 12 distinct values.';
+  assert.equal(
+    announcesUnrunWork(MID_RUN_NOTES),
+    false,
+    'the fixture must not be caught by the announcement rule — that would test the wrong half',
+  );
+
+  const { result, requests } = await runScripted([
+    // Content AND tool calls on one reply, with usage over the 200k budget:
+    // the loop executes the call, then breaks on the token check with a
+    // content-bearing message in hand. `!lastMessage?.content` was false, so
+    // the answering turn was skipped and these notes were published.
+    { content: MID_RUN_NOTES, toolCalls: FETCH_CALL.toolCalls, totalTokens: 250_000 },
+    { content: REAL_ANSWER },
+  ]);
+
+  assert.notEqual(result.content, MID_RUN_NOTES);
+  assert.equal(result.content, REAL_ANSWER);
+  assert.equal(requests.length, 2);
+  // The content branch never set this, so a truncated run did not even carry
+  // the flag its own banner is keyed on.
+  assert.equal(result.token_limit_exceeded, true);
+});
+
+// --- The answering turn's request, on the wire -----------------------------
+
+test('#319: the answering turn omits tools, restates the contract, and keeps the transcript well-formed', async () => {
+  const { requests } = await runScripted([FETCH_CALL, { content: NARRATION }, { content: REAL_ANSWER }]);
+
+  const final = requests[requests.length - 1];
+  assert.equal(final.stream, true);
+  // Tools omitted: the model cannot answer this turn with another tool call.
+  assert.equal('tools' in final, false, 'the answering turn must offer no tools');
+
+  const messages = final.messages as { role: string; content?: string; tool_call_id?: string }[];
+  const last = messages[messages.length - 1];
+  assert.equal(last.role, 'user');
+  assert.match(last.content!, /a statement of intent is not an answer/);
+  assert.match(last.content!, /no further tool calls will be made/);
+
+  // The narration stays in the transcript it is being corrected in.
+  assert.ok(
+    messages.some((m) => m.role === 'assistant' && m.content === NARRATION),
+    'the turn being corrected must still be in the history',
+  );
+
+  // Every tool call is answered exactly once. The old block pushed the last
+  // message and re-answered its tool calls even when the loop had already done
+  // both, which duplicates an assistant turn and answers one `tool_call_id`
+  // twice.
+  const answered = messages.filter((m) => m.role === 'tool').map((m) => m.tool_call_id);
+  assert.deepEqual(answered, [...new Set(answered)], `a tool_call_id was answered twice: ${answered}`);
+});
+
+test('#319: the token-limit answering turn does not duplicate the assistant turn or re-answer its tool call', async () => {
+  const { requests } = await runScripted([
+    { content: 'Working notes.', toolCalls: FETCH_CALL.toolCalls, totalTokens: 250_000 },
+    { content: REAL_ANSWER },
+  ]);
+
+  const messages = requests[requests.length - 1].messages as { role: string; content?: string; tool_call_id?: string }[];
+  const assistants = messages.filter((m) => m.role === 'assistant' && m.content === 'Working notes.');
+  assert.equal(assistants.length, 1, 'the assistant turn the loop already pushed must not be pushed again');
+  const answered = messages.filter((m) => m.role === 'tool').map((m) => m.tool_call_id);
+  assert.deepEqual(answered, ['call_1'], `expected one answer for call_1, saw ${JSON.stringify(answered)}`);
+});
+
+// --- The rule itself: where the line is drawn ------------------------------
+
+test('#319: announcesUnrunWork catches commitment to an unrun data step', () => {
+  assert.equal(announcesUnrunWork(NARRATION), true);
+  assert.equal(
+    announcesUnrunWork("I'll query the fraction of records that close within 14 and 30 days per type."),
+    true,
+  );
+  assert.equal(announcesUnrunWork('Let me check the closure rates for each type.'), true);
+  assert.equal(announcesUnrunWork('Now I will run the comparison across both years.'), true);
+  assert.equal(announcesUnrunWork('I need to fetch the 2023 rows before I can compare.'), true);
+});
+
+test('#319: announcesUnrunWork does NOT fire on a genuine answer, an offer, or a courtesy', () => {
+  // The false-positive side, which costs a model call and a rewrite of an
+  // answer that was already correct.
+  assert.equal(announcesUnrunWork(REAL_ANSWER), false);
+  assert.equal(announcesUnrunWork('Around 400,000.'), false);
+  // An OFFER of further work, made after answering, is not a commitment to it.
+  assert.equal(
+    announcesUnrunWork('71% closed within 14 days (dataset abcd-1234). I can pull the 30-day rates too.'),
+    false,
+  );
+  assert.equal(
+    announcesUnrunWork('The median was 9 days. Would you like me to compare this against last year?'),
+    false,
+  );
+  assert.equal(
+    announcesUnrunWork('The median was 9 days (dataset abcd-1234). Let me know if you want the monthly breakdown.'),
+    false,
+  );
+  // Blank is not an announcement — the call site handles "no answer at all"
+  // as its own condition.
+  assert.equal(announcesUnrunWork(''), false);
+  assert.equal(announcesUnrunWork('   '), false);
+  assert.equal(announcesUnrunWork(null), false);
+  assert.equal(announcesUnrunWork(undefined), false);
+});
+
+test('#319: a long answer that closes with an aside is not re-asked', () => {
+  // The length bound is the conservatism in the rule. A message that has
+  // already summarized findings at length has answered, whatever it says last.
+  const long =
+    'Across both years the portal recorded 4,812 requests of this type (dataset abcd-1234). ' +
+    'The median time to close was 9 days. '.repeat(14) +
+    "Next, I'll query the seasonal breakdown.";
+  assert.ok(long.length > 600, 'fixture must exceed the bound to test it');
+  assert.equal(announcesUnrunWork(long), false);
 });

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -142,6 +142,101 @@ const MAX_TOKENS_PER_REQUEST = Number(process.env.TOKEN_LIMIT_PER_REQUEST) || 20
 const MAX_TOOL_RESULT_CHARS = Number(process.env.MAX_TOOL_RESULT_CHARS) || 50_000;
 
 /**
+ * A final turn that ANNOUNCES a query instead of answering it (#319).
+ *
+ * The tool-call loop treats any assistant message carrying no `tool_calls` as
+ * the final answer. When the model narrates its next step in prose instead of
+ * emitting the call, that narration becomes the published answer. The measured
+ * case: eight tool calls completed, then 235 characters ending "...I'll query
+ * the fraction of records that close within 14 and 30 days per type". The
+ * notebook validated. The record was publishable. It is a statement of intent
+ * to run a query that was never run, published under the same signature and
+ * the same visual treatment as a real finding, and a reader cannot tell the
+ * two apart.
+ *
+ * THE RULE. A final message fails the output contract when BOTH hold:
+ *
+ *   1. it COMMITS, in the first person, to a data step it has not taken
+ *      ("I'll query...", "Let me check...", "Next I'll compute..."), and
+ *   2. the whole message is shorter than `ANNOUNCEMENT_MAX_CHARS`.
+ *
+ * Commitment rather than offer is the first half's whole point. "I can pull
+ * the 30-day rates too" and "would you like me to..." offer further work
+ * AFTER answering; they are not matched, and must not be. Only forms that
+ * assert the model is about to act are.
+ *
+ * The length bound is the conservatism. A long answer that closes with an
+ * aside has already answered, and re-asking it would cost a model call and a
+ * rewrite for nothing. The measured narration was 235 characters; 600 leaves
+ * room for a wordier one while sitting below any message that has actually
+ * summarized findings and cited a source.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO is inspect the answer's substance — no
+ * citation check, no "must reference a computed value" (#333). The output
+ * contract's only concrete requirement is citation, and a citation gate has no
+ * measured definition yet; a wrong one re-asks correct answers, which is a
+ * failure that looks like rigour. The distinction drawn here is the narrower
+ * one #319 is actually about: answering rather than announcing.
+ *
+ * COST WHEN WRONG, in each direction. A false positive costs one extra model
+ * call and a re-worded answer — a real cost, which is why both conjuncts are
+ * required rather than either alone. A false negative publishes a statement of
+ * intent as a signed finding. The second is much worse, but not so much worse
+ * that the rule should be loose.
+ *
+ * Not to be confused with `detectIncompleteResponse` in
+ * components/shared/McpResponseDisplay.tsx, which is display-only and matches
+ * the opposite admission — a model saying it could NOT finish. None of its
+ * patterns fire on a confident announcement, which is why #319 reached the
+ * reader with no banner at all. If a second caller ever needs this predicate,
+ * export it toward that one rather than growing a parallel matcher.
+ */
+const ANNOUNCEMENT_MAX_CHARS = 600;
+
+/**
+ * First-person commitment, then a data-acquisition or computation verb within
+ * two words. `let me` carries a negative lookahead for "know", because "let me
+ * know if you want the monthly breakdown" is a courtesy at the end of a real
+ * answer, not a plan. No `g` flag: this is shared module state and `test()`
+ * would otherwise carry `lastIndex` between calls.
+ */
+const DATA_STEP_COMMITMENT =
+  /(?:\bi['’]?ll\b|\bi\s+will\b|\bi['’]?m\s+going\s+to\b|\bi\s+am\s+going\s+to\b|\bi\s+need\s+to\b|\bi\s+plan\s+to\b|\bi\s+intend\s+to\b|\bi['’]?m\s+about\s+to\b|\bi\s+am\s+about\s+to\b|\blet\s+me\b(?!\s+know)|\blet['’]?s\b|\bnext,?\s+i\b|\bnow\s+i\b|\bthen\s+i\b)(?:\s+\w+){0,2}\s+(?:quer(?:y|ies|ying)|fetch(?:ing)?|retriev\w*|re-?run(?:ning)?|run(?:ning)?|pull(?:ing)?|request(?:ing)?|check(?:ing)?|search(?:ing)?|count(?:ing)?|calculat\w*|comput\w*|analyz\w*|analys\w*|examin\w*|inspect(?:ing)?|compar\w*|aggregat\w*|cross-?\s?referenc\w*|look(?:ing)?\s+(?:at|up|into))\b/i;
+
+/**
+ * True when `content` announces work the model has not done rather than
+ * answering. An absent or blank message is NOT this: "no answer at all" is a
+ * separate condition at the call site, handled by the same path but for its
+ * own reason.
+ */
+export function announcesUnrunWork(content: string | null | undefined): boolean {
+  const text = content?.trim();
+  if (!text) return false;
+  if (text.length >= ANNOUNCEMENT_MAX_CHARS) return false;
+  return DATA_STEP_COMMITMENT.test(text);
+}
+
+/**
+ * The output contract, restated at the one moment the model has demonstrably
+ * lost it. The previous wording ("Based on all the data you have collected
+ * from the tool calls above, please provide a comprehensive answer to my
+ * original question. Summarize the key findings.") asked for an answer but
+ * never said that announcing one does not count — which is the exact failure
+ * being corrected, so it is now said outright, along with the fact that this
+ * turn is the published one.
+ *
+ * Source identifiers are named by KIND, not by source: this string is the
+ * app's own copy and stays free of any particular server's vocabulary.
+ */
+const FINAL_ANSWER_REQUEST =
+  'This is the final turn: no further tool calls will be made, and what you write now is the ' +
+  'published answer. Answer my original question using only the data already collected above. ' +
+  'Do not describe a query you plan to run or a step you intend to take next — a statement of ' +
+  'intent is not an answer. State the findings themselves, and cite the source of each figure ' +
+  '(dataset ID, variable DCID plus source dataset, or resource UUID plus dataset title). If the ' +
+  'data collected is not enough to answer, say so plainly and state what it does show.';
+
+/**
  * The span attributes recording what the endpoint said it used, next to what
  * this instance declared (website#30 P3, E5 — G0 D3: record both, warn, never
  * gate).
@@ -300,12 +395,22 @@ export async function queryWithMcpStreaming(
     let cumulativePromptTokens = response.usage?.prompt_tokens || 0;
     let cumulativeCompletionTokens = response.usage?.completion_tokens || 0;
     let tokenLimitExceeded = false;
+    /**
+     * True when `response`'s message is ALREADY in `messages`. The loop pushes
+     * each assistant turn before executing its tools, so the token-limit break
+     * below leaves the loop with the final message already in the transcript,
+     * its tool calls already answered with real results. The terminal block
+     * must not push it a second time: that would duplicate the assistant turn
+     * and answer the same `tool_call_id` twice, which is a malformed request.
+     */
+    let lastMessageAlreadyInTranscript = false;
 
     // Handle tool calls iteratively
     while (response.choices[0]?.message?.tool_calls && iterations < maxIterations) {
       const assistantMessage = response.choices[0].message;
       const toolCalls = assistantMessage.tool_calls;
       messages.push(assistantMessage);
+      lastMessageAlreadyInTranscript = true;
 
       if (!toolCalls) break;
 
@@ -471,6 +576,7 @@ export async function queryWithMcpStreaming(
         tool_choice: 'auto',
         max_tokens: 4000,
       });
+      lastMessageAlreadyInTranscript = false;
       if (llmSpanId) {
         trace!.builder.endSpan(llmSpanId, {
           'gen_ai.response.prompt_tokens': response.usage?.prompt_tokens || 0,
@@ -490,15 +596,46 @@ export async function queryWithMcpStreaming(
     // Trace: start synthesis span (covers final output generation)
     const synthesisSpanId = trace?.builder.startSpan('synthesis', trace.parentSpanId);
 
-    // Handle max iterations, token limit, or pending tool calls
     const lastMessage = response.choices[0]?.message;
-    if (!lastMessage?.content && (iterations >= maxIterations || tokenLimitExceeded || lastMessage?.tool_calls)) {
-      if (lastMessage?.tool_calls) {
+    const pendingToolCalls = lastMessage?.tool_calls;
+
+    // Why this run cannot end on `lastMessage` as it stands. Three reasons,
+    // one answering turn — the machinery below already existed, gated on the
+    // wrong condition, so this extends that path rather than adding a second.
+    //
+    // `abortedMidPlan` is the pre-existing reason: a budget stopped the loop
+    // instead of the model finishing. It no longer also requires the message
+    // to be EMPTY. The old condition led with `!lastMessage?.content`, so a
+    // token-limit-exceeded run that happened to carry prose shipped that prose
+    // as the answer — mid-run working notes published as a finding, and
+    // without even the `token_limit_exceeded` flag that would have banner-ed
+    // them, because the content branch below never set it (#319).
+    //
+    // `answeredNothing` is the old else-branch, folded in: an empty final
+    // message now gets the same restated contract as every other re-ask
+    // instead of a bare re-stream of the same transcript.
+    //
+    // `announcesUnrunWork` is the new one, and the reason this phase exists.
+    const abortedMidPlan =
+      iterations >= maxIterations || tokenLimitExceeded || Boolean(pendingToolCalls);
+    const answeredNothing = !lastMessage?.content?.trim();
+
+    if (abortedMidPlan || answeredNothing || announcesUnrunWork(lastMessage?.content)) {
+      // Keep the transcript faithful. The model really did produce this turn,
+      // and the re-ask corrects it explicitly; re-asking into a history that no
+      // longer contains the turn being corrected would be a silent rewrite,
+      // and it would read oddly in the signed trace. Skipped when the loop
+      // already pushed this message (see `lastMessageAlreadyInTranscript`) and
+      // when there is nothing to push.
+      if (!lastMessageAlreadyInTranscript && lastMessage && (lastMessage.content || pendingToolCalls)) {
         messages.push(lastMessage);
+      }
+      // Only for tool calls the loop did NOT already answer with real results.
+      if (pendingToolCalls && !lastMessageAlreadyInTranscript) {
         const abortReason = tokenLimitExceeded
           ? 'Token budget exceeded. Please provide a summary based on the data already collected.'
           : 'Tool call limit reached. Please provide a summary based on the data already collected.';
-        for (const toolCall of lastMessage.tool_calls) {
+        for (const toolCall of pendingToolCalls) {
           messages.push({
             role: 'tool',
             tool_call_id: toolCall.id,
@@ -518,7 +655,7 @@ export async function queryWithMcpStreaming(
           ...messages,
           {
             role: 'user',
-            content: 'Based on all the data you have collected from the tool calls above, please provide a comprehensive answer to my original question. Summarize the key findings.',
+            content: FINAL_ANSWER_REQUEST,
           },
         ],
         max_tokens: 4000,
@@ -575,97 +712,53 @@ export async function queryWithMcpStreaming(
       return;
     }
 
-    // If we have content, stream the final response
-    if (lastMessage?.content) {
-      // We already have the content from non-streaming call, send it as tokens
-      callbacks.onProgress(panel, 'Synthesizing findings into response...', { phase: 'synthesize' });
+    // Everything above returned. What is left is a genuine answer: content the
+    // model produced on its own account, that no budget cut short and that
+    // does not announce work it has not done. It is published exactly as
+    // written, with NO extra model call — the fix for #319 must cost nothing on
+    // the common path, which is the great majority of queries.
+    const finalContent = lastMessage?.content;
+    if (!finalContent) {
+      // Unreachable: `answeredNothing` routes a blank final message into the
+      // answering turn above, which returns. Kept as a typed refusal rather
+      // than a silent fall-through, because a path that reaches the end
+      // without calling `onComplete` would hang the reader's stream instead of
+      // failing visibly. The message never reaches a reader: it goes through
+      // `reportStreamFailure`, which logs it server-side and puts sanitized
+      // copy on the wire.
+      throw new Error('final assistant message had no content after the answering turn');
+    }
 
-      // Send the content in chunks to simulate streaming
-      const content = lastMessage.content;
-      const chunkSize = 20; // characters per chunk
-      for (let i = 0; i < content.length; i += chunkSize) {
-        const chunk = content.slice(i, i + chunkSize);
-        callbacks.onToken(panel, chunk);
-        // Small delay to make it feel like streaming
-        await new Promise(resolve => setTimeout(resolve, 10));
-      }
+    callbacks.onProgress(panel, 'Synthesizing findings into response...', { phase: 'synthesize' });
 
-      const duration_ms = Date.now() - startTime;
+    // Send the content in chunks to simulate streaming
+    const content = finalContent;
+    const chunkSize = 20; // characters per chunk
+    for (let i = 0; i < content.length; i += chunkSize) {
+      const chunk = content.slice(i, i + chunkSize);
+      callbacks.onToken(panel, chunk);
+      // Small delay to make it feel like streaming
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
 
-      if (synthesisSpanId) {
-        trace!.builder.endSpan(synthesisSpanId, {
-          'output.hash': traceHash(content),
-          'output.length': content.length,
-        });
-      }
+    const duration_ms = Date.now() - startTime;
 
-      // cumulativeTokens already includes this response's tokens from the loop
-      callbacks.onComplete(panel, {
-        content,
-        duration_ms,
-        tokens_used: cumulativeTokens,
-        prompt_tokens: cumulativePromptTokens || undefined,
-        completion_tokens: cumulativeCompletionTokens || undefined,
-        tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
-      });
-    } else {
-      // No content - make a final streaming call
-      callbacks.onProgress(panel, 'Synthesizing findings into response...', { phase: 'synthesize' });
-
-      const finalStream = await getModelClient().chat.completions.create({
-        model: model.endpointModel,
-        messages,
-        max_tokens: 4000,
-        stream: true,
-        ...(includeStreamUsage() ? { stream_options: { include_usage: true } } : {}),
-      });
-
-      let content = '';
-      let finalCallTokens = 0;
-      let finalPromptTokens = 0;
-      let finalCompletionTokens = 0;
-      let finalReportedModel: string | undefined;
-
-      for await (const chunk of finalStream) {
-        const delta = chunk.choices[0]?.delta?.content;
-        if (delta) {
-          content += delta;
-          callbacks.onToken(panel, delta);
-        }
-        // Every chunk repeats the model the endpoint answered with; the last
-        // one wins, so the recorded report is the one that finished the answer.
-        if (chunk.model) finalReportedModel = chunk.model;
-        if (chunk.usage) {
-          if (chunk.usage.total_tokens) finalCallTokens = chunk.usage.total_tokens;
-          if (chunk.usage.prompt_tokens) finalPromptTokens = chunk.usage.prompt_tokens;
-          if (chunk.usage.completion_tokens) finalCompletionTokens = chunk.usage.completion_tokens;
-        }
-      }
-
-      cumulativeTokens += finalCallTokens;
-      cumulativePromptTokens += finalPromptTokens;
-      cumulativeCompletionTokens += finalCompletionTokens;
-      const duration_ms = Date.now() - startTime;
-
-      if (synthesisSpanId) {
-        trace!.builder.endSpan(synthesisSpanId, {
-          'output.hash': traceHash(content),
-          'output.length': content.length,
-          'gen_ai.response.prompt_tokens': finalPromptTokens,
-          'gen_ai.response.completion_tokens': finalCompletionTokens,
-          ...responseModelAttributes(model.declared, finalReportedModel, panel),
-        });
-      }
-
-      callbacks.onComplete(panel, {
-        content,
-        duration_ms,
-        tokens_used: cumulativeTokens,
-        prompt_tokens: cumulativePromptTokens || undefined,
-        completion_tokens: cumulativeCompletionTokens || undefined,
-        tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
+    if (synthesisSpanId) {
+      trace!.builder.endSpan(synthesisSpanId, {
+        'output.hash': traceHash(content),
+        'output.length': content.length,
       });
     }
+
+    // cumulativeTokens already includes this response's tokens from the loop
+    callbacks.onComplete(panel, {
+      content,
+      duration_ms,
+      tokens_used: cumulativeTokens,
+      prompt_tokens: cumulativePromptTokens || undefined,
+      completion_tokens: cumulativeCompletionTokens || undefined,
+      tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
+    });
   } catch (error) {
     reportStreamFailure(panel, error, callbacks);
   }


### PR DESCRIPTION
Closes #319. Wave N6 phase P4 — the last build phase.

## The defect

The tool-call loop treated *any* assistant response carrying no `tool_calls` as the final answer. When the model narrated its next step in prose instead of emitting a tool call, that narration became the published answer.

Measured on a live portal: 8 tool calls completed, final "answer" **235 characters**, ending `…I'll query the fraction of records that close within 14 and 30 days per type`. The notebook validated `ok`. The record was **publishable** — a statement of intent to run a query that was never run, published under the same signature and visual treatment as a real finding.

Worse than a hard failure, because it looked like success at every surface that would otherwise catch it.

## The machinery already existed; it was gated on the wrong condition

A final answering turn was already there — a tools-omitted streaming call with a re-ask appended. It fired only when the last message had **no content at all**, so a mid-plan narration sailed past it and was published directly. This re-gates that existing path rather than adding a second one.

## The rule, and what it costs when wrong

A final message fails the output contract when **both** hold:

1. it **commits, in the first person, to a data step it has not taken** — `I'll query`, `Let me check`, `Next I'll compute`, `I need to fetch` — and
2. the whole message is **under 600 characters**.

**Commitment, not offer.** `I can pull the 30-day rates too` and `Would you like me to compare…` propose further work *after* answering, and are deliberately unmatched. `let me` carries a negative lookahead for `know`, so `Let me know if you want the monthly breakdown` — a courtesy closing a real answer — does not match.

**The length bound is the conservatism.** The measured narration was 235 characters; 600 leaves roughly 2.5× headroom while sitting below any message that has actually summarized findings. A long answer closing with an aside has already answered.

**Both directions cost something.** A false positive costs one extra model call and a re-worded answer — which is why both conjuncts are required rather than either alone, and why the "genuine answer" test is pinned by a **request count** rather than by content. A false negative publishes a statement of intent as a signed finding. The second is worse, but not so much worse that the rule should be loose: an over-eager check puts a model call on the front of every query and rewrites answers that were already correct.

The rule never inspects the answer's substance — no citation check, no computed-value requirement. That is #333's territory, deliberately out of scope here.

## Also in this block

**The `!lastMessage?.content` guard.** A token-limit-exceeded run whose last message carried prose shipped that prose — and, because the content branch never set `token_limit_exceeded`, without even the flag its own banner is keyed on. Fixed; the flag is now asserted.

**A latent defect found, not assigned.** On the token-limit break the loop has *already* pushed the assistant turn and answered its tool calls with real results. The old code pushed it again and re-answered the same `tool_call_id` with synthetic abort text — a malformed request. Pre-existing and reachable on `main`; this change *widens* that path, so leaving it would have meant actively introducing malformed requests. Now tracked explicitly and pinned by two tests.

The empty-content branch is folded into the same answering turn, so there is **one** mechanism rather than two near-identical ones that can drift apart.

## Every criterion shown red under an isolated mutation

Cross-greens matter as much as the reds — they prove the criteria are independently pinned rather than all riding one mechanism.

| Mutation | Red | Stayed green |
|---|---|---|
| Drop the announcement term from the terminal condition | narration is published — **#319 reproduced in the harness** | token-limit criterion |
| Restore the original `!content &&` guard | token-limit run ships its working notes | announcement criterion |
| Raise the bound from one answering turn to two | request count 4, expected 3 | all others |
| Widen the predicate to fire on any short message | genuine answer costs an extra model call | — |

**The previous phase's regression tests were re-run on this branch and still go red**, including its discovery-sweep trap. No belt-and-braces guard was added anywhere; that phase's single mechanism is intact and its tests are not vacuous.

## Checks

| Check | Result |
|---|---|
| `npm test` | 1044 tests, 1044 pass, 0 fail — 1035 baseline + 9 new, none moved |
| `npm run build` | Compiled successfully, route table printed |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | 4 problems, 0 errors, 4 warnings — existing baseline |
| `npm run check:compose-env` | PASS |

## Blast zone

Two files, both declared: `openrouter-streaming.ts` and its test. **No exceptions to itemise.**

`model-identity.test.ts` was predicted likely to move and **did not** — for a load-bearing reason rather than luck: its fixture answer is short and genuine, so the new rule passes it through with zero extra calls, leaving its request-count assertions untouched. That file is effectively an independent pre-witness that the rule does not fire on real answers.

Both production callers were measured and need nothing. `OUTRO` was read, not edited.

## Flagged, not fixed

1. **A second consecutive narration is published.** The bound is one answering turn, and it is structural rather than tunable: the call streams, and tokens already handed to the reader cannot be retracted. Buffering the final turn would cost the streaming this surface is built around. Asserted by test so it stays deliberate rather than drifting into an accident. A content-level gate is the right home — #333.
2. **No signal on the result when the answering turn still fails the contract.** Adding one would touch the notebook synthesizer and publish gating, outside this zone.
3. **`detectIncompleteResponse` is a second, unrelated heuristic on the same subject** (`McpResponseDisplay.tsx:347`). It is display-only and matches the *opposite* admission — a model saying it could not finish. **None of its eight patterns fires on a confident announcement, and the measured narration ends with a period so its mid-sentence check does not fire either — which is why #319 reached the reader with no banner at all.** Not reused, moved, or unified: out of zone, and it answers a different question. If a future phase wants one predicate, `announcesUnrunWork` is exported and the direction of travel should be toward it rather than a third matcher.
4. **Scope question for the gate, not taken here.** `OUTRO` is unchanged and deliberately not imported — it is not exported today, and adding an import edge is exactly the kind of change that can fail the `.dockerignore`-filtered container build while every host check stays green. The re-ask restates the answering obligation in the app's own words, naming source identifiers by *kind* rather than by server. Whether `OUTRO` should be strengthened so the contract is stated once rather than twice is a real question, and an owner decision.
