### PR TITLE
feat: one tool-calling loop, and the streaming caller on it (#345 P2)

### DIFF
--- a/src/lib/model-identity.test.ts
+++ b/src/lib/model-identity.test.ts
@@ -21,7 +21,9 @@
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { AddressInfo } from 'node:net';
 import canonicalize from 'canonicalize';
 import {
@@ -761,19 +763,47 @@ test('#30 P6 F4: every inference span carries gen_ai.system (measured on a trace
 });
 
 test('#30 P6 F4: no inference span is started without gen_ai.system', () => {
-  // The drift guard the trace test cannot give: a THIRD `llm_inference` span
-  // added later without the attribute would not show up in a fixture that
-  // never takes that branch. Both current sites are in this one file.
-  const source = readFileSync(
-    new URL('./openrouter-streaming.ts', import.meta.url),
-    'utf8',
+  // The drift guard the trace test cannot give: a `llm_inference` span added
+  // later without the attribute would not show up in a fixture that never
+  // takes that branch.
+  //
+  // This walks the whole tree rather than naming a file. It used to read
+  // `openrouter-streaming.ts` and say "both current sites are in this one
+  // file" — true when it was written, false the moment the tool-calling loop
+  // moved into `model-loop/run-tool-loop.ts` (#345), at which point a guard
+  // that named a file went red while the invariant it protects was untouched.
+  // A guard on a tree-wide property does not need editing when code moves.
+  const sites = inferenceSpanStarts();
+  assert.ok(
+    sites.length >= 2,
+    `expected at least two llm_inference span sites under src/, found ${sites.length}`,
   );
-  const starts = [...source.matchAll(/startSpan\('llm_inference'[\s\S]{0,240}?\}\)/g)];
-  assert.ok(starts.length >= 2, 'both inference sites should be found');
-  for (const match of starts) {
+  for (const site of sites) {
     assert.ok(
-      match[0].includes("'gen_ai.system': getGenAiSystem()"),
-      'an inference span without gen_ai.system breaks conformance with the declared version',
+      site.source.includes("'gen_ai.system': getGenAiSystem()"),
+      `an inference span without gen_ai.system breaks conformance with the declared version (${site.file})`,
     );
   }
 });
+
+/** Every `startSpan('llm_inference'…)` call site in non-test source under `src/`. */
+function inferenceSpanStarts(): { file: string; source: string }[] {
+  const srcRoot = fileURLToPath(new URL('..', import.meta.url));
+  return sourceFilesUnder(srcRoot).flatMap((file) => {
+    const source = readFileSync(file, 'utf8');
+    return [...source.matchAll(/startSpan\('llm_inference'[\s\S]{0,240}?\}\)/g)].map((match) => ({
+      file: relative(srcRoot, file),
+      source: match[0],
+    }));
+  });
+}
+
+function sourceFilesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFilesUnder(full);
+    if (!/\.tsx?$/.test(entry.name)) return [];
+    if (/\.test\.tsx?$/.test(entry.name)) return [];
+    return [full];
+  });
+}

--- a/src/lib/model-loop/model-call-registry.test.ts
+++ b/src/lib/model-loop/model-call-registry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The registry: who is allowed to call the model directly (#345).
+ *
+ * WHY A TEST AND NOT A CONVENTION. Wave N6 fixed six defects and its cold read
+ * found three of them still alive elsewhere — each phase had fixed one copy of
+ * a duplicated defect while honouring its blast zone exactly. The largest
+ * family was the model-calling loop: three implementations, and every fix
+ * landed on one of them. Nothing in the repository could say "there are three
+ * of these" out loud, so nobody looked.
+ *
+ * This test says it out loud. Adding a `chat.completions.create` call to a
+ * file that is not on the list below fails the suite, and the list carries one
+ * line of justification per entry — including, for the two files this wave has
+ * not migrated yet, the phase that removes them.
+ *
+ * TWO ASSERTIONS, ONE INSTRUMENT. The first is the registry: who calls the
+ * model at all. The second is narrower and is the wave's own criterion: how
+ * many modules carry a TOOL-CALLING loop, which is the thing that was
+ * triplicated. A grep for `chat.completions.create` cannot answer the second
+ * (it counts single-turn calls too) and a grep for `tools` cannot answer it
+ * either (it hits every file that mentions the word), so the scanner below
+ * parses each call's argument block and asks whether that call passes tools.
+ *
+ * WHAT THE SCANNER DOES NOT DO. It reads source text; it does not build a call
+ * graph. A call assembled dynamically, or made through a helper that takes the
+ * arguments as a value, is invisible to it — the same limitation
+ * `ui-class-names.test.ts` and `design-tokens.test.ts` accept for their own
+ * scans. It is a drift guard against the pattern that actually recurs here
+ * (someone writes another loop), not a proof of exclusivity.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+/**
+ * Every file permitted to call `chat.completions.create`, with the reason it
+ * is on the list. An entry that names a phase is a debt with an owner; an
+ * entry that does not is a call this wave deliberately leaves where it is.
+ */
+const ALLOWED_MODEL_CALLERS: Record<string, string> = {
+  'src/lib/model-loop/run-tool-loop.ts':
+    'The shared tool-calling loop — the one implementation the wave consolidates onto.',
+  'src/lib/openrouter-streaming.ts':
+    'queryWithoutMcpStreaming: the no-tools A-side of the comparison. One turn, no loop, not loop-class.',
+  'src/app/api/evidence/[slug]/replay/route.ts':
+    'Its own loop, until P3 moves it onto the shared core (#338, #347).',
+  'src/lib/openrouter.ts':
+    'Its own loop, until P4 moves it onto the shared core (#344).',
+  'src/lib/evidence/adversarial-eval.ts':
+    'One rubric call, no loop. Out of this wave by ruling D4; the eval pair is #348.',
+  'src/app/api/evidence/[slug]/evaluate/route.ts':
+    'The second copy of that same rubric call, caller-keyed. Out of this wave by ruling D4 (#348).',
+  'src/app/api/evidence/generate-summary/route.ts':
+    'One summary call, no loop. Out of this wave.',
+};
+
+/**
+ * Modules carrying a tool-calling loop — a `chat.completions.create` that
+ * passes `tools`. Three at this wave's base; one when it closes.
+ */
+const ALLOWED_TOOL_LOOPS: Record<string, string> = {
+  'src/lib/model-loop/run-tool-loop.ts': 'The shared core.',
+  'src/app/api/evidence/[slug]/replay/route.ts': 'Removed by P3.',
+  'src/lib/openrouter.ts': 'Removed by P4.',
+};
+
+const MODEL_CALL = 'chat.completions.create';
+
+interface ModelCall {
+  file: string;
+  /** The text of the call's argument list, parens balanced. */
+  args: string;
+}
+
+test('#345: every model call site is on the registry, and every registry entry is a real call site', () => {
+  const calls = modelCallSites();
+  assert.ok(calls.length > 0, 'the scanner found no model calls at all — it has stopped measuring');
+
+  const callers = new Set(calls.map((c) => c.file));
+
+  for (const file of callers) {
+    assert.ok(
+      file in ALLOWED_MODEL_CALLERS,
+      `${file} calls ${MODEL_CALL} and is not on the registry in src/lib/model-loop/model-call-registry.test.ts. ` +
+        'Add it with one line saying why it is a separate call site — or, better, call runToolLoop.',
+    );
+  }
+
+  for (const file of Object.keys(ALLOWED_MODEL_CALLERS)) {
+    assert.ok(
+      callers.has(file),
+      `${file} is on the registry but no longer calls ${MODEL_CALL}. Remove the entry — a stale allowlist is a false statement about the tree.`,
+    );
+  }
+});
+
+test('#345: only the named modules carry a tool-calling loop', () => {
+  const loops = new Set(modelCallSites().filter(passesTools).map((c) => c.file));
+
+  for (const file of loops) {
+    assert.ok(
+      file in ALLOWED_TOOL_LOOPS,
+      `${file} calls ${MODEL_CALL} with tools — a second tool-calling loop. This is the shape wave #345 exists to end: call runToolLoop instead.`,
+    );
+  }
+  for (const file of Object.keys(ALLOWED_TOOL_LOOPS)) {
+    assert.ok(loops.has(file), `${file} is listed as carrying a tool loop but no longer does. Remove the entry.`);
+  }
+});
+
+/** True when this call passes `tools` — `tools,` shorthand or `tools:`. */
+function passesTools(call: ModelCall): boolean {
+  return /(^|[\s,{])tools\s*[,:]/.test(call.args);
+}
+
+function modelCallSites(): ModelCall[] {
+  return sourceFiles(SRC_ROOT).flatMap((path) => {
+    const source = readFileSync(path, 'utf8');
+    const file = `src/${relative(SRC_ROOT, path).split(sep).join('/')}`;
+    const calls: ModelCall[] = [];
+    let from = 0;
+    for (;;) {
+      const at = source.indexOf(MODEL_CALL, from);
+      if (at === -1) break;
+      from = at + MODEL_CALL.length;
+      if (onACommentLine(source, at)) continue;
+      calls.push({ file, args: argumentList(source, from) });
+    }
+    return calls;
+  });
+}
+
+/**
+ * True when the line holding `at` opens as a comment. Enough for this scan:
+ * the only non-call occurrence in the tree is a doc comment in
+ * `model-client.ts`, and a general comment stripper would have to reason about
+ * regex literals and URLs in string literals to do no worse.
+ */
+function onACommentLine(source: string, at: number): boolean {
+  const lineStart = source.lastIndexOf('\n', at) + 1;
+  const before = source.slice(lineStart, at).trimStart();
+  return before.startsWith('//') || before.startsWith('*') || before.startsWith('/*');
+}
+
+/**
+ * The text between the `(` at or after `from` and its matching `)`. String and
+ * template literals are skipped so a bracket inside one cannot unbalance the
+ * scan; nesting inside a template's `${}` is not tracked, which is fine
+ * because no call in this tree puts one in its argument list.
+ */
+function argumentList(source: string, from: number): string {
+  const open = source.indexOf('(', from);
+  if (open === -1) return '';
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = endOfString(source, i);
+      continue;
+    }
+    if (ch === '(' || ch === '{' || ch === '[') depth++;
+    else if (ch === ')' || ch === '}' || ch === ']') {
+      depth--;
+      if (depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  return source.slice(open + 1);
+}
+
+/** Index of the closing quote of the string literal opening at `start`. */
+function endOfString(source: string, start: number): number {
+  const quote = source[start];
+  for (let i = start + 1; i < source.length; i++) {
+    if (source[i] === '\\') { i++; continue; }
+    if (source[i] === quote) return i;
+  }
+  return source.length;
+}
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    if (!/\.tsx?$/.test(entry.name)) return [];
+    if (/\.test\.tsx?$/.test(entry.name)) return [];
+    return [full];
+  });
+}

--- a/src/lib/model-loop/run-tool-loop.test.ts
+++ b/src/lib/model-loop/run-tool-loop.test.ts
@@ -274,6 +274,21 @@ test('#349 (c): a malformed argument set does NOT end the run — the loop conti
   assert.equal(requests.length, 3);
 });
 
+test('#349: JSON that parses but is not an argument set is the same failure', async () => {
+  // `null` parses cleanly and then throws on the first property read, one step
+  // further along — outside the guard if the guard only watches the parse.
+  const { result, requests } = await runCore({}, [
+    { toolCalls: [{ id: 'call_null', name: 'get_data', args: {}, rawArguments: 'null' }] },
+    { content: REAL_ANSWER },
+  ]);
+
+  assert.equal(result.toolCalls[0].failed, true);
+  assert.equal(result.toolCalls[0].failureKind, 'unknown');
+  assert.deepEqual(result.toolCalls[0].args, {}, 'the record carries an empty set, never null');
+  assert.equal(result.content, REAL_ANSWER);
+  assert.equal(toolMessages(requests).length, 1);
+});
+
 // --- The args-identity constraint ------------------------------------------
 
 test('the args on the record is the SAME object handed to executeToolCall', async () => {

--- a/src/lib/model-loop/run-tool-loop.test.ts
+++ b/src/lib/model-loop/run-tool-loop.test.ts
@@ -1,0 +1,456 @@
+// Acceptance tests for the shared tool-calling loop (#345 P2).
+//
+// Everything here drives the REAL loop against a local scripted model server
+// (`test-harness.ts`) with an injected tool transport: no live endpoint, no
+// credential, no MCP server, and every key value an obviously fake fixture.
+//
+// Where a claim is about WHAT THE MODEL WAS SENT, it is asserted on the wire —
+// against the request bodies the mock server received — rather than on the
+// value the loop returned. A truncation that hands the model malformed JSON
+// (#331) and a raw parse error reaching a tool message (#349) are both
+// invisible from the return value.
+//
+// Run with: npm test
+//   (or: node --test --experimental-strip-types src/lib/model-loop/run-tool-loop.test.ts)
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { runToolLoop, type ToolLoopOptions, type ToolLoopResult } from './run-tool-loop.ts';
+import { startScriptedModelServer, type ScriptedReply } from './test-harness.ts';
+import { _resetDefaultModelClientForTests, getModelClient } from '../model-client.ts';
+import { describeToolFailureForLlm } from '../streaming.ts';
+
+const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ['OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'MODEL_API_BASE_URL'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+const REAL_ANSWER =
+  'Across both years the portal recorded 4,812 requests of this type. The median time to close ' +
+  'was 9 days, and 71% closed within 14 days (dataset abcd-1234).';
+
+const FETCH_CALL: ScriptedReply = {
+  toolCalls: [{ id: 'call_1', name: 'get_data', args: { type: 'query', dataset_id: 'abcd-1234' } }],
+};
+
+const ONE_ROW = JSON.stringify({ data: [{ request_type: 'A', days_to_close: 9 }], total_rows: 1 });
+
+interface Wire {
+  role: string;
+  content?: string;
+  tool_call_id?: string;
+  tool_calls?: { id: string; function: { name: string; arguments: string } }[];
+}
+
+/**
+ * Drive `runToolLoop` against a scripted endpoint. Only what a case is about
+ * is passed in `overrides`; everything else is a neutral default, so a case
+ * reads as the one thing it measures.
+ */
+async function runCore(
+  overrides: Partial<ToolLoopOptions>,
+  replies: ScriptedReply[],
+): Promise<{ result: ToolLoopResult; requests: Record<string, unknown>[] }> {
+  const { server, url, requests } = await startScriptedModelServer(replies);
+  try {
+    process.env.OPENROUTER_API_KEY = FAKE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    const result = await runToolLoop({
+      client: getModelClient(),
+      endpointModel: 'fake/model',
+      prompt: 'How long do these requests take to close?',
+      tools: [],
+      executeToolCall: async () => ONE_ROW,
+      ...overrides,
+    });
+    return { result, requests };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+/** Every message of every request the endpoint received, flattened. */
+function allMessages(requests: Record<string, unknown>[]): Wire[] {
+  return requests.flatMap((r) => (r.messages as Wire[] | undefined) ?? []);
+}
+
+function toolMessages(requests: Record<string, unknown>[]): Wire[] {
+  return allMessages(requests).filter((m) => m.role === 'tool');
+}
+
+// --- #331: an oversized envelope must stay readable ------------------------
+//
+// `truncateToolResult` recognised only a bare JSON array. A paginated envelope
+// — `{"data": [...], "total_rows": N}` — is not an array, so an oversized one
+// fell through to raw character truncation and was cut mid-record. Measured on
+// the issue's own reproduction: 296,028 characters in, 50,042 out, `Bad
+// control character in string literal at position 50000`, and no marker at all
+// telling the model that anything had been dropped.
+
+/** A Socrata-shaped envelope of `rows` rows — the shape #331 reproduces on. */
+function socrataEnvelope(rows: number): string {
+  return JSON.stringify({
+    data: Array.from({ length: rows }, (_, i) => ({
+      unique_key: String(100_000 + i),
+      created_date: '2026-01-01T00:00:00.000',
+      complaint_type: 'Noise - Residential',
+      borough: 'BROOKLYN',
+      incident_zip: '11201',
+    })),
+    total_rows: rows,
+  });
+}
+
+const ROW_MARKER = /\n\[Truncated: showing (\d+) of (\d+) rows\]$/;
+
+/** The JSON body of a truncated result, with its trailing marker line split off. */
+function splitTruncated(content: string): { body: string; kept: number; total: number } {
+  const marker = content.match(ROW_MARKER);
+  assert.ok(marker, `no row-truncation marker on the result fed to the model:\n…${content.slice(-160)}`);
+  return {
+    body: content.slice(0, marker.index),
+    kept: Number(marker[1]),
+    total: Number(marker[2]),
+  };
+}
+
+test('#331: an oversized Socrata envelope reaches the model as valid JSON carrying the truncation marker', async () => {
+  const envelope = socrataEnvelope(2_000);
+  assert.ok(envelope.length > 250_000, `fixture must exceed the bound: ${envelope.length}`);
+
+  const { requests } = await runCore(
+    { executeToolCall: async () => envelope },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  const fed = toolMessages(requests)[0]?.content;
+  assert.ok(fed, 'the tool result must reach the model');
+
+  // RED before the fix: there is no marker at all on this path, and the body
+  // ends inside a string literal, so this parse throws with `Bad control
+  // character in string literal at position 50000`.
+  const { body, kept, total } = splitTruncated(fed!);
+  const parsed = JSON.parse(body) as { data: unknown[]; total_rows: number };
+
+  assert.ok(Array.isArray(parsed.data), 'the envelope framing must survive truncation');
+  assert.equal(parsed.data.length, kept);
+  assert.equal(total, 2_000);
+  assert.ok(kept > 0 && kept < 2_000, `expected a partial page, kept ${kept}`);
+  // `total_rows` is preserved so the model still knows how large the matching
+  // set upstream was — the thing raw truncation destroyed.
+  assert.equal(parsed.total_rows, 2_000);
+  assert.ok(body.length < envelope.length, 'the bound is still enforced');
+  assert.ok(body.length < 60_000, `body should sit near the 50k budget, was ${body.length}`);
+});
+
+test('#331: a bare array still truncates by whole rows (no regression)', async () => {
+  const rows = Array.from({ length: 2_000 }, (_, i) => ({
+    id: `row-${i}`,
+    name: 'Restaurant Inspections',
+    detail: 'x'.repeat(60),
+  }));
+  const bare = JSON.stringify(rows);
+  assert.ok(bare.length > 50_000);
+
+  const { requests } = await runCore(
+    { executeToolCall: async () => bare },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  const { body, kept, total } = splitTruncated(toolMessages(requests)[0]!.content!);
+  const parsed = JSON.parse(body) as unknown[];
+  assert.equal(parsed.length, kept);
+  assert.equal(total, 2_000);
+});
+
+test('#331: a non-JSON result keeps the character-truncation marker', async () => {
+  // The fall-through is still there and still says what it did — the bound
+  // exists to limit input token growth, and that has not changed.
+  const prose = 'x'.repeat(60_000);
+  const { requests } = await runCore(
+    { executeToolCall: async () => prose },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+  const fed = toolMessages(requests)[0]!.content!;
+  assert.match(fed, /\n\[Truncated: result was 60000 characters\]$/);
+  assert.doesNotMatch(fed, ROW_MARKER);
+});
+
+test('#331: a result inside the bound is fed back untouched', async () => {
+  const { requests } = await runCore({}, [FETCH_CALL, { content: REAL_ANSWER }]);
+  assert.equal(toolMessages(requests)[0]!.content, ONE_ROW);
+});
+
+// --- #349: a tool call whose arguments will not parse -----------------------
+//
+// All three loops parsed the endpoint's tool-call arguments with a bare
+// `JSON.parse` sitting OUTSIDE the try that wraps tool execution. A malformed
+// set therefore bypassed every failure path: on this loop it escaped to the
+// outer catch and ended a query that may already have completed several
+// successful calls.
+
+const SENTINEL = 'sentinel-must-not-reach-a-tool-message';
+
+/** Arguments the endpoint cut off mid-string — the realistic malformed shape. */
+const MALFORMED_ARGUMENTS = `{"type":"query","dataset_id":"${SENTINEL}`;
+
+const MALFORMED_CALL: ScriptedReply = {
+  toolCalls: [{ id: 'call_bad', name: 'get_data', args: {}, rawArguments: MALFORMED_ARGUMENTS }],
+};
+
+test('#349 (a): a malformed argument set is RECORDED as a failed tool call', async () => {
+  const { result } = await runCore({}, [MALFORMED_CALL, { content: REAL_ANSWER }]);
+
+  assert.equal(result.toolCalls.length, 1, 'the call is still recorded — it was attempted');
+  assert.equal(result.toolCalls[0].failed, true);
+  assert.equal(result.toolCalls[0].failureKind, 'unknown');
+  assert.equal(result.toolCalls[0].name, 'get_data');
+});
+
+test('#349 (b): the model is told through describeToolFailureForLlm, with no parse-error text on the wire', async () => {
+  let executed = 0;
+  const { requests } = await runCore(
+    { executeToolCall: async () => { executed++; return ONE_ROW; } },
+    [MALFORMED_CALL, { content: REAL_ANSWER }],
+  );
+
+  assert.equal(executed, 0, 'a call whose arguments would not parse must not be executed');
+
+  const fed = toolMessages(requests).map((m) => m.content ?? '');
+  assert.equal(fed.length, 1);
+  assert.equal(fed[0], describeToolFailureForLlm('get_data', new Error('any')));
+  assert.match(fed[0], /Do not estimate, guess, or fabricate any values/);
+
+  // The parser's own message quotes the malformed bytes back and names an
+  // offset. None of it may reach a tool message.
+  assert.ok(!fed[0].includes(SENTINEL), `the malformed argument text reached the model:\n${fed[0]}`);
+  const wire = JSON.stringify(requests);
+  for (const needle of ['in JSON at position', 'Unterminated string', 'SyntaxError', 'Unexpected token']) {
+    assert.ok(!wire.includes(needle), `raw parse-error text on the wire: ${needle}`);
+  }
+
+  // The ASSISTANT turn legitimately still carries the arguments the endpoint
+  // sent — that is the model's own turn, and rewriting it would make the
+  // transcript a fiction. The sentinel is expected there and nowhere else.
+  const assistantTurns = allMessages(requests).filter((m) => m.role === 'assistant');
+  assert.ok(
+    assistantTurns.some((m) => JSON.stringify(m.tool_calls ?? []).includes(SENTINEL)),
+    'the turn being corrected must stay in the transcript',
+  );
+});
+
+test('#349 (c): a malformed argument set does NOT end the run — the loop continues and answers', async () => {
+  // Two rounds: the first call is unparseable, the second is fine. Before the
+  // guard the first threw out of the loop entirely and there was no second.
+  const { result, requests } = await runCore({}, [
+    MALFORMED_CALL,
+    { toolCalls: [{ id: 'call_2', name: 'get_data', args: { type: 'query', dataset_id: 'abcd-1234' } }] },
+    { content: REAL_ANSWER },
+  ]);
+
+  assert.equal(result.content, REAL_ANSWER, 'the query still answers');
+  assert.equal(result.toolCalls.length, 2);
+  assert.equal(result.toolCalls[0].failed, true);
+  assert.equal(result.toolCalls[1].failed, undefined, 'the good call is not tarred by the bad one');
+  assert.deepEqual(result.toolCalls[1].resultSummary, { rows: 1, columns: 2 });
+  assert.equal(requests.length, 3);
+});
+
+// --- The args-identity constraint ------------------------------------------
+
+test('the args on the record is the SAME object handed to executeToolCall', async () => {
+  // Not deep equality — identity. Callers inject fields into `args` inside the
+  // tool closure (a portal, most often), and the recorded arguments must show
+  // what was actually sent: they reach a signed package, and the replay
+  // identity key is computed over `name:args.type:args.dataset_id:args.portal`.
+  // A clone or a freeze here changes those keys with nothing in the diff
+  // pointing at the cause, which is why this probe checks BOTH the reference
+  // and a field injected after the record was made.
+  let handed: Record<string, unknown> | undefined;
+  const { result } = await runCore(
+    {
+      executeToolCall: async (_name, args) => {
+        handed = args;
+        args.portal = 'data.cityofnewyork.us';
+        return ONE_ROW;
+      },
+    },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  const recorded = result.toolCalls[0].args;
+  assert.ok(handed, 'the tool must have been called');
+  assert.equal(recorded, handed, 'the recorded args must BE the object the tool received');
+  assert.equal(
+    recorded.portal,
+    'data.cityofnewyork.us',
+    'a field injected in the tool closure must be visible on the record',
+  );
+});
+
+// --- #343: the output contract, stated once --------------------------------
+
+const CONTRACT_SENTENCE = 'a statement of intent is not an answer';
+
+test('#343: only ONE message states the output contract, on the path that writes an abort note', async () => {
+  // The max-iterations path is the one that still writes a note for tool calls
+  // the loop never ran. It used to paraphrase the contract ("Please provide a
+  // summary based on the data already collected") next to the restatement that
+  // replaced that wording — two statements, and editing one gave no reason to
+  // look at the other. The note now reports a fact and nothing else.
+  const { requests } = await runCore({ maxIterations: 2 }, [FETCH_CALL]);
+
+  const answering = requests[requests.length - 1];
+  const messages = answering.messages as Wire[];
+  const contractStatements = messages.filter((m) => (m.content ?? '').includes(CONTRACT_SENTENCE));
+  assert.equal(contractStatements.length, 1, 'the output contract is stated exactly once');
+  assert.equal(contractStatements[0].role, 'user');
+
+  const note = messages.filter((m) => m.role === 'tool').at(-1)!.content!;
+  // The paraphrase is the second statement, and it is the one that goes
+  // unnoticed: it does not repeat the restatement's words, so counting them
+  // will not find it. What identifies it is that it tells the model what to
+  // WRITE, which is the restatement's job and no one else's.
+  assert.doesNotMatch(note, /provide a summary|summari[sz]e|please provide/i,
+    `the abort note is stating the output contract a second time:\n${note}`);
+  assert.match(note, /was not run/);
+});
+
+test('#343: the token-limit path writes no abort note at all — the state the deleted arm required cannot occur', async () => {
+  // The deleted arm could only be selected when the token limit stopped the
+  // loop AND the last assistant turn was not already in the transcript —
+  // states that cannot both hold, because the break happens after the turn is
+  // pushed and its calls answered. This pins the measurement that made it
+  // unreachable, so an edit that makes the state occur has to face it.
+  const { requests } = await runCore(
+    { maxCumulativeTokens: 200_000 },
+    [{ ...FETCH_CALL, totalTokens: 250_000 }, { content: REAL_ANSWER }],
+  );
+
+  const wire = JSON.stringify(requests);
+  assert.ok(!wire.includes('Token budget exceeded'), 'a dead arm cannot be reintroduced quietly');
+
+  const messages = requests[requests.length - 1].messages as Wire[];
+  const answered = messages.filter((m) => m.role === 'tool');
+  assert.equal(answered.length, 1);
+  assert.equal(answered[0].content, ONE_ROW, 'the call the loop DID run keeps its real result');
+});
+
+// --- The exit condition is core behaviour, not a caller's option -----------
+
+test('#334: a final turn that announces a query is not returned as the answer', async () => {
+  const NARRATION =
+    "I now have the counts by request type for both years. Next, I'll query the fraction of " +
+    'records that close within 14 and 30 days per type.';
+
+  const { result, requests } = await runCore({}, [
+    FETCH_CALL,
+    { content: NARRATION },
+    { content: REAL_ANSWER },
+  ]);
+
+  assert.notEqual(result.content, NARRATION);
+  assert.equal(result.content, REAL_ANSWER);
+  assert.equal(result.answeringTurnTaken, true);
+  assert.equal(requests.length, 3, 'one answering turn, no more');
+});
+
+test('#334: a genuine answer costs no extra model call', async () => {
+  const { result, requests } = await runCore({}, [FETCH_CALL, { content: REAL_ANSWER }]);
+  assert.equal(result.content, REAL_ANSWER);
+  assert.equal(result.answeringTurnTaken, false);
+  assert.equal(requests.length, 2, 'a good answer must not be re-asked');
+});
+
+// --- A failed tool call is one failed call, not a failed query -------------
+
+test('#321: an execution failure is recorded and described, and the run survives it', async () => {
+  const { result, requests } = await runCore(
+    {
+      executeToolCall: async () => {
+        throw new Error('ECONNREFUSED db.internal.example:5432');
+      },
+    },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  assert.equal(result.toolCalls[0].failed, true);
+  assert.equal(result.toolCalls[0].failureKind, 'unavailable');
+  assert.equal(result.content, REAL_ANSWER);
+
+  const wire = JSON.stringify(requests);
+  assert.ok(!wire.includes('db.internal.example'), 'no raw error text reaches the model');
+});
+
+// --- The parameters a non-streaming caller needs ---------------------------
+
+test('a blocking final turn answers without streaming — the shape a route caller uses', async () => {
+  const deltas: string[] = [];
+  const { result, requests } = await runCore(
+    { finalTurn: 'blocking', onDelta: (d) => deltas.push(d) },
+    [FETCH_CALL, { content: '' }, { content: REAL_ANSWER }],
+  );
+
+  assert.equal(result.content, REAL_ANSWER);
+  assert.equal(result.streamed, false);
+  assert.deepEqual(deltas, [], 'a blocking caller receives no deltas');
+  assert.equal(requests[requests.length - 1].stream, undefined, 'the answering turn is not a stream');
+});
+
+test('maxIterations and maxTokens are caller parameters (the lower pair /api/compare keeps)', async () => {
+  // The wave leaves `/api/compare` on 10 iterations and 2000 max_tokens; this
+  // is the seam that lets it say so rather than inherit 20/4000.
+  const { result, requests } = await runCore(
+    { maxIterations: 10, maxTokens: 2_000 },
+    [FETCH_CALL],
+  );
+
+  assert.equal(result.iterations, 10, 'the cap is the caller’s');
+  for (const request of requests.slice(0, -1)) {
+    assert.equal(request.max_tokens, 2_000);
+  }
+  // 10 tool-calling rounds plus the opening call, plus one answering turn.
+  assert.equal(requests.length, 12);
+});
+
+test('an omitted token budget is unbounded — the default a caller with no budget needs', async () => {
+  // `maxCumulativeTokens` absent must not mean zero: a loop that treated it as
+  // a budget of 0 would abort every run on its first round.
+  const { result, requests } = await runCore({}, [
+    { ...FETCH_CALL, totalTokens: 500_000 },
+    { content: REAL_ANSWER },
+  ]);
+
+  assert.equal(result.tokenLimitExceeded, false);
+  assert.equal(result.content, REAL_ANSWER);
+  assert.equal(requests.length, 2);
+});
+
+test('a token budget, when given, stops the loop and reports itself', async () => {
+  const { result } = await runCore(
+    { maxCumulativeTokens: 200_000 },
+    [{ ...FETCH_CALL, totalTokens: 250_000 }, { content: REAL_ANSWER }],
+  );
+
+  assert.equal(result.tokenLimitExceeded, true);
+  assert.equal(result.answeringTurnTaken, true);
+  assert.equal(result.content, REAL_ANSWER);
+});

--- a/src/lib/model-loop/run-tool-loop.ts
+++ b/src/lib/model-loop/run-tool-loop.ts
@@ -1,0 +1,841 @@
+/**
+ * The shared tool-calling loop — one implementation, several callers (#345).
+ *
+ * WHY THIS MODULE EXISTS. Three copies of this loop existed independently
+ * (`openrouter-streaming.ts`, `evidence/[slug]/replay/route.ts`,
+ * `openrouter.ts`), and every defect found in one survived in the other two:
+ * the exit condition that published an announcement as an answer (#319 /
+ * #338 / #344), raw error text fed to the model instead of
+ * `describeToolFailureForLlm`, tool-call records with no failure fields
+ * (#321), a truncation that hands the model malformed JSON (#331), an
+ * unguarded argument parse (#349). A blast zone scoped by file cannot see a
+ * defect scoped to a class, so the class gets one implementation.
+ *
+ * WHAT IS CORE BEHAVIOUR AND WHAT IS A PARAMETER. Anything a caller could
+ * opt out of that would reintroduce one of those defects is core behaviour
+ * and has no switch: the three-way exit condition, the failure vocabulary on
+ * tool records, the error-to-model path, transcript well-formedness, the
+ * truncation, the single statement of the output contract. What a caller is
+ * given (client, model, tools, budgets, the tool transport) and what it does
+ * with the result (progress rendering, streaming, error surfacing) are
+ * parameters.
+ *
+ * THE ONE HARD CONSTRAINT: this loop never clones or freezes a tool call's
+ * `args`. The object recorded on the tool-call entry is the SAME object
+ * handed to `executeToolCall`, because callers inject fields into it inside
+ * that closure (a portal, for one) and the recorded arguments — which reach a
+ * signed package and the replay identity key — must show what was actually
+ * sent. Cloning or freezing here changes those recorded arguments with
+ * nothing in the diff pointing at the cause. `run-tool-loop.test.ts` holds a
+ * probe on the identity.
+ *
+ * SSE is not a concept here. The loop reports through `onEvent`/`onDelta`;
+ * panels, event encoding and reader-facing progress copy belong to whichever
+ * caller has a reader.
+ */
+
+import type OpenAI from 'openai';
+import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
+import { getGenAiSystem, includeStreamUsage } from '../model-client.ts';
+import { classifyStreamError, describeToolFailureForLlm, generateToolReason } from '../streaming.ts';
+import type { TraceBuilder } from '../evidence/trace.ts';
+import { hash as traceHash } from '../evidence/trace.ts';
+import { deriveOperationType } from '../mcp/operation-types.ts';
+import type { ToolFailureKind } from '../notebook-author/tool-to-cell.ts';
+
+export interface TraceContext {
+  builder: TraceBuilder;
+  parentSpanId: string;
+  systemPromptHash?: string;
+  /**
+   * Optional hook that maps a tool name to its MCP source id (e.g. "socrata",
+   * "data-commons"). When provided, the source is recorded on each
+   * `mcp_tool_call` span so the PROV-O builder can distinguish servers.
+   */
+  resolveToolSource?: (toolName: string) => string | undefined;
+}
+
+/**
+ * One attempted tool call, as every caller records it. `failed`/`failureKind`
+ * are set at the catch site where the rejection is already known: nothing
+ * downstream can recover the fact, because a failed call is not
+ * distinguishable from a successful zero-row one by its `resultSummary`
+ * (#321).
+ */
+export interface ToolCallRecord {
+  name: string;
+  args: Record<string, unknown>;
+  resultSummary?: { rows: number; columns: number };
+  duration_ms?: number;
+  operationType?: string;
+  reason?: string;
+  failed?: boolean;
+  failureKind?: ToolFailureKind;
+}
+
+/**
+ * What the loop reports while it runs. Deliberately structural rather than
+ * pre-rendered: reader-facing copy is a caller's concern, and two of the
+ * three callers have no reader at all. `priorCalls` is the tool-call list as
+ * it stood BEFORE the call being reported, which is what the progress
+ * formatters take as context — carrying it means a caller can render
+ * `tool_start` and `tool_complete` to the same string without keeping its own
+ * shadow copy of the list.
+ */
+export type LoopEvent =
+  | { type: 'tool_start'; iteration: number; call: ToolCallRecord; priorCalls: ToolCallRecord[] }
+  | { type: 'tool_complete'; iteration: number; call: ToolCallRecord; priorCalls: ToolCallRecord[]; durationMs: number }
+  | { type: 'tool_result'; iteration: number; call: ToolCallRecord }
+  | { type: 'thinking'; iteration: number }
+  | { type: 'token_budget_exhausted'; cumulativeTokens: number }
+  | { type: 'answering_turn'; tokenLimitExceeded: boolean }
+  | { type: 'pass_through' };
+
+export interface ToolLoopOptions {
+  /** Resolved by the caller, inside the caller's own error handling. */
+  client: OpenAI;
+  /** The string sent to the endpoint. */
+  endpointModel: string;
+  /** The identity this instance declares; trace attributes only. Defaults to `endpointModel`. */
+  declaredModel?: string;
+  prompt: string;
+  systemPrompt?: string;
+  tools: ChatCompletionTool[];
+  /**
+   * The seam every caller-side tool concern goes through: portal injection, a
+   * per-call timeout race, source routing. Receives the SAME args object the
+   * record holds — see the constraint in this file's header.
+   */
+  executeToolCall: (name: string, args: Record<string, unknown>) => Promise<string>;
+  /** Tool-calling rounds before the loop gives up and asks for an answer. */
+  maxIterations?: number;
+  /** `max_tokens` on every request this loop makes. */
+  maxTokens?: number;
+  /** Cumulative token budget. Omitted = unbounded. */
+  maxCumulativeTokens?: number;
+  /** Bound on a single tool result fed back as context. */
+  maxToolResultChars?: number;
+  /** Whether the final answering turn streams. Only that turn is affected. */
+  finalTurn?: 'blocking' | 'stream';
+  /**
+   * Optional pacing for the pass-through path — the run that ended with a
+   * genuine answer and needs no extra model call. A caller with a reader
+   * delivers that answer in chunks so it arrives like the streamed one;
+   * omitted, the content is simply returned.
+   */
+  passThroughDelivery?: { chunkChars: number; delayMs: number };
+  onDelta?: (delta: string) => void;
+  onEvent?: (event: LoopEvent) => void;
+  trace?: TraceContext;
+  /** Label for this loop's operator log lines. */
+  logContext?: string;
+}
+
+export interface ToolLoopResult {
+  content: string;
+  toolCalls: ToolCallRecord[];
+  usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  durationMs: number;
+  iterations: number;
+  tokenLimitExceeded: boolean;
+  /** Content was delivered through `onDelta` as it was produced. */
+  streamed: boolean;
+  /** The #334 answering turn was needed — an extra model call was made. */
+  answeringTurnTaken: boolean;
+}
+
+const DEFAULT_MAX_ITERATIONS = 20;
+const DEFAULT_MAX_TOKENS = 4000;
+const DEFAULT_MAX_TOOL_RESULT_CHARS = 50_000;
+
+/**
+ * A final turn that ANNOUNCES a query instead of answering it (#319).
+ *
+ * The tool-call loop treats any assistant message carrying no `tool_calls` as
+ * the final answer. When the model narrates its next step in prose instead of
+ * emitting the call, that narration becomes the published answer. The measured
+ * case: eight tool calls completed, then 235 characters ending "...I'll query
+ * the fraction of records that close within 14 and 30 days per type". The
+ * notebook validated. The record was publishable. It is a statement of intent
+ * to run a query that was never run, published under the same signature and
+ * the same visual treatment as a real finding, and a reader cannot tell the
+ * two apart.
+ *
+ * THE RULE. A final message fails the output contract when BOTH hold:
+ *
+ *   1. it COMMITS, in the first person, to a data step it has not taken
+ *      ("I'll query...", "Let me check...", "Next I'll compute..."), and
+ *   2. the whole message is shorter than `ANNOUNCEMENT_MAX_CHARS`.
+ *
+ * Commitment rather than offer is the first half's whole point. "I can pull
+ * the 30-day rates too" and "would you like me to..." offer further work
+ * AFTER answering; they are not matched, and must not be. Only forms that
+ * assert the model is about to act are.
+ *
+ * The length bound is the conservatism. A long answer that closes with an
+ * aside has already answered, and re-asking it would cost a model call and a
+ * rewrite for nothing. The measured narration was 235 characters; 600 leaves
+ * room for a wordier one while sitting below any message that has actually
+ * summarized findings and cited a source.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO is inspect the answer's substance — no
+ * citation check, no "must reference a computed value" (#333). The output
+ * contract's only concrete requirement is citation, and a citation gate has no
+ * measured definition yet; a wrong one re-asks correct answers, which is a
+ * failure that looks like rigour. The distinction drawn here is the narrower
+ * one #319 is actually about: answering rather than announcing.
+ *
+ * COST WHEN WRONG, in each direction. A false positive costs one extra model
+ * call and a re-worded answer — a real cost, which is why both conjuncts are
+ * required rather than either alone. A false negative publishes a statement of
+ * intent as a signed finding. The second is much worse, but not so much worse
+ * that the rule should be loose.
+ *
+ * Not to be confused with `detectIncompleteResponse` in
+ * components/shared/McpResponseDisplay.tsx, which is display-only and matches
+ * the opposite admission — a model saying it could NOT finish. None of its
+ * patterns fire on a confident announcement, which is why #319 reached the
+ * reader with no banner at all. If a second caller ever needs this predicate,
+ * export it toward that one rather than growing a parallel matcher.
+ */
+const ANNOUNCEMENT_MAX_CHARS = 600;
+
+/**
+ * First-person commitment, then a data-acquisition or computation verb within
+ * two words. `let me` carries a negative lookahead for "know", because "let me
+ * know if you want the monthly breakdown" is a courtesy at the end of a real
+ * answer, not a plan. No `g` flag: this is shared module state and `test()`
+ * would otherwise carry `lastIndex` between calls.
+ */
+const DATA_STEP_COMMITMENT =
+  /(?:\bi['’]?ll\b|\bi\s+will\b|\bi['’]?m\s+going\s+to\b|\bi\s+am\s+going\s+to\b|\bi\s+need\s+to\b|\bi\s+plan\s+to\b|\bi\s+intend\s+to\b|\bi['’]?m\s+about\s+to\b|\bi\s+am\s+about\s+to\b|\blet\s+me\b(?!\s+know)|\blet['’]?s\b|\bnext,?\s+i\b|\bnow\s+i\b|\bthen\s+i\b)(?:\s+\w+){0,2}\s+(?:quer(?:y|ies|ying)|fetch(?:ing)?|retriev\w*|re-?run(?:ning)?|run(?:ning)?|pull(?:ing)?|request(?:ing)?|check(?:ing)?|search(?:ing)?|count(?:ing)?|calculat\w*|comput\w*|analyz\w*|analys\w*|examin\w*|inspect(?:ing)?|compar\w*|aggregat\w*|cross-?\s?referenc\w*|look(?:ing)?\s+(?:at|up|into))\b/i;
+
+/**
+ * True when `content` announces work the model has not done rather than
+ * answering. An absent or blank message is NOT this: "no answer at all" is a
+ * separate condition at the call site, handled by the same path but for its
+ * own reason.
+ */
+export function announcesUnrunWork(content: string | null | undefined): boolean {
+  const text = content?.trim();
+  if (!text) return false;
+  if (text.length >= ANNOUNCEMENT_MAX_CHARS) return false;
+  return DATA_STEP_COMMITMENT.test(text);
+}
+
+/**
+ * The output contract, stated ONCE (#343).
+ *
+ * The previous wording ("Based on all the data you have collected from the
+ * tool calls above, please provide a comprehensive answer to my original
+ * question. Summarize the key findings.") asked for an answer but never said
+ * that announcing one does not count — which is the exact failure being
+ * corrected, so it is now said outright, along with the fact that this turn is
+ * the published one.
+ *
+ * It is the only place this loop tells the model what an answer must be. The
+ * abort message below deliberately reports a FACT (a tool call was not run)
+ * and says nothing about what to write: two paraphrases of one contract meant
+ * editing either gave no reason to look at the other, and the older paraphrase
+ * was the wording this one was written to replace.
+ *
+ * Source identifiers are named by KIND, not by source: this string is the
+ * app's own copy and stays free of any particular server's vocabulary.
+ */
+const FINAL_ANSWER_REQUEST =
+  'This is the final turn: no further tool calls will be made, and what you write now is the ' +
+  'published answer. Answer my original question using only the data already collected above. ' +
+  'Do not describe a query you plan to run or a step you intend to take next — a statement of ' +
+  'intent is not an answer. State the findings themselves, and cite the source of each figure ' +
+  '(dataset ID, variable DCID plus source dataset, or resource UUID plus dataset title). If the ' +
+  'data collected is not enough to answer, say so plainly and state what it does show.';
+
+/**
+ * What a `tool_call_id` the loop never ran gets answered with. A statement of
+ * fact only — see `FINAL_ANSWER_REQUEST` above for why it says nothing about
+ * how to answer.
+ *
+ * #343 measured the arm this replaces: a `'Token budget exceeded'` variant
+ * could never be selected, because the token-limit break can only happen after
+ * the assistant turn is already in the transcript with its tool calls already
+ * answered by real results, which is exactly the condition under which no
+ * abort message is written at all. One live arm, one reachable state.
+ */
+const UNRUN_TOOL_CALL_NOTE =
+  'This tool call was not run: the tool-call limit for this query was reached.';
+
+/**
+ * Map a thrown tool-call error onto the notebook's failure vocabulary (#321).
+ *
+ * `classifyStreamError` is the app's classifier for the same error shapes, so
+ * failure is classified ONCE, in one place, rather than re-derived downstream
+ * from prose. The mapping is narrowing and deliberately lossy:
+ * `ToolFailureKind` describes what a notebook reader needs to know about ONE
+ * request, so the six kinds that describe a whole query rather than a single
+ * tool call — this app's own rate limit, the two model-credential kinds,
+ * notebook execution — collapse into `unknown` rather than being asserted as
+ * something more specific than was measured (design-principles.md Principle 3).
+ *
+ * `connection` joins `mcp_unavailable`: to a reader deciding whether to re-run
+ * the notebook, "the source could not be reached" is the same fact either way.
+ */
+function toolFailureKindOf(error: unknown): ToolFailureKind {
+  switch (classifyStreamError(error)) {
+    case 'mcp_timeout':
+      return 'timeout';
+    case 'mcp_unavailable':
+    case 'connection':
+      return 'unavailable';
+    case 'mcp_not_configured':
+      return 'not_configured';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * The failure raised for a tool call whose arguments the endpoint sent as
+ * something other than valid JSON (#349).
+ *
+ * The text is this app's own, not the parser's. A `SyntaxError` message quotes
+ * the malformed bytes back, and those bytes are endpoint-supplied: routing
+ * them through `classifyStreamError` would let them steer the classification,
+ * and any of them reaching a `tool` message would put raw text in front of the
+ * model. Neither happens — this Error classifies to `generic`/`unknown`, which
+ * is the honest answer for "the model sent something we could not read".
+ */
+function malformedToolArgumentsError(): Error {
+  return new Error('The tool call arguments could not be parsed.');
+}
+
+/**
+ * The span attributes recording what the endpoint said it used, next to what
+ * this instance declared (website#30 P3, E5 — G0 D3: record both, warn, never
+ * gate).
+ *
+ * `gen_ai.request.model` carries the DECLARED identity, not the wire string.
+ * The trace is inside the signed package, so the rule that governs
+ * `cost.model` governs it too: a deployment alias is the operator's private
+ * label and does not go into a public record. `gen_ai.response.model` is the
+ * endpoint's own report, which is the only half of the pair this app does not
+ * choose — and having both under one signature is what lets a reader check the
+ * declaration against the report without trusting either of us.
+ *
+ * A mismatch is a disclosure, not a failure. It is normal and benign (an
+ * endpoint answering `gpt-4o-2024-11-20` for a request that said `gpt-4o`),
+ * and where it is not benign the record now carries the evidence either way.
+ * Gating on it would turn a routing detail into a lost answer.
+ */
+export function responseModelAttributes(
+  declared: string,
+  reported: string | undefined,
+  context: string,
+): Record<string, string> {
+  if (!reported) return {};
+  if (reported !== declared) {
+    console.warn(
+      `[stream:${context}] endpoint reported a different model than this instance declares`,
+      { declared, reported },
+    );
+  }
+  return { 'gen_ai.response.model': reported };
+}
+
+/**
+ * Bound one tool result before it is fed back as context, keeping what is fed
+ * back READABLE (#331).
+ *
+ * A bare JSON array was the only shape this recognised. A paginated envelope —
+ * `{"data": [...], "total_rows": N}` — is not an array, so an oversized one
+ * fell through to raw character truncation and was cut mid-record: the model
+ * received a fragment ending inside a string, with no marker telling it that
+ * anything had been dropped, and built its answer on whatever it made of that.
+ * Measured on the issue's own 296,028-character envelope: 50,042 characters
+ * out, not parseable, no marker.
+ *
+ * Both structured branches drop whole rows and say so. The envelope branch
+ * re-emits the envelope with its other fields intact, so `total_rows` still
+ * tells the model how large the matching set upstream was while `data` shows
+ * how much of it is actually here.
+ *
+ * The output contract, for every branch: a body the model can read, followed
+ * by one `[Truncated: ...]` line saying what was dropped. The character bound
+ * is on the body, not on the marker.
+ */
+function truncateToolResult(result: string, maxChars: number): string {
+  if (result.length <= maxChars) return result;
+
+  try {
+    const parsed: unknown = JSON.parse(result);
+
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      const kept = keepRowsWithinBudget(parsed, maxChars);
+      return `${JSON.stringify(kept)}\n[Truncated: showing ${kept.length} of ${parsed.length} rows]`;
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      const envelope = parsed as Record<string, unknown>;
+      const rows = envelope.data;
+      if (Array.isArray(rows) && rows.length > 0) {
+        const kept = keepRowsWithinBudget(rows, maxChars);
+        return `${JSON.stringify({ ...envelope, data: kept })}\n[Truncated: showing ${kept.length} of ${rows.length} rows]`;
+      }
+    }
+  } catch {
+    // Not JSON — fall through to raw truncation
+  }
+
+  return result.slice(0, maxChars) +
+    `\n[Truncated: result was ${result.length} characters]`;
+}
+
+/** How many whole rows fit in the budget, never fewer than five. */
+function keepRowsWithinBudget(rows: unknown[], maxChars: number): unknown[] {
+  const sampleRow = JSON.stringify(rows[0]);
+  const rowSize = (sampleRow ? sampleRow.length : 0) + 2; // comma + newline
+  const maxRows = Math.max(5, Math.floor(maxChars / Math.max(rowSize, 1)));
+  return rows.slice(0, maxRows);
+}
+
+/**
+ * Extract `{rows, columns}` from a tool result. Socrata (and any MCP server
+ * that paginates) answers with an envelope — `{ data: [...], total_rows: N }`
+ * — not a bare array, so a bare-array-only check silently reported nothing for
+ * every such call (#322).
+ *
+ * `rows` is what THIS CALL actually delivered — `data.length` — never
+ * `total_rows`. `total_rows` is the size of the matching set upstream; a capped
+ * page can return far fewer rows than that, and every downstream reader of
+ * `resultSummary.rows` means "how much data flowed through this call," not
+ * "how large is the source dataset." Reporting `total_rows` there would claim
+ * the model analyzed rows it never saw.
+ */
+function summarizeToolResult(result: string): { rows: number; columns: number } | undefined {
+  try {
+    const parsed: unknown = JSON.parse(result);
+    const rows: unknown[] | undefined = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>).data)
+        ? (parsed as Record<string, unknown>).data as unknown[]
+        : undefined;
+
+    if (!rows) {
+      // Not JSON-parseable as a bare array or a { data: [...] } envelope (e.g.
+      // a metadata/metrics payload, or an envelope with no `data` field) —
+      // skip, `resultSummary` stays unset.
+      return undefined;
+    }
+    if (rows.length === 0) {
+      // A valid, empty result set is a real answer ("no matching records"),
+      // not a parse failure — worth distinguishing from the silent-skip cases
+      // so a zero-row response is diagnosable rather than indistinguishable
+      // from "did not parse."
+      return { rows: 0, columns: 0 };
+    }
+    const firstRow = rows[0];
+    if (typeof firstRow === 'object' && firstRow !== null) {
+      return { rows: rows.length, columns: Object.keys(firstRow).length };
+    }
+    // A non-empty array whose elements are not objects (e.g. an array of
+    // strings) — not tabular, skip.
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopResult> {
+  const {
+    client,
+    endpointModel,
+    declaredModel = options.endpointModel,
+    prompt,
+    systemPrompt,
+    tools,
+    executeToolCall,
+    maxIterations = DEFAULT_MAX_ITERATIONS,
+    maxTokens = DEFAULT_MAX_TOKENS,
+    maxCumulativeTokens,
+    maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
+    finalTurn = 'blocking',
+    passThroughDelivery,
+    onDelta,
+    onEvent,
+    trace,
+    logContext = 'model-loop',
+  } = options;
+
+  const startTime = Date.now();
+  const toolCalls: ToolCallRecord[] = [];
+  const emit = (event: LoopEvent) => onEvent?.(event);
+
+  const messages: ChatCompletionMessageParam[] = [];
+  if (systemPrompt) {
+    messages.push({ role: 'system', content: systemPrompt });
+  }
+  messages.push({ role: 'user', content: prompt });
+
+  // First call — check if tools are needed (non-streaming, to see tool_calls)
+  let llmSpanId = trace?.builder.startSpan('llm_inference', trace.parentSpanId, {
+    'gen_ai.system': getGenAiSystem(),
+    'gen_ai.request.model': declaredModel,
+    ...(trace.systemPromptHash ? { 'gen_ai.system_prompt_hash': trace.systemPromptHash } : {}),
+    'gen_ai.inference_index': 0,
+  });
+  let response = await client.chat.completions.create({
+    model: endpointModel,
+    messages,
+    tools,
+    tool_choice: 'auto',
+    max_tokens: maxTokens,
+  });
+  if (llmSpanId) {
+    trace!.builder.endSpan(llmSpanId, {
+      'gen_ai.response.prompt_tokens': response.usage?.prompt_tokens || 0,
+      'gen_ai.response.completion_tokens': response.usage?.completion_tokens || 0,
+      ...responseModelAttributes(declaredModel, response.model, logContext),
+    });
+  }
+
+  let iterations = 0;
+  let cumulativeTokens = response.usage?.total_tokens || 0;
+  let cumulativePromptTokens = response.usage?.prompt_tokens || 0;
+  let cumulativeCompletionTokens = response.usage?.completion_tokens || 0;
+  let tokenLimitExceeded = false;
+  /**
+   * True when `response`'s message is ALREADY in `messages`. The loop pushes
+   * each assistant turn before executing its tools, so the token-limit break
+   * below leaves the loop with the final message already in the transcript,
+   * its tool calls already answered with real results. The terminal block
+   * must not push it a second time: that would duplicate the assistant turn
+   * and answer the same `tool_call_id` twice, which is a malformed request.
+   */
+  let lastMessageAlreadyInTranscript = false;
+
+  // Handle tool calls iteratively
+  while (response.choices[0]?.message?.tool_calls && iterations < maxIterations) {
+    const assistantMessage = response.choices[0].message;
+    const pendingCalls = assistantMessage.tool_calls;
+    messages.push(assistantMessage);
+    lastMessageAlreadyInTranscript = true;
+
+    if (!pendingCalls) break;
+
+    const currentIteration = iterations + 1;
+
+    for (const toolCall of pendingCalls) {
+      if (toolCall.type !== 'function') continue;
+
+      const name = toolCall.function.name;
+      /**
+       * #349: the parse sits INSIDE the failure path rather than upstream of
+       * it. The endpoint chooses these bytes, and an unparseable set used to
+       * throw straight out of the loop — past the failure record, past
+       * `describeToolFailureForLlm`, ending a query that may already have
+       * completed several successful calls. A malformed argument set is now
+       * one failed tool call, handled exactly as an unreachable data source
+       * is: recorded, described to the model, run continues.
+       */
+      let argumentsMalformed = false;
+      let args: Record<string, unknown> = {};
+      try {
+        args = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
+      } catch {
+        argumentsMalformed = true;
+      }
+
+      const operationType = deriveOperationType(name, args);
+      const reason = generateToolReason(args);
+      // `args` goes onto the record BY REFERENCE and is handed to
+      // `executeToolCall` unchanged — see this file's header.
+      const toolEntry: ToolCallRecord = { name, args, operationType, reason };
+      toolCalls.push(toolEntry);
+      const priorCalls = toolCalls.slice(0, -1);
+      emit({ type: 'tool_start', iteration: currentIteration, call: toolEntry, priorCalls });
+
+      // Trace: start MCP tool call span.
+      // `mcp.source` distinguishes which MCP server handled the call so the
+      // PROV-O builder can emit a distinct prov:Agent per source (see
+      // provenance.ts). Unknown tools fall back to "unknown".
+      const toolSource = trace?.resolveToolSource?.(name) ?? 'unknown';
+      const toolTraceSpanId = trace?.builder.startSpan('mcp_tool_call', trace.parentSpanId, {
+        'tool.name': name,
+        'tool.operation_type': operationType || 'unknown',
+        'tool.arguments': JSON.stringify(args),
+        'mcp.source': toolSource,
+        ...(args.dataset_id ? { 'tool.dataset_id': String(args.dataset_id) } : {}),
+        ...(args.portal ? { 'tool.portal_domain': String(args.portal) } : {}),
+      });
+
+      try {
+        if (argumentsMalformed) throw malformedToolArgumentsError();
+
+        const toolStartTime = Date.now();
+        const result = await executeToolCall(name, args);
+        const toolDuration = Date.now() - toolStartTime;
+        toolEntry.duration_ms = toolDuration;
+        toolEntry.resultSummary = summarizeToolResult(result);
+
+        // Trace: end tool call span with response metadata
+        if (toolTraceSpanId) {
+          trace!.builder.endSpan(toolTraceSpanId, {
+            'tool.response_hash': traceHash(result),
+            'tool.response_size_bytes': result.length,
+            'tool.duration_ms': toolDuration,
+            ...(toolEntry.resultSummary ? { 'tool.response_rows': toolEntry.resultSummary.rows } : {}),
+          });
+        }
+
+        emit({ type: 'tool_complete', iteration: currentIteration, call: toolEntry, priorCalls, durationMs: toolDuration });
+        emit({ type: 'tool_result', iteration: currentIteration, call: toolEntry });
+
+        messages.push({
+          role: 'tool',
+          tool_call_id: toolCall.id,
+          content: truncateToolResult(result, maxToolResultChars),
+        });
+      } catch (error) {
+        // #321: record the rejection ON the tool-call entry, here, where it is
+        // already known. `toolEntry` was pushed into `toolCalls` before the
+        // await, so this mutation reaches every consumer of the record —
+        // including the notebook synthesizer, which was rendering this call as
+        // an executable fetch cell that then threw on execution. Nothing
+        // downstream can recover this fact.
+        toolEntry.failed = true;
+        toolEntry.failureKind = toolFailureKindOf(error);
+        if (toolTraceSpanId) {
+          trace!.builder.endSpan(toolTraceSpanId, {
+            'error': true,
+            'error.message': error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+        // Feed the model neutral guidance instead of the raw error string:
+        // keep it honest (no invented data) without letting raw infra text
+        // (timeouts, status codes, server names) reach the final answer.
+        messages.push({
+          role: 'tool',
+          tool_call_id: toolCall.id,
+          content: describeToolFailureForLlm(name, error),
+        });
+      }
+    }
+
+    // Check the token budget before making the next model call
+    if (maxCumulativeTokens !== undefined && cumulativeTokens >= maxCumulativeTokens) {
+      tokenLimitExceeded = true;
+      emit({ type: 'token_budget_exhausted', cumulativeTokens });
+      break;
+    }
+
+    emit({ type: 'thinking', iteration: currentIteration });
+
+    llmSpanId = trace?.builder.startSpan('llm_inference', trace.parentSpanId, {
+      'gen_ai.system': getGenAiSystem(),
+      'gen_ai.request.model': declaredModel,
+      'gen_ai.inference_index': currentIteration,
+    });
+    response = await client.chat.completions.create({
+      model: endpointModel,
+      messages,
+      tools,
+      tool_choice: 'auto',
+      max_tokens: maxTokens,
+    });
+    lastMessageAlreadyInTranscript = false;
+    if (llmSpanId) {
+      trace!.builder.endSpan(llmSpanId, {
+        'gen_ai.response.prompt_tokens': response.usage?.prompt_tokens || 0,
+        'gen_ai.response.completion_tokens': response.usage?.completion_tokens || 0,
+        ...responseModelAttributes(declaredModel, response.model, logContext),
+      });
+    }
+
+    cumulativeTokens += response.usage?.total_tokens || 0;
+    cumulativePromptTokens += response.usage?.prompt_tokens || 0;
+    cumulativeCompletionTokens += response.usage?.completion_tokens || 0;
+
+    iterations++;
+  }
+
+  // Trace: start synthesis span (covers final output generation, including a
+  // caller's paced delivery of a pass-through answer — which is why the span
+  // is opened and closed here rather than around the call to this function).
+  const synthesisSpanId = trace?.builder.startSpan('synthesis', trace.parentSpanId);
+
+  const lastMessage = response.choices[0]?.message;
+  const pendingToolCalls = lastMessage?.tool_calls;
+
+  // Why this run cannot end on `lastMessage` as it stands. Three reasons, one
+  // answering turn — the machinery below already existed, gated on the wrong
+  // condition, so this extends that path rather than adding a second.
+  //
+  // `abortedMidPlan` is the pre-existing reason: a budget stopped the loop
+  // instead of the model finishing. It no longer also requires the message to
+  // be EMPTY. The old condition led with `!lastMessage?.content`, so a
+  // token-limit-exceeded run that happened to carry prose shipped that prose
+  // as the answer — mid-run working notes published as a finding, and without
+  // even the `token_limit_exceeded` flag that would have banner-ed them,
+  // because the content branch never set it (#319).
+  //
+  // `answeredNothing` is the old else-branch, folded in: an empty final
+  // message now gets the same restated contract as every other re-ask instead
+  // of a bare re-stream of the same transcript.
+  //
+  // `announcesUnrunWork` is the one #334 added, and it is why this condition
+  // is core behaviour rather than a parameter: a caller able to opt out of it
+  // is a caller able to publish an announcement as an answer.
+  const abortedMidPlan =
+    iterations >= maxIterations || tokenLimitExceeded || Boolean(pendingToolCalls);
+  const answeredNothing = !lastMessage?.content?.trim();
+
+  if (abortedMidPlan || answeredNothing || announcesUnrunWork(lastMessage?.content)) {
+    // Keep the transcript faithful. The model really did produce this turn,
+    // and the re-ask corrects it explicitly; re-asking into a history that no
+    // longer contains the turn being corrected would be a silent rewrite, and
+    // it would read oddly in the signed trace. Skipped when the loop already
+    // pushed this message (see `lastMessageAlreadyInTranscript`) and when
+    // there is nothing to push.
+    if (!lastMessageAlreadyInTranscript && lastMessage && (lastMessage.content || pendingToolCalls)) {
+      messages.push(lastMessage);
+    }
+    // Only for tool calls the loop did NOT already answer with real results.
+    if (pendingToolCalls && !lastMessageAlreadyInTranscript) {
+      for (const toolCall of pendingToolCalls) {
+        messages.push({
+          role: 'tool',
+          tool_call_id: toolCall.id,
+          content: UNRUN_TOOL_CALL_NOTE,
+        });
+      }
+    }
+
+    emit({ type: 'answering_turn', tokenLimitExceeded });
+
+    const answeringMessages: ChatCompletionMessageParam[] = [
+      ...messages,
+      { role: 'user', content: FINAL_ANSWER_REQUEST },
+    ];
+
+    let content = '';
+    let finalCallTokens = 0;
+    let finalPromptTokens = 0;
+    let finalCompletionTokens = 0;
+    let finalReportedModel: string | undefined;
+
+    if (finalTurn === 'stream') {
+      const finalStream = await client.chat.completions.create({
+        model: endpointModel,
+        messages: answeringMessages,
+        max_tokens: maxTokens,
+        stream: true,
+        ...(includeStreamUsage() ? { stream_options: { include_usage: true } } : {}),
+      });
+
+      for await (const chunk of finalStream) {
+        const delta = chunk.choices[0]?.delta?.content;
+        if (delta) {
+          content += delta;
+          onDelta?.(delta);
+        }
+        // Every chunk repeats the model the endpoint answered with; the last
+        // one wins, so the recorded report is the one that finished the answer.
+        if (chunk.model) finalReportedModel = chunk.model;
+        if (chunk.usage) {
+          if (chunk.usage.total_tokens) finalCallTokens = chunk.usage.total_tokens;
+          if (chunk.usage.prompt_tokens) finalPromptTokens = chunk.usage.prompt_tokens;
+          if (chunk.usage.completion_tokens) finalCompletionTokens = chunk.usage.completion_tokens;
+        }
+      }
+    } else {
+      const finalResponse = await client.chat.completions.create({
+        model: endpointModel,
+        messages: answeringMessages,
+        max_tokens: maxTokens,
+      });
+      content = finalResponse.choices[0]?.message?.content || '';
+      finalReportedModel = finalResponse.model;
+      finalCallTokens = finalResponse.usage?.total_tokens || 0;
+      finalPromptTokens = finalResponse.usage?.prompt_tokens || 0;
+      finalCompletionTokens = finalResponse.usage?.completion_tokens || 0;
+    }
+
+    cumulativeTokens += finalCallTokens;
+    cumulativePromptTokens += finalPromptTokens;
+    cumulativeCompletionTokens += finalCompletionTokens;
+
+    if (synthesisSpanId) {
+      trace!.builder.endSpan(synthesisSpanId, {
+        'output.hash': traceHash(content),
+        'output.length': content.length,
+        'gen_ai.response.prompt_tokens': finalPromptTokens,
+        'gen_ai.response.completion_tokens': finalCompletionTokens,
+        ...responseModelAttributes(declaredModel, finalReportedModel, logContext),
+      });
+    }
+
+    return {
+      content,
+      toolCalls,
+      usage: {
+        promptTokens: cumulativePromptTokens,
+        completionTokens: cumulativeCompletionTokens,
+        totalTokens: cumulativeTokens,
+      },
+      durationMs: Date.now() - startTime,
+      iterations,
+      tokenLimitExceeded,
+      streamed: finalTurn === 'stream',
+      answeringTurnTaken: true,
+    };
+  }
+
+  // Everything above returned. What is left is a genuine answer: content the
+  // model produced on its own account, that no budget cut short and that does
+  // not announce work it has not done. It is published exactly as written,
+  // with NO extra model call — the fix for #319 must cost nothing on the
+  // common path, which is the great majority of queries.
+  const finalContent = lastMessage?.content;
+  if (!finalContent) {
+    // Unreachable: `answeredNothing` routes a blank final message into the
+    // answering turn above, which returns. Kept as a typed refusal rather than
+    // a silent fall-through, because a path that reaches the end without
+    // producing a result would hang a reader's stream instead of failing
+    // visibly. The message never reaches a reader: every caller classifies and
+    // sanitizes what it puts on the wire.
+    throw new Error('final assistant message had no content after the answering turn');
+  }
+
+  emit({ type: 'pass_through' });
+
+  if (passThroughDelivery && onDelta) {
+    const { chunkChars, delayMs } = passThroughDelivery;
+    for (let i = 0; i < finalContent.length; i += chunkChars) {
+      onDelta(finalContent.slice(i, i + chunkChars));
+      // Small delay so a reader sees it arrive rather than appear.
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+
+  if (synthesisSpanId) {
+    trace!.builder.endSpan(synthesisSpanId, {
+      'output.hash': traceHash(finalContent),
+      'output.length': finalContent.length,
+    });
+  }
+
+  return {
+    content: finalContent,
+    toolCalls,
+    // cumulativeTokens already includes this response's tokens from the loop
+    usage: {
+      promptTokens: cumulativePromptTokens,
+      completionTokens: cumulativeCompletionTokens,
+      totalTokens: cumulativeTokens,
+    },
+    durationMs: Date.now() - startTime,
+    iterations,
+    tokenLimitExceeded,
+    streamed: Boolean(passThroughDelivery && onDelta),
+    answeringTurnTaken: false,
+  };
+}

--- a/src/lib/model-loop/run-tool-loop.ts
+++ b/src/lib/model-loop/run-tool-loop.ts
@@ -539,7 +539,15 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
       let argumentsMalformed = false;
       let args: Record<string, unknown> = {};
       try {
-        args = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
+        const parsed: unknown = JSON.parse(toolCall.function.arguments);
+        if (parsed !== null && typeof parsed === 'object') {
+          args = parsed as Record<string, unknown>;
+        } else {
+          // `null`, a number, a bare string: valid JSON that is not an
+          // argument set. It parses and then breaks the first reader that
+          // touches a property, which is the same failure one step later.
+          argumentsMalformed = true;
+        }
       } catch {
         argumentsMalformed = true;
       }

--- a/src/lib/model-loop/test-harness.ts
+++ b/src/lib/model-loop/test-harness.ts
@@ -1,0 +1,127 @@
+/**
+ * A scripted mock model endpoint, for driving the real tool-calling loop in a
+ * test with no live endpoint, no credential and no MCP server.
+ *
+ * It lived in `openrouter-streaming.test.ts` until the loop became shared
+ * (#345). It moves here because every caller of `runToolLoop` needs the same
+ * instrument, and because the assertions that matter most in this family are
+ * about WHAT THE MODEL WAS SENT — this server records every request body it
+ * received, so a test can read the transcript off the wire instead of
+ * inferring it from a return value.
+ *
+ * Every key, model id and hostname a test hands this server is an obviously
+ * fake fixture; the address is loopback.
+ *
+ * Not a `.test.ts` file on purpose: it holds no tests, and naming it one would
+ * make the runner execute it as an empty suite.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface ScriptedToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  /**
+   * Sent verbatim as `function.arguments` instead of `JSON.stringify(args)`.
+   * The endpoint chooses those bytes in production and is not obliged to make
+   * them parseable — which is the case #349 is about.
+   */
+  rawArguments?: string;
+}
+
+export interface ScriptedReply {
+  content?: string | null;
+  toolCalls?: ScriptedToolCall[];
+  totalTokens?: number;
+}
+
+export interface ScriptedModelServer {
+  server: Server;
+  url: string;
+  /** Every request body the server received, in order. */
+  requests: Record<string, unknown>[];
+}
+
+/**
+ * A model server that answers from a script. Reply N serves request N; the
+ * LAST reply repeats for every request beyond the script, which is what makes
+ * an unbounded re-ask observable — a loop would keep drawing the same
+ * unsatisfying answer and the request count would climb past the bound.
+ *
+ * It reads the request body, so it can answer `stream: true` with real SSE
+ * (the answering turn streams) and record what was actually sent (tools
+ * omitted, contract restated, transcript intact).
+ */
+export function startScriptedModelServer(replies: ScriptedReply[]): Promise<ScriptedModelServer> {
+  const requests: Record<string, unknown>[] = [];
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+        requests.push(body);
+        const reply = replies[Math.min(requests.length - 1, replies.length - 1)];
+        const usage = {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: reply.totalTokens ?? 15,
+        };
+
+        if (body.stream === true) {
+          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+          const frame = (payload: Record<string, unknown>) =>
+            `data: ${JSON.stringify({
+              id: 'chatcmpl-test-scripted',
+              object: 'chat.completion.chunk',
+              created: 1,
+              model: 'fake/model',
+              ...payload,
+            })}\n\n`;
+          res.write(frame({
+            choices: [{ index: 0, delta: { content: reply.content ?? '' }, finish_reason: null }],
+          }));
+          res.write(frame({ choices: [], usage }));
+          res.write('data: [DONE]\n\n');
+          res.end();
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test-scripted',
+          object: 'chat.completion',
+          created: 1,
+          model: 'fake/model',
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: reply.content ?? null,
+              ...(reply.toolCalls
+                ? {
+                    tool_calls: reply.toolCalls.map((tc) => ({
+                      id: tc.id,
+                      type: 'function',
+                      function: {
+                        name: tc.name,
+                        arguments: tc.rawArguments ?? JSON.stringify(tc.args),
+                      },
+                    })),
+                  }
+                : {}),
+            },
+            finish_reason: reply.toolCalls ? 'tool_calls' : 'stop',
+          }],
+          usage,
+        }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/v1`, requests });
+    });
+  });
+}

--- a/src/lib/openrouter-streaming.test.ts
+++ b/src/lib/openrouter-streaming.test.ts
@@ -15,6 +15,7 @@ import { queryWithoutMcpStreaming, queryWithMcpStreaming, announcesUnrunWork, ty
 import { carriedModelIdentity } from './model-catalog.ts';
 import { _resetDefaultModelClientForTests } from './model-client.ts';
 import { streamErrorPayload, buildStatsSummary, buildProvenanceLine, type StreamErrorCode, type PanelType, type ProgressPhase } from './streaming.ts';
+import { startScriptedModelServer, type ScriptedReply } from './model-loop/test-harness.ts';
 
 const FAKE_KEY = 'sk-or-test-obviously-fake-key-do-not-use';
 
@@ -638,94 +639,11 @@ test('#321: a SUCCESSFUL tool call is not marked failed', async () => {
 // "no extra model call on a good answer" and "at most one extra answering
 // turn" are pinned, neither of which is visible from the completion alone.
 
-interface ScriptedReply {
-  content?: string | null;
-  toolCalls?: { id: string; name: string; args: Record<string, unknown> }[];
-  totalTokens?: number;
-}
-
-/**
- * A model server that answers from a script. Reply N serves request N; the
- * LAST reply repeats for every request beyond the script, which is what makes
- * an unbounded re-ask observable — a loop would keep drawing the same
- * unsatisfying answer and the request count would climb past the bound.
- *
- * Unlike `startToolCallModelServer` above it reads the request body, so it can
- * answer `stream: true` with real SSE (the answering turn streams) and record
- * what was actually sent (tools omitted, contract restated, transcript intact).
- */
-function startScriptedModelServer(replies: ScriptedReply[]): Promise<{
-  server: Server;
-  url: string;
-  requests: Record<string, unknown>[];
-}> {
-  const requests: Record<string, unknown>[] = [];
-  return new Promise((resolve) => {
-    const server = createServer((req, res) => {
-      const chunks: Buffer[] = [];
-      req.on('data', (c: Buffer) => chunks.push(c));
-      req.on('end', () => {
-        const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
-        requests.push(body);
-        const reply = replies[Math.min(requests.length - 1, replies.length - 1)];
-        const usage = {
-          prompt_tokens: 10,
-          completion_tokens: 5,
-          total_tokens: reply.totalTokens ?? 15,
-        };
-
-        if (body.stream === true) {
-          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
-          const frame = (payload: Record<string, unknown>) =>
-            `data: ${JSON.stringify({
-              id: 'chatcmpl-test-scripted',
-              object: 'chat.completion.chunk',
-              created: 1,
-              model: 'fake/model',
-              ...payload,
-            })}\n\n`;
-          res.write(frame({
-            choices: [{ index: 0, delta: { content: reply.content ?? '' }, finish_reason: null }],
-          }));
-          res.write(frame({ choices: [], usage }));
-          res.write('data: [DONE]\n\n');
-          res.end();
-          return;
-        }
-
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          id: 'chatcmpl-test-scripted',
-          object: 'chat.completion',
-          created: 1,
-          model: 'fake/model',
-          choices: [{
-            index: 0,
-            message: {
-              role: 'assistant',
-              content: reply.content ?? null,
-              ...(reply.toolCalls
-                ? {
-                    tool_calls: reply.toolCalls.map((tc) => ({
-                      id: tc.id,
-                      type: 'function',
-                      function: { name: tc.name, arguments: JSON.stringify(tc.args) },
-                    })),
-                  }
-                : {}),
-            },
-            finish_reason: reply.toolCalls ? 'tool_calls' : 'stop',
-          }],
-          usage,
-        }));
-      });
-    });
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address() as AddressInfo;
-      resolve({ server, url: `http://127.0.0.1:${port}/v1`, requests });
-    });
-  });
-}
+// `startScriptedModelServer` used to be defined here. It moved to
+// `model-loop/test-harness.ts` when the loop became shared (#345): every
+// caller of `runToolLoop` needs the same instrument, and a second copy of a
+// mock endpoint is how two callers start disagreeing about what they are
+// testing. The cases below are unchanged.
 
 async function runScripted(replies: ScriptedReply[]): Promise<{
   result: CompletionResult;
@@ -901,6 +819,27 @@ test('#319: the token-limit answering turn does not duplicate the assistant turn
   assert.equal(assistants.length, 1, 'the assistant turn the loop already pushed must not be pushed again');
   const answered = messages.filter((m) => m.role === 'tool').map((m) => m.tool_call_id);
   assert.deepEqual(answered, ['call_1'], `expected one answer for call_1, saw ${JSON.stringify(answered)}`);
+});
+
+// --- The completion's shape, which differs by path on purpose --------------
+
+test('#345 P2: token_limit_exceeded is present on the answering-turn completion and ABSENT on the pass-through one', async () => {
+  // Wire-visible on the SSE `complete` event, and the easiest thing in this
+  // module for an adapter to flatten: the two completions carry different keys
+  // deliberately. A run that took the answering turn is the only one that can
+  // have been cut short, so it reports the flag the reader's truncation banner
+  // is keyed on; a run the model answered on its own account omits the key
+  // rather than asserting `false` on every ordinary query.
+  const answering = await runScripted([FETCH_CALL, { content: NARRATION }, { content: REAL_ANSWER }]);
+  assert.equal('token_limit_exceeded' in answering.result, true, 'the answering turn reports the flag');
+  assert.equal(answering.result.token_limit_exceeded, false);
+
+  const passThrough = await runScripted([FETCH_CALL, { content: REAL_ANSWER }]);
+  assert.equal(
+    'token_limit_exceeded' in passThrough.result,
+    false,
+    'the pass-through completion omits the key rather than sending token_limit_exceeded: false',
+  );
 });
 
 // --- The rule itself: where the line is drawn ------------------------------

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -1,23 +1,22 @@
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
-import { getModelClient, classifyModelError, getGenAiSystem, includeStreamUsage, getModelApiKind } from './model-client.ts';
+import { getModelClient, classifyModelError, includeStreamUsage, getModelApiKind } from './model-client.ts';
 import type { ModelIdentity } from './model-catalog.ts';
-import { formatToolProgress, formatToolResult, generateToolReason, describeToolFailureForLlm, classifyStreamError, streamErrorPayload, type PanelType, type ProgressPhase, type StreamErrorCode, type StreamErrorKind } from './streaming.ts';
-import type { TraceBuilder } from './evidence/trace.ts';
-import { hash as traceHash } from './evidence/trace.ts';
-import { deriveOperationType } from './mcp/operation-types.ts';
-import type { ToolFailureKind } from './notebook-author/tool-to-cell.ts';
+import { formatToolProgress, formatToolResult, classifyStreamError, streamErrorPayload, type PanelType, type ProgressPhase, type StreamErrorCode, type StreamErrorKind } from './streaming.ts';
+import { runToolLoop, type LoopEvent, type ToolCallRecord, type TraceContext } from './model-loop/run-tool-loop.ts';
 
-export interface TraceContext {
-  builder: TraceBuilder;
-  parentSpanId: string;
-  systemPromptHash?: string;
-  /**
-   * Optional hook that maps a tool name to its MCP source id (e.g. "socrata",
-   * "data-commons"). When provided, the source is recorded on each
-   * `mcp_tool_call` span so the PROV-O builder can distinguish servers.
-   */
-  resolveToolSource?: (toolName: string) => string | undefined;
-}
+/**
+ * The tool-calling loop itself lives in `model-loop/run-tool-loop.ts` (#345):
+ * three callers used to carry three copies of it, and every defect fixed in
+ * one survived in the other two. This module is now the SSE-facing caller —
+ * it binds the panel, renders reader-facing progress copy, paces the
+ * pass-through answer and classifies failures for the wire. Nothing about
+ * what the loop does lives here any more.
+ *
+ * The three names below stay exported from this module because callers and
+ * tests import them from here; they are re-exports, not second copies.
+ */
+export { announcesUnrunWork, responseModelAttributes } from './model-loop/run-tool-loop.ts';
+export type { TraceContext };
 
 export interface ProgressOpts {
   duration_ms?: number;
@@ -94,202 +93,79 @@ export interface CompletionResult {
   prompt_tokens?: number;
   completion_tokens?: number;
   token_limit_exceeded?: boolean;
-  tools_called?: {
-    name: string;
-    args: Record<string, unknown>;
-    resultSummary?: { rows: number; columns: number };
-    duration_ms?: number;
-    operationType?: string;
-    reason?: string;
-    /** Set when the tool call threw; see the catch block below (#321). */
-    failed?: boolean;
-    failureKind?: ToolFailureKind;
-  }[];
-}
-
-/**
- * Map a thrown tool-call error onto the notebook's failure vocabulary (#321).
- *
- * `classifyStreamError` is already this file's classifier for the same error
- * shapes (`reportStreamFailure` uses it), so failure is classified ONCE, in
- * one place, rather than re-derived downstream from prose. The mapping is
- * narrowing and deliberately lossy: `ToolFailureKind` describes what a
- * notebook reader needs to know about ONE request, so the six kinds that
- * describe a whole query rather than a single tool call — this app's own rate
- * limit, the two model-credential kinds, notebook execution — collapse into
- * `unknown` rather than being asserted as something more specific than was
- * measured (design-principles.md Principle 3).
- *
- * `connection` joins `mcp_unavailable`: to a reader deciding whether to re-run
- * the notebook, "the source could not be reached" is the same fact either way.
- */
-function toolFailureKindOf(error: unknown): ToolFailureKind {
-  switch (classifyStreamError(error)) {
-    case 'mcp_timeout':
-      return 'timeout';
-    case 'mcp_unavailable':
-    case 'connection':
-      return 'unavailable';
-    case 'mcp_not_configured':
-      return 'not_configured';
-    default:
-      return 'unknown';
-  }
+  tools_called?: ToolCallRecord[];
 }
 
 // Token safety limits (configurable via env vars)
 const MAX_TOKENS_PER_REQUEST = Number(process.env.TOKEN_LIMIT_PER_REQUEST) || 200_000;
 const MAX_TOOL_RESULT_CHARS = Number(process.env.MAX_TOOL_RESULT_CHARS) || 50_000;
 
-/**
- * A final turn that ANNOUNCES a query instead of answering it (#319).
- *
- * The tool-call loop treats any assistant message carrying no `tool_calls` as
- * the final answer. When the model narrates its next step in prose instead of
- * emitting the call, that narration becomes the published answer. The measured
- * case: eight tool calls completed, then 235 characters ending "...I'll query
- * the fraction of records that close within 14 and 30 days per type". The
- * notebook validated. The record was publishable. It is a statement of intent
- * to run a query that was never run, published under the same signature and
- * the same visual treatment as a real finding, and a reader cannot tell the
- * two apart.
- *
- * THE RULE. A final message fails the output contract when BOTH hold:
- *
- *   1. it COMMITS, in the first person, to a data step it has not taken
- *      ("I'll query...", "Let me check...", "Next I'll compute..."), and
- *   2. the whole message is shorter than `ANNOUNCEMENT_MAX_CHARS`.
- *
- * Commitment rather than offer is the first half's whole point. "I can pull
- * the 30-day rates too" and "would you like me to..." offer further work
- * AFTER answering; they are not matched, and must not be. Only forms that
- * assert the model is about to act are.
- *
- * The length bound is the conservatism. A long answer that closes with an
- * aside has already answered, and re-asking it would cost a model call and a
- * rewrite for nothing. The measured narration was 235 characters; 600 leaves
- * room for a wordier one while sitting below any message that has actually
- * summarized findings and cited a source.
- *
- * WHAT THIS DELIBERATELY DOES NOT DO is inspect the answer's substance — no
- * citation check, no "must reference a computed value" (#333). The output
- * contract's only concrete requirement is citation, and a citation gate has no
- * measured definition yet; a wrong one re-asks correct answers, which is a
- * failure that looks like rigour. The distinction drawn here is the narrower
- * one #319 is actually about: answering rather than announcing.
- *
- * COST WHEN WRONG, in each direction. A false positive costs one extra model
- * call and a re-worded answer — a real cost, which is why both conjuncts are
- * required rather than either alone. A false negative publishes a statement of
- * intent as a signed finding. The second is much worse, but not so much worse
- * that the rule should be loose.
- *
- * Not to be confused with `detectIncompleteResponse` in
- * components/shared/McpResponseDisplay.tsx, which is display-only and matches
- * the opposite admission — a model saying it could NOT finish. None of its
- * patterns fire on a confident announcement, which is why #319 reached the
- * reader with no banner at all. If a second caller ever needs this predicate,
- * export it toward that one rather than growing a parallel matcher.
- */
-const ANNOUNCEMENT_MAX_CHARS = 600;
+/** Tool-calling rounds, and `max_tokens` on every request this caller makes. */
+const MAX_ITERATIONS = 20;
+const MAX_TOKENS_PER_RESPONSE = 4000;
 
 /**
- * First-person commitment, then a data-acquisition or computation verb within
- * two words. `let me` carries a negative lookahead for "know", because "let me
- * know if you want the monthly breakdown" is a courtesy at the end of a real
- * answer, not a plan. No `g` flag: this is shared module state and `test()`
- * would otherwise carry `lastIndex` between calls.
+ * A pass-through answer — one the model produced on its own account, needing
+ * no answering turn — arrives whole. It is paced onto the wire so a reader
+ * sees it build the way a streamed answer does, rather than appearing at once
+ * after a long silence.
  */
-const DATA_STEP_COMMITMENT =
-  /(?:\bi['’]?ll\b|\bi\s+will\b|\bi['’]?m\s+going\s+to\b|\bi\s+am\s+going\s+to\b|\bi\s+need\s+to\b|\bi\s+plan\s+to\b|\bi\s+intend\s+to\b|\bi['’]?m\s+about\s+to\b|\bi\s+am\s+about\s+to\b|\blet\s+me\b(?!\s+know)|\blet['’]?s\b|\bnext,?\s+i\b|\bnow\s+i\b|\bthen\s+i\b)(?:\s+\w+){0,2}\s+(?:quer(?:y|ies|ying)|fetch(?:ing)?|retriev\w*|re-?run(?:ning)?|run(?:ning)?|pull(?:ing)?|request(?:ing)?|check(?:ing)?|search(?:ing)?|count(?:ing)?|calculat\w*|comput\w*|analyz\w*|analys\w*|examin\w*|inspect(?:ing)?|compar\w*|aggregat\w*|cross-?\s?referenc\w*|look(?:ing)?\s+(?:at|up|into))\b/i;
+const PASS_THROUGH_DELIVERY = { chunkChars: 20, delayMs: 10 };
 
 /**
- * True when `content` announces work the model has not done rather than
- * answering. An absent or blank message is NOT this: "no answer at all" is a
- * separate condition at the call site, handled by the same path but for its
- * own reason.
+ * Render one loop event as the SSE progress this panel's reader sees. The loop
+ * reports structurally and knows nothing about panels; the copy and the
+ * formatters live here, on the side that has a reader.
  */
-export function announcesUnrunWork(content: string | null | undefined): boolean {
-  const text = content?.trim();
-  if (!text) return false;
-  if (text.length >= ANNOUNCEMENT_MAX_CHARS) return false;
-  return DATA_STEP_COMMITMENT.test(text);
-}
-
-/**
- * The output contract, restated at the one moment the model has demonstrably
- * lost it. The previous wording ("Based on all the data you have collected
- * from the tool calls above, please provide a comprehensive answer to my
- * original question. Summarize the key findings.") asked for an answer but
- * never said that announcing one does not count — which is the exact failure
- * being corrected, so it is now said outright, along with the fact that this
- * turn is the published one.
- *
- * Source identifiers are named by KIND, not by source: this string is the
- * app's own copy and stays free of any particular server's vocabulary.
- */
-const FINAL_ANSWER_REQUEST =
-  'This is the final turn: no further tool calls will be made, and what you write now is the ' +
-  'published answer. Answer my original question using only the data already collected above. ' +
-  'Do not describe a query you plan to run or a step you intend to take next — a statement of ' +
-  'intent is not an answer. State the findings themselves, and cite the source of each figure ' +
-  '(dataset ID, variable DCID plus source dataset, or resource UUID plus dataset title). If the ' +
-  'data collected is not enough to answer, say so plainly and state what it does show.';
-
-/**
- * The span attributes recording what the endpoint said it used, next to what
- * this instance declared (website#30 P3, E5 — G0 D3: record both, warn, never
- * gate).
- *
- * `gen_ai.request.model` carries the DECLARED identity, not the wire string.
- * The trace is inside the signed package, so the rule that governs
- * `cost.model` governs it too: a deployment alias is the operator's private
- * label and does not go into a public record. `gen_ai.response.model` is the
- * endpoint's own report, which is the only half of the pair this app does not
- * choose — and having both under one signature is what lets a reader check the
- * declaration against the report without trusting either of us.
- *
- * A mismatch is a disclosure, not a failure. It is normal and benign (an
- * endpoint answering `gpt-4o-2024-11-20` for a request that said `gpt-4o`),
- * and where it is not benign the record now carries the evidence either way.
- * Gating on it would turn a routing detail into a lost answer.
- */
-export function responseModelAttributes(
-  declared: string,
-  reported: string | undefined,
-  context: string,
-): Record<string, string> {
-  if (!reported) return {};
-  if (reported !== declared) {
-    console.warn(
-      `[stream:${context}] endpoint reported a different model than this instance declares`,
-      { declared, reported },
-    );
-  }
-  return { 'gen_ai.response.model': reported };
-}
-
-// Truncate large tool results to limit input token growth
-function truncateToolResult(result: string): string {
-  if (result.length <= MAX_TOOL_RESULT_CHARS) return result;
-
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed) && parsed.length > 0) {
-      // Keep enough rows to stay under the limit
-      const sampleRow = JSON.stringify(parsed[0]);
-      const rowSize = sampleRow.length + 2; // comma + newline
-      const maxRows = Math.max(5, Math.floor(MAX_TOOL_RESULT_CHARS / rowSize));
-      const truncated = parsed.slice(0, maxRows);
-      return JSON.stringify(truncated) +
-        `\n[Truncated: showing ${truncated.length} of ${parsed.length} rows]`;
+function reportLoopEvent(panel: PanelType, event: LoopEvent, callbacks: StreamCallbacks): void {
+  switch (event.type) {
+    case 'tool_start':
+      callbacks.onProgress(
+        panel,
+        formatToolProgress(event.call.name, event.call.args, event.priorCalls),
+        { phase: 'tool_start', iteration: event.iteration, args: event.call.args },
+      );
+      return;
+    case 'tool_complete':
+      callbacks.onProgress(
+        panel,
+        formatToolProgress(event.call.name, event.call.args, event.priorCalls),
+        { phase: 'tool_complete', iteration: event.iteration, duration_ms: event.durationMs },
+      );
+      return;
+    case 'tool_result': {
+      const resultMessage = formatToolResult(event.call.args, event.call.resultSummary);
+      if (resultMessage) {
+        callbacks.onProgress(panel, resultMessage, {
+          phase: 'tool_result',
+          iteration: event.iteration,
+          args: event.call.args,
+        });
+      }
+      return;
     }
-  } catch {
-    // Not JSON — fall through to raw truncation
+    case 'thinking':
+      callbacks.onProgress(panel, 'Analyzing results and deciding next step...', {
+        phase: 'thinking',
+        iteration: event.iteration,
+      });
+      return;
+    case 'token_budget_exhausted':
+      callbacks.onProgress(
+        panel,
+        `Token limit reached (${event.cumulativeTokens.toLocaleString()} tokens used). Generating response with data collected so far...`,
+        { phase: 'synthesize' },
+      );
+      return;
+    case 'answering_turn':
+      if (!event.tokenLimitExceeded) {
+        callbacks.onProgress(panel, 'Generating final response...', { phase: 'synthesize' });
+      }
+      return;
+    case 'pass_through':
+      callbacks.onProgress(panel, 'Synthesizing findings into response...', { phase: 'synthesize' });
+      return;
   }
-
-  return result.slice(0, MAX_TOOL_RESULT_CHARS) +
-    `\n[Truncated: result was ${result.length} characters]`;
 }
 
 export async function queryWithoutMcpStreaming(
@@ -310,10 +186,13 @@ export async function queryWithoutMcpStreaming(
     }
     messages.push({ role: 'user', content: query });
 
+    // The A-side of the comparison: one turn, no tools, no loop. It is not a
+    // caller of the shared loop and must not become one — the whole point of
+    // this panel is what the model says with no data source at all.
     const stream = await getModelClient().chat.completions.create({
       model: model.endpointModel,
       messages,
-      max_tokens: 4000,
+      max_tokens: MAX_TOKENS_PER_RESPONSE,
       stream: true,
       ...(includeStreamUsage() ? { stream_options: { include_usage: true } } : {}),
     });
@@ -356,408 +235,61 @@ export async function queryWithMcpStreaming(
 ): Promise<void> {
   const startTime = Date.now();
   const panel: PanelType = 'withMcp';
-  const toolsCalled: { name: string; args: Record<string, unknown>; resultSummary?: { rows: number; columns: number }; duration_ms?: number; operationType?: string; reason?: string; failed?: boolean; failureKind?: ToolFailureKind }[] = [];
 
   try {
     callbacks.onProgress(panel, 'Reading your question...', { phase: 'analyze' });
 
-    const messages: ChatCompletionMessageParam[] = [];
-    if (systemPrompt) {
-      messages.push({ role: 'system', content: systemPrompt });
-    }
-    messages.push({ role: 'user', content: query });
-
-    // First call - check if tools needed (non-streaming to check for tool_calls)
-    let llmSpanId = trace?.builder.startSpan('llm_inference', trace.parentSpanId, {
-      'gen_ai.system': getGenAiSystem(),
-      'gen_ai.request.model': model.declared,
-      ...(trace.systemPromptHash ? { 'gen_ai.system_prompt_hash': trace.systemPromptHash } : {}),
-      'gen_ai.inference_index': 0,
-    });
-    let response = await getModelClient().chat.completions.create({
-      model: model.endpointModel,
-      messages,
+    const result = await runToolLoop({
+      client: getModelClient(),
+      endpointModel: model.endpointModel,
+      declaredModel: model.declared,
+      prompt: query,
+      systemPrompt,
       tools,
-      tool_choice: 'auto',
-      max_tokens: 4000,
+      // Handed straight through: whatever this closure injects into `args`
+      // (a portal, most often) is what the record shows, because the loop
+      // hands it the same object it recorded.
+      executeToolCall,
+      maxIterations: MAX_ITERATIONS,
+      maxTokens: MAX_TOKENS_PER_RESPONSE,
+      maxCumulativeTokens: MAX_TOKENS_PER_REQUEST,
+      maxToolResultChars: MAX_TOOL_RESULT_CHARS,
+      finalTurn: 'stream',
+      passThroughDelivery: PASS_THROUGH_DELIVERY,
+      onDelta: (delta) => callbacks.onToken(panel, delta),
+      onEvent: (event) => reportLoopEvent(panel, event, callbacks),
+      trace,
+      logContext: panel,
     });
-    if (llmSpanId) {
-      trace!.builder.endSpan(llmSpanId, {
-        'gen_ai.response.prompt_tokens': response.usage?.prompt_tokens || 0,
-        'gen_ai.response.completion_tokens': response.usage?.completion_tokens || 0,
-        ...responseModelAttributes(model.declared, response.model, panel),
-      });
-    }
 
-    let iterations = 0;
-    const maxIterations = 20;
-    let cumulativeTokens = response.usage?.total_tokens || 0;
-    let cumulativePromptTokens = response.usage?.prompt_tokens || 0;
-    let cumulativeCompletionTokens = response.usage?.completion_tokens || 0;
-    let tokenLimitExceeded = false;
-    /**
-     * True when `response`'s message is ALREADY in `messages`. The loop pushes
-     * each assistant turn before executing its tools, so the token-limit break
-     * below leaves the loop with the final message already in the transcript,
-     * its tool calls already answered with real results. The terminal block
-     * must not push it a second time: that would duplicate the assistant turn
-     * and answer the same `tool_call_id` twice, which is a malformed request.
-     */
-    let lastMessageAlreadyInTranscript = false;
+    const duration_ms = Date.now() - startTime;
+    const tools_called = result.toolCalls.length > 0 ? result.toolCalls : undefined;
 
-    // Handle tool calls iteratively
-    while (response.choices[0]?.message?.tool_calls && iterations < maxIterations) {
-      const assistantMessage = response.choices[0].message;
-      const toolCalls = assistantMessage.tool_calls;
-      messages.push(assistantMessage);
-      lastMessageAlreadyInTranscript = true;
-
-      if (!toolCalls) break;
-
-      const currentIteration = iterations + 1;
-
-      for (const toolCall of toolCalls) {
-        if (toolCall.type === 'function') {
-          const args = JSON.parse(toolCall.function.arguments);
-          const operationType = deriveOperationType(toolCall.function.name, args);
-          const reason = generateToolReason(args);
-          const toolEntry: typeof toolsCalled[number] = { name: toolCall.function.name, args, operationType, reason };
-
-          // Send progress update with human-readable message (pass previous calls for context)
-          const progressMessage = formatToolProgress(toolCall.function.name, args, toolsCalled);
-          toolsCalled.push(toolEntry);
-          callbacks.onProgress(panel, progressMessage, { phase: 'tool_start', iteration: currentIteration, args });
-
-          // Trace: start MCP tool call span.
-          // `mcp.source` distinguishes which MCP server handled the call so the
-          // PROV-O builder can emit a distinct prov:Agent per source (see
-          // provenance.ts). Unknown tools fall back to "unknown".
-          const toolSource = trace?.resolveToolSource?.(toolCall.function.name) ?? 'unknown';
-          const toolTraceSpanId = trace?.builder.startSpan('mcp_tool_call', trace.parentSpanId, {
-            'tool.name': toolCall.function.name,
-            'tool.operation_type': operationType || 'unknown',
-            'tool.arguments': JSON.stringify(args),
-            'mcp.source': toolSource,
-            ...(args.dataset_id ? { 'tool.dataset_id': String(args.dataset_id) } : {}),
-            ...(args.portal ? { 'tool.portal_domain': String(args.portal) } : {}),
-          });
-
-          try {
-            const toolStartTime = Date.now();
-            const result = await executeToolCall(toolCall.function.name, args);
-            const toolDuration = Date.now() - toolStartTime;
-            toolEntry.duration_ms = toolDuration;
-
-            // Parse result to extract row/column counts. Socrata (and any MCP
-            // server that paginates) answers with an envelope —
-            // { data: [...], total_rows: N, ... } — not a bare array, so the
-            // bare-array-only check below always missed it and `resultSummary`
-            // was silently null for every Socrata call (#322).
-            //
-            // `rows` is what THIS CALL actually delivered — `data.length` —
-            // never `total_rows`. `total_rows` is the size of the matching set
-            // upstream; a capped page can return far fewer rows than that, and
-            // every downstream reader of `resultSummary.rows` (the narration
-            // copy below, and the "records analyzed" / "rows returned" rollups
-            // in buildNarrativeSummary/buildProvenanceLine in streaming.ts)
-            // means "how much data flowed through this call," not "how large
-            // is the source dataset." Reporting `total_rows` there would claim
-            // the model analyzed rows it never saw.
-            try {
-              const parsed: unknown = JSON.parse(result);
-              const rows: unknown[] | undefined = Array.isArray(parsed)
-                ? parsed
-                : parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>).data)
-                  ? (parsed as Record<string, unknown>).data as unknown[]
-                  : undefined;
-
-              if (rows) {
-                const firstRow = rows[0];
-                if (rows.length === 0) {
-                  // A valid, empty result set is a real answer ("no matching
-                  // records"), not a parse failure — worth distinguishing from
-                  // the silent-skip cases below so a zero-row response is
-                  // diagnosable rather than indistinguishable from "did not
-                  // parse."
-                  toolEntry.resultSummary = { rows: 0, columns: 0 };
-                } else if (typeof firstRow === 'object' && firstRow !== null) {
-                  toolEntry.resultSummary = {
-                    rows: rows.length,
-                    columns: Object.keys(firstRow).length,
-                  };
-                }
-                // else: a non-empty array whose elements are not objects
-                // (e.g. an array of strings) - not tabular, skip, matching
-                // the prior bare-array behavior.
-              }
-              // else: not JSON-parseable as a bare array or a { data: [...] }
-              // envelope (e.g. a metadata/metrics payload, or an envelope with
-              // no `data` field) - skip, `resultSummary` stays unset.
-            } catch {
-              // Not JSON - skip
-            }
-
-            // Trace: end tool call span with response metadata
-            if (toolTraceSpanId) {
-              trace!.builder.endSpan(toolTraceSpanId, {
-                'tool.response_hash': traceHash(result),
-                'tool.response_size_bytes': result.length,
-                'tool.duration_ms': toolDuration,
-                ...(toolEntry.resultSummary ? { 'tool.response_rows': toolEntry.resultSummary.rows } : {}),
-              });
-            }
-
-            // Send a completion progress event with timing
-            callbacks.onProgress(panel, progressMessage, { phase: 'tool_complete', iteration: currentIteration, duration_ms: toolDuration });
-
-            // Send a result narration message
-            const resultMessage = formatToolResult(args, toolEntry.resultSummary);
-            if (resultMessage) {
-              callbacks.onProgress(panel, resultMessage, { phase: 'tool_result', iteration: currentIteration, args });
-            }
-
-            // Truncate large results before feeding back as context
-            const truncatedResult = truncateToolResult(result);
-
-            messages.push({
-              role: 'tool',
-              tool_call_id: toolCall.id,
-              content: truncatedResult,
-            });
-          } catch (error) {
-            // #321: record the rejection ON the tool-call entry, here, where
-            // it is already known. `toolEntry` was pushed into `toolsCalled`
-            // before the await, so this mutation reaches every consumer of
-            // `CompletionResult.tools_called` — including the notebook
-            // synthesizer, which was rendering this call as an executable
-            // fetch cell that then threw on execution. Nothing downstream can
-            // recover this fact: a failed call is not distinguishable from a
-            // successful zero-row one by its `resultSummary`.
-            toolEntry.failed = true;
-            toolEntry.failureKind = toolFailureKindOf(error);
-            if (toolTraceSpanId) {
-              trace!.builder.endSpan(toolTraceSpanId, {
-                'error': true,
-                'error.message': error instanceof Error ? error.message : 'Unknown error',
-              });
-            }
-            // Feed the model neutral guidance instead of the raw error string:
-            // keep it honest (no invented data) without letting raw infra text
-            // (timeouts, status codes, server names) reach the final answer.
-            messages.push({
-              role: 'tool',
-              tool_call_id: toolCall.id,
-              content: describeToolFailureForLlm(toolCall.function.name, error),
-            });
-          }
-        }
-      }
-
-      // Check token limit before making the next LLM call
-      if (cumulativeTokens >= MAX_TOKENS_PER_REQUEST) {
-        tokenLimitExceeded = true;
-        callbacks.onProgress(panel, `Token limit reached (${cumulativeTokens.toLocaleString()} tokens used). Generating response with data collected so far...`, { phase: 'synthesize' });
-        break;
-      }
-
-      // Narrate the thinking step
-      callbacks.onProgress(panel, 'Analyzing results and deciding next step...', { phase: 'thinking', iteration: currentIteration });
-
-      // Get next response
-      llmSpanId = trace?.builder.startSpan('llm_inference', trace.parentSpanId, {
-        'gen_ai.system': getGenAiSystem(),
-        'gen_ai.request.model': model.declared,
-        'gen_ai.inference_index': currentIteration,
-      });
-      response = await getModelClient().chat.completions.create({
-        model: model.endpointModel,
-        messages,
-        tools,
-        tool_choice: 'auto',
-        max_tokens: 4000,
-      });
-      lastMessageAlreadyInTranscript = false;
-      if (llmSpanId) {
-        trace!.builder.endSpan(llmSpanId, {
-          'gen_ai.response.prompt_tokens': response.usage?.prompt_tokens || 0,
-          'gen_ai.response.completion_tokens': response.usage?.completion_tokens || 0,
-          ...responseModelAttributes(model.declared, response.model, panel),
-        });
-      }
-
-      // Track cumulative tokens
-      cumulativeTokens += response.usage?.total_tokens || 0;
-      cumulativePromptTokens += response.usage?.prompt_tokens || 0;
-      cumulativeCompletionTokens += response.usage?.completion_tokens || 0;
-
-      iterations++;
-    }
-
-    // Trace: start synthesis span (covers final output generation)
-    const synthesisSpanId = trace?.builder.startSpan('synthesis', trace.parentSpanId);
-
-    const lastMessage = response.choices[0]?.message;
-    const pendingToolCalls = lastMessage?.tool_calls;
-
-    // Why this run cannot end on `lastMessage` as it stands. Three reasons,
-    // one answering turn — the machinery below already existed, gated on the
-    // wrong condition, so this extends that path rather than adding a second.
-    //
-    // `abortedMidPlan` is the pre-existing reason: a budget stopped the loop
-    // instead of the model finishing. It no longer also requires the message
-    // to be EMPTY. The old condition led with `!lastMessage?.content`, so a
-    // token-limit-exceeded run that happened to carry prose shipped that prose
-    // as the answer — mid-run working notes published as a finding, and
-    // without even the `token_limit_exceeded` flag that would have banner-ed
-    // them, because the content branch below never set it (#319).
-    //
-    // `answeredNothing` is the old else-branch, folded in: an empty final
-    // message now gets the same restated contract as every other re-ask
-    // instead of a bare re-stream of the same transcript.
-    //
-    // `announcesUnrunWork` is the new one, and the reason this phase exists.
-    const abortedMidPlan =
-      iterations >= maxIterations || tokenLimitExceeded || Boolean(pendingToolCalls);
-    const answeredNothing = !lastMessage?.content?.trim();
-
-    if (abortedMidPlan || answeredNothing || announcesUnrunWork(lastMessage?.content)) {
-      // Keep the transcript faithful. The model really did produce this turn,
-      // and the re-ask corrects it explicitly; re-asking into a history that no
-      // longer contains the turn being corrected would be a silent rewrite,
-      // and it would read oddly in the signed trace. Skipped when the loop
-      // already pushed this message (see `lastMessageAlreadyInTranscript`) and
-      // when there is nothing to push.
-      if (!lastMessageAlreadyInTranscript && lastMessage && (lastMessage.content || pendingToolCalls)) {
-        messages.push(lastMessage);
-      }
-      // Only for tool calls the loop did NOT already answer with real results.
-      if (pendingToolCalls && !lastMessageAlreadyInTranscript) {
-        const abortReason = tokenLimitExceeded
-          ? 'Token budget exceeded. Please provide a summary based on the data already collected.'
-          : 'Tool call limit reached. Please provide a summary based on the data already collected.';
-        for (const toolCall of pendingToolCalls) {
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: abortReason,
-          });
-        }
-      }
-
-      if (!tokenLimitExceeded) {
-        callbacks.onProgress(panel, 'Generating final response...', { phase: 'synthesize' });
-      }
-
-      // Make final streaming call without tools
-      const finalStream = await getModelClient().chat.completions.create({
-        model: model.endpointModel,
-        messages: [
-          ...messages,
-          {
-            role: 'user',
-            content: FINAL_ANSWER_REQUEST,
-          },
-        ],
-        max_tokens: 4000,
-        stream: true,
-        ...(includeStreamUsage() ? { stream_options: { include_usage: true } } : {}),
-      });
-
-      let content = '';
-      let finalCallTokens = 0;
-      let finalPromptTokens = 0;
-      let finalCompletionTokens = 0;
-      let finalReportedModel: string | undefined;
-
-      for await (const chunk of finalStream) {
-        const delta = chunk.choices[0]?.delta?.content;
-        if (delta) {
-          content += delta;
-          callbacks.onToken(panel, delta);
-        }
-        // Every chunk repeats the model the endpoint answered with; the last
-        // one wins, so the recorded report is the one that finished the answer.
-        if (chunk.model) finalReportedModel = chunk.model;
-        if (chunk.usage) {
-          if (chunk.usage.total_tokens) finalCallTokens = chunk.usage.total_tokens;
-          if (chunk.usage.prompt_tokens) finalPromptTokens = chunk.usage.prompt_tokens;
-          if (chunk.usage.completion_tokens) finalCompletionTokens = chunk.usage.completion_tokens;
-        }
-      }
-
-      cumulativeTokens += finalCallTokens;
-      cumulativePromptTokens += finalPromptTokens;
-      cumulativeCompletionTokens += finalCompletionTokens;
-      const duration_ms = Date.now() - startTime;
-
-      if (synthesisSpanId) {
-        trace!.builder.endSpan(synthesisSpanId, {
-          'output.hash': traceHash(content),
-          'output.length': content.length,
-          'gen_ai.response.prompt_tokens': finalPromptTokens,
-          'gen_ai.response.completion_tokens': finalCompletionTokens,
-          ...responseModelAttributes(model.declared, finalReportedModel, panel),
-        });
-      }
-
+    if (result.answeringTurnTaken) {
       callbacks.onComplete(panel, {
-        content,
+        content: result.content,
         duration_ms,
-        tokens_used: cumulativeTokens,
-        prompt_tokens: cumulativePromptTokens || undefined,
-        completion_tokens: cumulativeCompletionTokens || undefined,
-        token_limit_exceeded: tokenLimitExceeded,
-        tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
+        tokens_used: result.usage.totalTokens,
+        prompt_tokens: result.usage.promptTokens || undefined,
+        completion_tokens: result.usage.completionTokens || undefined,
+        // Carried only on this path, and deliberately: a run that took the
+        // answering turn is the only one that can have been cut short, and
+        // the reader's truncation banner is keyed on the flag being present.
+        // The pass-through completion below omits the key rather than
+        // asserting `false` on every ordinary answer.
+        token_limit_exceeded: result.tokenLimitExceeded,
+        tools_called,
       });
       return;
     }
 
-    // Everything above returned. What is left is a genuine answer: content the
-    // model produced on its own account, that no budget cut short and that
-    // does not announce work it has not done. It is published exactly as
-    // written, with NO extra model call — the fix for #319 must cost nothing on
-    // the common path, which is the great majority of queries.
-    const finalContent = lastMessage?.content;
-    if (!finalContent) {
-      // Unreachable: `answeredNothing` routes a blank final message into the
-      // answering turn above, which returns. Kept as a typed refusal rather
-      // than a silent fall-through, because a path that reaches the end
-      // without calling `onComplete` would hang the reader's stream instead of
-      // failing visibly. The message never reaches a reader: it goes through
-      // `reportStreamFailure`, which logs it server-side and puts sanitized
-      // copy on the wire.
-      throw new Error('final assistant message had no content after the answering turn');
-    }
-
-    callbacks.onProgress(panel, 'Synthesizing findings into response...', { phase: 'synthesize' });
-
-    // Send the content in chunks to simulate streaming
-    const content = finalContent;
-    const chunkSize = 20; // characters per chunk
-    for (let i = 0; i < content.length; i += chunkSize) {
-      const chunk = content.slice(i, i + chunkSize);
-      callbacks.onToken(panel, chunk);
-      // Small delay to make it feel like streaming
-      await new Promise(resolve => setTimeout(resolve, 10));
-    }
-
-    const duration_ms = Date.now() - startTime;
-
-    if (synthesisSpanId) {
-      trace!.builder.endSpan(synthesisSpanId, {
-        'output.hash': traceHash(content),
-        'output.length': content.length,
-      });
-    }
-
-    // cumulativeTokens already includes this response's tokens from the loop
     callbacks.onComplete(panel, {
-      content,
+      content: result.content,
       duration_ms,
-      tokens_used: cumulativeTokens,
-      prompt_tokens: cumulativePromptTokens || undefined,
-      completion_tokens: cumulativeCompletionTokens || undefined,
-      tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
+      tokens_used: result.usage.totalTokens,
+      prompt_tokens: result.usage.promptTokens || undefined,
+      completion_tokens: result.usage.completionTokens || undefined,
+      tools_called,
     });
   } catch (error) {
     reportStreamFailure(panel, error, callbacks);


### PR DESCRIPTION
# P2 — the shared loop core, and the streaming caller on it

Wave N7 (#345) phase 2. Branch `sprint-345/p2-shared-loop-core`, cut from `7357f27`.
Two commits: `059af3b` (the core and the streaming caller on it) and `9edd841` (one
extension to #349's guard, itemised below). Model: **Opus 5** (owner ruling D5 = C).
Closes #331, #343, #349.

## Diff stat and blast zone

```
 src/lib/model-identity.test.ts                 |  54 +-
 src/lib/model-loop/model-call-registry.test.ts | 193 ++++++
 src/lib/model-loop/run-tool-loop.test.ts       | 472 ++++++++++++++
 src/lib/model-loop/run-tool-loop.ts            | 848 +++++++++++++++++++++++++
 src/lib/model-loop/test-harness.ts             | 127 ++++
 src/lib/openrouter-streaming.test.ts           | 115 +---
 src/lib/openrouter-streaming.ts                | 704 ++++-----------------
 7 files changed, 1827 insertions(+), 686 deletions(-)
```

**Every file is inside the declared zone.** `src/lib/model-loop/**` (new, including the
registry test's own file), `openrouter-streaming.ts` and its test, and
`model-identity.test.ts` for the pre-authorized D6 drift-guard replacement only. Nothing
else in the tree is touched — no route, no consumer, no doc, no config. **No out-of-zone
edit was needed, so none is itemised.**

## What landed

`src/lib/model-loop/run-tool-loop.ts` exports `runToolLoop` to G1's signature. Carried in:
#334's three-way exit (`abortedMidPlan || answeredNothing || announcesUnrunWork`),
`describeToolFailureForLlm` on every tool failure, failure-bearing tool records
(`failed`/`failureKind`, #321's shape), and the `lastMessageAlreadyInTranscript`
discipline. `queryWithMcpStreaming` / `queryWithoutMcpStreaming` keep their external
signatures; `announcesUnrunWork`, `responseModelAttributes` and `TraceContext` are
re-exported from `openrouter-streaming.ts`, so no importer moves.

What is core behaviour and what is a parameter follows G1's ruling: anything a caller
could opt out of that would reintroduce a class defect has no switch (the exit condition,
the failure vocabulary, the error-to-model path, transcript well-formedness, the
truncation, the single contract statement); what a caller is given (client, model, tools,
budgets, tool transport) and what it does with the result (progress rendering, streaming,
error surfacing) are parameters. `PanelType` does not appear anywhere under
`src/lib/model-loop/`, and every import there is relative.

## Streaming behaviour is unchanged — measured, not asserted

The base implementation was materialized from `7357f27` beside the new one and both were
driven through the same scripted endpoint, the same tool transport and a **deterministic
trace clock and id source**. Compared: every callback invocation in order, every request
body the endpoint received, and the full finalized OTel trace.

```
  ok   pass-through answer — callbacks / requests / trace
  ok   answering turn after a narration — callbacks / requests / trace
  ok   token budget exhausted — callbacks / requests / trace
  ok   failing tool call — callbacks / requests / trace
  ok   two tool calls in one turn — callbacks / requests / trace
  ok   oversized envelope — callbacks, trace
  DIFF oversized envelope — requests
       base: …"unique_key":"11\n[Truncated: result was 84918 characters]"}],"tools":[]…
       core: …"unique_key":"1188","borough":"BROOKLYN"},{"unique_key":"1189"…
  ok   portal injected inside the tool closure — callbacks / requests / trace
```

20 of 21 comparison groups byte-identical; the one divergence is #331's fix, in the tool
message the model receives. Wall-clock measurements (`duration_ms`, span timestamps) were
elided — they jitter run to run and are not behaviour.

## Acceptance

### 1. The core exists; streaming runs on it; consumers are untouched — PASS

```
$ git diff 7357f27...HEAD -- src/app/api/compare-stream/route.ts src/app/api/query-notebook/route.ts | wc -l
0
$ git diff 7357f27 --stat -- src/app/api/
(no output)
```

### 2. Full suite green, nothing removed — PASS

`# tests 1065 · # pass 1065 · # fail 0` (baseline 1044 + 21 new). Test names compared, not
just counts — every `test('…')` name in every test file at `7357f27` against HEAD:

```
$ comm -23 /tmp/all-base.txt /tmp/all-head.txt     # present at base, absent at HEAD
(empty)
1044 names at 7357f27 · 1065 at HEAD
```

### 3. #334's exit logic is load-bearing in the core — SHOWN RED, THEN GREEN

*(This demonstration and the next were run at `059af3b`, before the second commit added
one test — hence 1064 rather than 1065 in their counts.)*

The core's condition was mutated to the pre-#334 form
(`!lastMessage?.content && (iterations >= maxIterations || lastMessage?.tool_calls)`) and
the full suite run:

```
not ok 823 - #334: a final turn that announces a query is not returned as the answer
not ok 826 - a blocking final turn answers without streaming — the shape a route caller uses
not ok 895 - #319: a tool_calls-free message that ANNOUNCES the next query is not published as the answer
not ok 897 - #319: at most ONE answering turn — a second unsatisfying answer is not re-asked forever
not ok 898 - #319: a token-limit-exceeded run with content asks for a summary instead of shipping that content
not ok 899 - #319: the answering turn omits tools, restates the contract, and keeps the transcript well-formed
not ok 900 - #319: the token-limit answering turn does not duplicate the assistant turn or re-answer its tool call
not ok 901 - #345 P2: token_limit_exceeded is present on the answering-turn completion and ABSENT on the pass-through one
# tests 1064
# pass 1056
# fail 8
```

Mutation reverted:

```
# tests 1064
# pass 1064
# fail 0
```

All five #319 cases go red on the mutation, plus the two core-level cases and the F-1 pin.

### 4. The registry test exists and can fail — SHOWN RED, THEN GREEN

`src/lib/model-loop/model-call-registry.test.ts`. A throwaway
`src/lib/throwaway-second-loop.ts` calling `chat.completions.create` with `tools` was
added:

```
not ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
  error: 'src/lib/throwaway-second-loop.ts calls chat.completions.create and is not on the registry in
          src/lib/model-loop/model-call-registry.test.ts. Add it with one line saying why it is a
          separate call site — or, better, call runToolLoop.'
not ok 2 - #345: only the named modules carry a tool-calling loop
  error: 'src/lib/throwaway-second-loop.ts calls chat.completions.create with tools — a second
          tool-calling loop. This is the shape wave #345 exists to end: call runToolLoop instead.'
# tests 1064 · # pass 1062 · # fail 2
```

Removed:

```
# tests 1064 · # pass 1064 · # fail 0
```

The allowlist at this head, each entry with its reason:

| File | Why |
|---|---|
| `src/lib/model-loop/run-tool-loop.ts` | The shared core |
| `src/lib/openrouter-streaming.ts` | `queryWithoutMcpStreaming`: the no-tools A-side. One turn, no loop, not loop-class |
| `src/app/api/evidence/[slug]/replay/route.ts` | Its own loop, **until P3** (#338, #347) |
| `src/lib/openrouter.ts` | Its own loop, **until P4** (#344) |
| `src/lib/evidence/adversarial-eval.ts` | One rubric call, no loop. Out of the wave by D4 (#348) |
| `src/app/api/evidence/[slug]/evaluate/route.ts` | The second copy of that rubric call. Out by D4 (#348) |
| `src/app/api/evidence/generate-summary/route.ts` | One summary call, no loop. Out of the wave |

The test is **two assertions on one instrument**, per G0 item 1: the registry (who calls
the model at all) and the narrower tool-loop count (which calls pass `tools` — three at
this head, one when the wave closes). It parses each call's argument block rather than
grepping, so `model-client.ts:458`'s doc comment is not counted and `openrouter.ts`'s
`tools,` shorthand is. Both directions are asserted: an unlisted caller fails, **and a
stale allowlist entry fails** — the list cannot rot into a false statement about the tree.

### 5. #331 and #343 close — PASS, each shown red

**#331.** A 2,000-row envelope (296,028 characters — the same size as the issue's own
reproduction) is driven through the core and the `tool` message is read **off the wire**.
With the envelope branch removed:

```
not ok 1 - #331: an oversized Socrata envelope reaches the model as valid JSON carrying the truncation marker
  error: |-
    no row-truncation marker on the result fed to the model:
    …"},{"unique_key":"100337","created_date":"2026-01-01T00:00:00.000","complaint_type":"Noise - Residential","borough":"B
    [Truncated: result was 296028 characters]
```

That is #331 verbatim — cut mid-record, no `[Truncated: showing N of M rows]`. With the
fix, the body before the marker parses, `data.length` equals the marker's N, and
`total_rows` survives so the model still knows the size of the matching set upstream.
Three companion cases hold the other branches: a bare array still slices whole rows, a
non-JSON result keeps its character-truncation marker, and a result inside the bound is
fed back untouched.

**#343.** The `'Token budget exceeded'` arm is deleted. The output contract is now stated
exactly **once** — `FINAL_ANSWER_REQUEST`. The surviving note for a tool call the loop
never ran reports a fact and nothing else: *"This tool call was not run: the tool-call
limit for this query was reached."* With the old two-arm paraphrase restored:

```
not ok 9 - #343: only ONE message states the output contract, on the path that writes an abort note
  error: |-
    the abort note is stating the output contract a second time:
    Tool call limit reached. Please provide a summary based on the data already collected.
```

The paraphrase is the statement that goes unnoticed: it shares no wording with the
restatement, so counting words will not find it. What identifies it is that it tells the
model what to *write*, which is the restatement's job and no one else's — that is what the
test asserts. A second case pins P1's measurement that the deleted arm was unreachable:
on the token path the transcript carries the call's real result and no abort note at all.

### 6. #349 closes with all three properties, and `args` identity holds — PASS, shown red

Fixture: a tool call whose `function.arguments` is cut mid-string
(`{"type":"query","dataset_id":"sentinel-…`).

- **(a)** recorded with `failed: true`, `failureKind: 'unknown'`.
- **(b)** the model is told through `describeToolFailureForLlm` — the tool message is
  byte-equal to that function's output, and no request body anywhere contains
  `in JSON at position`, `Unterminated string`, `SyntaxError` or `Unexpected token`. The
  parse failure is raised as an app-authored Error rather than the `SyntaxError`, so
  endpoint-supplied bytes cannot steer `classifyStreamError` either. The **assistant**
  turn still carries the arguments the endpoint sent — that is the model's own turn, and
  rewriting it would make the transcript a fiction; the test asserts the sentinel appears
  there and nowhere else.
- **(c)** the run continues: a second, well-formed call executes and the query answers.

With the parse moved back outside the `try`:

```
not ok 5 - #349 (a): a malformed argument set is RECORDED as a failed tool call
not ok 6 - #349 (b): the model is told through describeToolFailureForLlm, with no parse-error text on the wire
not ok 7 - #349 (c): a malformed argument set does NOT end the run — the loop continues and answers
  error: 'Unterminated string in JSON at position 68 (line 1 column 69)'
  name: 'SyntaxError'
  stack: JSON.parse (<anonymous>) / runToolLoop (run-tool-loop.ts:541:50)
```

**`args` identity.** The probe asserts reference identity (`assert.equal`, i.e.
`Object.is`) *and* that a field injected inside the tool closure after the record was made
is visible on the record. With `args: { ...args }` on the record:

```
not ok 8 - the args on the record is the SAME object handed to executeToolCall
  error: the recorded args must BE the object the tool received
    + actual - expected
      { dataset_id: 'abcd-1234',
    -   portal: 'data.cityofnewyork.us',
        type: 'query' }
```

A deep-equality probe would have passed on that clone. This one does not.

**One extension beyond the criterion (`9edd841`), itemised.** `null`, a number or a bare
string is valid JSON: it clears the parse and then throws on the first property read one
step later, outside a guard that only watches the parse. It is the same failure and is now
handled identically. Shown red first — accepting any parse result gives
`Cannot read properties of null (reading 'type')` out of `deriveOperationType`:

```
not ok 8 - #349: JSON that parses but is not an argument set is the same failure
  error: "Cannot read properties of null (reading 'type')"
```

## The F-1 decision: `token_limit_exceeded`

**Reproduced, not changed.** The key is **present** on the answering-turn completion and
**absent** on the pass-through one, exactly as at `7357f27`. The two `onComplete` sites in
`queryWithMcpStreaming` stay distinct rather than being unified behind one adapter.

Reasoning: `tokenLimitExceeded` can only be true on a run that took the answering turn
(`abortedMidPlan` includes it), so on the pass-through path the flag would always be
`false` — and emitting `token_limit_exceeded: false` on every ordinary answer is a new
field on the SSE `complete` event for every query the app serves, read by a client that
today distinguishes "no flag" from "flag false". It is also newly pinned by a test
(`#345 P2: token_limit_exceeded is present … and ABSENT …`), which goes red under the
criterion-3 mutation, so the distinction cannot be flattened silently by a later phase.

## Gates

`npm ci` first. All five run at the pushed head.

**`npm test`**

```
1..1032
# tests 1065
# suites 10
# pass 1065
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1811.249792
```

**`npm run build`** — fails in this sandboxed session, **re-measured rather than assumed**,
per the CLAUDE.md rule:

```
> Build error occurred
Error [TurbopackInternalError]: [project]/src/app/globals.css [app-client] (css)
Caused by:
- creating new process
- binding to a port
- Operation not permitted (os error 1)
exit 1
```

This session denies socket binding, so Turbopack's PostCSS worker pool dies. `--webpack`
skips it; CI's `build` job is the real gate.

**`npx next build --webpack`** — exit 0

```
▲ Next.js 16.3.0 (webpack)
- Environments: .env.local
✓ Running next.config.ts took 9ms

  Creating an optimized production build ...
✓ Compiled successfully in 2.1s
  Running TypeScript ...
  Finished TypeScript in 1177ms ...
  Collecting page data using 9 workers ...
✓ Generating static pages using 9 workers (32/32) in 178ms
  Finalizing page optimization ...
  Collecting build traces ...
Route (app)  … full table emitted, 32 routes …
```

**`npm run typecheck`** (run after the successful build) — exit 0, no output

```
> civic-ai-tools-website@0.1.0 typecheck
> tsc --noEmit
```

**`npm run lint`** — exit 0, the documented baseline, unchanged

```
scripts/eval-models.mjs
  388:7  warning  'TokenBudgetExceeded' is defined but never used  @typescript-eslint/no-unused-vars
src/components/evidence/AttestationDialog.tsx
  8:7  warning  'EXPERT_RATINGS' is assigned a value but only used as a type  @typescript-eslint/no-unused-vars
src/components/notebook/RenderingCellOutputs.tsx
  96:9  warning  Using `<img>` could result in slower LCP and higher bandwidth … @next/next/no-img-element
src/lib/bpmn/animation.ts
  8:10  warning  'mapEventToNodes' is defined but never used  @typescript-eslint/no-unused-vars

✖ 4 problems (0 errors, 4 warnings)
```

**`npm run check:compose-env`** — exit 0

```
  RESULT: PASS — every variable this profile reads can reach the container.
```

## The D6 pre-authorized edit, with its own RED

`model-identity.test.ts:763-779` read `openrouter-streaming.ts` as text and asserted ≥2
`startSpan('llm_inference')` sites in it. Both sites moved into the core, so after
extraction that file has zero. Shown red before it was touched:

```
not ok 16 - #30 P6 F4: no inference span is started without gen_ai.system
  error: 'both inference sites should be found'
# tests 16 · # pass 15 · # fail 1
```

Replaced with the stronger tree-wide form P1 proposed and ORCH ruled for: it walks every
non-test `.ts`/`.tsx` under `src/`, collects `startSpan('llm_inference'` everywhere, and
asserts ≥2 sites each carrying `'gen_ai.system': getGenAiSystem()`. The now-false comment
("Both current sites are in this one file") is deleted. Green after:
`ok 16 … # pass 16 · # fail 0`.

## Premises that did not survive

Six, none of them fatal; three needed a decision.

1. **The allowlist in the contract is one entry short.** It names the core, the two
   unmigrated loops and the three single-call sites — six. `openrouter-streaming.ts` still
   calls `chat.completions.create` at what was `:313`: `queryWithoutMcpStreaming`, one
   turn, no tools. It is the A-side of the comparison and is not loop-class (the same
   status G0 item 4 gives `openrouter.ts:29`), so it is **allowlisted with that reason**
   rather than moved into the core. Seven entries, not six. Flagged rather than resolved
   silently because the count is the contract's.

2. **G1 axis 9 — "the pass-through chunker stays caller-side" — does not survive
   implementation.** The `synthesis` span *brackets* the chunker: it opens at the old
   `:597`, before the exit decision, and closes at `:746`, after the 20-chars-per-10 ms
   loop. Moving the chunker out of the core while leaving the span in it would move the
   span's recorded `endTimeUnixNano` earlier by roughly `content.length / 20 × 10 ms` — a
   change inside a signed trace, invisible in any test. The chunker therefore moved into
   the core as a **parameter** (`passThroughDelivery: { chunkChars, delayMs }`), which
   only the streaming caller passes; replay and compare omit it and get the content whole.
   The equivalence probe above shows the trace identical on every pass-through scenario.
   **P1 did not see this; proposed as the correction to axis 9.**

3. **One option beyond G1's signature: `logContext?: string`.** `responseModelAttributes`
   logs `[stream:${context}]` on a declared/reported model mismatch, and the streaming
   caller's context string is its panel. Without the option the operator log line would
   change wording. Defaults to `'model-loop'`.

4. **G1's `finalTurn` has no stated default; the core defaults to `'blocking'`.** The
   streaming caller passes `'stream'` explicitly. A non-streaming caller (P3, P4) needs no
   argument for the mode it wants, and `'blocking'` needs no `onDelta`.

5. **#331's fixture size, incidentally settled.** The 2,000-row envelope this phase builds
   is 296,028 characters — the anchor's and the issue's figure, not the 296,053 the G0
   record cited. Both were always plausible; they are different row shapes. No action.

6. **Contract line references: all verified exact at `7357f27`** — exit logic `:599-623`,
   transcript discipline `:398-406 :413 :579 :630-645`, `describeToolFailureForLlm`
   `:547-551`, failure record `:536-537`, `FINAL_ANSWER_REQUEST` `:231-237`,
   `announcesUnrunWork` `:212`, `truncateToolResult` `:273-293`, `MAX_TOKENS_PER_REQUEST`
   `:141`, spans `:371 :436 :567 :597`, chunker `:732-742`, `TraceContext` `:10-20`,
   `ProgressOpts` `:22-28`, harness `:657-728` with its driver `:730-763`,
   `model-identity.test.ts:763-779`. The two hard constraints were re-measured and both
   hold: `:421 → :424 → :447` is one object, and 0 of 74 test files import `@/`.

## Behaviour changes, itemised

Two, both intended, both on the streaming path:

1. **#331** — an oversized paginated envelope now reaches the model as parseable JSON with
   a row marker instead of a fragment. Wire-visible; it is criterion 5.
2. **#349** — a tool call whose arguments will not parse no longer ends the query. Before,
   it escaped to `reportStreamFailure` and the reader got a sanitized failure for the
   whole run; now it is one failed tool call and the run continues. Wire-visible on the
   SSE `complete` event (an extra `tools_called[]` entry with `failed: true`) and on the
   absence of an `error` event.

`token_limit_exceeded` is **not** in this list — see the F-1 decision above.

## Flagged, not fixed

- **`mcp_tool_call` span attributes are built before `executeToolCall` runs**
  (`run-tool-loop.ts`, carried verbatim from `:436-443`), so a caller-injected `portal`
  reaches `tools_called[].args` but not `tool.portal_domain`. Pre-existing, unchanged,
  out of scope by the contract. Now that it lives in one place it is a one-line fix for
  whoever is next in the file — worth a phase of its own or a rider on P5.
- **`replay/route.ts` and `openrouter.ts` still carry their own loops**, with their own
  copies of #338/#344/#347/#349. Untouched, as the non-goals require. The registry test
  now names both with the phase that removes them, so the debt is visible in the suite
  rather than in an issue.
- **`src/lib/model-loop/test-harness.ts` is a non-test file that only tests import.** It
  is type-checked and linted like any source file and is not bundled by any route. P1
  recommended the extraction so P3 and P4 reuse the one instrument; naming it `.test.ts`
  would make the runner execute it as an empty suite.

## CI

All five checks pass at the pushed head **`9edd841`** — `build / test / lint / typecheck`,
`container image build`, `DCO`, `Vercel`, `Vercel Preview Comments` — and passed on
`059af3b` before it. `mergeable: MERGEABLE`.

## Riders honoured

One credentialed operation per Bash call — every commit and every push was its own
invocation, never bundled and never looped. `git commit -s`; the trailer matches the author exactly
(`Nathan Storey <npstorey@users.noreply.github.com>`). Pushed to `github-https`; the
global pre-push sensitivity hook ran and did not block, and nothing was bypassed. No
`.env*` file was read at any point; every key, model id and hostname in a fixture is an
obviously fake placeholder on a loopback address. No merge, no tag, no deploy.
