### PR TITLE
fix: replay runs on the shared loop core (#338, #347, #331)

### DIFF
--- a/src/app/api/evidence/[slug]/replay/route.ts
+++ b/src/app/api/evidence/[slug]/replay/route.ts
@@ -6,7 +6,8 @@ import {
   resolveCallerModelKey,
 } from '@/lib/caller-model-key';
 import { endpointModelForDeclared } from '@/lib/model-resolver';
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import { runToolLoop } from '@/lib/model-loop/run-tool-loop';
+import { replayLoopOptions } from '@/lib/model-loop/replay-loop';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { db } from '@/lib/db';
@@ -14,32 +15,9 @@ import { evidenceRecords } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getPackage } from '@/lib/storage';
 import { canReadRecord } from '@/lib/evidence/sealed-access';
-import { mcpTools } from '@/lib/mcp/tools';
-import { callMcpTool } from '@/lib/mcp/client';
 import { getMissingMcpRoutingError } from '@/lib/mcp/registry';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import type { EvidencePackage } from '@/lib/evidence/packager';
-
-const MAX_TOOL_RESULT_CHARS = 50_000;
-const MAX_ITERATIONS = 20;
-const MCP_TOOL_TIMEOUT_MS = 45_000;
-
-function truncateToolResult(result: string): string {
-  if (result.length <= MAX_TOOL_RESULT_CHARS) return result;
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed) && parsed.length > 0) {
-      const sampleRow = JSON.stringify(parsed[0]);
-      const rowSize = sampleRow.length + 2;
-      const maxRows = Math.max(5, Math.floor(MAX_TOOL_RESULT_CHARS / rowSize));
-      const truncated = parsed.slice(0, maxRows);
-      return JSON.stringify(truncated) +
-        `\n[Truncated: showing ${truncated.length} of ${parsed.length} rows]`;
-    }
-  } catch { /* fall through */ }
-  return result.slice(0, MAX_TOOL_RESULT_CHARS) +
-    `\n[Truncated: result was ${result.length} characters]`;
-}
 
 /**
  * POST /api/evidence/[slug]/replay
@@ -134,122 +112,32 @@ export async function POST(
   // Create a model client with the user's API key
   const openrouter = createModelClient({ apiKey: callerKey.apiKey });
 
-  const startTime = Date.now();
-  const toolsCalled: { name: string; args: Record<string, unknown> }[] = [];
-  let cumulativeTokens = 0;
-  let cumulativePromptTokens = 0;
-  let cumulativeCompletionTokens = 0;
-
   try {
-    const messages: ChatCompletionMessageParam[] = [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: prompt },
-    ];
+    // The shared tool-calling loop (#345). Replay carried its own copy until
+    // P3: the same loop, with its own exit condition, its own truncation and
+    // its own error-to-model path — and each of those was a filed defect
+    // (#338, #347, #331) that had already been fixed on the other copy.
+    // Everything the loop is GIVEN lives in `replayLoopOptions`; nothing about
+    // how it runs is decided here.
+    const result = await runToolLoop(replayLoopOptions({
+      client: openrouter,
+      endpointModel: model,
+      prompt,
+      systemPrompt,
+      portal,
+    }));
 
-    let response = await openrouter.chat.completions.create({
-      model,
-      messages,
-      tools: mcpTools,
-      tool_choice: 'auto',
-      max_tokens: 4000,
-    });
-
-    cumulativeTokens += response.usage?.total_tokens || 0;
-    cumulativePromptTokens += response.usage?.prompt_tokens || 0;
-    cumulativeCompletionTokens += response.usage?.completion_tokens || 0;
-
-    let iterations = 0;
-
-    // Tool-calling loop
-    while (response.choices[0]?.message?.tool_calls && iterations < MAX_ITERATIONS) {
-      const assistantMessage = response.choices[0].message;
-      messages.push(assistantMessage);
-
-      for (const toolCall of assistantMessage.tool_calls!) {
-        if (toolCall.type !== 'function') continue;
-
-        const args = JSON.parse(toolCall.function.arguments);
-        // Socrata's get_data expects a portal; Data Commons tools don't — only inject for Socrata.
-        if (toolCall.function.name === 'get_data' && !args.portal) args.portal = portal;
-        toolsCalled.push({ name: toolCall.function.name, args });
-
-        try {
-          const result = await Promise.race([
-            callMcpTool(toolCall.function.name, args),
-            new Promise<never>((_, reject) =>
-              setTimeout(
-                () => reject(new Error(`MCP tool timed out after ${MCP_TOOL_TIMEOUT_MS / 1000}s`)),
-                MCP_TOOL_TIMEOUT_MS,
-              ),
-            ),
-          ]);
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: truncateToolResult(result),
-          });
-        } catch (error) {
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          });
-        }
-      }
-
-      // Token budget check
-      if (cumulativeTokens >= 200_000) break;
-
-      response = await openrouter.chat.completions.create({
-        model,
-        messages,
-        tools: mcpTools,
-        tool_choice: 'auto',
-        max_tokens: 4000,
-      });
-
-      cumulativeTokens += response.usage?.total_tokens || 0;
-      cumulativePromptTokens += response.usage?.prompt_tokens || 0;
-      cumulativeCompletionTokens += response.usage?.completion_tokens || 0;
-      iterations++;
-    }
-
-    // Extract final output
-    let output = response.choices[0]?.message?.content || '';
-
-    // If still pending tool calls, force a final response
-    if (!output && response.choices[0]?.message?.tool_calls) {
-      messages.push(response.choices[0].message);
-      for (const tc of response.choices[0].message.tool_calls) {
-        messages.push({
-          role: 'tool',
-          tool_call_id: tc.id,
-          content: 'Limit reached. Please summarize based on data collected.',
-        });
-      }
-      const finalResponse = await openrouter.chat.completions.create({
-        model,
-        messages: [
-          ...messages,
-          { role: 'user', content: 'Based on the data collected, please provide a comprehensive answer.' },
-        ],
-        max_tokens: 4000,
-      });
-      output = finalResponse.choices[0]?.message?.content || '';
-      cumulativeTokens += finalResponse.usage?.total_tokens || 0;
-      cumulativePromptTokens += finalResponse.usage?.prompt_tokens || 0;
-      cumulativeCompletionTokens += finalResponse.usage?.completion_tokens || 0;
-    }
-
+    // The consistency-test payload, unchanged in shape. `toolCalls` entries
+    // now additionally carry `operationType`, `reason`, `resultSummary`,
+    // `duration_ms` and — for a call that failed — `failed`/`failureKind`
+    // (#338). The identity fields the client keys a run on
+    // (`name`, `args.type`, `args.dataset_id`, `args.portal`, the last of
+    // which this route injects) are byte-identical to what it read before.
     return NextResponse.json({
-      toolCalls: toolsCalled,
-      output,
-      tokenUsage: {
-        promptTokens: cumulativePromptTokens,
-        completionTokens: cumulativeCompletionTokens,
-        totalTokens: cumulativeTokens,
-      },
-      durationMs: Date.now() - startTime,
+      toolCalls: result.toolCalls,
+      output: result.content,
+      tokenUsage: result.usage,
+      durationMs: result.durationMs,
     });
   } catch (error) {
     console.error('[replay] Error:', error);

--- a/src/lib/model-loop/model-call-registry.test.ts
+++ b/src/lib/model-loop/model-call-registry.test.ts
@@ -10,8 +10,8 @@
  *
  * This test says it out loud. Adding a `chat.completions.create` call to a
  * file that is not on the list below fails the suite, and the list carries one
- * line of justification per entry — including, for the two files this wave has
- * not migrated yet, the phase that removes them.
+ * line of justification per entry — including, for the file this wave has not
+ * migrated yet, the phase that removes it.
  *
  * TWO ASSERTIONS, ONE INSTRUMENT. The first is the registry: who calls the
  * model at all. The second is narrower and is the wave's own criterion: how
@@ -47,8 +47,6 @@ const ALLOWED_MODEL_CALLERS: Record<string, string> = {
     'The shared tool-calling loop — the one implementation the wave consolidates onto.',
   'src/lib/openrouter-streaming.ts':
     'queryWithoutMcpStreaming: the no-tools A-side of the comparison. One turn, no loop, not loop-class.',
-  'src/app/api/evidence/[slug]/replay/route.ts':
-    'Its own loop, until P3 moves it onto the shared core (#338, #347).',
   'src/lib/openrouter.ts':
     'Its own loop, until P4 moves it onto the shared core (#344).',
   'src/lib/evidence/adversarial-eval.ts':
@@ -65,7 +63,6 @@ const ALLOWED_MODEL_CALLERS: Record<string, string> = {
  */
 const ALLOWED_TOOL_LOOPS: Record<string, string> = {
   'src/lib/model-loop/run-tool-loop.ts': 'The shared core.',
-  'src/app/api/evidence/[slug]/replay/route.ts': 'Removed by P3.',
   'src/lib/openrouter.ts': 'Removed by P4.',
 };
 

--- a/src/lib/model-loop/replay-loop.test.ts
+++ b/src/lib/model-loop/replay-loop.test.ts
@@ -1,0 +1,392 @@
+// Acceptance tests for the replay path on the shared loop core (#345 P3).
+//
+// WHAT IS UNDER TEST, and why it is this and not the route. `replay/route.ts`
+// is a Next route handler: `node --test` cannot invoke one. So the loop
+// configuration was moved OUT of the route into `replayLoopOptions`, and these
+// tests drive the real `runToolLoop` with the real options factory against a
+// local scripted model server. The only thing substituted is the tool
+// transport — one level BELOW the loop — so no case here restates a cap, a
+// budget, a tool set or the portal injection. Change replay's configuration
+// and these tests change with it; that is the point of the seam.
+//
+// A source-drift guard at the bottom closes the remaining gap: it asserts the
+// route actually obtains its options from this factory and supplies no
+// transport of its own. Between that and `model-call-registry.test.ts` (which
+// fails if the route calls the model at all), "the route runs this" is
+// measured rather than assumed.
+//
+// Every claim about what the model was SENT is asserted against the request
+// bodies the mock server received, because that is where the claims live: a
+// truncation that hands the model malformed JSON (#331), a raw error string in
+// a `tool` message (#338), and a duplicated assistant turn (#347) are all
+// invisible from the return value.
+//
+// No live endpoint, no credential, no MCP server. Every key value is an
+// obviously fake fixture and the address is loopback.
+//
+// Run with: npm test
+//   (or: node --test --experimental-strip-types src/lib/model-loop/replay-loop.test.ts)
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { runToolLoop, type ToolCallRecord } from './run-tool-loop.ts';
+import {
+  replayLoopOptions,
+  REPLAY_MAX_ITERATIONS,
+  REPLAY_MAX_TOKENS,
+  REPLAY_MAX_CUMULATIVE_TOKENS,
+  REPLAY_MAX_TOOL_RESULT_CHARS,
+  type ReplayToolTransport,
+} from './replay-loop.ts';
+import { startScriptedModelServer, type ScriptedReply } from './test-harness.ts';
+import { createModelClient } from '../model-client.ts';
+
+const FIXTURE_KEY = 'not-a-real-key-p3-replay-fixture';
+const PORTAL = 'data.cityofnewyork.us';
+const PROMPT = 'How long do these requests take to close?';
+const SYSTEM = 'You are a fixture system prompt.';
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ['MODEL_API_BASE_URL', 'MODEL_API_KIND', 'MODEL_API_AUTH', 'MODEL_API_VERSION'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+const REAL_ANSWER =
+  'Across both years the portal recorded 4,812 requests of this type. The median time to close ' +
+  'was 9 days, and 71% closed within 14 days (dataset abcd-1234).';
+
+/** A `get_data` call carrying NO portal — the injection this caller performs. */
+const FETCH_CALL: ScriptedReply = {
+  toolCalls: [{ id: 'call_1', name: 'get_data', args: { type: 'query', dataset_id: 'abcd-1234' } }],
+};
+
+const ONE_ROW = JSON.stringify({ data: [{ request_type: 'A', days_to_close: 9 }], total_rows: 1 });
+
+/**
+ * The payload `POST /api/records/:slug/replay` answers with, built exactly as
+ * the route builds it from a `ToolLoopResult`. Kept here so a case asserts on
+ * what the attestation client actually reads rather than on the loop's own
+ * return shape.
+ */
+interface ReplayPayload {
+  toolCalls: ToolCallRecord[];
+  output: string;
+  tokenUsage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  durationMs: number;
+}
+
+interface Wire {
+  role: string;
+  content?: string;
+  tool_call_id?: string;
+}
+
+/**
+ * Run one replay against a scripted endpoint. `callTool` is the ONLY thing a
+ * case supplies beyond the fixtures the route reads off a record — no cap, no
+ * budget, no tool list, no portal handling.
+ */
+async function runReplay(
+  replies: ScriptedReply[],
+  callTool: ReplayToolTransport,
+): Promise<{ payload: ReplayPayload; requests: Record<string, unknown>[] }> {
+  const { server, url, requests } = await startScriptedModelServer(replies);
+  try {
+    process.env.MODEL_API_BASE_URL = url;
+    const result = await runToolLoop(
+      replayLoopOptions({
+        client: createModelClient({ apiKey: FIXTURE_KEY }),
+        endpointModel: 'fake/model',
+        prompt: PROMPT,
+        systemPrompt: SYSTEM,
+        portal: PORTAL,
+        callTool,
+      }),
+    );
+    return {
+      payload: {
+        toolCalls: result.toolCalls,
+        output: result.content,
+        tokenUsage: result.usage,
+        durationMs: result.durationMs,
+      },
+      requests,
+    };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+const messagesOf = (requests: Record<string, unknown>[]): Wire[] =>
+  requests.flatMap((r) => (r.messages as Wire[] | undefined) ?? []);
+
+/**
+ * `AttestationDialog.canonicalizeToolCall`, copied verbatim from
+ * `src/components/evidence/AttestationDialog.tsx:55-63`. Copied rather than
+ * imported on purpose: the component is a client module behind the `@/` alias
+ * that `node --test` cannot resolve, and the point of this test is that the
+ * KEYS a signed attestation is built from do not move. If the component's
+ * function ever changes, this copy going stale is the loud failure — a shared
+ * helper would quietly agree with itself.
+ */
+function canonicalizeToolCall(tc: { name: string; args: Record<string, unknown> }): string {
+  return [
+    tc.name,
+    (tc.args.type as string) || '',
+    (tc.args.dataset_id as string) || '',
+    (tc.args.portal as string) || '',
+  ].join(':');
+}
+
+// --- #338: an announcement is not an answer --------------------------------
+//
+// The route's own loop took any assistant turn carrying content as the answer.
+// A turn that announced its next query was therefore returned as `output`, and
+// `AttestationDialog` fed it into a consistency score submitted as an
+// attestation against a published record. Measured on this fixture through the
+// loop at `a9681ab`: `output` WAS the announcement, in two model requests.
+
+test('#338: a final turn that announces a query is not returned as the replay output', async () => {
+  const NARRATION =
+    "I now have the counts by request type for both years. Next, I'll query the fraction of " +
+    'records that close within 14 and 30 days per type.';
+  assert.ok(NARRATION.length < 600, 'the fixture must be inside the announcement length bound');
+
+  const { payload, requests } = await runReplay(
+    [FETCH_CALL, { content: NARRATION }, { content: REAL_ANSWER }],
+    async () => ONE_ROW,
+  );
+
+  assert.notEqual(payload.output, NARRATION, 'a statement of intent must not be published as the answer');
+  assert.equal(payload.output, REAL_ANSWER);
+  assert.equal(requests.length, 3, 'one answering turn, no more');
+});
+
+test('#338: a genuine answer is published as written, with no extra model call', async () => {
+  const { payload, requests } = await runReplay([FETCH_CALL, { content: REAL_ANSWER }], async () => ONE_ROW);
+  assert.equal(payload.output, REAL_ANSWER);
+  assert.equal(requests.length, 2, 'a good answer must not be re-asked');
+});
+
+// --- #338: no raw error text reaches the model -----------------------------
+
+test('#338: a tool failure reaches the model as guidance, and the record says it failed', async () => {
+  const SENTINEL = 'db.internal.example';
+  const { payload, requests } = await runReplay(
+    [FETCH_CALL, { content: REAL_ANSWER }],
+    async () => {
+      throw new Error(`ECONNREFUSED ${SENTINEL}:5432`);
+    },
+  );
+
+  const toolMessages = messagesOf(requests).filter((m) => m.role === 'tool');
+  assert.equal(toolMessages.length, 1);
+  assert.ok(
+    !toolMessages[0].content?.includes(SENTINEL),
+    'the host name must not reach the model in a tool message',
+  );
+  assert.ok(
+    !JSON.stringify(requests).includes(SENTINEL),
+    'no raw error text anywhere on the wire',
+  );
+
+  assert.equal(payload.toolCalls[0].failed, true);
+  assert.equal(payload.toolCalls[0].failureKind, 'unavailable');
+  assert.equal(payload.output, REAL_ANSWER, 'one failed call is not a failed replay');
+});
+
+// --- #347: the token-budget path sends a well-formed transcript ------------
+//
+// The route pushed each assistant turn before running its tools, and its
+// token-budget `break` sat before the next request — so the terminal block
+// pushed the SAME turn a second time and answered every `tool_call_id` twice,
+// once with the real result and once with a placeholder. Measured through the
+// loop at `a9681ab` on this fixture: 2 assistant turns, `call_1` answered
+// twice. A malformed request, feeding a signed consistency attestation.
+
+test('#347: the token-budget path carries the assistant turn once and answers each call once', async () => {
+  const { requests } = await runReplay(
+    [{ ...FETCH_CALL, totalTokens: REPLAY_MAX_CUMULATIVE_TOKENS + 50_000 }, { content: REAL_ANSWER }],
+    async () => ONE_ROW,
+  );
+
+  const last = (requests[requests.length - 1].messages as Wire[]) ?? [];
+  assert.equal(last.filter((m) => m.role === 'assistant').length, 1, 'the assistant turn appears once');
+
+  const answers = last.filter((m) => m.role === 'tool' && m.tool_call_id === 'call_1');
+  assert.equal(answers.length, 1, 'each tool_call_id is answered exactly once');
+  assert.equal(answers[0].content, ONE_ROW, 'the call the loop DID run keeps its real result');
+});
+
+// --- #331: an oversized envelope stays readable ----------------------------
+//
+// The route carried its own copy of `truncateToolResult`, which recognised
+// only a bare JSON array. A paginated envelope fell through to raw character
+// truncation and was cut mid-record. Measured through the copy at `a9681ab` on
+// the envelope below: 296,028 characters in, 50,042 out, `Unterminated string
+// in JSON at position 50000`, and no marker telling the model anything was
+// dropped.
+
+/** A Socrata-shaped envelope of `rows` rows — the shape #331 reproduces on. */
+function socrataEnvelope(rows: number): string {
+  return JSON.stringify({
+    data: Array.from({ length: rows }, (_, i) => ({
+      unique_key: String(100_000 + i),
+      created_date: '2026-01-01T00:00:00.000',
+      complaint_type: 'Noise - Residential',
+      borough: 'BROOKLYN',
+      incident_zip: '11201',
+    })),
+    total_rows: rows,
+  });
+}
+
+test('#331: an oversized envelope reaches the model as valid JSON with a row marker', async () => {
+  const envelope = socrataEnvelope(2000);
+  assert.ok(envelope.length > REPLAY_MAX_TOOL_RESULT_CHARS, 'the fixture must exceed replay’s bound');
+
+  const { requests } = await runReplay([FETCH_CALL, { content: REAL_ANSWER }], async () => envelope);
+
+  const sent = messagesOf(requests).find((m) => m.role === 'tool')?.content;
+  assert.ok(sent, 'the tool result must reach the model');
+  assert.match(sent, /\n\[Truncated: showing \d+ of 2000 rows\]$/, 'the model is told rows were dropped');
+
+  const body = sent.slice(0, sent.lastIndexOf('\n[Truncated'));
+  const parsed = JSON.parse(body) as { data: unknown[]; total_rows: number };
+  assert.ok(Array.isArray(parsed.data) && parsed.data.length > 0, 'whole rows, not a fragment');
+  assert.equal(parsed.total_rows, 2000, 'the envelope’s other fields survive');
+  assert.ok(body.length <= REPLAY_MAX_TOOL_RESULT_CHARS, 'the bound is still enforced on the body');
+});
+
+// --- The attestation payload changes only additively -----------------------
+//
+// `AttestationDialog` keys a replay run on
+// `name:args.type:args.dataset_id:args.portal` and derives a consistency score
+// from the keys of N runs. The portal in that key is injected by this caller
+// INTO THE OBJECT THE CORE ALREADY RECORDED. If the loop ever clones or
+// freezes `args`, the injection stops reaching the record, every key changes,
+// and nothing in the diff points at the cause. These are the keys, spelled out.
+
+test('the attestation identity keys are unchanged, injected portal included', async () => {
+  const { payload } = await runReplay(
+    [
+      {
+        toolCalls: [
+          { id: 'call_1', name: 'get_data', args: { type: 'catalog', query: 'noise complaints' } },
+          { id: 'call_2', name: 'get_data', args: { type: 'query', dataset_id: 'erm2-nwe9' } },
+        ],
+      },
+      {
+        toolCalls: [
+          { id: 'call_3', name: 'get_data', args: { type: 'metrics', dataset_id: 'erm2-nwe9', portal: 'data.sfgov.org' } },
+          { id: 'call_4', name: 'get_variables', args: { place: 'geoId/36061' } },
+        ],
+      },
+      { content: REAL_ANSWER },
+    ],
+    async () => ONE_ROW,
+  );
+
+  assert.deepEqual(payload.toolCalls.map(canonicalizeToolCall), [
+    // portal injected by this caller — absent from what the endpoint sent
+    'get_data:catalog::data.cityofnewyork.us',
+    'get_data:query:erm2-nwe9:data.cityofnewyork.us',
+    // an explicit portal is never overwritten
+    'get_data:metrics:erm2-nwe9:data.sfgov.org',
+    // a non-Socrata tool gets no portal at all
+    'get_variables:::',
+  ]);
+});
+
+test('the payload still carries output, the three token counts and a duration', async () => {
+  const { payload } = await runReplay([FETCH_CALL, { content: REAL_ANSWER }], async () => ONE_ROW);
+
+  assert.equal(typeof payload.output, 'string');
+  assert.ok(payload.output.length > 0);
+  assert.equal(typeof payload.tokenUsage.promptTokens, 'number');
+  assert.equal(typeof payload.tokenUsage.completionTokens, 'number');
+  assert.equal(typeof payload.tokenUsage.totalTokens, 'number');
+  assert.ok(payload.tokenUsage.totalTokens > 0, 'usage is cumulative across the run, as before');
+  assert.equal(typeof payload.durationMs, 'number');
+
+  // Additive only: the two fields the client reads off a record are still
+  // there, and nothing it reads has been renamed.
+  assert.equal(payload.toolCalls[0].name, 'get_data');
+  assert.deepEqual(payload.toolCalls[0].args, {
+    type: 'query',
+    dataset_id: 'abcd-1234',
+    portal: PORTAL,
+  });
+});
+
+// --- The configuration this factory exists to hold -------------------------
+
+test('replayLoopOptions carries replay’s own caps and the shared tool set', () => {
+  const options = replayLoopOptions({
+    client: {} as never,
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    systemPrompt: SYSTEM,
+    portal: PORTAL,
+  });
+
+  assert.equal(options.maxIterations, REPLAY_MAX_ITERATIONS);
+  assert.equal(options.maxTokens, REPLAY_MAX_TOKENS);
+  assert.equal(options.maxCumulativeTokens, REPLAY_MAX_CUMULATIVE_TOKENS);
+  assert.equal(options.maxToolResultChars, REPLAY_MAX_TOOL_RESULT_CHARS);
+  assert.equal(options.finalTurn, 'blocking', 'a route caller has no stream to write into');
+  assert.ok(options.tools.length > 0, 'the replay runs against the instance’s MCP tool set');
+  assert.equal(options.systemPrompt, SYSTEM);
+  assert.equal(options.prompt, PROMPT);
+});
+
+test('a tool call that never settles fails on replay’s own timeout, and the run survives', async () => {
+  // Proves the race moved with the configuration rather than being lost with
+  // the loop. Driven by rejecting with the timeout's own wording instead of
+  // waiting 45 real seconds — the assertion is that a timeout is classified
+  // and described, not that `setTimeout` counts.
+  const { payload, requests } = await runReplay([FETCH_CALL, { content: REAL_ANSWER }], async (name) => {
+    throw new Error(`MCP tool "${name}" timed out after 45s`);
+  });
+
+  assert.equal(payload.toolCalls[0].failed, true);
+  assert.equal(payload.toolCalls[0].failureKind, 'timeout');
+  assert.ok(!JSON.stringify(requests).includes('timed out after 45s'), 'raw timeout text stays off the wire');
+  assert.equal(payload.output, REAL_ANSWER);
+});
+
+// --- The route runs this, and holds no configuration of its own ------------
+
+test('#345: the replay route obtains its loop options from this factory', () => {
+  const route = readFileSync(
+    fileURLToPath(new URL('../../app/api/evidence/[slug]/replay/route.ts', import.meta.url)),
+    'utf8',
+  );
+
+  assert.match(route, /replayLoopOptions\(/, 'the route must build its options here, not inline');
+  assert.match(route, /runToolLoop\(/, 'the route must drive the shared core');
+  assert.ok(
+    !route.includes('callTool'),
+    'the route must not supply a tool transport — the seam exists for tests, not for production',
+  );
+  for (const configuration of ['maxIterations', 'max_tokens', 'maxCumulativeTokens', 'truncateToolResult']) {
+    assert.ok(
+      !route.includes(configuration),
+      `the route must not restate ${configuration}: loop configuration lives in replay-loop.ts`,
+    );
+  }
+});

--- a/src/lib/model-loop/replay-loop.ts
+++ b/src/lib/model-loop/replay-loop.ts
@@ -1,0 +1,122 @@
+/**
+ * Replay's loop configuration, in one place (#345 P3).
+ *
+ * WHY THIS IS A MODULE AND NOT A LITERAL IN THE ROUTE. `replay/route.ts` is a
+ * Next route handler: `node --test` cannot invoke one, and 0 of the 74 test
+ * files in this tree resolve the `@/` alias the route imports through. A test
+ * that hand-rolled replay's options in its own body would therefore be
+ * measuring a copy — configuration written twice diverges, and the divergence
+ * would be invisible in exactly the direction that matters (a cap the route
+ * raised, a portal the route stopped injecting). So the configuration lives
+ * here, under relative imports only, and both the route and its tests obtain
+ * it from the same call.
+ *
+ * WHAT THE ROUTE STILL OWNS. Everything about being a route: the session
+ * check, the caller-supplied key, the MCP routing refusal, the record and
+ * package reads, the hash-only-visibility refusal, the declared→endpoint model
+ * mapping, the portal derivation, the system prompt, and the whole
+ * error-classification tail. This module owns only what the LOOP is given.
+ *
+ * THE ARGS-IDENTITY CONSTRAINT, restated because this is the caller it bites.
+ * `executeToolCall` below injects `portal` into the `args` object the core
+ * already recorded — the same object, by reference (see the header of
+ * `run-tool-loop.ts`). `AttestationDialog.canonicalizeToolCall` keys a replay
+ * run on `name:args.type:args.dataset_id:args.portal`, and those keys are an
+ * input to a signed consistency attestation. Clone the object here and the
+ * injected portal stops reaching the record, every key changes, and nothing in
+ * the diff points at the cause.
+ */
+
+import type OpenAI from 'openai';
+import { mcpTools } from '../mcp/tools.ts';
+import { callMcpTool } from '../mcp/client.ts';
+import type { ToolLoopOptions } from './run-tool-loop.ts';
+
+/** Tool-calling rounds before the loop stops and asks for an answer. */
+export const REPLAY_MAX_ITERATIONS = 20;
+/** `max_tokens` on every request a replay makes. */
+export const REPLAY_MAX_TOKENS = 4000;
+/** Cumulative token budget for one replay run. */
+export const REPLAY_MAX_CUMULATIVE_TOKENS = 200_000;
+/** Bound on one tool result fed back to the model as context. */
+export const REPLAY_MAX_TOOL_RESULT_CHARS = 50_000;
+/**
+ * Per-tool-call timeout. A replay is one leg of an N-run consistency test, so
+ * one unresponsive source must fail its own call rather than hold the whole
+ * run — and the caller of the route is a browser waiting on a response.
+ */
+export const REPLAY_MCP_TOOL_TIMEOUT_MS = 45_000;
+
+/** The tool transport. Substitutable so a test can drive the real loop. */
+export type ReplayToolTransport = (
+  name: string,
+  args: Record<string, unknown>,
+) => Promise<string>;
+
+export interface ReplayLoopInputs {
+  /** Built by the route from the caller-supplied key, in the route's own error handling. */
+  client: OpenAI;
+  /** The wire string this instance reaches the record's model with. */
+  endpointModel: string;
+  /** The record's prompt text, verbatim. */
+  prompt: string;
+  /** Regenerated fresh for the record's portal by the route. */
+  systemPrompt: string;
+  /** The record's portal, injected into Socrata calls that omit one. */
+  portal: string;
+  /**
+   * The tool transport, for tests. Defaults to the live MCP client — the
+   * ONLY seam this factory exposes, and deliberately one level below the
+   * loop: substituting it restates no loop configuration at all.
+   */
+  callTool?: ReplayToolTransport;
+}
+
+/**
+ * Everything `runToolLoop` needs to run one replay. The caps, the tool set,
+ * the portal injection and the per-call timeout are all fixed here; the route
+ * supplies only what it read off the record.
+ */
+export function replayLoopOptions(inputs: ReplayLoopInputs): ToolLoopOptions {
+  const { client, endpointModel, prompt, systemPrompt, portal, callTool = callMcpTool } = inputs;
+
+  return {
+    client,
+    endpointModel,
+    prompt,
+    systemPrompt,
+    tools: mcpTools,
+    maxIterations: REPLAY_MAX_ITERATIONS,
+    maxTokens: REPLAY_MAX_TOKENS,
+    maxCumulativeTokens: REPLAY_MAX_CUMULATIVE_TOKENS,
+    maxToolResultChars: REPLAY_MAX_TOOL_RESULT_CHARS,
+    // A replay has no reader attached to the model call: the client that
+    // started it is waiting on one JSON body, and the answering turn is the
+    // published output of this run.
+    finalTurn: 'blocking',
+    logContext: 'replay',
+    executeToolCall: async (name, args) => {
+      // Socrata's get_data expects a portal; Data Commons tools don't — only
+      // inject for Socrata. Mutating `args` IN PLACE is required, not
+      // incidental: see this file's header.
+      if (name === 'get_data' && !args.portal) args.portal = portal;
+
+      // Race the source against a timeout so one unresponsive tool call
+      // cannot hold the replay open indefinitely.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          callTool(name, args),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error(`MCP tool "${name}" timed out after ${REPLAY_MCP_TOOL_TIMEOUT_MS / 1000}s`)),
+              REPLAY_MCP_TOOL_TIMEOUT_MS,
+            );
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    },
+  };
+}


### PR DESCRIPTION
# P3 — replay on the shared loop core

**Branch** `sprint-345/p3-replay-on-core` · **head** `b8b3cedc4d61c7f558b60f3b630f82ef171b5c0b` · **base** `a9681ab` · rollback tag `rollback/pre-345-p3` (pre-existing). Ran on **Opus 5** (`claude-opus-5[1m]`).

Closes #338
Closes #347
Closes #331

## Diff and blast zone

```
 src/app/api/evidence/[slug]/replay/route.ts    | 164 ++---------
 src/lib/model-loop/model-call-registry.test.ts |   7 +-
 src/lib/model-loop/replay-loop.test.ts         | 392 +++++++++++++++++++++++++
 src/lib/model-loop/replay-loop.ts              | 122 ++++++++
 4 files changed, 542 insertions(+), 143 deletions(-)
```

`git diff --name-only a9681ab...HEAD` returns **exactly the four declared paths and nothing else**. `src/components/evidence/AttestationDialog.tsx` is **untouched** — see criterion 6 for why no edit was forced. Nothing out of zone was needed, so nothing is itemised as an out-of-zone need.

## What moved where

| Concern | Now lives in |
|---|---|
| the tool-calling loop, its exit condition, truncation, error-to-model path, transcript discipline | `src/lib/model-loop/run-tool-loop.ts` (P2's core, unchanged) |
| caps (20 iterations / 4000 `max_tokens` / 200k cumulative / 50k tool-result chars), the MCP tool set, the `portal` injection, the 45 s per-call race | `src/lib/model-loop/replay-loop.ts` — new, relative imports only |
| session check, caller key, MCP routing refusal, record + package reads, `canReadRecord`, hash-only refusal, `endpointModelForDeclared`, the `portal` derivation, `buildSystemPrompt(portal)`, `createModelClient`, the whole error-classification tail | `replay/route.ts`, unchanged |

The route's private loop and its private `truncateToolResult` are deleted. The route now holds no loop configuration at all; a test in `replay-loop.test.ts` asserts that (`replayLoopOptions(` present, no `callTool`, no `maxIterations` / `max_tokens` / `maxCumulativeTokens` / `truncateToolResult`).

`replayLoopOptions` exposes exactly one seam, `callTool`, one level **below** the loop. A test substitutes the tool transport and restates no loop configuration — change replay's caps and the tests change with it.

## Acceptance — six criteria, RED then GREEN

RED for criteria 2–6 was produced by a driver that **mechanically slices** the loop out of `a9681ab:src/app/api/evidence/[slug]/replay/route.ts` (byte ranges `:23-25`, `:27-42`, `:137-253`) via `git show` and runs it against the same scripted endpoint and the same fixtures as the new path. Nothing is hand-transcribed; the substitutions are the route wrapper (replaced by parameters), `NextResponse.json` (identity), and the `:254-276` classifier tail (dropped, caller-side by design). This is the same limitation G1 recorded: it proves the defect is in that code, not that the route file executes it. The registry test and the route drift guard close that gap from the other side.

### 1 — Replay drives the core; its loop and its truncation copy are gone

`replay/route.ts` contains no `chat.completions.create`, no tool-calling `while`, and no `truncateToolResult`. Both `model-call-registry.test.ts` entries removed. **Both directions of the bidirectional test were exercised:**

*RED direction A — entries left behind, call site gone:*

```
not ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
  error: 'src/app/api/evidence/[slug]/replay/route.ts is on the registry but no longer calls chat.completions.create. Remove the entry — a stale allowlist is a false statement about the tree.'
not ok 2 - #345: only the named modules carry a tool-calling loop
  error: 'src/app/api/evidence/[slug]/replay/route.ts is listed as carrying a tool loop but no longer does. Remove the entry.'
# tests 2 · # pass 0 · # fail 2
```

*RED direction B — entries removed, base route restored:*

```
not ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
  error: 'src/app/api/evidence/[slug]/replay/route.ts calls chat.completions.create and is not on the registry ... Add it with one line saying why it is a separate call site — or, better, call runToolLoop.'
not ok 2 - #345: only the named modules carry a tool-calling loop
  error: 'src/app/api/evidence/[slug]/replay/route.ts calls chat.completions.create with tools — a second tool-calling loop. This is the shape wave #345 exists to end: call runToolLoop instead.'
# tests 2 · # pass 0 · # fail 2
```

*GREEN at head:* `# tests 2 · # pass 2 · # fail 0`.

A third guard was added in `replay-loop.test.ts` — *"the replay route obtains its loop options from this factory"*. Shown red against the base route: `error: 'the route must build its options here, not inline'`.

### 2 — No announcement is published as replay's output (the wave's property-shaped criterion)

Fixture final turn, 137 characters, first person, a data verb:
`"I now have the counts by request type for both years. Next, I'll query the fraction of records that close within 14 and 30 days per type."`

```
RED  base a9681ab  output === the announcement: true
RED  base a9681ab  output: "I now have the counts by request type for both years. Next, I'll query the fraction of records that close within 14 and 30 days per type."
RED  base a9681ab  model requests made: 2

GREEN P3           output === the announcement: false
GREEN P3           output: "Across both years the portal recorded 4,812 requests of this type. The median time to close was 9 days, and 71% closed within 14 days (dataset abcd-1234)."
GREEN P3           model requests made: 3
```

Pinned by `#338: a final turn that announces a query is not returned as the replay output` and its companion `a genuine answer is published as written, with no extra model call` (2 requests, not 3 — the fix costs nothing on the common path).

### 3 — No raw error text reaches the model; failed calls are recorded as failed

A tool throwing `Error("ECONNREFUSED db.internal.example:5432")`, asserted **on the wire**:

```
RED  base a9681ab  tool message on the wire: "Error: ECONNREFUSED db.internal.example:5432"
RED  base a9681ab  wire contains "db.internal.example": true
RED  base a9681ab  record: {"name":"get_data","args":{"type":"query","dataset_id":"abcd-1234","portal":"data.cityofnewyork.us"}}
RED  base a9681ab  record has failed/failureKind: false / false

GREEN P3           tool message on the wire: "This data request returned no data. Do not estimate, guess, or fabricate any values to fill the gap. The live data source is temporarily unavailable. Suggest trying again shortly. In your answer, briefly tell the user in plain language that the live data could not be retrieved, and do not include any raw error text, status codes, server names, or system details."
GREEN P3           wire contains "db.internal.example": false
GREEN P3           record failed=true failureKind=unavailable
```

### 4 — #347 closes with a regression test

Token-budget path, final outgoing request:

```
RED  base a9681ab  final request: assistant turns = 2
RED  base a9681ab  final request: tool messages for call_1 = 2
RED  base a9681ab  their contents = ["{\"data\":[{\"request_type\":\"A\",\"days_to_close\":9}],\"total_rows\":1}","Limit reached. Please summarize based on data collected."]

GREEN P3           final request: assistant turns = 1
GREEN P3           final request: tool messages for call_1 = 1
GREEN P3           their contents = ["{\"data\":[{\"request_type\":\"A\",\"days_to_close\":9}],\"total_rows\":1}"]
```

P1's measurement reproduced exactly (2 turns, `call_1` answered twice) before the fix.

### 5 — #331's second instance is gone

A 2,000-row paginated envelope. Its length came out at **296,028 characters** — the issue's own figure, from an independently generated fixture.

```
envelope length: 296028

RED  base a9681ab  tool message length: 50042
RED  base a9681ab  carries a row marker: false
RED  base a9681ab  body is valid JSON: false — Unterminated string in JSON at position 50000 (line 1 column 50001)
RED  base a9681ab  last 120 chars: ":\"2026-01-01T00:00:00.000\",\"complaint_type\":\"Noise - Residential\",\"borough\":\"B\n[Truncated: result was 296028 characters]"

GREEN P3           tool message length: 49646
GREEN P3           carries a row marker: true
GREEN P3           body is valid JSON: true
GREEN P3           last 120 chars: "se - Residential\",\"borough\":\"BROOKLYN\",\"incident_zip\":\"11201\"}],\"total_rows\":2000}\n[Truncated: showing 335 of 2000 rows]"
```

50,042 characters out, and a parse failure at position 50000, matches #331's own measurement. The committed test asserts on the wire: marker present, body parses, `total_rows` survives, body within the bound.

### 6 — The attestation payload changes only additively

Keys computed with `canonicalizeToolCall` copied verbatim from `AttestationDialog.tsx:55-63`, over a four-call fixture that exercises injection, a portal already supplied, and a non-Socrata tool:

```
base a9681ab keys: ["get_data:catalog::data.cityofnewyork.us","get_data:query:erm2-nwe9:data.cityofnewyork.us","get_data:metrics:erm2-nwe9:data.sfgov.org","get_variables:::"]
P3           keys: ["get_data:catalog::data.cityofnewyork.us","get_data:query:erm2-nwe9:data.cityofnewyork.us","get_data:metrics:erm2-nwe9:data.sfgov.org","get_variables:::"]
byte-identical: true
```

The first two carry a `portal` **the endpoint never sent** — injected by `executeToolCall` into the object the core already recorded. That is the constraint the wave named, and it is asserted as literal expected strings in the committed test, not as "toolCalls is non-empty".

```
base a9681ab record[0] keys: ["name","args"]
P3           record[0] keys: ["name","args","operationType","reason","duration_ms","resultSummary"]
P3 adds only: ["operationType","reason","duration_ms","resultSummary"]   (plus failed/failureKind on a failed call)
P3 drops:     []

base payload top-level keys: ["toolCalls","output","tokenUsage","durationMs"]
P3   payload top-level keys: ["toolCalls","output","tokenUsage","durationMs"]
base tokenUsage: {"promptTokens":30,"completionTokens":15,"totalTokens":45}  durationMs typeof number
P3   tokenUsage: {"promptTokens":30,"completionTokens":15,"totalTokens":45}  durationMs typeof number
P3   output produced: true
```

**Why `AttestationDialog.tsx` needed no edit.** `ReplayResult` (`:33-38`) types a value that arrives from `await res.json()`, so extra runtime fields are not an excess-property error; `canonicalizeToolCall` reads four fields; and the *signed* payload (`:300-308`) carries only `toolCallCount`, `toolCallKeys`, `outputExcerpt`, `tokenUsage`, `durationMs` — none of which changes shape. The signed consistency attestation is byte-compatible except where `outputExcerpt` now holds an answer rather than an announcement, which is the fix.

## Gate checks — run after `npm ci`

```
### npm test
1..1042
# tests 1075
# suites 10
# pass 1075
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2100.273208
```

The suite with `replay-loop.test.ts` removed reports **1065**, so this branch adds 10 tests and removes none. (1044 at `1ddd61a` and `7357f27`; P2 took it to 1065.)

```
### npm run build
> next build
Build error occurred
Error [TurbopackInternalError]: [project]/src/app/globals.css [app-client] (css)
Caused by:
- creating new process
- binding to a port
- Operation not permitted (os error 1)
```

**Re-measured, not assumed.** This session denies socket binding, so Turbopack's PostCSS worker pool dies — the documented environment failure, not a defect in this change. `--webpack` skips the worker pool:

```
### npx next build --webpack
▲ Next.js 16.3.0 (webpack)
- Environments: .env.local
✓ Running next.config.ts took 53ms

  Creating an optimized production build ...
✓ Compiled successfully in 2.2s
  Running TypeScript ...
  Finished TypeScript in 1213ms ...
  Collecting page data using 9 workers ...
✓ Generating static pages using 9 workers (32/32) in 236ms
  Finalizing page optimization ...
  Collecting build traces ...

Route (app) table emitted; both /api/evidence/[slug]/replay and /api/records/[slug]/replay present.
```

CI's `build` job is the real gate.

```
### npm run typecheck   (run after a successful build)
> tsc --noEmit
exit=0   (no output)
```

```
### npm run lint
> eslint

/Users/npstorey/code/civic-ai-tools-website/scripts/eval-models.mjs
  388:7  warning  'TokenBudgetExceeded' is defined but never used  @typescript-eslint/no-unused-vars

/Users/npstorey/code/civic-ai-tools-website/src/components/evidence/AttestationDialog.tsx
  8:7  warning  'EXPERT_RATINGS' is assigned a value but only used as a type  @typescript-eslint/no-unused-vars

/Users/npstorey/code/civic-ai-tools-website/src/components/notebook/RenderingCellOutputs.tsx
  96:9  warning  Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

/Users/npstorey/code/civic-ai-tools-website/src/lib/bpmn/animation.ts
  8:10  warning  'mapEventToNodes' is defined but never used  @typescript-eslint/no-unused-vars

✖ 4 problems (0 errors, 4 warnings)
```

The documented baseline, unchanged: 4 warnings, 0 errors.

```
### npm run check:compose-env
RESULT: PASS — every variable this profile reads can reach the container.
```

No `.env*` file was read at any point.

## Premises that did not survive

**P3-1 — the client is constructed OUTSIDE the route's `try`, and stays there.** The contract said to construct it inside the existing `try` "so a `createModelClient` throw is classified exactly as today". At `a9681ab` it is at `:135` and the `try` opens at `:143`, so today a `createModelClient` throw is **not** classified — it escapes the handler entirely. Moving it in would have changed behaviour: a `ModelConfigurationError` classifies to `model_not_configured`, which `callerModelKeyFailure` deliberately returns `null` for, so it would have fallen through to a JSON 500 carrying the configuration message plus a `[replay] Error:` log line, where today the framework answers. Since the instruction's stated purpose was *no change*, the construction was left exactly where it was. Proposed correction, not made: classifying it is a small legibility win and belongs with whoever next revisits this route's error tail.

**P3-2 — G1's `replayLoopOptions` sketch predates two options P2 added.** Reconciled against the interface as built: the factory sets `finalTurn: 'blocking'` explicitly (the core's default, stated so the choice is visible to a reader) and `logContext: 'replay'`. It does not pass `passThroughDelivery` (no reader), `onDelta`/`onEvent` (nothing to report to), `trace` (replay writes no trace today) or `declaredModel` (only reachable through a trace).

**P3-3 — a rider that could not be honoured as written: `git commit -s` with the mandated block order.** Measured: `git commit -s` deduplicates the sign-off only when it is the **last** trailer line. With the mandated order (sign-off first, `Co-Authored-By` second) it appends a second `Signed-off-by`, which is what the first commit got. The commit was amended to the exact block the repo's merged commits carry — one sign-off first, one `Co-Authored-By` second, contiguous, author matching `npstorey@users.noreply.github.com`. Verified with `git log -1 --format='%(trailers:key=Signed-off-by,valueonly)|%(trailers:key=Co-Authored-By,valueonly)'`: one value each.

**Everything else in the contract verified exact at `a9681ab`:** `route.ts:23-25`, `:27-42` (the #331 gate at `:31`, the raw slice at `:40`), `:129`, `:132`, `:135`, `:137`, `:138`, `:149`, `:173`, `:174`, `:177-185`, `:195`, `:201`, `:203`, `:218`, `:221-229`, `:230`, `:238`, `:254-275`; `AttestationDialog.tsx:33-38`, `:55-63`, `:233`; the core's `:94-132` option members and its three defaults; `test-harness.ts`'s three exports; both "Removed by P3" registry entries; and #331's reopened state (the defective copy was still at `:27-42`).

## Behaviour changes, itemised

Beyond the three defect fixes, four things a reader would otherwise discover rather than be told:

1. **The per-call timeout is now cleared.** The route's race left a 45-second `setTimeout` pending after every successful tool call (so do `compare-stream` and `query-notebook`). `replayLoopOptions` clears it in a `finally`. No payload effect; it is also what lets the test suite finish in 200 ms rather than 45 seconds per tool call.
2. **The timeout message gains the tool name** — `MCP tool "get_data" timed out after 45s` rather than `MCP tool timed out after 45s`, matching the other two callers. It classifies identically (`mcp_timeout`) and never reaches the model, which sees `describeToolFailureForLlm` copy.
3. **The unrun-tool-call note changes wording**, from `Limit reached. Please summarize based on data collected.` to the core's `This tool call was not run: the tool-call limit for this query was reached.` — #343's one-contract-stated-once, inherited from the core.
4. **A malformed tool-argument set is now one failed call rather than a 500** (#349, inherited from the core). On this route that matters more than elsewhere: it used to abort an N-run consistency test after N−1 replays had already been paid for.

`model-call-registry.test.ts` carries **one comment line beyond the two entries**: the header sentence "for the two files this wave has not migrated yet" became false with one file left, so it now reads "for the file this wave has not migrated yet". No other comment was touched — the `ALLOWED_TOOL_LOOPS` doc comment ("Three at this wave's base; one when it closes") is still true and was left alone.

## Flagged, not fixed

- **`openrouter.ts` still carries its own loop** with copies of #344, #349 and the pre-#334 exit condition. P4's, and now the only entry left in `ALLOWED_TOOL_LOOPS` besides the core.
- **`mcp_tool_call` span attributes are still built before `executeToolCall` runs**, so a caller-injected `portal` reaches `tools_called[].args` but not `tool.portal_domain`. Pre-existing, carried from P2's flag; replay passes no trace, so it is invisible on this path today. Still a rider for P5.
- **The replay route writes no trace at all.** It is the one signed-attestation-feeding path with no `llm_inference` or `mcp_tool_call` spans. Out of charter here; worth a decision rather than a silent continuation.
- **P3-1's classification gap** (above): a `createModelClient` misconfiguration on this route answers a framework 500 with no `[replay]` log line. Unchanged by this phase, deliberately.
- **`canonicalizeToolCall` now exists twice** — in `AttestationDialog.tsx:55-63` and copied verbatim into `replay-loop.test.ts`, with a comment saying why (the component is behind the `@/` alias `node --test` cannot resolve, and a shared helper would quietly agree with itself). The duplication is deliberate and load-bearing for criterion 6, but it is duplication and the next reader should know.
- **The RED driver lives only in the session scratchpad**, not in the repository. Its input is `git show a9681ab:…`, so it is reproducible from the rollback tag, but it is not runnable from a checkout of this branch.

## What was not touched

`src/lib/openrouter.ts` and `/api/compare` (P4); `AttestationDialog.tsx`; the eval pair (#348); the notebook paths (#341, #342); version bumps, CHANGELOG headings, publishing. No merge, no tag, no deploy.
