### PR TITLE
fix: /api/compare runs on the shared loop core (#344, #349)

### DIFF
--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -196,17 +196,42 @@ Demonstrate the tangible value of MCP by letting users see the difference betwee
     "tokens_used": 450,
     "tools_called": [
       {
-        "name": "search_datasets",
-        "args": { "query": "311 complaints" }
+        "name": "get_data",
+        "args": { "type": "catalog", "query": "311 complaints", "portal": "data.sfgov.org" },
+        "operationType": "catalog",
+        "reason": "to find datasets about \"311 complaints\"",
+        "duration_ms": 210,
+        "resultSummary": { "rows": 1, "columns": 3 }
       },
       {
-        "name": "query_dataset",
-        "args": { "dataset_id": "abc123", "query": "..." }
+        "name": "get_data",
+        "args": { "type": "query", "dataset_id": "vw9i-7mzq", "query": "...", "portal": "data.sfgov.org" },
+        "operationType": "query",
+        "reason": "to query dataset vw9i-7mzq",
+        "duration_ms": 890,
+        "resultSummary": { "rows": 2, "columns": 2 }
       }
     ]
   }
 }
 ```
+
+Both halves ask one model the same question; only the MCP half is given tools.
+That half runs on the shared tool-calling loop
+(`src/lib/model-loop/run-tool-loop.ts`, configured by `compare-loop.ts`) — the
+same implementation `/api/compare-stream` and a record replay use, since #345.
+Reading the body:
+
+- `tokens_used` on the MCP half is the run's **cumulative** total across every
+  model call the loop made, not the last call's.
+- `tools_called` is **omitted** rather than empty when no tool ran. Each entry
+  carries `name` and `args` — the arguments actually sent, the portal this route
+  injects into Socrata calls included — plus `operationType`, `reason`,
+  `duration_ms` and `resultSummary` where each can be derived.
+- A call that **failed** carries `"failed": true` and a `failureKind` (`timeout`,
+  `unavailable`, `not_configured` or `unknown`) in place of a `resultSummary`. A
+  failed call and a zero-row one are otherwise indistinguishable (#321), and one
+  failed call does not fail the comparison.
 
 ### GET /api/models
 

--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { queryWithoutMcp, queryWithMcp } from '@/lib/openrouter';
-import { mcpTools } from '@/lib/mcp/tools';
-import { callMcpTool } from '@/lib/mcp/client';
+import { queryWithoutMcp } from '@/lib/openrouter';
+import { runToolLoop } from '@/lib/model-loop/run-tool-loop';
+import { compareLoopOptions, compareCompletionResult } from '@/lib/model-loop/compare-loop';
 import { buildSystemPrompt } from '@/lib/mcp/socrata-skill';
 import { checkRateLimit, incrementRateLimit, isRateLimited } from '@/lib/rate-limit';
-import { getMissingModelCredentialError, classifyModelError, ModelConfigurationError } from '@/lib/model-client';
+import { getMissingModelCredentialError, getModelClient, classifyModelError, ModelConfigurationError } from '@/lib/model-client';
 import { resolveModelIdentity, ModelNotOfferedError } from '@/lib/model-resolver';
 import type { ModelIdentity } from '@/lib/model-catalog';
 import { streamErrorPayload } from '@/lib/streaming';
@@ -121,27 +121,33 @@ When answering questions about civic data, government statistics, or local infor
 do your best to provide helpful information based on your training data.
 Be honest if you don't have access to current or real-time data.`;
 
-    // Run both queries in parallel
+    // Run both queries in parallel. The MCP side runs on the shared
+    // tool-calling loop (#345 P4): this route carried its own copy — the
+    // original one, with the pre-#334 exit condition, raw error text fed to
+    // the model, no truncation and `{name, args}`-only records (#344, #349) —
+    // until the loop became one implementation. Everything the loop is GIVEN,
+    // this caller's own caps included, lives in `compareLoopOptions`; nothing
+    // about how it runs is decided here.
     const [withoutMcpResult, withMcpResult] = await Promise.all([
       queryWithoutMcp(query, model, systemPromptWithoutMcp),
-      queryWithMcp(
-        query,
-        model,
-        mcpTools,
-        async (name, args) => {
-          // Socrata tools expect a portal; Data Commons tools don't — only inject the default for Socrata's `get_data`.
-          if (name === 'get_data' && !args.portal) {
-            args.portal = portal;
-          }
-          return callMcpTool(name, args);
-        },
-        systemPromptWithMcp
-      ),
+      runToolLoop(compareLoopOptions({
+        client: getModelClient(),
+        endpointModel: model.endpointModel,
+        prompt: query,
+        systemPrompt: systemPromptWithMcp,
+        portal,
+      })),
     ]);
 
+    // Same four fields, same order, as before the migration. `tools_called[]`
+    // entries now additionally carry `operationType`, `reason`,
+    // `resultSummary`, `duration_ms` and — for a call that failed —
+    // `failed`/`failureKind`, and `tokens_used` is the run's cumulative total
+    // rather than its last call's. Both are documented in
+    // `docs/project-plan.md`.
     return NextResponse.json({
       withoutMcp: withoutMcpResult,
-      withMcp: withMcpResult,
+      withMcp: compareCompletionResult(withMcpResult),
     });
   } catch (error) {
     console.error('Compare API error:', error);

--- a/src/lib/model-loop/compare-loop.test.ts
+++ b/src/lib/model-loop/compare-loop.test.ts
@@ -1,0 +1,443 @@
+// Acceptance tests for /api/compare on the shared loop core (#345 P4).
+//
+// WHAT IS UNDER TEST, and why it is this and not the route. `compare/route.ts`
+// is a Next route handler: `node --test` cannot invoke one. So the loop
+// configuration was moved OUT of `openrouter.ts` — whose loop was the original
+// one this family forked from — into `compareLoopOptions`, and these tests
+// drive the real `runToolLoop` with the real options factory against a local
+// scripted model server. The only thing substituted is the tool transport, one
+// level BELOW the loop, so no case here restates a cap, a bound, a tool set or
+// the portal injection. Change compare's configuration and these tests change
+// with it; that is the point of the seam.
+//
+// A source-drift guard at the bottom closes the remaining gap: it asserts the
+// route actually obtains its options from this factory and supplies no
+// transport and no configuration of its own. Between that and
+// `model-call-registry.test.ts` (which fails if the route or `openrouter.ts`
+// carries a tool loop at all), "the route runs this" is measured rather than
+// assumed.
+//
+// Every claim about what the model was SENT is asserted against the request
+// bodies the mock server received, because that is where those claims live: a
+// raw error string in a `tool` message (#344), a cap that silently became the
+// core's higher default, and a result handed over untruncated are all invisible
+// from the return value.
+//
+// The RED baseline for each case was measured at 08858a9 by driving the real
+// `queryWithMcp` — the loop this replaces — against this same harness. It
+// returned the announcement as `content` in 2 requests, put
+// `Error executing tool: ECONNREFUSED db.internal.example:5432` on the wire
+// verbatim, recorded `{name, args}` with no `failed`/`failureKind`, and threw a
+// `SyntaxError` out of the loop on a malformed argument set after 1 request.
+//
+// No live endpoint, no credential, no MCP server. Every key value is an
+// obviously fake fixture and the address is loopback.
+//
+// Run with: npm test
+//   (or: node --test --experimental-strip-types src/lib/model-loop/compare-loop.test.ts)
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { runToolLoop } from './run-tool-loop.ts';
+import {
+  compareLoopOptions,
+  compareCompletionResult,
+  COMPARE_MAX_ITERATIONS,
+  COMPARE_MAX_TOKENS,
+  COMPARE_MAX_TOOL_RESULT_CHARS,
+  type CompareCompletionResult,
+  type CompareToolTransport,
+} from './compare-loop.ts';
+import { startScriptedModelServer, type ScriptedReply } from './test-harness.ts';
+import { createModelClient } from '../model-client.ts';
+
+const FIXTURE_KEY = 'not-a-real-key-p4-compare-fixture';
+const PORTAL = 'data.cityofnewyork.us';
+const PROMPT = 'How long do these requests take to close?';
+const SYSTEM = 'You are a fixture system prompt.';
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ['MODEL_API_BASE_URL', 'MODEL_API_KIND', 'MODEL_API_AUTH', 'MODEL_API_VERSION'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+const REAL_ANSWER =
+  'Across both years the portal recorded 4,812 requests of this type. The median time to close ' +
+  'was 9 days, and 71% closed within 14 days (dataset abcd-1234).';
+
+/** A `get_data` call carrying NO portal — the injection this caller performs. */
+const FETCH_CALL: ScriptedReply = {
+  toolCalls: [{ id: 'call_1', name: 'get_data', args: { type: 'query', dataset_id: 'abcd-1234' } }],
+};
+
+const ONE_ROW = JSON.stringify({ data: [{ request_type: 'A', days_to_close: 9 }], total_rows: 1 });
+
+interface Wire {
+  role: string;
+  content?: string;
+  tool_call_id?: string;
+}
+
+/**
+ * Run the MCP half of one comparison against a scripted endpoint, and return
+ * the `withMcp` body the route answers with — built by the same function the
+ * route calls, so a case asserts on what an API client actually reads rather
+ * than on the loop's own return shape.
+ *
+ * `callTool` is the ONLY thing a case supplies beyond what the route reads off
+ * the request — no cap, no bound, no tool list, no portal handling.
+ */
+async function runCompare(
+  replies: ScriptedReply[],
+  callTool: CompareToolTransport,
+): Promise<{ withMcp: CompareCompletionResult; requests: Record<string, unknown>[] }> {
+  const { server, url, requests } = await startScriptedModelServer(replies);
+  try {
+    process.env.MODEL_API_BASE_URL = url;
+    const result = await runToolLoop(
+      compareLoopOptions({
+        client: createModelClient({ apiKey: FIXTURE_KEY }),
+        endpointModel: 'fake/model',
+        prompt: PROMPT,
+        systemPrompt: SYSTEM,
+        portal: PORTAL,
+        callTool,
+      }),
+    );
+    return { withMcp: compareCompletionResult(result), requests };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+const messagesOf = (requests: Record<string, unknown>[]): Wire[] =>
+  requests.flatMap((r) => (r.messages as Wire[] | undefined) ?? []);
+
+// --- #344: an announcement is not an answer --------------------------------
+//
+// The deleted loop exited on `!lastMessage?.content && (...)` — the pre-#334
+// condition, keyed on content being ABSENT. A final turn that announced its
+// next query carried content, so it was returned as `content` and served as the
+// answer to a public API call. Measured through that loop at 08858a9 on this
+// fixture: `content` WAS the announcement, in 2 model requests.
+
+test('#344: a final turn that announces a query is not returned as compare’s answer', async () => {
+  const NARRATION =
+    "I now have the counts by request type for both years. Next, I'll query the fraction of " +
+    'records that close within 14 and 30 days per type.';
+  assert.ok(NARRATION.length < 600, 'the fixture must be inside the announcement length bound');
+
+  const { withMcp, requests } = await runCompare(
+    [FETCH_CALL, { content: NARRATION }, { content: REAL_ANSWER }],
+    async () => ONE_ROW,
+  );
+
+  assert.notEqual(withMcp.content, NARRATION, 'a statement of intent must not be served as the answer');
+  assert.equal(withMcp.content, REAL_ANSWER);
+  assert.equal(requests.length, 3, 'one answering turn, no more');
+});
+
+test('#344: a genuine answer is returned as written, with no extra model call', async () => {
+  const { withMcp, requests } = await runCompare([FETCH_CALL, { content: REAL_ANSWER }], async () => ONE_ROW);
+  assert.equal(withMcp.content, REAL_ANSWER);
+  assert.equal(requests.length, 2, 'a good answer must not be re-asked');
+});
+
+// --- #344: no raw error text reaches the model, and the record says so ------
+
+test('#344: a tool failure reaches the model as guidance, and the record says it failed', async () => {
+  const SENTINEL = 'db.internal.example';
+  const { withMcp, requests } = await runCompare(
+    [FETCH_CALL, { content: REAL_ANSWER }],
+    async () => {
+      throw new Error(`ECONNREFUSED ${SENTINEL}:5432`);
+    },
+  );
+
+  const toolMessages = messagesOf(requests).filter((m) => m.role === 'tool');
+  assert.equal(toolMessages.length, 1);
+  assert.ok(
+    !toolMessages[0].content?.includes(SENTINEL),
+    'the host name must not reach the model in a tool message',
+  );
+  assert.ok(
+    !JSON.stringify(requests).includes(SENTINEL),
+    'no raw error text anywhere on the wire',
+  );
+  assert.ok(
+    !JSON.stringify(requests).includes('Error executing tool'),
+    'the deleted loop’s verbatim error wrapper is gone from the wire',
+  );
+
+  assert.equal(withMcp.tools_called?.[0].failed, true);
+  assert.equal(withMcp.tools_called?.[0].failureKind, 'unavailable');
+  assert.equal(withMcp.content, REAL_ANSWER, 'one failed call is not a failed comparison');
+});
+
+// --- #349, the last instance: a malformed argument set does not end the run -
+//
+// The deleted loop parsed `toolCall.function.arguments` with a bare
+// `JSON.parse` OUTSIDE the `try` that wrapped execution, so unparseable bytes
+// from the endpoint threw straight past every failure path and out of the
+// function — a 500 from this route, after any successful calls had been paid
+// for. Measured through that loop at 08858a9 on this fixture: a `SyntaxError`
+// out of the loop, 1 model request, no result at all.
+
+test('#349: a malformed tool-argument set is one failed call, and the run continues', async () => {
+  let transportCalled = false;
+  const { withMcp, requests } = await runCompare(
+    [
+      { toolCalls: [{ id: 'call_1', name: 'get_data', args: {}, rawArguments: '{"type": "query",' }] },
+      { content: REAL_ANSWER },
+    ],
+    async () => {
+      transportCalled = true;
+      return ONE_ROW;
+    },
+  );
+
+  assert.equal(withMcp.content, REAL_ANSWER, 'the run reaches an answer rather than throwing');
+  assert.equal(requests.length, 2, 'the loop went on to ask the model again');
+  assert.equal(transportCalled, false, 'an unreadable argument set never reaches the source');
+
+  assert.equal(withMcp.tools_called?.length, 1, 'the attempt is recorded, not dropped');
+  assert.equal(withMcp.tools_called?.[0].failed, true);
+  assert.equal(withMcp.tools_called?.[0].failureKind, 'unknown');
+
+  const toolMessages = messagesOf(requests).filter((m) => m.role === 'tool');
+  assert.equal(toolMessages.length, 1, 'the model is told the call failed');
+  assert.ok(
+    !toolMessages[0].content?.includes('{"type": "query",'),
+    'the endpoint’s malformed bytes are not quoted back at it',
+  );
+  // The parser's own message quotes the malformed bytes back and names a
+  // position; none of that is the app's to put in front of a model.
+  const wire = JSON.stringify(requests);
+  for (const parserText of ['in JSON at position', 'Unexpected end of JSON input', 'SyntaxError']) {
+    assert.ok(!wire.includes(parserText), `no parser text on the wire: ${parserText}`);
+  }
+});
+
+// --- The caps this caller keeps, asserted where they land ------------------
+//
+// Owner ruling: /api/compare keeps 10 iterations and max_tokens 2000 rather
+// than adopting the core's 20 and 4000. It is a rate-limited public endpoint
+// and the documented operator smoke test, so the higher defaults would double
+// the worst-case cost of a call anyone can make. Both halves are asserted ON
+// THE WIRE, because a cap that quietly reverted to a default is invisible from
+// the return value — and 10 vs 20 is exactly the difference this measures.
+
+test('compareLoopOptions carries compare’s own caps and the shared tool set', () => {
+  const options = compareLoopOptions({
+    client: {} as never,
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    systemPrompt: SYSTEM,
+    portal: PORTAL,
+  });
+
+  assert.equal(options.maxIterations, COMPARE_MAX_ITERATIONS);
+  assert.equal(COMPARE_MAX_ITERATIONS, 10, 'half the core’s default, by owner ruling');
+  assert.equal(options.maxTokens, COMPARE_MAX_TOKENS);
+  assert.equal(COMPARE_MAX_TOKENS, 2000, 'half the core’s default, by owner ruling');
+  assert.equal(options.maxToolResultChars, COMPARE_MAX_TOOL_RESULT_CHARS);
+  assert.equal(
+    options.maxCumulativeTokens,
+    undefined,
+    'this caller has never had a cumulative budget; undefined is unbounded in the core',
+  );
+  assert.equal(options.finalTurn, 'blocking', 'a JSON route has no stream to write into');
+  assert.ok(options.tools.length > 0, 'the comparison runs against the instance’s MCP tool set');
+  assert.equal(options.systemPrompt, SYSTEM);
+  assert.equal(options.prompt, PROMPT);
+});
+
+test('every request this caller makes carries max_tokens 2000', async () => {
+  const { requests } = await runCompare(
+    [FETCH_CALL, { content: REAL_ANSWER }],
+    async () => ONE_ROW,
+  );
+  assert.equal(requests.length, 2);
+  for (const request of requests) {
+    assert.equal(request.max_tokens, COMPARE_MAX_TOKENS, 'the core’s 4000 default must not reach the endpoint');
+  }
+});
+
+test('the loop stops after ten tool-calling rounds, not the core’s twenty', async () => {
+  // The scripted server repeats its LAST reply forever, so a model that never
+  // stops calling tools is what bounds this: the request count is the cap made
+  // observable. One opening call, `maxIterations` rounds, one answering turn.
+  const { withMcp, requests } = await runCompare(
+    [{ toolCalls: [{ id: 'call_n', name: 'get_data', args: { type: 'query', dataset_id: 'abcd-1234' } }] }],
+    async () => ONE_ROW,
+  );
+
+  assert.equal(requests.length, COMPARE_MAX_ITERATIONS + 2);
+  assert.equal(requests.length, 12, 'the core’s default cap would make this 22');
+  assert.equal(withMcp.tools_called?.length, COMPARE_MAX_ITERATIONS);
+  // The answering turn is the one request that offers no tools.
+  assert.equal(requests.filter((r) => r.tools === undefined).length, 1);
+});
+
+// --- The truncation bound this caller gains --------------------------------
+//
+// The deleted loop pushed a tool result as returned, with no bound at all
+// (#344 item 3). It now gets the core's shared bound, and #331's envelope
+// handling with it: whole rows and a marker rather than a fragment cut
+// mid-record.
+
+/** A Socrata-shaped envelope of `rows` rows — the shape #331 reproduces on. */
+function socrataEnvelope(rows: number): string {
+  return JSON.stringify({
+    data: Array.from({ length: rows }, (_, i) => ({
+      unique_key: String(100_000 + i),
+      created_date: '2026-01-01T00:00:00.000',
+      complaint_type: 'Noise - Residential',
+      borough: 'BROOKLYN',
+      incident_zip: '11201',
+    })),
+    total_rows: rows,
+  });
+}
+
+test('an oversized envelope now reaches the model bounded, as valid JSON with a row marker', async () => {
+  const envelope = socrataEnvelope(2000);
+  assert.ok(envelope.length > COMPARE_MAX_TOOL_RESULT_CHARS, 'the fixture must exceed compare’s new bound');
+
+  const { requests } = await runCompare([FETCH_CALL, { content: REAL_ANSWER }], async () => envelope);
+
+  const sent = messagesOf(requests).find((m) => m.role === 'tool')?.content;
+  assert.ok(sent, 'the tool result must reach the model');
+  assert.ok(sent.length < envelope.length, 'the deleted loop sent this whole, unbounded');
+  assert.match(sent, /\n\[Truncated: showing \d+ of 2000 rows\]$/, 'the model is told rows were dropped');
+
+  const body = sent.slice(0, sent.lastIndexOf('\n[Truncated'));
+  const parsed = JSON.parse(body) as { data: unknown[]; total_rows: number };
+  assert.ok(Array.isArray(parsed.data) && parsed.data.length > 0, 'whole rows, not a fragment');
+  assert.equal(parsed.total_rows, 2000, 'the envelope’s other fields survive');
+  assert.ok(body.length <= COMPARE_MAX_TOOL_RESULT_CHARS, 'the bound is enforced on the body');
+});
+
+// --- The documented response body ------------------------------------------
+//
+// `docs/project-plan.md` documents this body. The four fields, their names and
+// their order are unchanged; `tools_called[]` entries are additive, and
+// `tokens_used` is now the run's cumulative total rather than its last call's.
+
+test('the withMcp body keeps its four documented fields, tools_called additively', async () => {
+  const { withMcp } = await runCompare([FETCH_CALL, { content: REAL_ANSWER }], async () => ONE_ROW);
+
+  assert.deepEqual(Object.keys(withMcp), ['content', 'duration_ms', 'tokens_used', 'tools_called']);
+  assert.equal(typeof withMcp.content, 'string');
+  assert.equal(typeof withMcp.duration_ms, 'number');
+  assert.equal(typeof withMcp.tokens_used, 'number');
+
+  // The two documented fields of a tools_called entry, unchanged.
+  assert.equal(withMcp.tools_called?.[0].name, 'get_data');
+  assert.deepEqual(withMcp.tools_called?.[0].args, {
+    type: 'query',
+    dataset_id: 'abcd-1234',
+    portal: PORTAL,
+  });
+  // Additive: the shared record's own fields, which this caller never had.
+  assert.equal(withMcp.tools_called?.[0].operationType, 'query');
+  assert.deepEqual(withMcp.tools_called?.[0].resultSummary, { rows: 1, columns: 2 });
+  assert.equal(typeof withMcp.tools_called?.[0].duration_ms, 'number');
+});
+
+test('tokens_used is the run’s cumulative total, not its last call’s', async () => {
+  // The harness reports 15 total tokens per response. Two responses, so a
+  // last-call reading is 15 and a cumulative one is 30 — the deleted loop
+  // reported the former.
+  const { withMcp, requests } = await runCompare([FETCH_CALL, { content: REAL_ANSWER }], async () => ONE_ROW);
+  assert.equal(requests.length, 2);
+  assert.equal(withMcp.tokens_used, 30);
+});
+
+test('tools_called is omitted, not empty, when no tool ran', async () => {
+  const { withMcp } = await runCompare([{ content: REAL_ANSWER }], async () => ONE_ROW);
+  assert.equal(withMcp.tools_called, undefined, 'an API client distinguishing absent from empty sees what it saw');
+  assert.deepEqual(Object.keys(withMcp), ['content', 'duration_ms', 'tokens_used', 'tools_called']);
+  assert.equal(JSON.parse(JSON.stringify(withMcp)).tools_called, undefined, 'and the field is absent on the wire');
+});
+
+// --- The portal injection, and the args object it injects into -------------
+//
+// The route injected the request's portal into `args` inside its own tool
+// closure; that closure moved here whole. The recorded arguments are what
+// `tools_called[].args` reports, so the injection must reach THE OBJECT THE
+// CORE ALREADY RECORDED — the same object, by reference. If the loop ever
+// clones or freezes `args`, the injection stops reaching the record and nothing
+// in the diff points at the cause.
+
+test('the request’s portal is injected into Socrata calls, into the recorded object itself', async () => {
+  const seen: Record<string, unknown>[] = [];
+  const { withMcp } = await runCompare(
+    [
+      {
+        toolCalls: [
+          { id: 'call_1', name: 'get_data', args: { type: 'catalog', query: 'noise complaints' } },
+          { id: 'call_2', name: 'get_data', args: { type: 'metrics', dataset_id: 'erm2-nwe9', portal: 'data.sfgov.org' } },
+          { id: 'call_3', name: 'get_variables', args: { place: 'geoId/36061' } },
+        ],
+      },
+      { content: REAL_ANSWER },
+    ],
+    async (_name, args) => {
+      seen.push(args);
+      return ONE_ROW;
+    },
+  );
+
+  const recorded = withMcp.tools_called ?? [];
+  assert.equal(recorded[0].args.portal, PORTAL, 'a Socrata call with no portal gets the request’s');
+  assert.equal(recorded[1].args.portal, 'data.sfgov.org', 'an explicit portal is never overwritten');
+  assert.equal(recorded[2].args.portal, undefined, 'a non-Socrata tool gets no portal at all');
+
+  for (const [i, args] of seen.entries()) {
+    assert.equal(args, recorded[i].args, 'the transport receives the very object the record holds');
+  }
+});
+
+// --- The route runs this, and holds no configuration of its own ------------
+
+test('#345: the compare route obtains its loop options from this factory', () => {
+  const route = readFileSync(
+    fileURLToPath(new URL('../../app/api/compare/route.ts', import.meta.url)),
+    'utf8',
+  );
+
+  assert.match(route, /compareLoopOptions\(/, 'the route must build its options here, not inline');
+  assert.match(route, /runToolLoop\(/, 'the route must drive the shared core');
+  assert.ok(
+    !route.includes('queryWithMcp'),
+    'the deleted loop must have no caller left',
+  );
+  assert.ok(
+    !route.includes('callTool'),
+    'the route must not supply a tool transport — the seam exists for tests, not for production',
+  );
+  for (const configuration of ['maxIterations', 'max_tokens', 'maxCumulativeTokens', 'maxToolResultChars', 'truncateToolResult']) {
+    assert.ok(
+      !route.includes(configuration),
+      `the route must not restate ${configuration}: loop configuration lives in compare-loop.ts`,
+    );
+  }
+
+  // The A-side stays where it is: one call, no tools, nothing to consolidate.
+  assert.match(route, /queryWithoutMcp\(/, 'the no-tools half of the comparison is unchanged');
+});

--- a/src/lib/model-loop/compare-loop.ts
+++ b/src/lib/model-loop/compare-loop.ts
@@ -1,0 +1,154 @@
+/**
+ * `/api/compare`'s loop configuration, in one place (#345 P4).
+ *
+ * WHY THIS IS A MODULE AND NOT A LITERAL IN THE ROUTE — the same reason
+ * `replay-loop.ts` gives, and it applies unchanged here. `compare/route.ts` is
+ * a Next route handler: `node --test` cannot invoke one, and no test file in
+ * this tree resolves the `@/` alias the route imports through. A test that
+ * hand-rolled compare's options in its own body would be measuring a copy, and
+ * configuration written twice diverges in exactly the direction that matters —
+ * a cap the route raised, a portal the route stopped injecting. So the
+ * configuration lives here, under relative imports only, and both the route and
+ * its tests obtain it from the same call.
+ *
+ * WHAT THE ROUTE STILL OWNS. Everything about being a route: the request body,
+ * the credential and MCP-routing refusals, the strict model resolution and its
+ * 400/503 pair, this app's own per-day rate limit, both system prompts, the
+ * no-tools A-side of the comparison, and the whole error-classification tail.
+ * This module owns only what the LOOP is given.
+ *
+ * WHY THE CAPS ARE LOWER THAN THE CORE'S DEFAULTS. `/api/compare` is a
+ * rate-limited public endpoint and the documented operator smoke test
+ * (`docs/deploy.md`, `docs/instance-setup.md`): a new instance's first real
+ * query is an anonymous POST to it. Ten rounds at `max_tokens` 2000 is what it
+ * has always cost; adopting the core's 20 and 4000 would double the worst-case
+ * cost of a call anyone can make. The caps are this caller's, not the core's,
+ * which is precisely why they are parameters.
+ *
+ * THE ARGS-IDENTITY CONSTRAINT. `executeToolCall` below injects `portal` into
+ * the `args` object the core has already recorded — the same object, by
+ * reference (see the header of `run-tool-loop.ts`). The recorded arguments are
+ * what `tools_called[].args` reports to an API client, and they must show what
+ * was actually sent. Clone the object here and the injected portal stops
+ * reaching the record, with nothing in the diff pointing at the cause.
+ */
+
+import type OpenAI from 'openai';
+import { mcpTools } from '../mcp/tools.ts';
+import { callMcpTool } from '../mcp/client.ts';
+import type { ToolCallRecord, ToolLoopOptions, ToolLoopResult } from './run-tool-loop.ts';
+
+/**
+ * Tool-calling rounds before the loop stops and asks for an answer. Ten, as
+ * this caller has always used — half the core's default, deliberately.
+ */
+export const COMPARE_MAX_ITERATIONS = 10;
+/** `max_tokens` on every request this comparison makes. Half the core's default. */
+export const COMPARE_MAX_TOKENS = 2000;
+/**
+ * Bound on one tool result fed back to the model as context.
+ *
+ * NEW FOR THIS CALLER. Its own loop had no bound at all (#344), so an oversized
+ * result was handed to the next turn whole. The core's shared bound applies
+ * here now, and an oversized paginated envelope reaches the model as parseable
+ * JSON with a row marker rather than as a fragment cut mid-record (#331).
+ */
+export const COMPARE_MAX_TOOL_RESULT_CHARS = 50_000;
+
+/** The tool transport. Substitutable so a test can drive the real loop. */
+export type CompareToolTransport = (
+  name: string,
+  args: Record<string, unknown>,
+) => Promise<string>;
+
+export interface CompareLoopInputs {
+  /** Resolved by the route, inside the route's own error handling. */
+  client: OpenAI;
+  /** The wire string this instance reaches the requested model with. */
+  endpointModel: string;
+  /** The caller's question, verbatim. */
+  prompt: string;
+  /** Built by the route for the requested portal. */
+  systemPrompt: string;
+  /** The requested portal, injected into Socrata calls that omit one. */
+  portal: string;
+  /**
+   * The tool transport, for tests. Defaults to the live MCP client — the ONLY
+   * seam this factory exposes, and deliberately one level below the loop:
+   * substituting it restates no loop configuration at all.
+   */
+  callTool?: CompareToolTransport;
+}
+
+/**
+ * Everything `runToolLoop` needs to run the MCP half of one comparison. The
+ * caps, the tool set and the portal injection are all fixed here; the route
+ * supplies only what it read off the request.
+ */
+export function compareLoopOptions(inputs: CompareLoopInputs): ToolLoopOptions {
+  const { client, endpointModel, prompt, systemPrompt, portal, callTool = callMcpTool } = inputs;
+
+  return {
+    client,
+    endpointModel,
+    prompt,
+    systemPrompt,
+    tools: mcpTools,
+    maxIterations: COMPARE_MAX_ITERATIONS,
+    maxTokens: COMPARE_MAX_TOKENS,
+    // No cumulative token budget: this caller has never had one, and the cap
+    // above already bounds a run. Omitted rather than set to some number
+    // nothing measured — `undefined` is unbounded in the core.
+    maxToolResultChars: COMPARE_MAX_TOOL_RESULT_CHARS,
+    // The route answers with one JSON body; there is no reader attached to the
+    // model call to stream an answer to.
+    finalTurn: 'blocking',
+    logContext: 'compare',
+    executeToolCall: async (name, args) => {
+      // Socrata tools expect a portal; Data Commons tools don't — only inject
+      // the request's portal for Socrata's `get_data`. Mutating `args` IN
+      // PLACE is required, not incidental: see this file's header.
+      if (name === 'get_data' && !args.portal) args.portal = portal;
+      return callTool(name, args);
+    },
+  };
+}
+
+/**
+ * The `withMcp` half of the `POST /api/compare` response body.
+ *
+ * Same four fields, same names, same order as before the migration. What
+ * changed is inside `tools_called[]`, which now carries the shared record
+ * (`operationType`, `reason`, `resultSummary`, `duration_ms` and, for a call
+ * that failed, `failed`/`failureKind`) instead of `{name, args}` alone — the
+ * shape #321 gave every other caller, because a failed call is otherwise
+ * indistinguishable from a zero-row one. `docs/project-plan.md` documents the
+ * body and was updated with this change.
+ */
+export interface CompareCompletionResult {
+  content: string;
+  duration_ms: number;
+  tokens_used: number;
+  tools_called?: ToolCallRecord[];
+}
+
+/**
+ * Adapt one `ToolLoopResult` into that body.
+ *
+ * `tokens_used` is the run's CUMULATIVE total. The deleted loop reported the
+ * last call's `usage.total_tokens` only, which under-reported a multi-round
+ * query by every round but the last — the same field on `/api/compare-stream`
+ * and on a replay has always been cumulative.
+ *
+ * `tools_called` is omitted rather than empty when no tool ran, exactly as
+ * before: an API client distinguishing "no tools" from "an empty list" sees
+ * what it saw.
+ */
+export function compareCompletionResult(result: ToolLoopResult): CompareCompletionResult {
+  return {
+    content: result.content,
+    duration_ms: result.durationMs,
+    tokens_used: result.usage.totalTokens,
+    tools_called: result.toolCalls.length > 0 ? result.toolCalls : undefined,
+  };
+}

--- a/src/lib/model-loop/model-call-registry.test.ts
+++ b/src/lib/model-loop/model-call-registry.test.ts
@@ -10,8 +10,9 @@
  *
  * This test says it out loud. Adding a `chat.completions.create` call to a
  * file that is not on the list below fails the suite, and the list carries one
- * line of justification per entry — including, for the file this wave has not
- * migrated yet, the phase that removes it.
+ * line of justification per entry. The wave closed with every tool-calling
+ * loop consolidated: the second list below now names exactly one module, and
+ * a second entry appearing on it is a regression this test reports by name.
  *
  * TWO ASSERTIONS, ONE INSTRUMENT. The first is the registry: who calls the
  * model at all. The second is narrower and is the wave's own criterion: how
@@ -48,7 +49,7 @@ const ALLOWED_MODEL_CALLERS: Record<string, string> = {
   'src/lib/openrouter-streaming.ts':
     'queryWithoutMcpStreaming: the no-tools A-side of the comparison. One turn, no loop, not loop-class.',
   'src/lib/openrouter.ts':
-    'Its own loop, until P4 moves it onto the shared core (#344).',
+    'queryWithoutMcp: the no-tools A-side of the comparison. One turn, no loop, not loop-class.',
   'src/lib/evidence/adversarial-eval.ts':
     'One rubric call, no loop. Out of this wave by ruling D4; the eval pair is #348.',
   'src/app/api/evidence/[slug]/evaluate/route.ts':
@@ -59,11 +60,12 @@ const ALLOWED_MODEL_CALLERS: Record<string, string> = {
 
 /**
  * Modules carrying a tool-calling loop — a `chat.completions.create` that
- * passes `tools`. Three at this wave's base; one when it closes.
+ * passes `tools`. Three when this wave opened (`openrouter-streaming.ts`,
+ * `evidence/[slug]/replay/route.ts`, `openrouter.ts`); one now. That count is
+ * the wave's own first acceptance criterion, and this is where it is measured.
  */
 const ALLOWED_TOOL_LOOPS: Record<string, string> = {
   'src/lib/model-loop/run-tool-loop.ts': 'The shared core.',
-  'src/lib/openrouter.ts': 'Removed by P4.',
 };
 
 const MODEL_CALL = 'chat.completions.create';

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -1,15 +1,37 @@
-import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions';
+/**
+ * The A-side of `/api/compare`: one model call, no tools, no loop.
+ *
+ * WHAT USED TO BE HERE. This file held the ORIGINAL tool-calling loop — the
+ * January implementation `openrouter-streaming.ts` was forked from, and the one
+ * every defect in the family was written in first: the exit condition that
+ * returned an announcement as the answer (#319 / #344), raw error text fed to
+ * the model instead of `describeToolFailureForLlm`, tool-call records with no
+ * failure fields (#321), no truncation at all, an unguarded argument parse
+ * (#349). Wave #345 P4 deleted it: `/api/compare`'s MCP side now runs on the
+ * shared core (`model-loop/run-tool-loop.ts`), configured by
+ * `model-loop/compare-loop.ts`.
+ *
+ * WHY WHAT IS LEFT STAYS. `queryWithoutMcp` is the control half of the
+ * comparison — the same model, the same question, no data source — and it is
+ * deliberately not loop-class: one completion, no `tools`, nothing to
+ * consolidate. It keeps its entry on `model-call-registry.test.ts`'s
+ * ALLOWED_MODEL_CALLERS for exactly that reason, and has none on
+ * ALLOWED_TOOL_LOOPS.
+ */
+
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import { getModelClient } from './model-client.ts';
 import type { ModelIdentity } from './model-catalog.ts';
 
+/**
+ * The `withoutMcp` half of the `POST /api/compare` response body. The `withMcp`
+ * half is `CompareCompletionResult` in `model-loop/compare-loop.ts`; it carries
+ * a `tools_called[]` as well, which this side never has.
+ */
 export interface CompletionResult {
   content: string;
   duration_ms: number;
   tokens_used: number;
-  tools_called?: {
-    name: string;
-    args: Record<string, unknown>;
-  }[];
 }
 
 export async function queryWithoutMcp(
@@ -40,120 +62,5 @@ export async function queryWithoutMcp(
     content,
     duration_ms,
     tokens_used,
-  };
-}
-
-export async function queryWithMcp(
-  query: string,
-  model: ModelIdentity,
-  tools: ChatCompletionTool[],
-  executeToolCall: (name: string, args: Record<string, unknown>) => Promise<string>,
-  systemPrompt?: string
-): Promise<CompletionResult> {
-  const startTime = Date.now();
-  const toolsCalled: { name: string; args: Record<string, unknown> }[] = [];
-
-  const messages: ChatCompletionMessageParam[] = [];
-
-  if (systemPrompt) {
-    messages.push({ role: 'system', content: systemPrompt });
-  }
-  messages.push({ role: 'user', content: query });
-
-  let response = await getModelClient().chat.completions.create({
-    model: model.endpointModel,
-    messages,
-    tools,
-    tool_choice: 'auto',
-    max_tokens: 2000,
-  });
-
-  // Handle tool calls iteratively
-  let iterations = 0;
-  const maxIterations = 10; // Prevent infinite loops
-
-  while (response.choices[0]?.message?.tool_calls && iterations < maxIterations) {
-    const assistantMessage = response.choices[0].message;
-    const toolCalls = assistantMessage.tool_calls;
-    messages.push(assistantMessage);
-
-    // Execute each tool call
-    if (!toolCalls) break;
-    for (const toolCall of toolCalls) {
-      // Handle both function and custom tool call types
-      if (toolCall.type === 'function') {
-        const args = JSON.parse(toolCall.function.arguments);
-        toolsCalled.push({ name: toolCall.function.name, args });
-
-        try {
-          const result = await executeToolCall(toolCall.function.name, args);
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: result,
-          });
-        } catch (error) {
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: `Error executing tool: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          });
-        }
-      }
-    }
-
-    // Get next response
-    response = await getModelClient().chat.completions.create({
-      model: model.endpointModel,
-      messages,
-      tools,
-      tool_choice: 'auto',
-      max_tokens: 2000,
-    });
-
-    iterations++;
-  }
-
-  // If we hit max iterations or the response still has tool_calls but no content,
-  // force a final response without tools
-  const lastMessage = response.choices[0]?.message;
-  if (!lastMessage?.content && (iterations >= maxIterations || lastMessage?.tool_calls)) {
-    // Add the last assistant message if it has tool calls
-    if (lastMessage?.tool_calls) {
-      messages.push(lastMessage);
-      // Add placeholder tool responses for any pending calls
-      for (const toolCall of lastMessage.tool_calls) {
-        messages.push({
-          role: 'tool',
-          tool_call_id: toolCall.id,
-          content: 'Tool call limit reached. Please provide a summary based on the data already collected.',
-        });
-      }
-    }
-
-    // Make final call without tools to force a text response
-    response = await getModelClient().chat.completions.create({
-      model: model.endpointModel,
-      messages: [
-        ...messages,
-        {
-          role: 'user',
-          content: 'Based on all the data you have collected from the tool calls above, please provide a comprehensive answer to my original question. Summarize the key findings.',
-        },
-      ],
-      max_tokens: 2000,
-      // No tools - forces text response
-    });
-  }
-
-  const duration_ms = Date.now() - startTime;
-  const content = response.choices[0]?.message?.content || '';
-  const tokens_used = response.usage?.total_tokens || 0;
-
-  return {
-    content,
-    duration_ms,
-    tokens_used,
-    tools_called: toolsCalled.length > 0 ? toolsCalled : undefined,
   };
 }


### PR DESCRIPTION
# P4 — `/api/compare` on the shared loop core

Wave N7 (#345), phase 4. Sprint anchor: #345. Ran on **Opus 5** (`claude-opus-5[1m]`).

**Branch** `sprint-345/p4-compare-on-core` · **head** `a77ea09cf1753dc9c622e623703cd3ccf0da4a24` · **base** `08858a9` · rollback tag `rollback/pre-345-p4` (pre-cut by ORCH).

Closes #344. Closes #349 (its last surviving instance).

## Blast zone

Six paths declared, six paths touched, **nothing else**. No out-of-zone edit was needed and none is itemised.

```
 docs/project-plan.md                           |  33 +-
 src/app/api/compare/route.ts                   |  44 +--
 src/lib/model-loop/compare-loop.test.ts        | 443 +++++++++++++++++++++++++
 src/lib/model-loop/compare-loop.ts             | 154 +++++++++
 src/lib/model-loop/model-call-registry.test.ts |  12 +-
 src/lib/openrouter.ts                          | 147 ++------
 6 files changed, 685 insertions(+), 148 deletions(-)
```

One in-zone scope note: in `model-call-registry.test.ts` the contract named "the two entries". Alongside them I corrected the two comment passages that *describe* those entries — the header sentence promising "the phase that removes it" and the `ALLOWED_TOOL_LOOPS` docblock reading "Three at this wave's base; one when it closes." Both were about to become false statements in a file whose entire purpose is to state the tree's shape out loud.

## What changed

`src/lib/openrouter.ts` held the **original** tool-calling loop — the January implementation `openrouter-streaming.ts` was forked from, and the one every defect in this family was written in first. Its loop is deleted. `/api/compare`'s MCP side now calls `runToolLoop(compareLoopOptions({…}))`; `queryWithoutMcp` — one call, no tools, no loop, the control half of the comparison — stays exactly where it is.

The route's own concerns are untouched: the request body, the two fail-fast guards, the strict model resolution and its 400/503 pair, this app's per-day limiter, both system prompts, and the whole error-classification tail. The only lines that changed are the imports, the MCP half of the `Promise.all`, and the response adapter.

## Acceptance — six criteria

### 1. One loop under `src/` — the wave's criterion 1 ✅

`ALLOWED_TOOL_LOOPS` now holds **exactly one entry**:

```ts
const ALLOWED_TOOL_LOOPS: Record<string, string> = {
  'src/lib/model-loop/run-tool-loop.ts': 'The shared core.',
};
```

`openrouter.ts` remains on `ALLOWED_MODEL_CALLERS` with the reason naming the survivor: `'queryWithoutMcp: the no-tools A-side of the comparison. One turn, no loop, not loop-class.'`

The file itself carries no tool-passing `chat.completions.create` and no tool-calling `while` — the only occurrences of the words `tools` and `while` left in it are in prose:

```
$ grep -n "while\|tools" src/lib/openrouter.ts
2: * The A-side of `/api/compare`: one model call, no tools, no loop.
16: * deliberately not loop-class: one completion, no `tools`, nothing to
29: * a `tools_called[]` as well, which this side never has.
```

**RED, both directions, exercised** (temporary edits, reverted; the file's diff is the 12 lines above):

```
############ DIRECTION A: leave the ALLOWED_TOOL_LOOPS entry after the loop is gone ############
ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
not ok 2 - #345: only the named modules carry a tool-calling loop
  error: 'src/lib/openrouter.ts is listed as carrying a tool loop but no longer does. Remove the entry.'
# tests 2
# pass 1
# fail 1

############ DIRECTION B: delete the ALLOWED_MODEL_CALLERS entry while queryWithoutMcp still calls create ############
not ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
  error: 'src/lib/openrouter.ts calls chat.completions.create and is not on the registry in src/lib/model-loop/model-call-registry.test.ts. Add it with one line saying why it is a separate call site — or, better, call runToolLoop.'
ok 2 - #345: only the named modules carry a tool-calling loop
# tests 2
# pass 1
# fail 1

############ RESTORED ############
ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
ok 2 - #345: only the named modules carry a tool-calling loop
# tests 2
# pass 2
# fail 0
```

### 2. No announcement is returned as `content` — RED then GREEN ✅

The RED driver imports the **real production module** at the phase base and drives it against the repo's own scripted model server over loopback. Nothing is transcribed; no live endpoint, no MCP server, no real key. The GREEN driver is the same file with the call site swapped for `runToolLoop(compareLoopOptions({ client: getModelClient(), … }))` — the route's own line — and the response adapter the route calls. Same fixtures, same harness.

**RED at `08858a9`, through `queryWithMcp`:**

```
=== RED, criterion 2: an announcement returned as `content` ===
fixture narration is 137 characters (bound is 600)
model requests made : 2
content === narration: true
content            : "I now have the counts by request type for both years. Next, I'll query the fraction of records that close within 14 and 30 days per type."
```

**GREEN at head, through `compareLoopOptions`:**

```
=== GREEN, criterion 2: an announcement returned as `content` ===
fixture narration is 137 characters (bound is 600)
model requests made : 3
content === narration: false
content            : "Across both years the portal recorded 4,812 requests of this type. The median time to close was 9 days, and 71% closed within 14 days (dataset abcd-1234)."
```

Committed as `#344: a final turn that announces a query is not returned as compare's answer`, with its companion asserting a genuine answer costs **no** extra model call (2 requests, not 3).

### 3. No raw error text on the wire; failed calls recorded ✅

**RED at `08858a9`:**

```
=== RED, criterion 3: raw error text on the wire, no failure fields ===
tool message sent  : "Error executing tool: ECONNREFUSED db.internal.example:5432"
sentinel on wire   : true
record[0]          : {"name":"get_data","args":{"type":"query","dataset_id":"abcd-1234"}}
record has failed  : false
record failureKind : undefined
```

**GREEN at head:**

```
=== GREEN, criterion 3: raw error text on the wire, no failure fields ===
tool message sent  : "This data request returned no data. Do not estimate, guess, or fabricate any values to fill the gap. The live data source is temporarily unavailable. Suggest trying again shortly. In your answer, briefly tell the user in plain language that the live data could not be retrieved, and do not include any raw error text, status codes, server names, or system details."
sentinel on wire   : false
record[0]          : {"name":"get_data","args":{"type":"query","dataset_id":"abcd-1234","portal":"data.cityofnewyork.us"},"operationType":"query","reason":"to query dataset abcd-1234","failed":true,"failureKind":"unavailable"}
record has failed  : true
record failureKind : unavailable
```

The committed test asserts the sentinel appears **nowhere** in any request body the server received, not only in the `tool` message, and additionally that the deleted loop's `Error executing tool` wrapper is gone from the wire.

### 4. #349's last instance is gone ✅

**RED at `08858a9`** — the parse at `:85` sits outside the `try` at `:88`:

```
=== RED, criterion 4: a malformed argument set ends the run (#349) ===
threw out of the loop: true
error constructor    : SyntaxError
model requests made  : 1
content              : (no result — the run ended)
```

**GREEN at head:**

```
=== GREEN, criterion 4: a malformed argument set ends the run (#349) ===
threw out of the loop: false
error constructor    : -
model requests made  : 2
content              : "Across both years the portal recorded 4,812 requests of this type. The median time to close was 9 days, and 71% closed within 14 days (dataset abcd-1234)."
```

The committed test additionally asserts the transport is **never called** with an unreadable argument set, that the attempt is recorded (`failed: true`, `failureKind: 'unknown'`), that the endpoint's malformed bytes are not quoted back at it, and that no parser text (`in JSON at position`, `Unexpected end of JSON input`, `SyntaxError`) reaches the wire.

### 5. The route's contract holds, and its guards are untouched ✅

Neither guard file appears in the diff:

```
$ git diff --name-only 08858a9 | grep -E 'model-refusal-ordering\.test\.ts|rate-limit-split\.test\.ts'
NEITHER GUARD FILE APPEARS IN THE DIFF
```

Both pass with zero edits:

```
$ node --test --experimental-strip-types src/app/api/model-refusal-ordering.test.ts src/app/api/rate-limit-split.test.ts
ok 1 - #30 P6 F1: both compare routes resolve a caller id strictly
ok 2 - #30 P6 F1: the refusal is the existing one — 400 for the caller, 503 for the operator
ok 3 - #30 P6 F1: the refusal precedes every upstream call and the rate limiter
ok 4 - #30 P6 F3: /api/query-notebook uses the shared endpoint guard, up front
ok 5 - #30 P6 F3: the guard reports the variable actually missing, not the key
ok 6 - #30 P6 F1 / #314: no query client names a model id in its own source
ok 7 - #30 P6: no query route reaches the model before it has refused what it can
ok 8 - #30 P4: every app-limiter route still answers its own 429, unchanged
ok 9 - #30 P4: no app-limiter route reports its own limit as the model service's
ok 10 - #30 P4: the two limits read differently to a reader
ok 11 - #30 P4: both kinds exist and neither displaced the other
# tests 11
# pass 11
# fail 0
```

**The caps reach the core as 10 and 2000, asserted on the wire** — not only on the options object, because a cap that quietly reverted to the core's default is invisible from a return value:

- `every request this caller makes carries max_tokens 2000` reads `max_tokens` off **every** request body the scripted server received.
- `the loop stops after ten tool-calling rounds, not the core's twenty` scripts an endpoint that never stops calling tools and counts requests: **12** (one opening call + 10 rounds + one answering turn). Under the core's default it would be 22. It also asserts exactly one request offers no tools — the answering turn.

`rate-limit-split.test.ts` was flagged by P1 as F-3 and unverified then. **Confirmed, not assumed:** it does read `compare/route.ts` (`APP_LIMITER_ROUTES`, `:39-43`), and it passes untouched. Its 600-character window after `isRateLimited(rateLimitInfo)` is unchanged; the new code sits well past it.

### 6. Suite green, nothing removed, shape change reconciled ✅

**No test present at `08858a9` is deleted or renamed** — compared by name, not by count, across every `*.test.ts(x)`/`*.test.mjs` at both refs:

```
base test names: 1074
head test names: 1087
present at 08858a9 and absent now: 0
added: 13
```

(1074/1087 are *distinct names*; the runner reports 1088 tests because two suites share a name across files.)

`docs/project-plan.md`'s `POST /api/compare` response block is updated in this PR, transcribed from a measured run rather than written from memory: the real tool name (`get_data`, not the never-existing `search_datasets`/`query_dataset`), the record's real field set and order, and three prose bullets covering cumulative `tokens_used`, the omitted-not-empty `tools_called`, and the failure fields.

## Behaviour changes, itemised

All in the **`withMcp`** half of the response and in what the model is sent. `withoutMcp` is byte-identical.

1. **A tool-result truncation bound, where there was none.** `:93` pushed the result as returned. It now gets the core's 50,000-character bound and #331's envelope handling with it: an oversized paginated envelope reaches the model as parseable JSON with a `[Truncated: showing N of M rows]` marker instead of a fragment cut mid-record. (G1 item 1.)
2. **`tokens_used` is cumulative, not last-call.** The deleted loop reported the final response's `usage.total_tokens` only, under-reporting a multi-round query by every round but the last. (G1 item 2.)
3. **`tools_called[]` entries gain six fields, additively:** `operationType`, `reason`, `duration_ms`, `resultSummary`, and — for a call that failed — `failed` and `failureKind`. `name` and `args` are unchanged, `args` still including the portal this route injects. (G1 item 3.)
4. **The #334 answering turn.** A run that ends with an announcement, with an empty final message, with pending tool calls, or at the iteration cap now costs one extra model call and returns the answer that turn produces. Two consequences worth naming: the announcing turn is now pushed into the transcript before the re-ask (the core keeps the transcript faithful rather than silently rewriting it), and a capped run that happened to carry prose is re-asked rather than shipped — the old condition led with `!lastMessage?.content`, so prose plus a cap shipped the prose. The common path — a genuine answer — still costs **nothing**. (G1 item 4.)
5. **#349: a malformed tool-argument set no longer ends the run.** It becomes one recorded failed call, described to the model through `describeToolFailureForLlm`, and the query continues. Previously it threw a `SyntaxError` out of the loop into the route's catch, which does not classify a `SyntaxError` — so it surfaced as a bare 500 after any successful calls had already been paid for. Also: the transport is no longer invoked with an unreadable argument set at all.
6. **No raw error text to the model.** A failed tool call's `tool` message is now neutral guidance instead of `Error executing tool: <the exception's own message>` — status codes, host names and stack fragments no longer reach the model or, through it, the answer.
7. **The final-answer request wording** is the core's single statement of the output contract (#343), replacing the sentence #334's own comment quotes as superseded. The placeholder answering an unrun `tool_call_id` changes wording with it.
8. **Source-level, no wire effect:** `CompletionResult` in `openrouter.ts` loses its `tools_called?` field. Nothing set it once the loop left; the `withMcp` half's type is now `CompareCompletionResult` in `compare-loop.ts`. The JSON body's field set and order are pinned by a test on `Object.keys`.

**Unchanged and verified:** the four response fields and their order; `tools_called` omitted rather than empty when no tool ran; the portal injection's semantics (inject for `get_data` when absent, never overwrite an explicit one, never touch a non-Socrata tool) and its in-place mutation of the very object the record holds — asserted by identity (`args === record.args`), which is the failure mode with nothing in the diff pointing at it; `tool_choice: 'auto'`; the iteration cap (10) and `max_tokens` (2000); the absence of any cumulative token budget; the absence of any per-tool-call timeout, which this caller has never had.

## Checks

`npm ci` first, then every check CI gates on.

```
$ npm test
# tests 1088
# suites 10
# pass 1088
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1725.231834
```

```
$ npm run build
FATAL: An unexpected Turbopack error occurred.
Error [TurbopackInternalError]: [project]/src/app/globals.css [app-client] (css)
Caused by:
- creating new process
- binding to a port
- Operation not permitted (os error 1)
```

**Re-measured, not assumed**, per the CLAUDE.md rule: this session denies socket binding, so Turbopack's PostCSS worker pool dies. It is the environment, not this change. `--webpack` skips the worker pool:

```
$ npx next build --webpack
▲ Next.js 16.3.0 (webpack)
- Environments: .env.local
✓ Running next.config.ts took 53ms

  Creating an optimized production build ...
✓ Compiled successfully in 2.1s
  Running TypeScript ...
  Finished TypeScript in 1141ms ...
  Collecting page data using 9 workers ...
✓ Generating static pages using 9 workers (32/32) in 210ms
  Finalizing page optimization ...
  Collecting build traces ...

Route (app)  … (full table emitted; /api/compare present as ƒ)
EXIT: 0
```

CI's `build` job is the real gate.

```
$ npm run typecheck     # run after the successful build
> tsc --noEmit
EXIT: 0
```

```
$ npm run lint
/Users/npstorey/code/civic-ai-tools-website/scripts/eval-models.mjs
  388:7  warning  'TokenBudgetExceeded' is defined but never used  @typescript-eslint/no-unused-vars

/Users/npstorey/code/civic-ai-tools-website/src/components/evidence/AttestationDialog.tsx
  8:7  warning  'EXPERT_RATINGS' is assigned a value but only used as a type  @typescript-eslint/no-unused-vars

/Users/npstorey/code/civic-ai-tools-website/src/components/notebook/RenderingCellOutputs.tsx
  96:9  warning  Using `<img>` could result in slower LCP and higher bandwidth. …  @next/next/no-img-element

/Users/npstorey/code/civic-ai-tools-website/src/lib/bpmn/animation.ts
  8:10  warning  'mapEventToNodes' is defined but never used  @typescript-eslint/no-unused-vars

✖ 4 problems (0 errors, 4 warnings)
```

The documented baseline, unchanged: zero errors.

```
$ npm run check:compose-env
  RESULT: PASS — every variable this profile reads can reach the container.
```

## Premise check

Every line reference in the contract was verified at `08858a9`. **All of them held**: `openrouter.ts` `:9-12` `{name,args}`, `:15-44`/`:29` the no-tools A-side, `:46-159` the loop, `:73` cap 10, `:85` the parse, `:86` the record push, `:88` the `try`, `:93` no truncation, `:99` the raw error, `:120` the pre-#334 exit, `:141` the superseded wording; `compare/route.ts` `:75`, `:113`, `:116`, `:126-127`, `:133-135`; the core's exports and defaults; the harness's `startScriptedModelServer`; both registry maps as described.

Two imprecisions, neither material:

- **The doc block's range.** The contract says `docs/project-plan.md:185-206`; G1 item 3 said `:185-201`. The block actually runs `185`–`209` (`**Response:**` through the closing fence), with the `tools_called` example at `197`–`206`. Everything both cites is inside it.
- **P1's F-3 flag was a question, not a claim, and the answer is yes.** `rate-limit-split.test.ts` does read `compare/route.ts`. Confirmed by reading it and by running it, not assumed.

## Flagged, not fixed

1. **`docs/project-plan.md:466-500`** still carries a January design sketch of `lib/openrouter.ts` showing a `queryWithMcp` that no longer exists, built on a hardcoded OpenRouter base URL and `OPENROUTER_API_KEY` — an endpoint the app stopped assuming when `model-client.ts` became dialect-agnostic. Out of the declared zone, which named the response block only. A one-block correction for whoever is next in that file.
2. **`docs/instance-setup.md:368-372`** tells an operator to watch the server log after the step-3 `POST /api/compare` for `endpoint reported a different model than this instance declares`. That line comes from `responseModelAttributes`, which the core reaches only when a trace is present — and `/api/compare` passes no trace. It never emitted that line, before this phase or after. Pre-existing, unchanged here, out of zone.
3. **If a trace is ever added to `/api/compare`, `declaredModel` must be passed.** The factory omits it today because the route writes no trace, so the core's default (the wire string) is inert. Add a trace without it and the span records the deployment alias as the declared identity — precisely the defect website#30 P3 fixed elsewhere.
4. **Carried from P2/P3, still open for P5:** `mcp_tool_call` span attributes are built before `executeToolCall` runs (invisible on compare, which has no trace); the replay route writes no trace at all.
5. **#352 does not extend to this route.** `/api/compare` has no per-tool-call timeout to leak — it never had one, and this phase deliberately did not add one, since adding a 45-second race would be a behaviour change nobody asked for.
6. **The RED drivers live in the session scratchpad only** — the same limitation P3 reported. They import the production module rather than transcribing it, so they are reproducible from `rollback/pre-345-p4`, but they are not runnable from a checkout of this branch. The 13 committed tests are what guard the fix going forward.
7. Untouched per the non-goals: `compare-stream/route.ts`, `query-notebook/route.ts`, `replay/route.ts`, `AttestationDialog.tsx`, the eval pair (#348), the notebook paths (#341, #342).

## Hygiene

Single commit `a77ea09`, GPG signature `G`, author `Nathan Storey <npstorey@users.noreply.github.com>`, exactly one `Signed-off-by` and one `Co-Authored-By` in one contiguous trailer block, sign-off first. `Closes #344` and `Closes #349` on their own lines. Pushed to `github-https`; `origin` untouched; the pre-push guard ran and did not block. No `.env*` file was read at any point, and every fixture key value is an obviously fake string against a loopback address.
