### PR TITLE
fix: the bound bounds, and two instruments stop overstating (#355, #357, #356)

### DIFF
--- a/src/lib/model-loop/model-call-registry.test.ts
+++ b/src/lib/model-loop/model-call-registry.test.ts
@@ -11,8 +11,19 @@
  * This test says it out loud. Adding a `chat.completions.create` call to a
  * file that is not on the list below fails the suite, and the list carries one
  * line of justification per entry. The wave closed with every tool-calling
- * loop consolidated: the second list below now names exactly one module, and
- * a second entry appearing on it is a regression this test reports by name.
+ * loop in the application consolidated: the second list below names the shared
+ * core and one script, and a further entry appearing on it is a regression
+ * this test reports by name.
+ *
+ * WHAT "A FILE" MEANS HERE, because getting this wrong is what #356 was. The
+ * scan first rooted at `src/` and accepted only `.ts`/`.tsx`, so a fourth
+ * tool-calling loop in `scripts/eval-models.mjs` was invisible to it and the
+ * claim in the paragraph above was false as written, with a live
+ * counter-example in the tree. It now covers `src/`, `scripts/` and the
+ * configuration files at the repository root — every JavaScript or TypeScript
+ * file this repository tracks — in every extension of the family (`.ts`,
+ * `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, `.cjs`). A guard whose header
+ * overstates its reach is worse than no guard, because it is trusted.
  *
  * TWO ASSERTIONS, ONE INSTRUMENT. The first is the registry: who calls the
  * model at all. The second is narrower and is the wave's own criterion: how
@@ -36,7 +47,14 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+
+/**
+ * Where the scan looks. `src` and `scripts` are walked; the repository root is
+ * read one level deep, which is where the four configuration modules live and
+ * is what keeps `node_modules`, `.next` and the build output out of the walk.
+ */
+const SCAN_DIRECTORIES = ['src', 'scripts'];
 
 /**
  * Every file permitted to call `chat.completions.create`, with the reason it
@@ -56,16 +74,27 @@ const ALLOWED_MODEL_CALLERS: Record<string, string> = {
     'The second copy of that same rubric call, caller-keyed. Out of this wave by ruling D4 (#348).',
   'src/app/api/evidence/generate-summary/route.ts':
     'One summary call, no loop. Out of this wave.',
+  'scripts/eval-models.mjs':
+    'The model-selection harness: a fourth tool-calling loop that carries the full class. Migration is the next wave’s (#356).',
 };
 
 /**
  * Modules carrying a tool-calling loop — a `chat.completions.create` that
- * passes `tools`. Three when this wave opened (`openrouter-streaming.ts`,
- * `evidence/[slug]/replay/route.ts`, `openrouter.ts`); one now. That count is
- * the wave's own first acceptance criterion, and this is where it is measured.
+ * passes `tools`. Three in `src/` when this wave opened
+ * (`openrouter-streaming.ts`, `evidence/[slug]/replay/route.ts`,
+ * `openrouter.ts`); one now. That count is the wave's own first acceptance
+ * criterion, and this is where it is measured.
+ *
+ * The second entry is the debt #356 found, listed rather than fixed: the point
+ * of naming it here is that it stops being invisible to the suite. It is not a
+ * fourth application loop — nothing it writes is served, signed or
+ * user-facing — but it is the same shape, and it chooses which models this
+ * instance offers.
  */
 const ALLOWED_TOOL_LOOPS: Record<string, string> = {
   'src/lib/model-loop/run-tool-loop.ts': 'The shared core.',
+  'scripts/eval-models.mjs':
+    'The model-selection harness: carries the full class; migration is the next wave’s (#356).',
 };
 
 const MODEL_CALL = 'chat.completions.create';
@@ -118,9 +147,9 @@ function passesTools(call: ModelCall): boolean {
 }
 
 function modelCallSites(): ModelCall[] {
-  return sourceFiles(SRC_ROOT).flatMap((path) => {
+  return scannedFiles().flatMap((path) => {
     const source = readFileSync(path, 'utf8');
-    const file = `src/${relative(SRC_ROOT, path).split(sep).join('/')}`;
+    const file = relative(REPO_ROOT, path).split(sep).join('/');
     const calls: ModelCall[] = [];
     let from = 0;
     for (;;) {
@@ -181,12 +210,34 @@ function endOfString(source: string, start: number): number {
   return source.length;
 }
 
+/** Every JavaScript/TypeScript source file in the scanned scope. */
+function scannedFiles(): string[] {
+  return [
+    ...rootLevelFiles(),
+    ...SCAN_DIRECTORIES.flatMap((dir) => sourceFiles(join(REPO_ROOT, dir))),
+  ];
+}
+
+/** The configuration modules at the repository root — read, never walked. */
+function rootLevelFiles(): string[] {
+  return readdirSync(REPO_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && isSource(entry.name))
+    .map((entry) => join(REPO_ROOT, entry.name));
+}
+
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) return sourceFiles(full);
-    if (!/\.tsx?$/.test(entry.name)) return [];
-    if (/\.test\.tsx?$/.test(entry.name)) return [];
-    return [full];
+    return isSource(entry.name) ? [full] : [];
   });
+}
+
+/**
+ * A source file of the JavaScript/TypeScript family, tests excluded. Written
+ * as one predicate over the whole family rather than as `.tsx?`, because the
+ * gap #356 found was an extension the filter had never been asked about.
+ */
+function isSource(name: string): boolean {
+  return /\.(c|m)?[jt]sx?$/.test(name) && !/\.test\.(c|m)?[jt]sx?$/.test(name);
 }

--- a/src/lib/model-loop/replay-loop.test.ts
+++ b/src/lib/model-loop/replay-loop.test.ts
@@ -4,10 +4,12 @@
 // is a Next route handler: `node --test` cannot invoke one. So the loop
 // configuration was moved OUT of the route into `replayLoopOptions`, and these
 // tests drive the real `runToolLoop` with the real options factory against a
-// local scripted model server. The only thing substituted is the tool
-// transport — one level BELOW the loop — so no case here restates a cap, a
-// budget, a tool set or the portal injection. Change replay's configuration
-// and these tests change with it; that is the point of the seam.
+// local scripted model server. What a case may substitute is the tool
+// transport — one level BELOW the loop — and, in exactly one case, the
+// per-call timeout, so that a transport which genuinely never settles does not
+// cost 45 real seconds (#357). Neither substitution restates a cap, a budget,
+// a tool set or the portal injection. Change replay's configuration and these
+// tests change with it; that is the point of the seam.
 //
 // A source-drift guard at the bottom closes the remaining gap: it asserts the
 // route actually obtains its options from this factory and supplies no
@@ -38,6 +40,7 @@ import {
   REPLAY_MAX_TOKENS,
   REPLAY_MAX_CUMULATIVE_TOKENS,
   REPLAY_MAX_TOOL_RESULT_CHARS,
+  REPLAY_MCP_TOOL_TIMEOUT_MS,
   type ReplayToolTransport,
 } from './replay-loop.ts';
 import { startScriptedModelServer, type ScriptedReply } from './test-harness.ts';
@@ -96,13 +99,15 @@ interface Wire {
 }
 
 /**
- * Run one replay against a scripted endpoint. `callTool` is the ONLY thing a
- * case supplies beyond the fixtures the route reads off a record — no cap, no
- * budget, no tool list, no portal handling.
+ * Run one replay against a scripted endpoint. `callTool` — and, for the one
+ * case that needs it, `toolTimeoutMs` — are all a case supplies beyond the
+ * fixtures the route reads off a record: no cap, no budget, no tool list, no
+ * portal handling.
  */
 async function runReplay(
   replies: ScriptedReply[],
   callTool: ReplayToolTransport,
+  overrides: { toolTimeoutMs?: number } = {},
 ): Promise<{ payload: ReplayPayload; requests: Record<string, unknown>[] }> {
   const { server, url, requests } = await startScriptedModelServer(replies);
   try {
@@ -115,6 +120,7 @@ async function runReplay(
         systemPrompt: SYSTEM,
         portal: PORTAL,
         callTool,
+        ...overrides,
       }),
     );
     return {
@@ -348,6 +354,11 @@ test('replayLoopOptions carries replay’s own caps and the shared tool set', ()
   assert.equal(options.maxTokens, REPLAY_MAX_TOKENS);
   assert.equal(options.maxCumulativeTokens, REPLAY_MAX_CUMULATIVE_TOKENS);
   assert.equal(options.maxToolResultChars, REPLAY_MAX_TOOL_RESULT_CHARS);
+  assert.equal(
+    REPLAY_MCP_TOOL_TIMEOUT_MS,
+    45_000,
+    'production’s per-tool-call bound: the test seam below overrides it, this is what it overrides',
+  );
   assert.equal(options.finalTurn, 'blocking', 'a route caller has no stream to write into');
   assert.ok(options.tools.length > 0, 'the replay runs against the instance’s MCP tool set');
   assert.equal(options.systemPrompt, SYSTEM);
@@ -355,18 +366,50 @@ test('replayLoopOptions carries replay’s own caps and the shared tool set', ()
 });
 
 test('a tool call that never settles fails on replay’s own timeout, and the run survives', async () => {
-  // Proves the race moved with the configuration rather than being lost with
-  // the loop. Driven by rejecting with the timeout's own wording instead of
-  // waiting 45 real seconds — the assertion is that a timeout is classified
-  // and described, not that `setTimeout` counts.
-  const { payload, requests } = await runReplay([FETCH_CALL, { content: REAL_ANSWER }], async (name) => {
-    throw new Error(`MCP tool "${name}" timed out after 45s`);
+  // #357. A transport that GENUINELY never settles: the only thing that can
+  // end this call is the `Promise.race` in `replayLoopOptions`. Delete that
+  // block and the guard below fires and this case fails.
+  //
+  // The version this replaces threw an error whose TEXT read `timed out after
+  // 45s`, so what it measured was `classifyStreamError`'s text-to-kind
+  // mapping. It stayed green with the whole race deleted — a test named for a
+  // behaviour, reporting on something else, while the race is the only thing
+  // standing between a hung source and a replay run that never returns.
+  //
+  // `toolTimeoutMs` is why this costs 50 ms instead of 45 seconds. Production
+  // passes no override: the constant is asserted in the case above and the
+  // route is guarded in the case below.
+  let release = () => {};
+  const neverSettles: ReplayToolTransport = () =>
+    new Promise<string>((resolve) => {
+      release = () => resolve(ONE_ROW);
+    });
+
+  const run = runReplay([FETCH_CALL, { content: REAL_ANSWER }], neverSettles, { toolTimeoutMs: 50 });
+
+  // The case's own bound, so a lost race fails here in two seconds rather than
+  // hanging the suite — and so the transport can be released afterwards and
+  // the scripted server closed.
+  const guard = new Promise<'hung'>((resolve) => {
+    setTimeout(() => resolve('hung'), 2_000).unref();
   });
 
-  assert.equal(payload.toolCalls[0].failed, true);
-  assert.equal(payload.toolCalls[0].failureKind, 'timeout');
-  assert.ok(!JSON.stringify(requests).includes('timed out after 45s'), 'raw timeout text stays off the wire');
-  assert.equal(payload.output, REAL_ANSWER);
+  try {
+    assert.equal(
+      await Promise.race([run.then(() => 'settled' as const), guard]),
+      'settled',
+      'the run never returned: nothing ended a tool call that never settles',
+    );
+
+    const { payload, requests } = await run;
+    assert.equal(payload.toolCalls[0].failed, true);
+    assert.equal(payload.toolCalls[0].failureKind, 'timeout');
+    assert.ok(!JSON.stringify(requests).includes('timed out after'), 'raw timeout text stays off the wire');
+    assert.equal(payload.output, REAL_ANSWER, 'one timed-out call is not a failed replay');
+  } finally {
+    release();
+    await run.catch(() => {});
+  }
 });
 
 // --- The route runs this, and holds no configuration of its own ------------
@@ -379,10 +422,12 @@ test('#345: the replay route obtains its loop options from this factory', () => 
 
   assert.match(route, /replayLoopOptions\(/, 'the route must build its options here, not inline');
   assert.match(route, /runToolLoop\(/, 'the route must drive the shared core');
-  assert.ok(
-    !route.includes('callTool'),
-    'the route must not supply a tool transport — the seam exists for tests, not for production',
-  );
+  for (const seam of ['callTool', 'toolTimeoutMs']) {
+    assert.ok(
+      !route.includes(seam),
+      `the route must not supply ${seam}: these seams exist for tests, not for production`,
+    );
+  }
   for (const configuration of ['maxIterations', 'max_tokens', 'maxCumulativeTokens', 'truncateToolResult']) {
     assert.ok(
       !route.includes(configuration),

--- a/src/lib/model-loop/replay-loop.ts
+++ b/src/lib/model-loop/replay-loop.ts
@@ -65,11 +65,24 @@ export interface ReplayLoopInputs {
   /** The record's portal, injected into Socrata calls that omit one. */
   portal: string;
   /**
-   * The tool transport, for tests. Defaults to the live MCP client — the
-   * ONLY seam this factory exposes, and deliberately one level below the
-   * loop: substituting it restates no loop configuration at all.
+   * The tool transport, for tests. Defaults to the live MCP client —
+   * deliberately one level below the loop: substituting it restates no loop
+   * configuration at all.
    */
   callTool?: ReplayToolTransport;
+  /**
+   * The per-tool-call timeout, in milliseconds. Overridable for ONE reason
+   * (#357): a case that drives a transport which genuinely never settles
+   * cannot wait 45 real seconds, and a case that fakes the timeout by throwing
+   * its wording measures `classifyStreamError`'s text mapping instead of the
+   * race — which is why the test named for this behaviour stayed green with
+   * the whole race deleted.
+   *
+   * Production passes nothing and gets `REPLAY_MCP_TOOL_TIMEOUT_MS`. The
+   * source-drift guard in this file's tests asserts the route supplies neither
+   * this nor `callTool`: both seams exist for tests, not for production.
+   */
+  toolTimeoutMs?: number;
 }
 
 /**
@@ -78,7 +91,15 @@ export interface ReplayLoopInputs {
  * supplies only what it read off the record.
  */
 export function replayLoopOptions(inputs: ReplayLoopInputs): ToolLoopOptions {
-  const { client, endpointModel, prompt, systemPrompt, portal, callTool = callMcpTool } = inputs;
+  const {
+    client,
+    endpointModel,
+    prompt,
+    systemPrompt,
+    portal,
+    callTool = callMcpTool,
+    toolTimeoutMs = REPLAY_MCP_TOOL_TIMEOUT_MS,
+  } = inputs;
 
   return {
     client,
@@ -109,8 +130,8 @@ export function replayLoopOptions(inputs: ReplayLoopInputs): ToolLoopOptions {
           callTool(name, args),
           new Promise<never>((_, reject) => {
             timer = setTimeout(
-              () => reject(new Error(`MCP tool "${name}" timed out after ${REPLAY_MCP_TOOL_TIMEOUT_MS / 1000}s`)),
-              REPLAY_MCP_TOOL_TIMEOUT_MS,
+              () => reject(new Error(`MCP tool "${name}" timed out after ${toolTimeoutMs / 1000}s`)),
+              toolTimeoutMs,
             );
           }),
         ]);

--- a/src/lib/model-loop/run-tool-loop.test.ts
+++ b/src/lib/model-loop/run-tool-loop.test.ts
@@ -199,6 +199,157 @@ test('#331: a result inside the bound is fed back untouched', async () => {
   assert.equal(toolMessages(requests)[0]!.content, ONE_ROW);
 });
 
+// --- #355: the character bound must actually bound -------------------------
+//
+// The row-dropping branch #331 added sized the kept-row count from `rows[0]`
+// alone and never re-checked the assembled string, so a page whose rows differ
+// in size breached the budget by any factor. Socrata's SODA JSON omits the
+// columns a record has no value for, so a sparsely-populated record at the
+// head of a page of fully-populated ones is an ordinary response rather than a
+// contrived one — and that one row set the assumed row size for the whole
+// page.
+//
+// A HOMOGENEOUS FIXTURE CANNOT FAIL HERE. It is the one shape where sizing
+// from `rows[0]` happens to be right, which is why `replay-loop.test.ts` and
+// `compare-loop.test.ts` each assert `body.length <= maxChars` and were both
+// true by construction of their fixtures. Every fixture below is
+// heterogeneous, or oversized per row, on purpose.
+
+const BUDGET = 50_000;
+
+/** One fully-populated 311 record — the wide end of a real page. */
+function fullComplaint(i: number): Record<string, string> {
+  return {
+    unique_key: String(100_000 + i),
+    created_date: '2026-01-01T00:00:00.000',
+    closed_date: '2026-01-03T14:22:00.000',
+    agency: 'NYPD',
+    agency_name: 'New York City Police Department',
+    complaint_type: 'Noise - Residential',
+    descriptor: 'Loud Music/Party',
+    location_type: 'Residential Building/House',
+    incident_zip: '11201',
+    incident_address: '123 EXAMPLE STREET',
+    street_name: 'EXAMPLE STREET',
+    city: 'BROOKLYN',
+    status: 'Closed',
+    resolution_description: 'The Police Department responded and a report was prepared.',
+    borough: 'BROOKLYN',
+    latitude: '40.694000',
+    longitude: '-73.990000',
+  };
+}
+
+/** The same record as SODA returns it when only two columns are populated. */
+const SPARSE_COMPLAINT = { unique_key: '100000', complaint_type: 'Noise - Residential' };
+
+/** A page whose FIRST row is sparse and whose remaining rows are full. */
+function sparseFirstEnvelope(rows: number): string {
+  return JSON.stringify({
+    data: [SPARSE_COMPLAINT, ...Array.from({ length: rows - 1 }, (_, i) => fullComplaint(i + 1))],
+    total_rows: rows,
+  });
+}
+
+test('#355: a sparse first row does not lift the bound off the envelope branch', async () => {
+  const envelope = sparseFirstEnvelope(3_000);
+  assert.ok(envelope.length > BUDGET, `the fixture must exceed the budget: ${envelope.length}`);
+
+  const { requests } = await runCore(
+    { executeToolCall: async () => envelope, maxToolResultChars: BUDGET },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  const fed = toolMessages(requests)[0]?.content;
+  assert.ok(fed, 'the tool result must reach the model');
+
+  const { body, kept, total } = splitTruncated(fed!);
+
+  // RED at 45aa6c0: the kept-row count came from the 60-character sparse row,
+  // so 806 full rows were kept and the body ran far past the budget.
+  assert.ok(
+    body.length <= BUDGET,
+    `the body fed to the model must fit the budget: ${body.length} > ${BUDGET}`,
+  );
+
+  // #331 must not regress: still valid JSON, still an envelope, still carrying
+  // the size of the matching set upstream.
+  const parsed = JSON.parse(body) as { data: unknown[]; total_rows: number };
+  assert.ok(Array.isArray(parsed.data), 'the envelope framing must survive truncation');
+  assert.equal(parsed.total_rows, 3_000, '`total_rows` survives');
+  assert.equal(total, 3_000, 'the marker names the whole page');
+  assert.equal(parsed.data.length, kept, 'the marker counts the rows actually present');
+  assert.ok(kept > 0, `a page this shape still carries rows, kept ${kept}`);
+});
+
+test('#355: the bare-array branch is bounded on heterogeneous rows too', async () => {
+  const bare = JSON.stringify([
+    SPARSE_COMPLAINT,
+    ...Array.from({ length: 2_999 }, (_, i) => fullComplaint(i + 1)),
+  ]);
+  assert.ok(bare.length > BUDGET, `the fixture must exceed the budget: ${bare.length}`);
+
+  const { requests } = await runCore(
+    { executeToolCall: async () => bare, maxToolResultChars: BUDGET },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  const { body, kept, total } = splitTruncated(toolMessages(requests)[0]!.content!);
+  assert.ok(
+    body.length <= BUDGET,
+    `the body fed to the model must fit the budget: ${body.length} > ${BUDGET}`,
+  );
+  const parsed = JSON.parse(body) as unknown[];
+  assert.equal(parsed.length, kept, 'the marker counts the rows actually present');
+  assert.equal(total, 3_000);
+  assert.ok(kept > 0, `a page this shape still carries rows, kept ${kept}`);
+});
+
+test('#355: rows too large to fit are dropped, and the marker counts what is there', async () => {
+  // The issue's fourth row: three 100 KB records. At 45aa6c0 the five-row
+  // floor kept all three — 300,082 characters, three times the budget — and
+  // the marker still announced `showing 3 of 3 rows`.
+  const rows = Array.from({ length: 3 }, (_, i) => ({ id: i, blob: 'x'.repeat(100_000) }));
+  const envelope = JSON.stringify({ data: rows, total_rows: 3 });
+
+  const { requests } = await runCore(
+    { executeToolCall: async () => envelope, maxToolResultChars: BUDGET },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  const { body, kept, total } = splitTruncated(toolMessages(requests)[0]!.content!);
+  assert.ok(
+    body.length <= BUDGET,
+    `the body fed to the model must fit the budget: ${body.length} > ${BUDGET}`,
+  );
+  const parsed = JSON.parse(body) as { data: unknown[]; total_rows: number };
+  assert.equal(parsed.data.length, kept, 'the marker counts the rows actually present');
+  assert.equal(total, 3);
+  assert.equal(parsed.total_rows, 3, 'the model is still told how large the page was');
+});
+
+test('#355: a result that loses no rows makes no truncation claim', async () => {
+  // A pretty-printed page: over the budget as it arrives, under it once
+  // re-serialised, and every row survives. RED at 45aa6c0: all 300 rows were
+  // kept AND the model was told `[Truncated: showing 300 of 300 rows]` — a
+  // model told rows were dropped may caveat a complete answer, or re-query for
+  // data it already has.
+  const pretty = JSON.stringify(JSON.parse(socrataEnvelope(300)), null, 2);
+  assert.ok(pretty.length > BUDGET, `the fixture must exceed the budget: ${pretty.length}`);
+
+  const { requests } = await runCore(
+    { executeToolCall: async () => pretty, maxToolResultChars: BUDGET },
+    [FETCH_CALL, { content: REAL_ANSWER }],
+  );
+
+  const fed = toolMessages(requests)[0]!.content!;
+  assert.doesNotMatch(fed, ROW_MARKER, 'nothing was dropped, so nothing may claim it was');
+  const parsed = JSON.parse(fed) as { data: unknown[]; total_rows: number };
+  assert.equal(parsed.data.length, 300, 'every row is still there');
+  assert.equal(parsed.total_rows, 300);
+  assert.ok(fed.length <= BUDGET, `the body still fits the budget: ${fed.length}`);
+});
+
 // --- #349: a tool call whose arguments will not parse -----------------------
 //
 // All three loops parsed the endpoint's tool-call arguments with a bare

--- a/src/lib/model-loop/run-tool-loop.ts
+++ b/src/lib/model-loop/run-tool-loop.ts
@@ -343,7 +343,7 @@ export function responseModelAttributes(
 
 /**
  * Bound one tool result before it is fed back as context, keeping what is fed
- * back READABLE (#331).
+ * back READABLE (#331) and keeping it INSIDE THE BUDGET (#355).
  *
  * A bare JSON array was the only shape this recognised. A paginated envelope —
  * `{"data": [...], "total_rows": N}` — is not an array, so an oversized one
@@ -360,7 +360,17 @@ export function responseModelAttributes(
  *
  * The output contract, for every branch: a body the model can read, followed
  * by one `[Truncated: ...]` line saying what was dropped. The character bound
- * is on the body, not on the marker.
+ * is on the body, not on the marker — and the marker appears only when rows
+ * were actually dropped.
+ *
+ * WHY THE BOUND IS MEASURED ON THE ASSEMBLED STRING. The first version of the
+ * row-dropping branch sized the kept-row count from `rows[0]` alone. Socrata's
+ * SODA JSON omits the columns a record has no value for, so a sparse record at
+ * the head of a page of full ones is an ordinary response — and it made every
+ * row look that small. Measured at `45aa6c0` with a 50,000-character budget on
+ * a 3,000-row page with one 62-character first row and 569-character rows
+ * after it: 444,691 characters fed back, 8.9 times the budget. Sizing against
+ * a sample can only ever be right for the one shape the sample matches.
  */
 function truncateToolResult(result: string, maxChars: number): string {
   if (result.length <= maxChars) return result;
@@ -369,16 +379,16 @@ function truncateToolResult(result: string, maxChars: number): string {
     const parsed: unknown = JSON.parse(result);
 
     if (Array.isArray(parsed) && parsed.length > 0) {
-      const kept = keepRowsWithinBudget(parsed, maxChars);
-      return `${JSON.stringify(kept)}\n[Truncated: showing ${kept.length} of ${parsed.length} rows]`;
-    }
-
-    if (parsed && typeof parsed === 'object') {
+      const bounded = boundedRows(parsed, maxChars, (kept) => JSON.stringify(kept));
+      if (bounded !== undefined) return bounded;
+    } else if (parsed && typeof parsed === 'object') {
       const envelope = parsed as Record<string, unknown>;
       const rows = envelope.data;
       if (Array.isArray(rows) && rows.length > 0) {
-        const kept = keepRowsWithinBudget(rows, maxChars);
-        return `${JSON.stringify({ ...envelope, data: kept })}\n[Truncated: showing ${kept.length} of ${rows.length} rows]`;
+        const bounded = boundedRows(rows, maxChars, (kept) =>
+          JSON.stringify({ ...envelope, data: kept }),
+        );
+        if (bounded !== undefined) return bounded;
       }
     }
   } catch {
@@ -389,12 +399,73 @@ function truncateToolResult(result: string, maxChars: number): string {
     `\n[Truncated: result was ${result.length} characters]`;
 }
 
-/** How many whole rows fit in the budget, never fewer than five. */
-function keepRowsWithinBudget(rows: unknown[], maxChars: number): unknown[] {
-  const sampleRow = JSON.stringify(rows[0]);
-  const rowSize = (sampleRow ? sampleRow.length : 0) + 2; // comma + newline
-  const maxRows = Math.max(5, Math.floor(maxChars / Math.max(rowSize, 1)));
-  return rows.slice(0, maxRows);
+/**
+ * One bounded body plus, if and only if rows were dropped, the marker saying
+ * so — or `undefined` when even zero rows will not fit, which sends the caller
+ * to raw truncation rather than letting the bound break.
+ *
+ * THE MARKER IS CONDITIONAL BECAUSE IT IS A CLAIM. A result can exceed the
+ * budget as it arrives and fit once re-serialised — a pretty-printed page is
+ * the ordinary case — and the earlier version announced `showing 300 of 300
+ * rows` on exactly that input. A model told rows were dropped may caveat a
+ * complete answer, or spend another call re-querying data it already has.
+ */
+function boundedRows(
+  rows: unknown[],
+  maxChars: number,
+  render: (kept: unknown[]) => string,
+): string | undefined {
+  const kept = keepRowsWithinBudget(rows, maxChars, render);
+  const body = render(kept);
+  if (body.length > maxChars) return undefined;
+  if (kept.length === rows.length) return body;
+  return `${body}\n[Truncated: showing ${kept.length} of ${rows.length} rows]`;
+}
+
+/**
+ * The longest leading run of `rows` whose RENDERED body fits `maxChars`.
+ *
+ * `render` assembles the body the model will actually receive — the bare array
+ * or the whole envelope — so the framing and the envelope's other fields are
+ * counted, not estimated. Its length grows monotonically with the number of
+ * rows, which is what makes the search below valid.
+ *
+ * The search doubles and then bisects, so its cost tracks the number of rows
+ * KEPT rather than the number received: a 200,000-row page that yields 90 rows
+ * renders a few hundred rows, not 200,000.
+ *
+ * ZERO ROWS IS A REAL ANSWER, not a failure. When one row does not fit the
+ * budget the model is handed the envelope with an empty `data`, its
+ * `total_rows` intact and `showing 0 of N rows`, which is a signal it can act
+ * on — narrow the query, ask for fewer columns. The version this replaces kept
+ * a floor of five rows that could exceed the budget by any factor, and a floor
+ * that breaks the bound is not a floor, it is the defect.
+ */
+function keepRowsWithinBudget(
+  rows: unknown[],
+  maxChars: number,
+  render: (kept: unknown[]) => string,
+): unknown[] {
+  const fits = (count: number) => render(rows.slice(0, count)).length <= maxChars;
+
+  if (fits(rows.length)) return rows;
+
+  // Double until a count does not fit; `low` is the largest count known to fit.
+  let low = 0;
+  let high = 1;
+  while (high < rows.length && fits(high)) {
+    low = high;
+    high *= 2;
+  }
+  if (high > rows.length) high = rows.length;
+
+  // Bisect (low, high): low fits, high does not.
+  while (high - low > 1) {
+    const mid = Math.floor((low + high) / 2);
+    if (fits(mid)) low = mid;
+    else high = mid;
+  }
+  return rows.slice(0, low);
 }
 
 /**


### PR DESCRIPTION
Wave N7 (#345) Phase 6 — the fix phase the G5 cold read opened. Three things: a
defect the wave **introduced** while closing #331, a new test that cannot fail,
and an instrument whose claim is wider than its scan.

**Branch** `sprint-345/p6-bound-and-instruments` · **head** `c313ab1` · cut from
`45aa6c0`. Rollback tag `rollback/pre-345-p6` verified → `45aa6c0` (local
`^{commit}` and the peeled remote ref both). **Model: Opus 5** (`claude-opus-5[1m]`).

```
 src/lib/model-loop/model-call-registry.test.ts |  73 ++++++++++--
 src/lib/model-loop/replay-loop.test.ts         |  87 ++++++++++----
 src/lib/model-loop/replay-loop.ts              |  33 +++++-
 src/lib/model-loop/run-tool-loop.test.ts       | 151 +++++++++++++++++++++++++
 src/lib/model-loop/run-tool-loop.ts            | 101 ++++++++++++++---
 5 files changed, 392 insertions(+), 53 deletions(-)
```

**Blast zone honoured exactly** — five files, all declared. Untouched:
`compare-loop.ts` and `compare-loop.test.ts`, both route handlers,
`scripts/eval-models.mjs` itself, `CLAUDE.md`, `docs/`, `.github/`. No version
bump, no CHANGELOG heading, no publish.

| Commit | Subject |
|---|---|
| `36b8a07` | fix: the tool-result character bound is measured on the assembled body (#355) |
| `adfe82e` | test: the replay timeout case detects the timeout it is named for (#357) |
| `c313ab1` | test: the model-call registry scans beyond src/ and beyond .ts (#356) |

## Criterion 1 — the bound holds on heterogeneous rows

`keepRowsWithinBudget` sized the kept-row count from `rows[0]` alone and never
re-checked the assembled string. It now searches against the **rendered body**
— bare array or whole envelope, framing and all — doubling then bisecting, so
cost tracks rows kept rather than rows received.

Four fixtures, each driven through the real loop with a 50,000-character
budget, each **measured red at `45aa6c0` before the fix** and green after. The
first two are heterogeneous on purpose: a homogeneous fixture is the one shape
where sizing from `rows[0]` happens to be right, which is why the existing
`body.length <= maxChars` assertions were true by construction.

| Fixture | Body fed to the model — RED at `45aa6c0` | GREEN |
|---|---|---|
| **envelope**, sparse first row (62 chars) then 2,999 full rows (569 chars); input 1,709,521 chars | **444,691** (8.9× budget) | **49,681** |
| **bare array**, same shape | **444,664** | **49,654** |
| envelope, three 100 KB rows | **300,082**, marker `showing 3 of 3 rows` with nothing dropped | **26**, marker `showing 0 of 3 rows` |
| envelope, 300 rows pretty-printed | 44,427 **and** `[Truncated: showing 300 of 300 rows]` | 44,427, **no marker**, 300 rows |

RED, verbatim from the run:

```
not ok 5 - #355: a sparse first row does not lift the bound off the envelope branch
  error: 'the body fed to the model must fit the budget: 444691 > 50000'
not ok 6 - #355: the bare-array branch is bounded on heterogeneous rows too
  error: 'the body fed to the model must fit the budget: 444664 > 50000'
not ok 7 - #355: rows too large to fit are dropped, and the marker counts what is there
  error: 'the body fed to the model must fit the budget: 300082 > 50000'
not ok 8 - #355: a result that loses no rows makes no truncation claim
  error: 'nothing was dropped, so nothing may claim it was'
# tests 22 / # pass 18 / # fail 4
```

Every green body is valid JSON with `total_rows` intact and the marker counting
the rows actually present — #331 does not regress, asserted on the wire.

**Note on the issue's own figures.** #355 reports 871,116 characters on a
"sparse first row, rest full" fixture. That figure is **not byte-reproducible**:
the issue does not publish its fixture, and its own numbers imply a
different one (a ~345-char full row and an 18-char first row against my
569/62). The *class* reproduces exactly — with an 18-character first row the
marker arithmetic lands on `showing 2500 of 3000`, the issue's value, verbatim.

## Criterion 2 — the marker tells the truth

Row 4 above. A page that exceeds the budget as it arrives and fits once
re-serialised keeps every row and now carries **no** truncation claim. RED at
`45aa6c0` on the same fixture: `[Truncated: showing 300 of 300 rows]`.

Row 3 is the issue's own case, and its behaviour changes in a second way worth
stating plainly: when a single row will not fit, the model now receives the
envelope with an empty `data`, `total_rows` intact, and `showing 0 of 3 rows`.
The five-row floor this replaces could exceed the budget by any factor. A floor
that breaks the bound is the defect, not a floor.

## Criterion 3 — the replay timeout case detects its own subject

Premise re-verified at `45aa6c0` first: with the whole `Promise.race` block at
`replay-loop.ts:104-119` replaced by `return callTool(name, args)`, **10 pass /
0 fail** — the case named for the race among them.

The case now drives a transport that genuinely never settles.

```
RED  (race deleted, new test):  not ok 9 - a tool call that never settles fails on replay's own timeout, and the run survives
                                  error: 'the run never returned: nothing ended a tool call that never settles'
                                # tests 10 / # pass 9 / # fail 1   (2.15s, process exits cleanly)
GREEN (race restored):          # tests 10 / # pass 10 / # fail 0  (0.27s)
```

The case carries a two-second bound of its own and releases the transport in a
`finally`, so a lost race fails loudly instead of hanging the suite.

`replayLoopOptions` gains a `toolTimeoutMs` seam — 50 ms in the case, which is
why it does not cost 45 seconds. **Production keeps 45 seconds**: the
configuration case asserts `REPLAY_MCP_TOOL_TIMEOUT_MS === 45_000`, and the
source-drift guard, which already asserted the route supplies no tool
transport, now asserts it supplies **neither** seam. Verified directly too —
`replay/route.ts` contains neither `callTool` nor `toolTimeoutMs`.

## Criterion 4 — the registry instrument's claim is true

The scan now covers `src/`, `scripts/` and the four configuration modules at the
repository root — every JS/TS file this repository tracks — across the whole
extension family (`.ts .tsx .mts .cts .js .jsx .mjs .cjs`), written as one
predicate because the gap was an extension the filter had never been asked
about. Paths report relative to the repository root.

`scripts/eval-models.mjs` is registered in **both** maps with its reason:
*carries the full class; migration is the next wave's (#356)*. It belongs in
both because `:432` and `:505` pass `tools` and `:571` does not — verified by
reading the three argument blocks.

RED, with the scan widened and the entry removed — both cases fail, each naming
the file:

```
not ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
  error: 'scripts/eval-models.mjs calls chat.completions.create and is not on the registry in
          src/lib/model-loop/model-call-registry.test.ts. Add it with one line saying why it is a
          separate call site — or, better, call runToolLoop.'
not ok 2 - #345: only the named modules carry a tool-calling loop
  error: 'scripts/eval-models.mjs calls chat.completions.create with tools — a second tool-calling
          loop. This is the shape wave #345 exists to end: call runToolLoop instead.'
# tests 2 / # pass 0 / # fail 2
```

Widening the scan surfaced **no** model caller other than that one — the
complete set is the six already registered plus `scripts/eval-models.mjs`. The
header at `:11-13` now matches what the test checks, and says in its own
paragraph what "a file" means and why getting that wrong is what #356 was.

**The migration is out of scope and was not done.** Every defect #356 lists in
that script is still there.

## Nothing removed

Test *names* compared, `45aa6c0` vs head: **0 names present at base and absent
at head**. 1,055 → 1,059; the four added are the #355 cases. The replay timeout
case kept its exact name, rewritten in place.

## Gates — full output

`npm ci` run first (cold), then:

```
$ npm test
# tests 1092
# suites 10
# pass 1092
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1733.538542
```
(`not ok` lines in the whole TAP stream: **0**. The stream is 1,059 top-level
cases; the summary block above is its complete terminal output.)

```
$ npm run build
FATAL: An unexpected Turbopack error occurred.
Error [TurbopackInternalError]: [project]/src/app/globals.css [app-client] (css)
Caused by:
- creating new process
- binding to a port
- Operation not permitted (os error 1)
```
Re-measured, as CLAUDE.md requires: this is the sandbox's port-binding
restriction, not the change. `npx next build --webpack` skips the PostCSS
worker pool:

```
$ npx next build --webpack
▲ Next.js 16.3.0 (webpack)
✓ Compiled successfully in 2.9s
  Running TypeScript ...
  Finished TypeScript in 1434ms ...
✓ Generating static pages using 9 workers (32/32) in 179ms
  Collecting build traces ...
Route (app)  … full route table emitted, 32 static pages …
```
CI's `build` job is the real gate and it passed on this branch — Turbopack, on
a runner, green.

```
$ npm run typecheck
> tsc --noEmit
(no output, exit 0)          # run after a successful build
```

```
$ npm run lint
> eslint

/…/scripts/eval-models.mjs
  388:7  warning  'TokenBudgetExceeded' is defined but never used  @typescript-eslint/no-unused-vars
/…/src/components/evidence/AttestationDialog.tsx
  8:7  warning  'EXPERT_RATINGS' is assigned a value but only used as a type  @typescript-eslint/no-unused-vars
/…/src/components/notebook/RenderingCellOutputs.tsx
  96:9  warning  Using `<img>` could result in slower LCP … @next/next/no-img-element
/…/src/lib/bpmn/animation.ts
  8:10  warning  'mapEventToNodes' is defined but never used  @typescript-eslint/no-unused-vars

✖ 4 problems (0 errors, 4 warnings)
```
The documented baseline, unchanged — none of the four is in this diff.

```
$ npm run check:compose-env
  PROFILE: db=node-postgres  blob=s3  executor=container  model=openai-compatible
  72 environment entries, 10 build arg(s), 72 applicable spec entr(ies)
  NOTE: 6 variable(s) passed through under a prior-era name. …
  RESULT: PASS — every variable this profile reads can reach the container.
```

CI on this PR: `build / test / lint / typecheck` **pass** (1m24s) ·
`container image build` **pass** (1m3s) · `Vercel` **pass** · `DCO` **pass**.
Run: https://github.com/npstorey/civic-ai-tools-website/actions/runs/33176867539

## Item 4 — the runner demonstration: a finding, not a pass

**Anchor criterion 2 is still not demonstrated on a runner, and cannot be by
the procedure this contract specifies.** Reported rather than worked around.

Executed as instructed: branch `throwaway/345-registry-red` cut from this
phase branch, exactly one file added
(`scripts/throwaway-registry-red.mjs` — one `chat.completions.create`, no
`tools`, off the allowlist; placed in `scripts/` as `.mjs` so the same run
would also measure the #356 widening), committed signed, pushed to
`github-https` at `afeeeb0`, **no pull request opened**.

**No CI run was dispatched.** `.github/workflows/ci.yml` triggers on
`pull_request` and `push: branches: [main]` only; `standalone.yml` is
`pull_request`-only; `update-portal-registries.yml` is schedule +
`workflow_dispatch` and does not run the suite. Measured rather than read off
the YAML — polled for 2.5 minutes after the push:

```
$ gh run list --branch throwaway/345-registry-red      # 6 polls, 25s apart
(no output, every poll)

$ gh api ".../actions/runs?branch=throwaway/345-registry-red" --jq .total_count
0

$ gh api ".../commits/afeeeb0.../check-runs"
{"total":1,"runs":[{"name":"Vercel Preview Comments","conclusion":"success"}]}
```

`build / test / lint / typecheck` has no conclusion on that ref because it never
ran. This is precisely the failure mode the wave's own lesson names: **absence
and success look identical**, so it is recorded as absence.

The RED itself is real, and was measured locally on the throwaway commit:

```
not ok 1 - #345: every model call site is on the registry, and every registry entry is a real call site
  error: 'scripts/throwaway-registry-red.mjs calls chat.completions.create and is not on the
          registry in src/lib/model-loop/model-call-registry.test.ts. …'
# tests 2 / # pass 1 / # fail 1
```

That is a fifth local demonstration, not the runner one the criterion asks for.

**Branch deleted and verified gone:**

```
$ git push github-https --delete throwaway/345-registry-red
 - [deleted]         throwaway/345-registry-red

$ git ls-remote github-https 'refs/heads/throwaway/*'
(empty)
```
Also deleted locally; the commit never reached this phase branch (head is
`c313ab1`, tree clean).

**What would close it** — an owner decision, not mine to take, and both options
are outside this phase's blast zone:

1. add `workflow_dispatch:` (or a `push:` trigger for `throwaway/**`) to
   `.github/workflows/ci.yml`, then re-run this exact procedure; or
2. accept a **draft** PR from the throwaway branch as the dispatch mechanism —
   which this contract forbids ("Open no pull request"), so it needs an explicit
   ruling to reverse.

## Premises that did not survive

1. **#355's measured figures are not byte-reproducible.** The issue publishes
   871,116 / 206,740 / 300,113 / 50,055 characters but not the fixture that
   produced them, and its own numbers imply a fixture different from any
   plausible reading (an ~18-char first row with ~345-char rows after it). My
   fixtures measure 444,691 / 444,664 / 300,082. The defect class, the marker
   arithmetic and the order of magnitude all reproduce; the digits do not.
   Nothing turns on it — the criterion is "≤ 50,000", which is met.
2. **Off-by-one in the registry premise.** The contract and #356 both put the
   `.ts`/`.tsx` accept filter at `model-call-registry.test.ts:189`. At
   `45aa6c0` it is at **`:188`**; `:189` is the `.test.tsx?` exclusion. Both
   lines were in the widening, so nothing changes.
3. **`CLAUDE.md`'s Commands table is stale on the test count** — it states
   `npm test` → `# pass 1044`; measured 1088 at `45aa6c0`, 1092 here.
   `CLAUDE.md` is out of zone (and already carries #358's separate correction),
   so it is flagged, not touched.

Everything else held: the rollback tag, `run-tool-loop.ts:393-398`, the stated
contract at `:361-363`, both call sites at `:372`/`:380`, the race block at
`replay-loop.ts:104-119`, the test at `replay-loop.test.ts:357`, `SRC_ROOT` at
`:39`, the header claim at `:11-13`, and `eval-models.mjs`'s three calls at
`:432`/`:505`/`:571` with two passing `tools`.

## Flagged, not fixed — file by file

- `src/lib/model-loop/compare-loop.test.ts:332` — still asserts
  `body.length <= COMPARE_MAX_TOOL_RESULT_CHARS` against a **homogeneous**
  2,000-row fixture, so the assertion remains true by construction. It passes
  unchanged (rows are still dropped on that shape, so the marker is still
  emitted); out of zone, and no change was required.
- `src/lib/model-loop/replay-loop.test.ts:272` — the same true-by-construction
  assertion, in zone. Left alone deliberately: it is #331's case, the #355
  class is now covered at the core where the shared helper actually lives, and
  duplicating a heterogeneous fixture per caller is scope this phase was not
  given. Cheap to strengthen in a follow-up.
- `scripts/eval-models.mjs` — registered, not migrated. Every defect #356 lists
  is still live: the pre-#334 exit at `:557`, raw error text at `:484`,
  `{name, args}`-only records at `:471`, no truncation at all, the superseded
  final-answer wording at `:577`, the unguarded parse at `:466` **outside any
  try**, and portal injection at `:469` without the `name === 'get_data'` guard.
- `docs/deploy.md:583-584` — `MAX_TOOL_RESULT_CHARS` is documented as an
  instance knob but reaches one of three callers (#358/F6), and now also needs a
  line about what an operator sees when one row exceeds the budget (empty
  `data`, `total_rows` intact, `showing 0 of N rows`).
- `.github/workflows/ci.yml` — has no trigger that a pushed non-`main` branch
  can reach. See item 4.
- Out of scope by contract and untouched: #359, #354, #358, #352, #348, #341,
  #342, and #356's migration half.

Closes #355
Closes #357

Refs #356
