### PR TITLE
THROWAWAY — do not merge: prove the model-call registry reds on a runner (#345)

### DIFF
--- a/scripts/throwaway-registry-red.mjs
+++ b/scripts/throwaway-registry-red.mjs
@@ -1,0 +1,18 @@
+// THROWAWAY — Wave N7 (#345) anchor criterion 2, demonstrated on a runner.
+//
+// This file exists to make the model-call registry test go red in CI, proving
+// the guard fails on a runner and not only on a developer's machine. It is
+// pushed on a disposable branch, never merged, and the branch is deleted as
+// soon as the run is recorded.
+//
+// It is deliberately NOT on the allowlist in
+// src/lib/model-loop/model-call-registry.test.ts.
+import OpenAI from 'openai';
+
+export async function unregisteredModelCall(client = new OpenAI()) {
+  return client.chat.completions.create({
+    model: 'fake/model',
+    messages: [{ role: 'user', content: 'this call site is not on the registry' }],
+    max_tokens: 16,
+  });
+}


### PR DESCRIPTION
**Draft. Never to be merged. This branch is deleted as soon as the run is recorded.**

Wave N7 (#345) anchor criterion 2:

> The registry test exists and can fail. A throwaway file calling
> `chat.completions.create` outside the allowlist makes the suite go red on a
> runner, and its removal makes it green. **RED is demonstrated on a pushed
> throwaway branch, not asserted.**

It had been demonstrated locally five times — by P2, by P4, by the cold read in
four directions, and by P6 — and never once on a runner. The first attempt
pushed a branch with no pull request, which dispatched nothing:
`.github/workflows/ci.yml` triggers on `pull_request` and
`push: branches: [main]` only.

A **draft** pull request dispatches that workflow **unchanged**, which is the
point — the guard is being demonstrated, not modified. No `secrets.` reference
and no placeholder-credential `env:` block is involved; the workflow's
credential-free invariant is untouched.

This branch adds exactly one file, `scripts/throwaway-registry-red.mjs`, calling
`chat.completions.create` from outside the allowlist in
`src/lib/model-loop/model-call-registry.test.ts`. `build / test / lint /
typecheck` is expected to go **red** on the registry assertion.

Recorded, then closed unmerged and deleted.
