### PR TITLE
docs: wave N7 close — the loop rule rewritten to the tree, and a knob's real scope (#345)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ remote) — don't design an owner-run leg around the assumption that it doesn't.
 
 | Command | Healthy output |
 |---|---|
-| `npm test` | `# pass 1044` / `# fail 0` (`node --test` TAP summary) |
+| `npm test` | `# pass 1092` / `# fail 0` (`node --test` TAP summary) |
 | `npm run build` | `✓ Compiled successfully`, then the Route (app) table |
 | `npm run typecheck` | no output, exit 0 — **run after `npm run build`** (tsconfig includes `.next/types`, which the build emits) |
 | `npm run lint` | `✖ 4 problems (0 errors, 4 warnings)` — warnings are the baseline; **zero errors** is the gate |
@@ -123,14 +123,21 @@ Each cost a real mistake; the incident sits in an HTML comment beside it. Path-s
   Ask the owner to run env edits in their own terminal.
   <!-- Repeated subagent stalls traced to .env* reads in agent sessions; the owner-run appends that
        replaced them had to be newline-defensive and verified structurally afterward. -->
-- **The model-calling loop has several implementations — fixing one is not fixing it.** Besides
-  `src/lib/openrouter-streaming.ts`, the model is called from `openrouter.ts`, `evidence/[slug]/replay`,
-  `evidence/[slug]/evaluate`, `evidence/generate-summary`, and `evidence/adversarial-eval.ts`. Some
-  carry their own loop-exit condition, their own result truncation, and their own error handling.
-  Before fixing anything in the answer path, `grep -rl "chat.completions.create" src` and say in the
-  PR which copies you did and did not change.
+- **The model-calling loop is one implementation, and a test keeps it that way.** Every
+  tool-calling loop lives in `src/lib/model-loop/run-tool-loop.ts`; a caller supplies options
+  through a factory beside it (`replay-loop.ts`, `compare-loop.ts`) and never carries its own
+  loop. `src/lib/model-loop/model-call-registry.test.ts` is the guard, and it is bidirectional:
+  it fails when a call site is not on its allowlist **and** when an allowlist entry no longer
+  names a real call site. Run the suite, not a grep — the scan covers `src/`, `scripts/` and the
+  root config modules, and a grep scoped to `src` is exactly what hid the fourth loop. Single-turn
+  calls that pass no `tools` are a separate, allow-listed class and are not loop-class.
   <!-- Wave #325: three phases each fixed one instance of a defect that lived in a class, each
        honoring its blast zone exactly. #319 was fixed in openrouter-streaming.ts while
        openrouter.ts:120 kept the literal pre-fix condition and replay/route.ts kept it twice while
        feeding a signed attestation (#338). A zone scoped by file cannot see a defect scoped to a
-       class. The same shape hit the preamble (#323 reopened) and the notebook path (notebook.ts:123). -->
+       class. The same shape hit the preamble (#323 reopened) and the notebook path (notebook.ts:123).
+       Wave #345 consolidated the three loops onto one core and replaced the grep with the registry
+       test. Its cold read then found a FOURTH loop, scripts/eval-models.mjs, carrying the whole
+       class — invisible to both the census and the first version of that test, because both were
+       scoped to `src/` and to `.ts` (#356). A check scoped to a directory cannot see a defect
+       scoped to a behaviour; that is the same lesson one level up. -->

--- a/docs/RETROSPECTIVE.md
+++ b/docs/RETROSPECTIVE.md
@@ -6,6 +6,44 @@ Reverse-chronological session retros for the civic-ai-tools-website project.
 
 ---
 
+## 2026-08-28 — Wave N7 (#345): the model-calling loop as a class — one core, three callers (six gated phases)
+
+**Scope:** Not six defects; one defect *shape*. N6's cold read found that three of its phases had each fixed one instance of a defect living in several places, honouring their blast zones exactly while doing so. The largest family was the model-calling loop: three independent implementations, one fixed. This wave was chartered against the family rather than its members — the fix-shape under test was **one loop core, three callers**, not three patches.
+
+**Phases:** P1 design (no source files) · P2 `a9681ab` (the core, #331 #343 #349) · P3 `08858a9` (replay, #338 #347 #331) · P4 `45aa6c0` (`/api/compare`, #344 #349) · P5 cold read · P6 `859abae` (#355 #357, #356's instrument half). Eight `rollback/pre-345-*` tags — P1 and P5 changed no source and needed none. Tests 1044 → 1092, **no test name removed at any step**, compared by name rather than by count at every gate. `main` auto-deploys, so all four merges were production deploys; all four green.
+
+### What the wave was for, measured
+
+At `1ddd61a`, three modules passed `tools` to `chat.completions.create`. At `859abae`, one does. The measurement is now a bidirectional test rather than a grep: `model-call-registry.test.ts` fails both when a call site is unlisted and when a listed entry stops being real, so P3's and P4's deletions were self-enforcing — migrate and leave the entry, red; remove the entry without migrating, red.
+
+### Four things the phases got right that were not asked for
+
+**P1 corrected the design it was given.** The contract assumed replay's 45-second MCP race and portal injection had to live inside the loop. Measured: both were *already* caller-side in the two streaming callers, through the `executeToolCall` closure. The seam existed; the contract had not noticed.
+
+**P2 overrode the design and was right.** The design ruled the pass-through chunker caller-side. At base, the `synthesis` span opened before it and closed after it, so moving the chunker out would have shifted a span's recorded `endTimeUnixNano` **inside a signed trace**, where no test that does not compare traces would ever see it.
+
+**P3 refused a self-contradicting instruction.** The contract said to construct the model client inside the route's `try` "so a throw is classified exactly as today". It is outside the `try` today, so such a throw is *not* classified; following the sentence would have changed behaviour under a rationale of preserving it.
+
+**P6 recorded absence as absence.** Asked to demonstrate a CI red on a pushed branch, it found no run had been dispatched and said so — six polls, `total_count: 0` — rather than inferring a pass from a missing failure.
+
+### The cold read, again worth the phase
+
+Fourth consecutive cold read to find what the implementing context missed, and this time **the wave itself had introduced the defect**. Closing #331 replaced a bounded-but-malformed truncation with a parseable-but-unbounded one: the kept-row count was sized from `rows[0]` alone, so an ordinary Socrata response with a sparse first row fed the model **871,116 characters against a 50,000 bound**. Both shipped assertions checked the bound honestly — against homogeneous fixtures, the one shape where the arithmetic happens to be right. It also found a test that passes with the thing it names deleted, and a **fourth** loop in `scripts/eval-models.mjs` carrying the entire class.
+
+### The lesson, one level up from N6's
+
+N6: *a zone scoped by file cannot see a defect scoped to a class.* N7: **the instrument we built to fix that was scoped to a directory, and could not see the fourth loop.** The census used `git grep -- 'src/**'`; the registry test rooted at `src/` and accepted only `.ts`/`.tsx`. Both inherited the same blind spot, and the guard's own header claimed a reach it did not have. P6 widened the scan and registered the fourth loop rather than migrating it — the debt is now visible in the suite instead of invisible to it.
+
+### What this wave did not do
+
+The fourth loop's migration (#356), the four surviving copies of portal injection, the span/args divergence inside the signed trace (#359), the trace-gated warning that cannot appear on two callers (#354), and the uncleared MCP timers in the two streaming callers (#352). Those are the next wave's census, not this one's tail — named here so the next census does not rediscover them as findings.
+
+### Three ORCH-layer premise failures, recorded
+
+The contracts carried three errors the phases caught: a fix-shape assumption (P1), a self-contradicting instruction (P3), and a CI procedure that could not dispatch a run because `ci.yml` triggers only on `pull_request` and pushes to `main` (P6). The premise-check rider is written to point at the anchor; all three times it pointed at the orchestrator instead, which is the direction that matters when the orchestrator is the one writing the contracts.
+
+---
+
 ## 2026-08-27 — Wave N6 (#325): the answer path, and the diagnostics that should have caught it (six gated phases)
 
 **Scope:** Six defects in the code an operator deploys, gathered into one wave so merges into `main` serialized through a single lane. Five found by running the app against a live Socrata portal; one a container-build break that had been on `main` since 2026-08-20. Run as a gated ORCH sprint against anchor #325, with a coordinating planning seat and the owner holding a second key at every merge.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -581,7 +581,9 @@ in the disable-when-absent table above, not here; see
 rate-limit and token-budget tuning knobs
 (`ANONYMOUS_RATE_LIMIT`, `AUTHENTICATED_RATE_LIMIT`,
 `APP_TIER_RATE_LIMIT`, `TOKEN_LIMIT_PER_REQUEST`,
-`MAX_TOOL_RESULT_CHARS`),
+`MAX_TOOL_RESULT_CHARS` — read on the streaming query path only; the
+replay and `/api/compare` callers pass a fixed 50,000, so setting this
+variable does not change what they feed the model (website#358)),
 `S3_REGION` / `S3_FORCE_PATH_STYLE` / `S3_PUBLIC_BASE_URL` (coded
 defaults described in the storage section), and analytics
 (`NEXT_PUBLIC_GA_MEASUREMENT_ID`).


### PR DESCRIPTION
Wave N7 (#345) closeout. **Docs only — no source file changes.**

## The three corrections

**1. `CLAUDE.md`'s loop rule described a tree that no longer exists.**

It sent a reader to `replay/route.ts` — which now contains **zero**
`chat.completions.create` — and to `openrouter.ts`, which has one, no-tools, in
`queryWithoutMcp`. It named neither `src/lib/model-loop/run-tool-loop.ts` nor
the registry test that supersedes its grep. And the grep it prescribed,
`grep -rl "chat.completions.create" src`, is scoped to `src` — the exact scope
that hid a fourth loop in `scripts/eval-models.mjs` (#356).

Rewritten to the tree as it is: one core, factories beside it, and the
bidirectional registry test named as the guard to run instead of a grep. The
incident comment keeps N6's class lesson and adds N7's, which is the same lesson
one level up — *a check scoped to a directory cannot see a defect scoped to a
behaviour.*

**2. `MAX_TOOL_RESULT_CHARS` was documented without its scope.**

`docs/deploy.md` listed it among the instance tuning knobs with no qualifier. It
is read on the streaming query path only (`openrouter-streaming.ts`); the replay
and `/api/compare` callers pass a fixed `50_000`. Setting it on an instance today
does nothing to two of the three callers. Now stated where an operator reads it
(#358).

**3. The commands table claimed `# pass 1044`.**

Measured **1092** on the runner at `859abae` —
[run 33178112116](https://github.com/npstorey/civic-ai-tools-website/actions/runs/33178112116),
`# tests 1092 / # pass 1092 / # fail 0`. Taken from CI rather than a local run,
because that table is what a reader checks their own run against.

## The retrospective entry

Beyond the three named corrections, and flagged as such: `docs/RETROSPECTIVE.md`
is where this repo keeps session retros, and N6's closeout set the precedent. The
entry records what the wave did, four things the phases got right that were not
asked for, what the cold read found — **including a defect the wave itself
introduced while closing #331** — the three ORCH-layer premise failures the
phases caught, and what the wave deliberately did **not** do, so the next census
does not rediscover those as findings.

Strike that section if the closeout was meant to be the three corrections alone.

## Verification

`npm run lint` → `✖ 4 problems (0 errors, 4 warnings)`, the documented baseline,
unchanged. No source file is touched, so no behaviour changes.
