### PR TITLE
fix: two surfaces stop asserting numbers they did not compute (#339, #307)

### DIFF
--- a/src/app/api/evidence/list/route.ts
+++ b/src/app/api/evidence/list/route.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/db';
 import { evidenceRecords, attestationPackages, users } from '@/lib/db/schema';
 import { eq, desc, asc, ilike, or, and, gte, isNull, isNotNull, sql } from 'drizzle-orm';
 import { visibilityMatches } from '@/lib/evidence/visibility-sql';
+import { buildRecordListItems, sortByAttestationCount } from '@/lib/evidence/record-list';
 
 const PAGE_SIZE = 20;
 
@@ -122,9 +123,24 @@ export async function GET(request: NextRequest) {
     : [];
   const creatorMap = new Map(creators.map(c => [c.id, c]));
 
-  // Fetch attestation counts if sorting by 'attested'
-  let attestationCountMap = new Map<string, number>();
-  if (sort === 'attested' && records.length > 0) {
+  // Fetch attestation counts — on EVERY listing, not only `sort=attested`
+  // (#307).
+  //
+  // The query used to be gated on the sort, while the projection below emitted
+  // `attestationCount` unconditionally. Under every other sort the map was
+  // empty and the field fell through to `0`, so the public index told every
+  // reader that no one had reviewed any record — measured against production,
+  // where the database held nine attestation rows across seven records.
+  //
+  // The count is a review signal on a page whose whole job is scrutiny, so a
+  // false zero is worse than a slower page. It is one grouped count over at
+  // most `PAGE_SIZE` ids, on a page that already runs three queries.
+  //
+  // `null` (rather than an empty map) is what the projection reads as "not
+  // computed" and omits the field for; it is never `0`. See
+  // `@/lib/evidence/record-list`.
+  let attestationCountMap: Map<string, number> | null = null;
+  if (records.length > 0) {
     const counts = await db
       .select({
         evidenceRecordId: attestationPackages.evidenceRecordId,
@@ -141,23 +157,18 @@ export async function GET(request: NextRequest) {
     attestationCountMap = new Map(counts.map(c => [c.evidenceRecordId, c.count]));
   }
 
-  const results = records.map(r => ({
-    id: r.id,
-    slug: r.slug,
-    title: r.title,
-    summary: r.summary.slice(0, 200) + (r.summary.length > 200 ? '...' : ''),
-    model: r.model,
-    verificationStatus: r.verificationStatus,
-    withdrawnAt: r.withdrawnAt?.toISOString() || null,
-    reinstatedAt: r.reinstatedAt?.toISOString() || null,
-    createdAt: r.createdAt.toISOString(),
-    creatorName: creatorMap.get(r.creatorId)?.displayName || 'Unknown',
-    attestationCount: attestationCountMap.get(r.id) || 0,
-  }));
+  // The row -> response projection lives in `@/lib/evidence/record-list` so it
+  // is reachable by the test runner, which cannot load this module (it imports
+  // `db` at module scope). Same reason `[slug]`'s read-back projection lives in
+  // `@/lib/evidence/readback`.
+  const results = buildRecordListItems(records, {
+    creators: creatorMap,
+    attestationCounts: attestationCountMap,
+  });
 
   // Re-sort by attestation count if needed
   if (sort === 'attested') {
-    results.sort((a, b) => b.attestationCount - a.attestationCount);
+    sortByAttestationCount(results);
   }
 
   return NextResponse.json({ records: results, total, page, totalPages });

--- a/src/lib/evidence/record-list.test.ts
+++ b/src/lib/evidence/record-list.test.ts
@@ -1,0 +1,265 @@
+// Tests for the `GET /api/evidence/list` row → response projection
+// (record-list.ts) and for the property #307 turns on: the public index never
+// states an attestation count it did not compute.
+//
+// WHY THIS FILE EXISTS
+//
+// The route ran the attestation-count query only when `sort=attested`, then
+// emitted `attestationCount: map.get(id) || 0` under every sort. Measured
+// against production, every record on the public list reported `0` while the
+// database held nine attestation rows across seven records. A count reading
+// zero tells a reader nobody reviewed an analysis when someone did — on the
+// page whose entire job is scrutiny.
+//
+// The issue notes that this defect is invisible without a test, and it is
+// right: `0` is a plausible-looking value, the endpoint returns 200, nothing
+// logs, and the number is correct on the one sort anybody exercising the
+// feature would use. Nothing short of an assertion catches it.
+//
+// The route could not carry that assertion, because it imports `db` at module
+// scope and the test runner resolves no path aliases and cannot load a route
+// module. So the projection was extracted, in the shape `visibility.test.ts`
+// already uses for `buildRecordReadback` / `buildCommitmentView`: fixture rows,
+// the schema imported for types only, and no database anywhere.
+//
+// Two halves, and both are needed:
+//
+//   1. the PROJECTION never turns "not computed" into `0` — asserted below
+//      against the pure function;
+//   2. the ROUTE computes on every listing — asserted below by reading the
+//      route's source, because the sort gate is a property of the route and
+//      the projection cannot see it.
+//
+// Run with: npm test  (or: node --test --experimental-strip-types src/lib/evidence/record-list.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildRecordListItem,
+  buildRecordListItems,
+  sortByAttestationCount,
+  SUMMARY_PREVIEW_CHARS,
+  UNKNOWN_CREATOR_NAME,
+  type RecordListRow,
+  type RecordListCreator,
+} from './record-list.ts';
+
+const CREATOR_ID = '11111111-1111-4111-8111-111111111111';
+
+function makeRow(overrides: Partial<RecordListRow> = {}): RecordListRow {
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    slug: 'noise-complaints-2025',
+    title: 'Noise complaints by borough, 2025',
+    summary: 'A short summary.',
+    model: 'anthropic/claude-sonnet-4',
+    verificationStatus: 'unverified',
+    withdrawnAt: null,
+    reinstatedAt: null,
+    createdAt: new Date('2026-08-01T12:00:00.000Z'),
+    creatorId: CREATOR_ID,
+    ...overrides,
+  };
+}
+
+const creators = new Map<string, RecordListCreator>([
+  [CREATOR_ID, { displayName: 'A Publisher' }],
+]);
+
+// --- 1. The projection: a computed count is stated, an uncomputed one is not ---
+
+test('#307: a record with two attestations lists `attestationCount: 2`', () => {
+  const row = makeRow();
+  const item = buildRecordListItem(row, {
+    creators,
+    attestationCounts: new Map([[row.id, 2]]),
+  });
+
+  assert.equal(item.attestationCount, 2);
+});
+
+test('#307: an UNCOMPUTED count is ABSENT, never `0`', () => {
+  // The whole defect in one assertion. `null` means the caller did not run the
+  // count query; the only honest rendering of that is to say nothing. Before
+  // the fix this path emitted `0`, which is a claim — and a false one.
+  const item = buildRecordListItem(makeRow(), {
+    creators,
+    attestationCounts: null,
+  });
+
+  assert.equal(
+    'attestationCount' in item,
+    false,
+    'an uncomputed count must be absent from the object, not present as 0',
+  );
+  assert.equal(item.attestationCount, undefined);
+  // And absent from the wire, not merely undefined-valued.
+  assert.equal(Object.hasOwn(JSON.parse(JSON.stringify(item)), 'attestationCount'), false);
+});
+
+test('#307: a COMPUTED zero is stated — the two zeros are different facts', () => {
+  // A record genuinely absent from a computed map has no attestations, and
+  // saying so is correct. The distinction the type carries is "we counted and
+  // found none" versus "we never counted", and only the first may render 0.
+  const computed = buildRecordListItem(makeRow(), {
+    creators,
+    attestationCounts: new Map(),
+  });
+  const uncomputed = buildRecordListItem(makeRow(), {
+    creators,
+    attestationCounts: null,
+  });
+
+  assert.equal(computed.attestationCount, 0);
+  assert.equal('attestationCount' in computed, true);
+  assert.notDeepEqual(computed, uncomputed, 'a counted zero and an uncounted one must not serialize alike');
+});
+
+test('#307: counts are matched per record, not spread across the page', () => {
+  const a = makeRow({ id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', slug: 'a' });
+  const b = makeRow({ id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', slug: 'b' });
+  const c = makeRow({ id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', slug: 'c' });
+
+  const items = buildRecordListItems([a, b, c], {
+    creators,
+    attestationCounts: new Map([[a.id, 3], [c.id, 1]]),
+  });
+
+  assert.deepEqual(items.map(i => [i.slug, i.attestationCount]), [
+    ['a', 3],
+    ['b', 0],
+    ['c', 1],
+  ]);
+});
+
+// --- 2. The rest of the projection, pinned so the extraction changed nothing ---
+
+test('the extracted projection emits exactly the keys the route emitted inline', () => {
+  const row = makeRow();
+  const item = buildRecordListItem(row, {
+    creators,
+    attestationCounts: new Map([[row.id, 0]]),
+  });
+
+  assert.deepEqual(Object.keys(item).sort(), [
+    'attestationCount',
+    'createdAt',
+    'creatorName',
+    'id',
+    'model',
+    'reinstatedAt',
+    'slug',
+    'summary',
+    'title',
+    'verificationStatus',
+    'withdrawnAt',
+  ]);
+});
+
+test('summary is elided at the preview length, and only when it is longer', () => {
+  const exact = 'x'.repeat(SUMMARY_PREVIEW_CHARS);
+  const long = 'y'.repeat(SUMMARY_PREVIEW_CHARS + 1);
+  const ctx = { creators, attestationCounts: new Map<string, number>() };
+
+  assert.equal(buildRecordListItem(makeRow({ summary: exact }), ctx).summary, exact);
+  assert.equal(
+    buildRecordListItem(makeRow({ summary: long }), ctx).summary,
+    'y'.repeat(SUMMARY_PREVIEW_CHARS) + '...',
+  );
+});
+
+test('timestamps serialize as ISO-8601 strings and a null stays null', () => {
+  const ctx = { creators, attestationCounts: new Map<string, number>() };
+  const withdrawn = buildRecordListItem(
+    makeRow({
+      withdrawnAt: new Date('2026-08-02T00:00:00.000Z'),
+      reinstatedAt: new Date('2026-08-03T00:00:00.000Z'),
+    }),
+    ctx,
+  );
+
+  assert.equal(withdrawn.createdAt, '2026-08-01T12:00:00.000Z');
+  assert.equal(withdrawn.withdrawnAt, '2026-08-02T00:00:00.000Z');
+  assert.equal(withdrawn.reinstatedAt, '2026-08-03T00:00:00.000Z');
+
+  const live = buildRecordListItem(makeRow(), ctx);
+  assert.equal(live.withdrawnAt, null);
+  assert.equal(live.reinstatedAt, null);
+});
+
+test('a record whose creator row is missing falls back to the placeholder name', () => {
+  const item = buildRecordListItem(makeRow({ creatorId: 'no-such-user' }), {
+    creators,
+    attestationCounts: null,
+  });
+  assert.equal(item.creatorName, UNKNOWN_CREATOR_NAME);
+});
+
+test('`sort=attested` orders by count descending, and an absent count sorts last', () => {
+  const rows = [
+    makeRow({ id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', slug: 'one' }),
+    makeRow({ id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', slug: 'two' }),
+    makeRow({ id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', slug: 'three' }),
+  ];
+  const items = buildRecordListItems(rows, {
+    creators,
+    attestationCounts: new Map([[rows[0].id, 1], [rows[2].id, 5]]),
+  });
+
+  assert.deepEqual(sortByAttestationCount(items).map(i => i.slug), ['three', 'one', 'two']);
+
+  // Uncounted items are ordered as if they had none rather than throwing —
+  // which is exactly why the route counts unconditionally instead of relying
+  // on this function to be reached only on the counted path.
+  const uncounted = buildRecordListItems(rows, { creators, attestationCounts: null });
+  assert.equal(sortByAttestationCount(uncounted).length, 3);
+});
+
+// --- 3. The route half: the count query is not gated on the sort ---
+//
+// The projection cannot see `sort`; the gate that caused #307 lives in the
+// route, and the route cannot be imported here (module-scope `db`). So this
+// reads the route's source and asserts the shape of the guard. It is a
+// text-level instrument and it says so — but it is the only thing standing
+// between the fix and a future edit that re-gates the query and leaves the
+// projection emitting a computed-looking zero for every record.
+
+const ROUTE_PATH = fileURLToPath(
+  new URL('../../app/api/evidence/list/route.ts', import.meta.url),
+);
+const ROUTE_SOURCE = fs.readFileSync(ROUTE_PATH, 'utf8');
+
+test('#307: the attestation-count query in the list route is not gated on the sort', () => {
+  const declaration = ROUTE_SOURCE.indexOf('let attestationCountMap');
+  const query = ROUTE_SOURCE.indexOf('.from(attestationPackages)');
+  assert.ok(declaration >= 0, 'the count map declaration moved — update this guard');
+  assert.ok(query > declaration, 'the count query moved — update this guard');
+
+  const guard = ROUTE_SOURCE.slice(declaration, query);
+  assert.ok(
+    /if \(records\.length > 0\)/.test(guard),
+    'the count query should run whenever the page has rows',
+  );
+  assert.ok(
+    !/\bsort\b/.test(guard.replace(/\/\/[^\n]*/g, '')),
+    'the count query must not be gated on `sort` — that gate IS #307: it left ' +
+      'every record on every other sort reporting a count nobody computed',
+  );
+});
+
+test('#307: the list route never substitutes 0 for an uncounted attestation count', () => {
+  // The literal that shipped the defect: `attestationCountMap.get(r.id) || 0`
+  // inline in the route, reached whether or not the map had been filled.
+  assert.ok(
+    !/attestationCount\s*:/.test(ROUTE_SOURCE),
+    'the route must not assemble `attestationCount` itself — the projection in ' +
+      '@/lib/evidence/record-list owns the computed/uncomputed distinction',
+  );
+  assert.ok(
+    /attestationCounts:\s*attestationCountMap/.test(ROUTE_SOURCE),
+    'the route should hand the map (or null) to the projection',
+  );
+});

--- a/src/lib/evidence/record-list.ts
+++ b/src/lib/evidence/record-list.ts
@@ -1,0 +1,141 @@
+// The `GET /api/evidence/list` row → response projection.
+//
+// Extracted from the route for the same reason `./readback.ts` was: the route
+// imports `db` at module scope, so the test runner — which resolves no path
+// aliases and cannot load a route module — could not reach the projection to
+// assert anything about it. #307 is a defect that is invisible without such a
+// test, because the value it emitted (`0`) is a perfectly plausible-looking
+// number. Nothing here touches the database; the route does the queries, then
+// hands the rows to this pure function.
+//
+// ---------------------------------------------------------------------------
+// THE PROPERTY (#307): a listing never states a count it did not compute
+// ---------------------------------------------------------------------------
+//
+// The route used to run the attestation-count query ONLY when `sort=attested`,
+// then emit `attestationCount: map.get(id) || 0` for every record under every
+// sort. Under the default sort the map was empty, so every record on the
+// public index reported `0` — measured against production, while the database
+// held nine attestation rows across seven records.
+//
+// A count reading zero tells a reader nobody reviewed an analysis when someone
+// did. That is a stronger claim than the honest one, and it is exactly the
+// failure `docs/design-principles.md` principle 3 names: no false precision.
+// The number was not stale or rounded; it was never computed.
+//
+// So `attestationCounts` is `Map | null`, not `Map`, and the two states mean
+// different things:
+//
+//   a Map  — the counts WERE computed. A record absent from the map genuinely
+//            has zero attestations, and `attestationCount: 0` is a true
+//            statement. `?? 0` on a computed map is fine.
+//   `null` — the counts were NOT computed. The field is OMITTED. A caller that
+//            cannot count has no way, through this function, to say "zero"
+//            instead of saying nothing — which is the point.
+//
+// The route computes on every listing, so the served responses always carry
+// the field. The `null` arm is the contract that keeps a future caller (a
+// lighter listing, a cache-warm path) from re-introducing the defect by
+// passing an empty map.
+
+import type { evidenceRecords, users } from '../db/schema.ts';
+
+/** The columns `GET /api/evidence/list` selects off each record row. */
+export type RecordListRow = Pick<
+  typeof evidenceRecords.$inferSelect,
+  | 'id'
+  | 'slug'
+  | 'title'
+  | 'summary'
+  | 'model'
+  | 'verificationStatus'
+  | 'withdrawnAt'
+  | 'reinstatedAt'
+  | 'createdAt'
+  | 'creatorId'
+>;
+
+/** The creator fields the listing renders — public display identity only. */
+export type RecordListCreator = Pick<typeof users.$inferSelect, 'displayName'>;
+
+/** One row of the public index, as it goes on the wire. */
+export type RecordListItem = {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  model: string;
+  verificationStatus: RecordListRow['verificationStatus'];
+  withdrawnAt: string | null;
+  reinstatedAt: string | null;
+  createdAt: string;
+  creatorName: string;
+  /** Present only when the count was actually computed — see the header. */
+  attestationCount?: number;
+};
+
+/** Characters of `summary` the index preview carries before it is elided. */
+export const SUMMARY_PREVIEW_CHARS = 200;
+
+/** Shown when a record's creator row is missing from the batch. */
+export const UNKNOWN_CREATOR_NAME = 'Unknown';
+
+export type RecordListContext = {
+  /** Creator rows, keyed by `users.id`. */
+  creators: ReadonlyMap<string, RecordListCreator>;
+  /**
+   * Attestation counts keyed by record id, or `null` when the caller did not
+   * run the count query. `null` omits the field; it never becomes `0`.
+   */
+  attestationCounts: ReadonlyMap<string, number> | null;
+};
+
+/** Project one selected record row onto its public index entry. */
+export function buildRecordListItem(
+  row: RecordListRow,
+  context: RecordListContext,
+): RecordListItem {
+  const item: RecordListItem = {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    summary:
+      row.summary.slice(0, SUMMARY_PREVIEW_CHARS) +
+      (row.summary.length > SUMMARY_PREVIEW_CHARS ? '...' : ''),
+    model: row.model,
+    verificationStatus: row.verificationStatus,
+    withdrawnAt: row.withdrawnAt?.toISOString() || null,
+    reinstatedAt: row.reinstatedAt?.toISOString() || null,
+    createdAt: row.createdAt.toISOString(),
+    creatorName: context.creators.get(row.creatorId)?.displayName || UNKNOWN_CREATOR_NAME,
+  };
+
+  // Assigned only on the computed branch. Spreading a `{ attestationCount:
+  // undefined }` would put the key on the object with an undefined value,
+  // which `JSON.stringify` drops but `'attestationCount' in item` does not —
+  // and "the field is absent" is the property under test.
+  if (context.attestationCounts) {
+    item.attestationCount = context.attestationCounts.get(row.id) ?? 0;
+  }
+
+  return item;
+}
+
+/** Project a page of record rows onto their public index entries. */
+export function buildRecordListItems(
+  rows: readonly RecordListRow[],
+  context: RecordListContext,
+): RecordListItem[] {
+  return rows.map(row => buildRecordListItem(row, context));
+}
+
+/**
+ * Order a page by attestation count, descending — the `sort=attested` view.
+ *
+ * Separate from the projection because it is only meaningful over items whose
+ * counts were computed: an uncounted item sorts as if it had none, which is
+ * why the route computes unconditionally rather than counting only here.
+ */
+export function sortByAttestationCount(items: RecordListItem[]): RecordListItem[] {
+  return items.sort((a, b) => (b.attestationCount ?? 0) - (a.attestationCount ?? 0));
+}

--- a/src/lib/streaming-stats.test.ts
+++ b/src/lib/streaming-stats.test.ts
@@ -1,0 +1,215 @@
+// Tests for the two reader-facing volume claims in `streaming.ts` —
+// `buildStatsSummary`'s "N records analyzed" and `buildProvenanceLine`'s
+// "N rows returned" (#339, wave N8 criterion 6).
+//
+// WHY THIS FILE EXISTS
+//
+// "N records analyzed" is the most prominent number on the answer surface, it
+// is carried into the copy-to-clipboard block, and through the published
+// package it becomes part of what a signed record says about how much data
+// backed a claim. Before this phase it was a sum of `resultSummary.rows` over
+// EVERY tool call, with no operation-type filter: a catalog search that
+// returned 40 dataset DESCRIPTIONS contributed 40 "records" beside a query
+// that returned 12 actual rows, and the line read "52 records analyzed". The
+// provenance line one component over already filtered to query calls and said
+// "12 rows returned", so the same run described itself two ways and the more
+// prominent description was the wrong one.
+//
+// That is `docs/design-principles.md` principle 3 (no false precision) failing
+// in the direction that matters: a specific number, rendered confidently,
+// larger than the truth.
+//
+// RED AT THE BASE (`96c4f76`): `streaming.ts:1083` was
+//   `toolsCalled.reduce((sum, t) => sum + (t.resultSummary?.rows || 0), 0)`
+// and the first test below rendered "52 records analyzed".
+//
+// These tests take fixture tool-call arrays straight to the two exported pure
+// functions — no model server, no MCP client, no database. The end-to-end
+// coverage of the same helpers over a real `queryWithMcpStreaming` run lives
+// in `openrouter-streaming.test.ts`; this file is the unit-level guard on the
+// filter itself, and on the property that the two lines cannot drift apart.
+//
+// Run with: npm test  (or: node --test --experimental-strip-types src/lib/streaming-stats.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildStatsSummary, buildProvenanceLine, isQueryCall } from './streaming.ts';
+
+type Fixture = {
+  name: string;
+  args: Record<string, unknown>;
+  resultSummary?: { rows: number; columns: number };
+  operationType?: string;
+};
+
+/** The digits the "records analyzed" segment actually rendered, or null. */
+function recordsAnalyzed(stats: string): number | null {
+  const m = stats.match(/([\d,]+) records analyzed/);
+  return m ? Number(m[1].replace(/,/g, '')) : null;
+}
+
+/** The digits the "rows returned" segment actually rendered, or null. */
+function rowsReturned(provenance: string | null): number | null {
+  if (!provenance) return null;
+  const m = provenance.match(/([\d,]+) rows returned/);
+  return m ? Number(m[1].replace(/,/g, '')) : null;
+}
+
+// The defect fixture, exactly as #339 describes it: one catalog search whose
+// 40 hits are dataset descriptions, one query whose 12 rows are civic data.
+const CATALOG_40_THEN_QUERY_12: Fixture[] = [
+  {
+    name: 'get_data',
+    args: { type: 'catalog', portal: 'data.cityofnewyork.us', q: 'noise complaints' },
+    resultSummary: { rows: 40, columns: 4 },
+    operationType: 'catalog',
+  },
+  {
+    name: 'get_data',
+    args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    resultSummary: { rows: 12, columns: 6 },
+    operationType: 'query',
+  },
+];
+
+test('#339: a catalog search returning 40 hits beside a query returning 12 rows renders "12 records analyzed"', () => {
+  const stats = buildStatsSummary(CATALOG_40_THEN_QUERY_12, 3200);
+
+  assert.equal(recordsAnalyzed(stats), 12, `stats line was: ${stats}`);
+  assert.match(stats, /\b12 records analyzed\b/);
+  // The pre-fix total. Asserted by value, not just by the correct number being
+  // present, so a future change that renders both cannot pass.
+  assert.doesNotMatch(stats, /\b52\b/, `catalog hits leaked into the total: ${stats}`);
+  // The catalog call is still a tool call and still counts as work done — only
+  // the RECORDS claim is filtered.
+  assert.match(stats, /\b1 query\b/);
+});
+
+test('#339: the two lines report the SAME row count for the same run', () => {
+  // The property, not two literals: whatever number the volume claim carries,
+  // the provenance claim under it carries that same number. At the base these
+  // disagreed (52 vs 12) and the more prominent one overcounted.
+  const stats = buildStatsSummary(CATALOG_40_THEN_QUERY_12, 3200);
+  const provenance = buildProvenanceLine(CATALOG_40_THEN_QUERY_12);
+
+  assert.ok(provenance, 'a run with a query call must produce a provenance line');
+  assert.equal(
+    recordsAnalyzed(stats),
+    rowsReturned(provenance),
+    `the two reader-facing counts disagree — stats: ${stats} / provenance: ${provenance}`,
+  );
+  assert.equal(rowsReturned(provenance), 12);
+});
+
+test('#339: `args.type` alone still identifies a query, on both lines', () => {
+  // A recorded call read back off a published package can predate
+  // `operationType`. `deriveOperationType` resolves Socrata's operation FROM
+  // `args.type`, so the fallback is the same value by another route — and both
+  // lines must take it, or a legacy record shows a count with no source.
+  const legacy: Fixture[] = [
+    { name: 'get_data', args: { type: 'catalog', portal: 'data.cityofnewyork.us' }, resultSummary: { rows: 40, columns: 4 } },
+    { name: 'get_data', args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' }, resultSummary: { rows: 12, columns: 6 } },
+  ];
+
+  const stats = buildStatsSummary(legacy, 3200);
+  const provenance = buildProvenanceLine(legacy);
+
+  assert.equal(recordsAnalyzed(stats), 12, `stats line was: ${stats}`);
+  assert.ok(provenance, 'a legacy call carrying only args.type must still produce a provenance line');
+  assert.equal(recordsAnalyzed(stats), rowsReturned(provenance));
+});
+
+test('#339: `operationType` wins over `args.type` when the two disagree', () => {
+  // `operationType` is the RESOLVED value; `args.type` is only the fallback.
+  // A call the resolver classified as a search is not counted as records even
+  // if the raw arguments say otherwise.
+  const conflicting: Fixture[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us' },
+      resultSummary: { rows: 40, columns: 4 },
+      operationType: 'catalog',
+    },
+  ];
+
+  assert.equal(isQueryCall(conflicting[0]), false);
+  assert.doesNotMatch(buildStatsSummary(conflicting, 900), /records analyzed/);
+  assert.equal(buildProvenanceLine(conflicting), null);
+});
+
+test('#339: a run that only searched the catalog claims no records at all', () => {
+  // Not "0 records analyzed" — the segment is absent. Nothing was analyzed,
+  // and the honest rendering of "nothing" is silence, not a zero (the same
+  // no-false-precision judgment the index projection makes for an
+  // uncomputed attestation count).
+  const catalogOnly: Fixture[] = [
+    {
+      name: 'get_data',
+      args: { type: 'catalog', portal: 'data.cityofnewyork.us', q: 'parking' },
+      resultSummary: { rows: 40, columns: 4 },
+      operationType: 'catalog',
+    },
+  ];
+
+  const stats = buildStatsSummary(catalogOnly, 1200);
+  assert.equal(recordsAnalyzed(stats), null, `stats line was: ${stats}`);
+  assert.doesNotMatch(stats, /records analyzed/);
+  assert.doesNotMatch(stats, /\b40\b/);
+  // The work is still reported, as tool calls rather than as queries.
+  assert.match(stats, /\b1 tool call\b/);
+  assert.equal(buildProvenanceLine(catalogOnly), null);
+});
+
+test('#339: the filter is by operation, not by server — a Data Commons run counts the same way', () => {
+  // Data Commons carries no `args.type`; `deriveOperationType` maps the TOOL
+  // NAME (`search_indicators` -> search, `get_observations` -> query). The
+  // predicate must read the resolved operation, so the filter holds for every
+  // source, not just Socrata's unified tool.
+  const dataCommons: Fixture[] = [
+    { name: 'search_indicators', args: { query: 'median income' }, resultSummary: { rows: 25, columns: 3 }, operationType: 'search' },
+    { name: 'get_observations', args: { variable: 'Count_Person' }, resultSummary: { rows: 7, columns: 5 }, operationType: 'query' },
+  ];
+
+  const stats = buildStatsSummary(dataCommons, 2100);
+  assert.equal(recordsAnalyzed(stats), 7, `stats line was: ${stats}`);
+  assert.doesNotMatch(stats, /\b32\b/);
+});
+
+test('#339: metadata reads contribute no records', () => {
+  const withMetadata: Fixture[] = [
+    { name: 'get_data', args: { type: 'metadata', dataset_id: 'erm2-nwe9', portal: 'data.cityofnewyork.us' }, resultSummary: { rows: 18, columns: 2 }, operationType: 'metadata' },
+    { name: 'get_data', args: { type: 'query', dataset_id: 'erm2-nwe9', portal: 'data.cityofnewyork.us' }, resultSummary: { rows: 12, columns: 6 }, operationType: 'query' },
+  ];
+
+  const stats = buildStatsSummary(withMetadata, 2400);
+  assert.equal(recordsAnalyzed(stats), 12, `stats line was: ${stats}`);
+  assert.equal(rowsReturned(buildProvenanceLine(withMetadata)), 12);
+});
+
+test('#339: the agreement holds across every mix of operation types', () => {
+  // Exhaustive over the operation labels this codebase produces, in every
+  // one-and-two-call combination. The two lines are computed by two different
+  // functions on two different surfaces; the property is that no input
+  // separates them.
+  const OPS = ['query', 'catalog', 'metadata', 'metrics', 'search', undefined] as const;
+  const call = (op: string | undefined, rows: number): Fixture => ({
+    name: 'get_data',
+    args: { type: op, portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    resultSummary: { rows, columns: 3 },
+    operationType: op,
+  });
+
+  for (const a of OPS) {
+    for (const b of OPS) {
+      const tools = [call(a, 11), call(b, 13)];
+      const stats = buildStatsSummary(tools, 1000);
+      const provenance = buildProvenanceLine(tools);
+      assert.equal(
+        recordsAnalyzed(stats),
+        rowsReturned(provenance),
+        `${a} + ${b} split the two counts — stats: ${stats} / provenance: ${provenance}`,
+      );
+    }
+  }
+});

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -1073,6 +1073,47 @@ export function buildNarrativeSummary(
   return `${prefix}${parts.join(', ')}, then ${last}.`;
 }
 
+/** The minimum shape every rows-counting reader needs off a recorded call. */
+type CountableToolCall = {
+  args: Record<string, unknown>;
+  resultSummary?: { rows: number; columns: number };
+  operationType?: string;
+};
+
+/**
+ * Did this tool call return DATA ROWS, as opposed to catalog hits or metadata?
+ *
+ * Socrata's unified `get_data` carries the operation in `args.type`; every
+ * other server's operation type is derived from the tool name and arrives as
+ * `operationType` (see `@/lib/mcp/operation-types`). `operationType` wins when
+ * present because it is the resolved value; `args.type` is the fallback for a
+ * recorded call that predates the field or that is read back off a published
+ * package.
+ *
+ * This is the ONE predicate for "this call returned records" (#339). The
+ * `records analyzed` count, the query count and the provenance line all read
+ * it, so the three can never disagree about the same run.
+ */
+export function isQueryCall(t: CountableToolCall): boolean {
+  return (t.operationType || t.args.type) === 'query';
+}
+
+/**
+ * Rows this run actually pulled from datasets.
+ *
+ * Counts QUERY calls only. A catalog search that returned 40 dataset
+ * descriptions analyzed no records — reporting it as 40 tells a reader (and,
+ * once published, every later reader of a signed record) that forty rows of
+ * civic data backed a claim that rested on twelve. Both reader-facing lines
+ * sum through here so neither can drift from the other (#339).
+ */
+function sumQueryRows(tools: CountableToolCall[]): number {
+  return tools.reduce(
+    (sum, t) => (isQueryCall(t) ? sum + (t.resultSummary?.rows || 0) : sum),
+    0,
+  );
+}
+
 // Build a stats summary line leading with data volume
 export function buildStatsSummary(
   toolsCalled: { name: string; args: Record<string, unknown>; resultSummary?: { rows: number; columns: number }; duration_ms?: number; operationType?: string }[],
@@ -1080,12 +1121,12 @@ export function buildStatsSummary(
 ): string {
   const statParts: string[] = [];
 
-  const totalRows = toolsCalled.reduce((sum, t) => sum + (t.resultSummary?.rows || 0), 0);
+  const totalRows = sumQueryRows(toolsCalled);
   if (totalRows > 0) {
     statParts.push(`${totalRows.toLocaleString()} records analyzed`);
   }
 
-  const queryCount = toolsCalled.filter(t => (t.operationType || t.args.type) === 'query').length;
+  const queryCount = toolsCalled.filter(isQueryCall).length;
   if (queryCount > 0) {
     statParts.push(`${queryCount} ${queryCount === 1 ? 'query' : 'queries'}`);
   } else {
@@ -1109,7 +1150,11 @@ export function datasetUrl(portal: string | undefined, datasetId: string | undef
 export function buildProvenanceLine(
   tools: { args: Record<string, unknown>; resultSummary?: { rows: number; columns: number }; operationType?: string }[]
 ): string | null {
-  const queryTools = tools.filter(t => t.operationType === 'query');
+  // Same predicate as `buildStatsSummary` (#339). Before this, provenance read
+  // `operationType` alone while the stats line read `operationType || args.type`,
+  // so a recorded call carrying only `args.type` produced a "records analyzed"
+  // count with no "Source:" line under it.
+  const queryTools = tools.filter(isQueryCall);
   if (queryTools.length === 0) return null;
 
   const parts: string[] = [];
@@ -1147,7 +1192,9 @@ export function buildProvenanceLine(
     }
   }
 
-  const totalRows = queryTools.reduce((sum, t) => sum + (t.resultSummary?.rows || 0), 0);
+  // Through the same helper `buildStatsSummary` uses, so "N records analyzed"
+  // and "N rows returned" describe the same N for the same run (#339).
+  const totalRows = sumQueryRows(tools);
   if (totalRows > 0) {
     parts.push(`${totalRows.toLocaleString()} rows returned`);
   }


### PR DESCRIPTION
Wave N8, phase **P4a** (lane 2) of sprint #363. Closes #339 and #307.

Two reader-facing surfaces asserted numbers they had not computed. Both are attestation surfaces: the first is carried into published record packages, the second is the public record index.

- **#339** — `buildStatsSummary` summed `resultSummary.rows` over *every* tool call with no operation-type filter and rendered the total as `N records analyzed`. A catalog search returning 40 dataset **descriptions** contributed 40 beside a query returning 12 actual rows, so the most prominent number on the answer surface read **52** while the provenance line under it (which already filtered to query calls) read **12**.
- **#307** — `GET /api/evidence/list` ran the attestation-count query only when `sort=attested`, then emitted `attestationCount: … || 0` under every sort. Measured against production: every record on the public list reported `0` while the database held nine attestation rows across seven records.

Both are `docs/design-principles.md` principle 3 (no false precision) failing in the direction that matters — a specific figure, rendered confidently, that overstates.

## Branch and diff

Branch `sprint-363/p4a-signed-counts`, from `96c4f76` (tag `rollback/pre-n8-p4a`). Two commits.

```
 src/app/api/evidence/list/route.ts   |  45 +++---
 src/lib/evidence/record-list.test.ts | 265 +++++++++++++++++++++++++++++++++++
 src/lib/evidence/record-list.ts      | 141 +++++++++++++++++++
 src/lib/streaming-stats.test.ts      | 215 ++++++++++++++++++++++++++++
 src/lib/streaming.ts                 |  55 +++++++-
 5 files changed, 700 insertions(+), 21 deletions(-)
```

**Blast zone honoured — five files, every one declared.** `src/lib/openrouter-streaming.test.ts`, `src/lib/model-loop/*`, `src/lib/openrouter-streaming.ts`, `src/app/api/compare-stream/route.ts` and `src/app/api/query-notebook/route.ts` — lane 1's files — are untouched (`git diff --name-status 96c4f76..HEAD` lists exactly the five above). `ProgressLog.tsx`, `McpResponseDisplay.tsx` and `dashboard/page.tsx` were read for confirmation and not edited.

## The lane prediction held

ORCH predicted at G2 that the query-only filter would **not** move `openrouter-streaming.test.ts:504` (`assert.match(stats, /\b5 records analyzed\b/)`), because both tool calls in that fixture carry `type: 'query'` at `:447-448`.

**Held.** `git diff --exit-code -- src/lib/openrouter-streaming.test.ts` is clean, the file is byte-identical to the base, and the test passes unmodified: `ok 9 - queryWithMcpStreaming: buildStatsSummary and buildProvenanceLine sum data.length (5) across calls, never total_rows (300) and never 0`.

## What changed

**#339 — one predicate, three readers.** `isQueryCall` (exported) and `sumQueryRows` in `src/lib/streaming.ts`. The volume count, the query count and the provenance line all read the same predicate, so they cannot drift apart again. `buildProvenanceLine` moves onto it too — it read `operationType` alone, so a call recorded with only `args.type` (a legacy package read back) produced a records count with no `Source:` line beneath it; it now produces both or neither.

**#307 — the count is computed on every listing, and the projection is extracted.** The query runs whenever the page has rows. The row→response projection moves to `src/lib/evidence/record-list.ts`, in the shape `src/lib/evidence/readback.ts` already uses, because the route imports `db` at module scope and the test runner (no path aliases, cannot load a route module) could not reach it. `attestationCounts` is `Map | null`: a Map means computed, so a record missing from it genuinely has none and `0` is true; `null` means not computed and the field is **omitted**. A caller that did not count has no way, through this function, to say "zero" instead of saying nothing.

## Acceptance criteria

| # | Criterion | Evidence |
|---|---|---|
| 1 | `records analyzed` counts query rows only | `#339: a catalog search returning 40 hits beside a query returning 12 rows renders "12 records analyzed"` |
| 2 | `buildStatsSummary` and `buildProvenanceLine` agree | `#339: the two lines report the SAME row count for the same run`, plus an exhaustive sweep over every pair of operation labels |
| 3 | The index computes what it asserts | `#307: a record with two attestations lists 'attestationCount: 2'` + `#307: the attestation-count query in the list route is not gated on the sort` |
| 4 | Never asserted when not computed | `#307: an UNCOMPUTED count is ABSENT, never '0'` and `#307: a COMPUTED zero is stated — the two zeros are different facts` |
| 5 | Pinned by a test that runs without a database | `src/lib/evidence/record-list.test.ts` — fixture rows, schema imported for types only, no `db` |
| 6 | Nothing lost | 1092 → **1111**, `# fail 0`, zero test names absent (set difference over the TAP names, both runs) |
| 7 | Trailers | both commits carry `Signed-off-by` then `Co-Authored-By`, one contiguous block, author matching |

**RED demonstrated before green, three separate injections:**

- `sumQueryRows` reverted to the base unfiltered reduce → all 8 `#339` tests fail; the first renders `52 records analyzed · 1 query · 3.2s`.
- the base `list/route.ts` restored → the two route-source guards fail.
- the projection reverted to the base's inline `|| 0` → the two uncomputed-count assertions fail.

## Gates

`npm ci` first. `npm test` 1111/1111; `npm run build` compiled, route table emitted; `npm run typecheck` exit 0, no output; `npm run lint` `✖ 4 problems (0 errors, 4 warnings)` — the documented baseline, unchanged; `npm run check:compose-env` `RESULT: PASS`.

Model: Opus 5.

Draft — ORCH merges on evidence-pass. Full phase report, including flagged-not-fixed findings and the contract premises that did not survive, is in the phase report to ORCH.
