### PR TITLE
fix: portal injection and the tool bound become the loop's, not each caller's (#359, #352)

### DIFF
--- a/src/app/api/compare-stream/route.ts
+++ b/src/app/api/compare-stream/route.ts
@@ -205,33 +205,26 @@ Be honest if you don't have access to current or real-time data.`;
     // Run queries (both in parallel, or MCP-only when mcpOnly flag is set)
     const runQueries = async () => {
       try {
-        const MCP_TOOL_TIMEOUT_MS = 45_000; // 45s timeout per individual tool call
+        // 45s per individual tool call. The route states the value; the race
+        // and the timer's disposal live in the loop core (#352) — this file
+        // used to arm a timer inside the tool closure and never clear it, so a
+        // call that answered in 200 ms left one pending for the rest of the
+        // bound.
+        const MCP_TOOL_TIMEOUT_MS = 45_000;
 
         const mcpQuery = queryWithMcpStreaming(
           query,
           model,
           mcpTools,
-          async (name, args) => {
-            // Socrata tools expect a portal; Data Commons tools don't.
-            if (name === 'get_data' && !args.portal) {
-              args.portal = portal;
-            }
-            // Race the MCP call against a timeout so one slow tool call
-            // cannot hang the entire SSE stream indefinitely.
-            const result = await Promise.race([
-              callMcpTool(name, args),
-              new Promise<never>((_, reject) =>
-                setTimeout(
-                  () => reject(new Error(`MCP tool "${name}" timed out after ${MCP_TOOL_TIMEOUT_MS / 1000}s`)),
-                  MCP_TOOL_TIMEOUT_MS,
-                )
-              ),
-            ]);
-            return result;
-          },
+          // Just the transport. Portal injection moved into the core (#359):
+          // done here, it ran after the core had recorded the call and
+          // stringified its arguments onto the span, so the span reported no
+          // portal on exactly the calls that had just been given one.
+          callMcpTool,
           systemPromptWithMcp,
           callbacks,
           { builder: trace, parentSpanId: trace.rootSpanId, systemPromptHash, resolveToolSource: (name) => routeTool(name).sourceId },
+          { portal, toolTimeoutMs: MCP_TOOL_TIMEOUT_MS },
         );
 
         if (mcpOnly) {

--- a/src/app/api/query-notebook/route.ts
+++ b/src/app/api/query-notebook/route.ts
@@ -379,6 +379,8 @@ async function runPhaseA(args: {
   return new Promise<CompletionResult>((resolve, reject) => {
     let completionResult: CompletionResult | null = null;
     const sentToolCalls = new Set<string>();
+    // 45s per individual tool call. The route states the value; the race and
+    // the timer's disposal live in the loop core (#352).
     const MCP_TOOL_TIMEOUT_MS = 45_000;
 
     const callbacks: StreamCallbacks = {
@@ -430,23 +432,15 @@ async function runPhaseA(args: {
       query,
       model,
       mcpTools,
-      async (name, toolArgs) => {
-        if (name === 'get_data' && !toolArgs.portal) {
-          toolArgs.portal = portal;
-        }
-        return Promise.race([
-          callMcpTool(name, toolArgs),
-          new Promise<never>((_, rj) =>
-            setTimeout(
-              () => rj(new Error(`MCP tool "${name}" timed out after ${MCP_TOOL_TIMEOUT_MS / 1000}s`)),
-              MCP_TOOL_TIMEOUT_MS,
-            ),
-          ),
-        ]);
-      },
+      // Just the transport. Portal injection and the timeout race are the loop
+      // core's now (#359, #352): performed here they ran after the core had
+      // recorded the call and stringified its arguments onto the span, and the
+      // timer this file armed per tool call was never cleared.
+      callMcpTool,
       systemPrompt,
       callbacks,
       { builder: trace, parentSpanId: trace.rootSpanId, systemPromptHash, resolveToolSource: (name) => routeTool(name).sourceId },
+      { portal, toolTimeoutMs: MCP_TOOL_TIMEOUT_MS },
     )
       .then(() => {
         if (completionResult) resolve(completionResult);

--- a/src/lib/model-loop/compare-loop.ts
+++ b/src/lib/model-loop/compare-loop.ts
@@ -25,12 +25,15 @@
  * cost of a call anyone can make. The caps are this caller's, not the core's,
  * which is precisely why they are parameters.
  *
- * THE ARGS-IDENTITY CONSTRAINT. `executeToolCall` below injects `portal` into
- * the `args` object the core has already recorded — the same object, by
- * reference (see the header of `run-tool-loop.ts`). The recorded arguments are
- * what `tools_called[].args` reports to an API client, and they must show what
- * was actually sent. Clone the object here and the injected portal stops
- * reaching the record, with nothing in the diff pointing at the cause.
+ * PORTAL INJECTION AND THE TOOL BOUND ARE THE CORE'S NOW (#359, #352). This
+ * factory used to inject `portal` inside its own `executeToolCall` closure —
+ * which the core invokes after it has recorded the call, emitted `tool_start`
+ * and stringified the arguments onto the `mcp_tool_call` span, so the span
+ * disagreed with the record on every injected call. Both are options the core
+ * reads before it builds any of that; this module supplies the two values and
+ * nothing else. The args-identity constraint they rest on is unchanged and
+ * still stated in `run-tool-loop.ts`'s header: the recorded object IS the
+ * injected one, and `tools_called[].args` is what an API client reads.
  */
 
 import type OpenAI from 'openai';
@@ -54,6 +57,21 @@ export const COMPARE_MAX_TOKENS = 2000;
  * JSON with a row marker rather than as a fragment cut mid-record (#331).
  */
 export const COMPARE_MAX_TOOL_RESULT_CHARS = 50_000;
+/**
+ * Per-tool-call timeout. NEW FOR THIS CALLER (#352): `/api/compare` has never
+ * had one, so a source that accepted the connection and then stopped
+ * responding held the request open until the platform killed the invocation —
+ * and the caller, who is waiting on one JSON body with nothing streamed, got a
+ * platform error page naming no tool. With the bound, the hung call fails on
+ * its own account, is recorded `failed`/`timeout` like any other tool failure,
+ * and the comparison still answers from what did come back.
+ *
+ * 45 seconds, the same bound the three other callers use. The counterweight,
+ * stated because it is real: this is the blocking caller, so the bound is a
+ * hard ceiling with no partial output already delivered — a legitimately slow
+ * query that today would eventually succeed now fails instead.
+ */
+export const COMPARE_MCP_TOOL_TIMEOUT_MS = 45_000;
 
 /** The tool transport. Substitutable so a test can drive the real loop. */
 export type CompareToolTransport = (
@@ -82,8 +100,8 @@ export interface CompareLoopInputs {
 
 /**
  * Everything `runToolLoop` needs to run the MCP half of one comparison. The
- * caps, the tool set and the portal injection are all fixed here; the route
- * supplies only what it read off the request.
+ * caps, the tool set, the portal and the tool bound are all fixed here; the
+ * route supplies only what it read off the request.
  */
 export function compareLoopOptions(inputs: CompareLoopInputs): ToolLoopOptions {
   const { client, endpointModel, prompt, systemPrompt, portal, callTool = callMcpTool } = inputs;
@@ -104,13 +122,11 @@ export function compareLoopOptions(inputs: CompareLoopInputs): ToolLoopOptions {
     // model call to stream an answer to.
     finalTurn: 'blocking',
     logContext: 'compare',
-    executeToolCall: async (name, args) => {
-      // Socrata tools expect a portal; Data Commons tools don't — only inject
-      // the request's portal for Socrata's `get_data`. Mutating `args` IN
-      // PLACE is required, not incidental: see this file's header.
-      if (name === 'get_data' && !args.portal) args.portal = portal;
-      return callTool(name, args);
-    },
+    // The core injects this into a Socrata `get_data` call that omits a
+    // portal, above the record and the span; Data Commons tools are untouched.
+    portal,
+    toolTimeoutMs: COMPARE_MCP_TOOL_TIMEOUT_MS,
+    executeToolCall: callTool,
   };
 }
 

--- a/src/lib/model-loop/injection-and-bound.test.ts
+++ b/src/lib/model-loop/injection-and-bound.test.ts
@@ -1,0 +1,828 @@
+// Acceptance tests for #359 and #352: portal injection and the per-tool-call
+// timeout are properties of the LOOP, and every caller gets them.
+//
+// WHY THIS FILE RANGES OVER CALLERS INSTEAD OF SITTING BESIDE ONE. Both
+// defects lived in a class, not in a file. Four callers each carried a copy of
+// the injection inside the `executeToolCall` closure the core invokes — which
+// runs AFTER the core has built the tool-call record, emitted `tool_start` and
+// stringified the arguments onto the `mcp_tool_call` span. So the span
+// reported no `tool.portal_domain` on exactly the calls a portal had just been
+// injected into, while the signed package and the replay identity key read the
+// mutated object and did carry it (#359). The timeout had three shapes across
+// those same callers: cleared in a `finally` in one, armed and never cleared
+// in two, and absent entirely in the third (#352).
+//
+// A test scoped to one caller cannot see that. The property is "the span
+// agrees with the record, on every caller" and "no timer outlives its call, on
+// every caller that has a bound", so the cases below drive `runToolLoop`
+// directly, through `compareLoopOptions`, through `replayLoopOptions` and
+// through `queryWithMcpStreaming` — the four ways a tool call is made in this
+// repository — and a source-drift guard at the bottom closes the two route
+// callers, which `node --test` cannot invoke.
+//
+// The RED baseline, measured at 96c4f76 before the move: with injection in the
+// caller's closure, `tool.portal_domain` was absent from the span and
+// `tool.arguments` carried `{"type":"query","dataset_id":"abcd-1234"}` while
+// the record carried the same object WITH `portal` — the two disagreeing about
+// the same call. And `/api/compare-stream` and `/api/query-notebook` each left
+// one 45-second timer pending per tool call.
+//
+// No live endpoint, no credential, no MCP server, no database. Every key value
+// is an obviously fake fixture and every address is loopback.
+//
+// Run with: npm test
+//   (or: node --test --experimental-strip-types src/lib/model-loop/injection-and-bound.test.ts)
+
+import { test, mock, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type OpenAI from 'openai';
+import { runToolLoop, type LoopEvent, type ToolCallRecord, type ToolLoopOptions } from './run-tool-loop.ts';
+import { compareLoopOptions, COMPARE_MCP_TOOL_TIMEOUT_MS } from './compare-loop.ts';
+import { replayLoopOptions, REPLAY_MCP_TOOL_TIMEOUT_MS } from './replay-loop.ts';
+import { startScriptedModelServer } from './test-harness.ts';
+import { queryWithMcpStreaming, type CompletionResult } from '../openrouter-streaming.ts';
+import { carriedModelIdentity } from '../model-catalog.ts';
+import { _resetDefaultModelClientForTests } from '../model-client.ts';
+import { TraceBuilder, CIVICAITOOLS_TRACE_CONFIG } from '../evidence/trace.ts';
+
+const FIXTURE_KEY = 'not-a-real-key-p2-injection-fixture';
+const PORTAL = 'data.cityofnewyork.us';
+const OTHER_PORTAL = 'data.sfgov.org';
+const PROMPT = 'How long do these requests take to close?';
+const SYSTEM = 'You are a fixture system prompt.';
+const REAL_ANSWER =
+  'Across both years the portal recorded 4,812 requests of this type. The median time to close ' +
+  'was 9 days, and 71% closed within 14 days (dataset abcd-1234).';
+const ONE_ROW = JSON.stringify({ data: [{ request_type: 'A', days_to_close: 9 }], total_rows: 1 });
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ['OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'MODEL_API_BASE_URL'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+// --- Instruments -----------------------------------------------------------
+
+interface StubToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  /** Sent verbatim instead of `JSON.stringify(args)` — the #349 shape. */
+  rawArguments?: string;
+}
+
+interface StubReply {
+  content?: string | null;
+  toolCalls?: StubToolCall[];
+}
+
+/**
+ * An in-process model client, for the cases that run under fake timers.
+ *
+ * `test-harness.ts`'s scripted server is the instrument everywhere else in
+ * this family, and it stays that way for every claim about WHAT THE MODEL WAS
+ * SENT — a wire claim belongs on the wire. It cannot be used here: replacing
+ * the global `setTimeout` while an HTTP request is in flight is a hazard, and
+ * the claims in the timer cases are about a timer, not about the transcript.
+ * So the model is a function call, the timers are the only asynchrony left,
+ * and `mock.timers.tick()` advances 45 seconds in microseconds.
+ */
+function stubClient(replies: StubReply[]): OpenAI {
+  let served = 0;
+  return {
+    chat: {
+      completions: {
+        create: async () => {
+          const reply = replies[Math.min(served++, replies.length - 1)];
+          return {
+            id: 'chatcmpl-p2-stub',
+            object: 'chat.completion',
+            created: 1,
+            model: 'fake/model',
+            choices: [{
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: reply.content ?? null,
+                ...(reply.toolCalls
+                  ? {
+                      tool_calls: reply.toolCalls.map((tc) => ({
+                        id: tc.id,
+                        type: 'function',
+                        function: {
+                          name: tc.name,
+                          arguments: tc.rawArguments ?? JSON.stringify(tc.args),
+                        },
+                      })),
+                    }
+                  : {}),
+              },
+              finish_reason: reply.toolCalls ? 'tool_calls' : 'stop',
+            }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+          };
+        },
+      },
+    },
+  } as unknown as OpenAI;
+}
+
+interface TimerLedger {
+  /** Timers created and neither cleared nor fired — the ones that outlive a call. */
+  pending: Map<unknown, number>;
+  /** Every timer created while the ledger was installed. */
+  created: number[];
+  /** The delays of every still-pending timer, for an assertion that names one. */
+  pendingDelays: () => number[];
+  restore: () => void;
+}
+
+/**
+ * Track every timer armed while this is installed.
+ *
+ * "Zero pending timers" needs a definition that survives a timer that FIRED:
+ * the loop's pass-through delivery arms one per chunk and lets each expire, so
+ * a bare created-minus-cleared count is non-zero on a healthy streaming run
+ * and would measure the wrong thing. `pending` drops a timer both when it is
+ * cleared and when its callback runs, so what is left in it is exactly the set
+ * of timers still holding the event loop when the call that armed them is
+ * over — the RED state `/api/compare-stream` and `/api/query-notebook` were in.
+ *
+ * Layers OVER whatever `setTimeout` is current, so it composes with
+ * `mock.timers.enable()` (install it after enabling; `mock.timers.reset()`
+ * then restores the real globals underneath).
+ */
+function trackTimers(): TimerLedger {
+  const currentSet = globalThis.setTimeout;
+  const currentClear = globalThis.clearTimeout;
+  const pending = new Map<unknown, number>();
+  const created: number[] = [];
+
+  globalThis.setTimeout = ((fn: (...a: unknown[]) => void, ms?: number, ...rest: unknown[]) => {
+    // The callback closes over `handle`, which this very statement assigns.
+    // Safe because a timer callback cannot run before its own `setTimeout`
+    // returns — and it is what lets a timer that FIRED leave `pending` on its
+    // own, which is the distinction this ledger exists to draw.
+    const handle: unknown = (currentSet as unknown as (...a: unknown[]) => unknown)(
+      (...a: unknown[]) => {
+        pending.delete(handle);
+        return fn(...a);
+      },
+      ms,
+      ...rest,
+    );
+    pending.set(handle, ms ?? 0);
+    created.push(ms ?? 0);
+    return handle;
+  }) as unknown as typeof globalThis.setTimeout;
+
+  globalThis.clearTimeout = ((handle: unknown) => {
+    pending.delete(handle);
+    return (currentClear as unknown as (h: unknown) => unknown)(handle);
+  }) as unknown as typeof globalThis.clearTimeout;
+
+  return {
+    pending,
+    created,
+    pendingDelays: () => [...pending.values()],
+    restore() {
+      globalThis.setTimeout = currentSet;
+      globalThis.clearTimeout = currentClear;
+    },
+  };
+}
+
+/**
+ * The suite's own bound on a case that drives a transport which never settles.
+ *
+ * Built on the clock captured BEFORE `mock.timers.enable()`, so it is a real
+ * two seconds no matter what the case has done to the global one. Without it,
+ * deleting the race under test does not turn a case red — it hangs the runner,
+ * which is a worse failure than the defect. `replay-loop.test.ts` learned this
+ * from #357 and uses the same shape.
+ *
+ * Cancelled on the way out rather than `unref`-ed: an unreferenced guard lets
+ * the loop drain and the runner reports "the event loop has already resolved"
+ * for the whole file instead of failing the one case that hung.
+ */
+function hangGuard(clock: RealClock): { promise: Promise<'hung'>; cancel: () => void } {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<'hung'>((resolve) => {
+    handle = clock.set(() => resolve('hung'), 2_000);
+  });
+  return { promise, cancel: () => { if (handle) clock.clear(handle); } };
+}
+
+interface RealClock {
+  set: typeof globalThis.setTimeout;
+  clear: typeof globalThis.clearTimeout;
+}
+
+/** Capture the real clock before anything replaces it. */
+function realClock(): RealClock {
+  return { set: globalThis.setTimeout, clear: globalThis.clearTimeout };
+}
+
+interface Span {
+  name: string;
+  attributes: { key: string; value: { stringValue?: string; intValue?: string } }[];
+}
+
+function spansOf(trace: Record<string, unknown>): Span[] {
+  const resourceSpans = trace.resourceSpans as { scopeSpans: { spans: Span[] }[] }[];
+  return resourceSpans.flatMap((rs) => rs.scopeSpans.flatMap((ss) => ss.spans));
+}
+
+function attr(span: Span, key: string): string | undefined {
+  const found = span.attributes.find((a) => a.key === key);
+  return found?.value?.stringValue ?? found?.value?.intValue;
+}
+
+function toolSpans(trace: Record<string, unknown>): Span[] {
+  return spansOf(trace).filter((s) => s.name === 'mcp_tool_call');
+}
+
+/** Build a trace the way every production caller does. */
+function freshTrace(): TraceBuilder {
+  const builder = new TraceBuilder(CIVICAITOOLS_TRACE_CONFIG);
+  builder.startRoot('analysis', { 'analysis.portal': PORTAL });
+  return builder;
+}
+
+function finish(builder: TraceBuilder): Record<string, unknown> {
+  builder.endRoot();
+  return builder.finalize() as unknown as Record<string, unknown>;
+}
+
+/**
+ * The property, in one assertion, for whichever caller produced the pair.
+ *
+ * This is what #359 is: `tool.arguments` is a serialization of the recorded
+ * `args`, and `tool.portal_domain` is read off the same object, so the ONLY
+ * way they can disagree is if something changed `args` between the span and
+ * the reader — which is precisely what a caller-side injection did.
+ */
+function assertSpanAgreesWithRecord(span: Span, record: ToolCallRecord, expectedPortal: string) {
+  assert.equal(record.args.portal, expectedPortal, 'the record must carry the injected portal');
+  const spanArgs = JSON.parse(attr(span, 'tool.arguments')!) as Record<string, unknown>;
+  assert.deepEqual(
+    spanArgs,
+    record.args,
+    'the span serialized different arguments than the record holds (#359)',
+  );
+  assert.equal(
+    attr(span, 'tool.portal_domain'),
+    expectedPortal,
+    'the span must report the portal the call was actually made with (#359)',
+  );
+}
+
+const FETCH_NO_PORTAL: StubToolCall = {
+  id: 'call_1',
+  name: 'get_data',
+  args: { type: 'query', dataset_id: 'abcd-1234' },
+};
+
+// --- Criterion 2, at the core ----------------------------------------------
+
+test('#359: the portal reaches the record, the tool_start event AND the span — one injection, above all three', async () => {
+  const builder = freshTrace();
+  const events: LoopEvent[] = [];
+  let handed: Record<string, unknown> | undefined;
+
+  const result = await runToolLoop({
+    client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    tools: [],
+    portal: PORTAL,
+    executeToolCall: async (_name, args) => {
+      handed = args;
+      return ONE_ROW;
+    },
+    onEvent: (event) => events.push(event),
+    trace: { builder, parentSpanId: builder.rootSpanId },
+  });
+  const trace = finish(builder);
+
+  assertSpanAgreesWithRecord(toolSpans(trace)[0], result.toolCalls[0], PORTAL);
+
+  // The `tool_start` event fires between the record and the span and carries
+  // the record by reference; a consumer that serializes it synchronously — the
+  // notebook route does — saw the un-injected arguments before this moved.
+  const started = events.find((e) => e.type === 'tool_start');
+  assert.ok(started && started.type === 'tool_start');
+  assert.equal(started.call.args.portal, PORTAL, 'tool_start reports the arguments actually sent');
+
+  // The args-identity constraint still holds: the core injected into the very
+  // object it recorded and handed on.
+  assert.equal(handed, result.toolCalls[0].args, 'the transport receives the object the record holds');
+});
+
+test('#359: the guard is the four callers’ guard, unchanged — Socrata get_data only, never an explicit portal', async () => {
+  const builder = freshTrace();
+  const result = await runToolLoop({
+    client: stubClient([
+      {
+        toolCalls: [
+          FETCH_NO_PORTAL,
+          { id: 'call_2', name: 'get_data', args: { type: 'query', dataset_id: 'wxyz-9999', portal: OTHER_PORTAL } },
+          { id: 'call_3', name: 'get_variables', args: { place: 'geoId/36061' } },
+        ],
+      },
+      { content: REAL_ANSWER },
+    ]),
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    tools: [],
+    portal: PORTAL,
+    executeToolCall: async () => ONE_ROW,
+    trace: { builder, parentSpanId: builder.rootSpanId },
+  });
+  const spans = toolSpans(finish(builder));
+
+  assert.equal(result.toolCalls[0].args.portal, PORTAL, 'a Socrata call with no portal gets the caller’s');
+  assert.equal(result.toolCalls[1].args.portal, OTHER_PORTAL, 'an explicit portal is never overwritten');
+  assert.equal(result.toolCalls[2].args.portal, undefined, 'a non-Socrata tool gets no portal at all');
+
+  assert.equal(attr(spans[0], 'tool.portal_domain'), PORTAL);
+  assert.equal(attr(spans[1], 'tool.portal_domain'), OTHER_PORTAL);
+  assert.equal(attr(spans[2], 'tool.portal_domain'), undefined, 'and the span agrees on all three');
+});
+
+test('a loop given no portal injects nothing — omitted is off, as it was for a caller that wrote no closure', async () => {
+  const builder = freshTrace();
+  const result = await runToolLoop({
+    client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    tools: [],
+    executeToolCall: async () => ONE_ROW,
+    trace: { builder, parentSpanId: builder.rootSpanId },
+  });
+
+  assert.equal(result.toolCalls[0].args.portal, undefined);
+  assert.equal(attr(toolSpans(finish(builder))[0], 'tool.portal_domain'), undefined);
+});
+
+// --- Criterion 3: a malformed tool call is never injected into --------------
+
+test('#359: a tool call whose arguments never parsed is NOT given a portal — not on the record, not on the span', async () => {
+  // The exposure this closes is created by the move. Before it, a caller's
+  // closure could not run on a malformed set, because the core throws
+  // `malformedToolArgumentsError()` before it calls the closure. Injection
+  // above the record runs earlier than that throw, on the `{}` the failed
+  // parse left behind — so without `!argumentsMalformed` in the guard this
+  // call would be recorded, spanned and SIGNED carrying a portal that was
+  // never sent to anything.
+  //
+  // RED demonstration, measured by deleting `!argumentsMalformed &&` from the
+  // guard: this case fails on the first assertion with
+  // `Expected values to be strictly deep-equal: {} !== { portal: 'data.cityofnewyork.us' }`.
+  const builder = freshTrace();
+  const result = await runToolLoop({
+    client: stubClient([
+      { toolCalls: [{ id: 'call_bad', name: 'get_data', args: {}, rawArguments: '{"type": "quer' }] },
+      { content: REAL_ANSWER },
+    ]),
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    tools: [],
+    portal: PORTAL,
+    executeToolCall: async () => assert.fail('a malformed call must never reach the transport'),
+    trace: { builder, parentSpanId: builder.rootSpanId },
+  });
+  const span = toolSpans(finish(builder))[0];
+
+  assert.deepEqual(result.toolCalls[0].args, {}, 'the record carries the empty set, with no portal');
+  assert.equal(attr(span, 'tool.arguments'), '{}', 'and the span carries the same empty set');
+  assert.equal(attr(span, 'tool.portal_domain'), undefined, 'no portal is asserted for a call never made');
+
+  // And it still fails exactly the way it failed before (#349): one failed
+  // tool call, described to the model, run continues.
+  assert.equal(result.toolCalls[0].failed, true);
+  assert.equal(result.toolCalls[0].failureKind, 'unknown');
+  assert.equal(result.content, REAL_ANSWER, 'a malformed call is not a failed run');
+});
+
+// --- Criterion 4: no timer outlives its call -------------------------------
+
+test('#352: a tool call that resolves inside its bound leaves ZERO pending timers', async () => {
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const timers = trackTimers();
+  try {
+    const result = await runToolLoop({
+      client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+      endpointModel: 'fake/model',
+      prompt: PROMPT,
+      tools: [],
+      portal: PORTAL,
+      toolTimeoutMs: 45_000,
+      executeToolCall: async () => ONE_ROW,
+    });
+
+    assert.equal(result.toolCalls[0].failed, undefined, 'the call succeeded well inside the bound');
+    assert.deepEqual(timers.created, [45_000], 'exactly one timer was armed, at the bound');
+    assert.equal(
+      timers.pending.size,
+      0,
+      'a timer outlived the call it bounded — this is the state /api/compare-stream and ' +
+        '/api/query-notebook were in, one per tool call, at 45 seconds each',
+    );
+  } finally {
+    timers.restore();
+    mock.timers.reset();
+  }
+});
+
+test('#352: the bound still fires when the call hangs, and the run survives it', async () => {
+  const guard = hangGuard(realClock());
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const timers = trackTimers();
+  let release = () => {};
+  try {
+    const run = runToolLoop({
+      client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+      endpointModel: 'fake/model',
+      prompt: PROMPT,
+      tools: [],
+      portal: PORTAL,
+      toolTimeoutMs: 45_000,
+      executeToolCall: () =>
+        new Promise<string>((resolve) => {
+          release = () => resolve(ONE_ROW);
+        }),
+    });
+
+    // Let the stub client's first reply and the tool call be dispatched, then
+    // advance past the bound. Nothing but the timer can end this call.
+    await Promise.resolve();
+    await new Promise((r) => process.nextTick(r));
+    await new Promise((r) => setImmediate(r));
+    mock.timers.tick(45_000);
+
+    assert.equal(
+      await Promise.race([run.then(() => 'settled' as const), guard.promise]),
+      'settled',
+      'the run never returned: nothing ended a tool call that never settles',
+    );
+    const result = await run;
+    assert.equal(result.toolCalls[0].failed, true);
+    assert.equal(result.toolCalls[0].failureKind, 'timeout', 'the bound is what ended it');
+    assert.equal(result.content, REAL_ANSWER, 'one timed-out call is not a failed run');
+    assert.equal(timers.pending.size, 0, 'the fired timer is gone and nothing replaced it');
+  } finally {
+    guard.cancel();
+    release();
+    timers.restore();
+    mock.timers.reset();
+  }
+});
+
+test('#352: omitting the bound arms no timer at all — unbounded is expressible', async () => {
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const timers = trackTimers();
+  try {
+    await runToolLoop({
+      client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+      endpointModel: 'fake/model',
+      prompt: PROMPT,
+      tools: [],
+      executeToolCall: async () => ONE_ROW,
+    });
+
+    assert.deepEqual(timers.created, [], 'a core default would have made "no bound" unsayable');
+  } finally {
+    timers.restore();
+    mock.timers.reset();
+  }
+});
+
+// --- Every caller: /api/compare ---------------------------------------------
+
+test('compare: the span agrees with the record on a get_data call that omitted a portal', async () => {
+  const builder = freshTrace();
+  const result = await runToolLoop({
+    ...compareLoopOptions({
+      client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+      endpointModel: 'fake/model',
+      prompt: PROMPT,
+      systemPrompt: SYSTEM,
+      portal: PORTAL,
+      callTool: async () => ONE_ROW,
+    }),
+    trace: { builder, parentSpanId: builder.rootSpanId },
+  });
+
+  assertSpanAgreesWithRecord(toolSpans(finish(builder))[0], result.toolCalls[0], PORTAL);
+});
+
+test('#352: /api/compare now has a tool bound, it is 45s, and it fires', async () => {
+  // This caller had NO per-tool-call bound at all: `git grep` for a timer in
+  // `compare-loop.ts` returned nothing at 96c4f76. A source that accepted the
+  // connection and then stopped answering held a public, rate-limited endpoint
+  // open until the platform killed the invocation, and the caller — waiting on
+  // one JSON body, with nothing streamed — got a platform error naming no tool.
+  assert.equal(COMPARE_MCP_TOOL_TIMEOUT_MS, 45_000, 'the same bound the three other callers use');
+  assert.equal(
+    compareLoopOptions({
+      client: {} as never,
+      endpointModel: 'fake/model',
+      prompt: PROMPT,
+      systemPrompt: SYSTEM,
+      portal: PORTAL,
+    }).toolTimeoutMs,
+    COMPARE_MCP_TOOL_TIMEOUT_MS,
+    'and the factory hands it to the core',
+  );
+
+  const guard = hangGuard(realClock());
+  mock.timers.enable({ apis: ['setTimeout'] });
+  const timers = trackTimers();
+  let release = () => {};
+  try {
+    const run = runToolLoop(
+      compareLoopOptions({
+        client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+        endpointModel: 'fake/model',
+        prompt: PROMPT,
+        systemPrompt: SYSTEM,
+        portal: PORTAL,
+        callTool: () =>
+          new Promise<string>((resolve) => {
+            release = () => resolve(ONE_ROW);
+          }),
+      }),
+    );
+
+    await Promise.resolve();
+    await new Promise((r) => process.nextTick(r));
+    await new Promise((r) => setImmediate(r));
+    mock.timers.tick(COMPARE_MCP_TOOL_TIMEOUT_MS);
+
+    assert.equal(
+      await Promise.race([run.then(() => 'settled' as const), guard.promise]),
+      'settled',
+      'the run never returned: /api/compare has no bound after all',
+    );
+    const result = await run;
+    assert.equal(result.toolCalls[0].failureKind, 'timeout');
+    assert.equal(result.content, REAL_ANSWER, 'the comparison still answers from what did come back');
+    assert.equal(timers.pending.size, 0, 'and the timer did not outlive the call');
+  } finally {
+    guard.cancel();
+    release();
+    timers.restore();
+    mock.timers.reset();
+  }
+});
+
+// --- Every caller: the replay route -----------------------------------------
+
+test('replay: the span agrees with the record, and the recorded args still feed the identity key', async () => {
+  const builder = freshTrace();
+  const result = await runToolLoop({
+    ...replayLoopOptions({
+      client: stubClient([{ toolCalls: [FETCH_NO_PORTAL] }, { content: REAL_ANSWER }]),
+      endpointModel: 'fake/model',
+      prompt: PROMPT,
+      systemPrompt: SYSTEM,
+      portal: PORTAL,
+      callTool: async () => ONE_ROW,
+    }),
+    trace: { builder, parentSpanId: builder.rootSpanId },
+  });
+  const record = result.toolCalls[0];
+
+  assertSpanAgreesWithRecord(toolSpans(finish(builder))[0], record, PORTAL);
+
+  // The replay identity key is `name:type:dataset_id:portal` — canonicalized
+  // in `AttestationDialog.tsx` and pinned verbatim in `replay-loop.test.ts`.
+  // It reads the recorded args, so the injected portal must still be there.
+  assert.equal(
+    [record.name, record.args.type, record.args.dataset_id, record.args.portal].join(':'),
+    `get_data:query:abcd-1234:${PORTAL}`,
+  );
+});
+
+test('replay keeps its own 45s bound, now as a value rather than a race it performs', async () => {
+  assert.equal(REPLAY_MCP_TOOL_TIMEOUT_MS, 45_000);
+  const options = replayLoopOptions({
+    client: {} as never,
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    systemPrompt: SYSTEM,
+    portal: PORTAL,
+  });
+  assert.equal(options.toolTimeoutMs, REPLAY_MCP_TOOL_TIMEOUT_MS);
+  assert.equal(options.portal, PORTAL);
+});
+
+// --- Every caller: the streaming path ---------------------------------------
+//
+// `/api/compare-stream` and `/api/query-notebook` both reach the core through
+// `queryWithMcpStreaming`, two frames below the closure they used to inject in
+// — which is why the fix had to reach this module too. These cases use the
+// real scripted HTTP endpoint and real timers: the bound is a parameter now,
+// so a small one costs milliseconds, and mocking the global clock underneath
+// an in-flight HTTP request buys nothing here.
+
+const FAKE_MODEL = carriedModelIdentity('fake/model');
+
+async function runStreaming(
+  toolCallOptions: { portal?: string; toolTimeoutMs?: number },
+  executeToolCall: (name: string, args: Record<string, unknown>) => Promise<string>,
+): Promise<{ completion: CompletionResult; trace: Record<string, unknown> }> {
+  const { server, url } = await startScriptedModelServer([
+    { toolCalls: [FETCH_NO_PORTAL] },
+    { content: REAL_ANSWER },
+  ]);
+  try {
+    process.env.OPENROUTER_API_KEY = FIXTURE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    const builder = freshTrace();
+    let completion: CompletionResult | undefined;
+    await queryWithMcpStreaming(
+      PROMPT,
+      FAKE_MODEL,
+      [],
+      executeToolCall,
+      SYSTEM,
+      {
+        onProgress: () => {},
+        onToken: () => {},
+        onComplete: (_panel, result) => { completion = result; },
+        onError: (_panel, message) => assert.fail(`unexpected onError: ${message}`),
+      },
+      { builder, parentSpanId: builder.rootSpanId },
+      toolCallOptions,
+    );
+    assert.ok(completion, 'onComplete must fire');
+    return { completion: completion!, trace: finish(builder) };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test('queryWithMcpStreaming: the span agrees with the record — the caller two frames up no longer injects', async () => {
+  const { completion, trace } = await runStreaming({ portal: PORTAL }, async () => ONE_ROW);
+  const record = (completion.tools_called ?? [])[0];
+  assert.ok(record, 'the completion must carry the tool call');
+  assertSpanAgreesWithRecord(toolSpans(trace)[0], record, PORTAL);
+});
+
+test('#352: the streaming path’s bound fires and leaves no timer behind', async () => {
+  const guard = hangGuard(realClock());
+  const timers = trackTimers();
+  let release = () => {};
+  try {
+    const running = runStreaming(
+      { portal: PORTAL, toolTimeoutMs: 40 },
+      () =>
+        new Promise<string>((resolve) => {
+          release = () => resolve(ONE_ROW);
+        }),
+    );
+    assert.equal(
+      await Promise.race([running.then(() => 'settled' as const), guard.promise]),
+      'settled',
+      'the run never returned: nothing ended a tool call that never settles',
+    );
+    const { completion } = await running;
+    const record = (completion.tools_called ?? [])[0];
+    assert.equal(record.failed, true);
+    assert.equal(record.failureKind, 'timeout');
+    assert.equal(completion.content, REAL_ANSWER, 'one timed-out call is not a failed stream');
+    assert.ok(
+      !JSON.stringify(completion).includes('timed out after'),
+      'the raw timeout text never reaches the reader (#154)',
+    );
+    assert.deepEqual(
+      timers.pendingDelays().filter((ms) => ms === 40),
+      [],
+      'the fired bound left nothing behind',
+    );
+  } finally {
+    guard.cancel();
+    release();
+    timers.restore();
+  }
+});
+
+test('#352: a streaming tool call that resolves inside its bound leaves no timer pending', async () => {
+  const timers = trackTimers();
+  try {
+    const { completion } = await runStreaming(
+      { portal: PORTAL, toolTimeoutMs: 45_000 },
+      async () => ONE_ROW,
+    );
+    assert.equal((completion.tools_called ?? [])[0].failed, undefined);
+    assert.ok(
+      timers.created.includes(45_000),
+      'the bound was armed — otherwise this case measures nothing',
+    );
+    // Named rather than counted, because this path does real HTTP and the
+    // client library keeps timers of its own (a request deadline, a socket
+    // keep-alive). The claim is about the TOOL bound, so it names the bound:
+    // 45_000 pending here is the RED state both route callers were in, one
+    // such timer per tool call.
+    assert.deepEqual(
+      timers.pendingDelays().filter((ms) => ms === 45_000),
+      [],
+      'the 45s tool bound is still pending after the call it bounded resolved',
+    );
+  } finally {
+    timers.restore();
+  }
+});
+
+// --- The two route callers, which node --test cannot invoke -----------------
+
+function sourceOf(relative: string): string {
+  return readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
+}
+
+test('#359 / #352: no caller in src/ carries an injection or a tool timer of its own', () => {
+  const callers: [string, string][] = [
+    ['compare-stream/route.ts', sourceOf('../../app/api/compare-stream/route.ts')],
+    ['query-notebook/route.ts', sourceOf('../../app/api/query-notebook/route.ts')],
+    ['compare-loop.ts', sourceOf('./compare-loop.ts')],
+    ['replay-loop.ts', sourceOf('./replay-loop.ts')],
+    ['openrouter-streaming.ts', sourceOf('../openrouter-streaming.ts')],
+  ];
+
+  for (const [name, source] of callers) {
+    assert.doesNotMatch(
+      source,
+      /(args|toolArgs)\.portal\s*=[^=]/,
+      `${name} still injects a portal itself: the span is built before that runs (#359)`,
+    );
+    assert.ok(
+      !source.includes('setTimeout('),
+      `${name} still arms a tool timer: the race and its clear live in the core (#352)`,
+    );
+  }
+});
+
+test('#359 / #352: both streaming routes pass the two values down instead of performing them', () => {
+  for (const [name, source] of [
+    ['compare-stream/route.ts', sourceOf('../../app/api/compare-stream/route.ts')],
+    ['query-notebook/route.ts', sourceOf('../../app/api/query-notebook/route.ts')],
+  ] as [string, string][]) {
+    assert.match(source, /\{ portal, toolTimeoutMs: MCP_TOOL_TIMEOUT_MS \}/, `${name} must forward both`);
+    assert.match(source, /MCP_TOOL_TIMEOUT_MS = 45_000/, `${name} still states its own bound`);
+    assert.ok(
+      !source.includes('Promise.race'),
+      `${name} must not race the call itself`,
+    );
+  }
+});
+
+test('the two factories hand the core values, not a closure that does the work', () => {
+  for (const [name, source] of [
+    ['compare-loop.ts', sourceOf('./compare-loop.ts')],
+    ['replay-loop.ts', sourceOf('./replay-loop.ts')],
+  ] as [string, string][]) {
+    assert.match(source, /executeToolCall: callTool,/, `${name} must hand the transport through unwrapped`);
+    assert.match(source, /^\s+portal,$/m, `${name} must pass the portal as an option`);
+    assert.match(source, /toolTimeoutMs/, `${name} must pass a bound`);
+  }
+});
+
+// --- The option surface, stated once ---------------------------------------
+
+test('both options are on ToolLoopOptions and both are optional', () => {
+  // A compile-time claim, asserted at runtime so it appears in the suite:
+  // omitting either is legal, which is what "omitted = no injection" and
+  // "omitted = unbounded" mean.
+  const minimal: ToolLoopOptions = {
+    client: {} as never,
+    endpointModel: 'fake/model',
+    prompt: PROMPT,
+    tools: [],
+    executeToolCall: async () => ONE_ROW,
+  };
+  assert.equal(minimal.portal, undefined);
+  assert.equal(minimal.toolTimeoutMs, undefined);
+
+  const configured: ToolLoopOptions = { ...minimal, portal: PORTAL, toolTimeoutMs: 45_000 };
+  assert.equal(configured.portal, PORTAL);
+  assert.equal(configured.toolTimeoutMs, 45_000);
+});

--- a/src/lib/model-loop/replay-loop.ts
+++ b/src/lib/model-loop/replay-loop.ts
@@ -18,13 +18,13 @@
  * error-classification tail. This module owns only what the LOOP is given.
  *
  * THE ARGS-IDENTITY CONSTRAINT, restated because this is the caller it bites.
- * `executeToolCall` below injects `portal` into the `args` object the core
- * already recorded — the same object, by reference (see the header of
- * `run-tool-loop.ts`). `AttestationDialog.canonicalizeToolCall` keys a replay
- * run on `name:args.type:args.dataset_id:args.portal`, and those keys are an
- * input to a signed consistency attestation. Clone the object here and the
- * injected portal stops reaching the record, every key changes, and nothing in
- * the diff points at the cause.
+ * The core injects `portal` into the very `args` object it records — the same
+ * object, by reference (see the header of `run-tool-loop.ts`).
+ * `AttestationDialog.canonicalizeToolCall` keys a replay run on
+ * `name:args.type:args.dataset_id:args.portal`, and those keys are an input to
+ * a signed consistency attestation. Clone or freeze that object anywhere on
+ * this path and the injected portal stops reaching the record, every key
+ * changes, and nothing in the diff points at the cause.
  */
 
 import type OpenAI from 'openai';
@@ -87,8 +87,19 @@ export interface ReplayLoopInputs {
 
 /**
  * Everything `runToolLoop` needs to run one replay. The caps, the tool set,
- * the portal injection and the per-call timeout are all fixed here; the route
- * supplies only what it read off the record.
+ * the portal and the per-call timeout are all fixed here; the route supplies
+ * only what it read off the record.
+ *
+ * The portal and the timeout are now VALUES this factory hands the core
+ * rather than behaviour it performs (#359, #352). This module held the
+ * reference implementation of both — the `get_data` guard three other callers
+ * copied, and the only timer of the four that was cleared — and what it kept
+ * is the two numbers and the one portal that are genuinely replay's. The
+ * injection had to move because it ran inside `executeToolCall`, which the
+ * core invokes after it has already recorded the call and stringified the
+ * arguments onto the `mcp_tool_call` span: the span disagreed with the record,
+ * and on a replay the record is what a signed consistency attestation is
+ * computed over.
  */
 export function replayLoopOptions(inputs: ReplayLoopInputs): ToolLoopOptions {
   const {
@@ -116,28 +127,12 @@ export function replayLoopOptions(inputs: ReplayLoopInputs): ToolLoopOptions {
     // published output of this run.
     finalTurn: 'blocking',
     logContext: 'replay',
-    executeToolCall: async (name, args) => {
-      // Socrata's get_data expects a portal; Data Commons tools don't — only
-      // inject for Socrata. Mutating `args` IN PLACE is required, not
-      // incidental: see this file's header.
-      if (name === 'get_data' && !args.portal) args.portal = portal;
-
-      // Race the source against a timeout so one unresponsive tool call
-      // cannot hold the replay open indefinitely.
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      try {
-        return await Promise.race([
-          callTool(name, args),
-          new Promise<never>((_, reject) => {
-            timer = setTimeout(
-              () => reject(new Error(`MCP tool "${name}" timed out after ${toolTimeoutMs / 1000}s`)),
-              toolTimeoutMs,
-            );
-          }),
-        ]);
-      } finally {
-        if (timer) clearTimeout(timer);
-      }
-    },
+    // Injected by the core into a Socrata `get_data` call that omits a portal,
+    // above the record and the span; Data Commons tools are untouched.
+    portal,
+    // Raced and cleared by the core, so one unresponsive source fails its own
+    // call rather than holding the replay open.
+    toolTimeoutMs,
+    executeToolCall: callTool,
   };
 }

--- a/src/lib/model-loop/run-tool-loop.ts
+++ b/src/lib/model-loop/run-tool-loop.ts
@@ -21,13 +21,25 @@
  * parameters.
  *
  * THE ONE HARD CONSTRAINT: this loop never clones or freezes a tool call's
- * `args`. The object recorded on the tool-call entry is the SAME object
- * handed to `executeToolCall`, because callers inject fields into it inside
- * that closure (a portal, for one) and the recorded arguments — which reach a
- * signed package and the replay identity key — must show what was actually
- * sent. Cloning or freezing here changes those recorded arguments with
- * nothing in the diff pointing at the cause. `run-tool-loop.test.ts` holds a
- * probe on the identity.
+ * `args`. The object recorded on the tool-call entry is the SAME object the
+ * `portal` option is injected into and the SAME object handed to
+ * `executeToolCall`, and the recorded arguments — which reach a signed
+ * package and the replay identity key — must show what was actually sent.
+ * Cloning or freezing here changes those recorded arguments with nothing in
+ * the diff pointing at the cause. `run-tool-loop.test.ts` holds a probe on
+ * the identity, and a caller may still inject a field of its own inside its
+ * `executeToolCall` closure on the same terms.
+ *
+ * WHAT MOVED IN, AND WHY (#359, #352). Portal injection and the per-tool-call
+ * timeout used to live in every caller's `executeToolCall` closure — four
+ * copies in `src/`, three different timeout shapes, one of which did not
+ * exist. Injection there runs AFTER this loop has already built the record,
+ * emitted `tool_start` and opened the `mcp_tool_call` span, so the span
+ * serialised arguments the caller was about to change: `tool.portal_domain`
+ * was absent on exactly the calls the portal was injected into, while the
+ * signed record carried it. Both are now options — injection happens above
+ * the record, the timer is cleared in one `finally` — because neither is a
+ * caller concern: what differs between callers is the value, not the rule.
  *
  * SSE is not a concept here. The loop reports through `onEvent`/`onDelta`;
  * panels, event encoding and reader-facing progress copy belong to whichever
@@ -102,11 +114,26 @@ export interface ToolLoopOptions {
   systemPrompt?: string;
   tools: ChatCompletionTool[];
   /**
-   * The seam every caller-side tool concern goes through: portal injection, a
-   * per-call timeout race, source routing. Receives the SAME args object the
-   * record holds — see the constraint in this file's header.
+   * The tool transport: source routing, and whatever else a caller still owns
+   * about reaching a server. Portal injection and the per-call timeout are NOT
+   * among them any more — they are the two options below. Receives the SAME
+   * args object the record holds — see the constraint in this file's header.
    */
   executeToolCall: (name: string, args: Record<string, unknown>) => Promise<string>;
+  /**
+   * Default portal for a Socrata `get_data` call whose arguments omit one.
+   * Injected into the SAME args object the record holds, BEFORE the record,
+   * the `tool_start` event and the `mcp_tool_call` span are built (#359), so
+   * every consumer of the call sees what was actually sent.
+   * Omitted = no injection; the loop passes arguments through untouched.
+   */
+  portal?: string;
+  /**
+   * Per-tool-call timeout in milliseconds. The call is raced against it and
+   * the timer is cleared in a `finally`, once, here (#352).
+   * Omitted = unbounded, the same idiom `maxCumulativeTokens` above uses.
+   */
+  toolTimeoutMs?: number;
   /** Tool-calling rounds before the loop gives up and asks for an answer. */
   maxIterations?: number;
   /** `max_tokens` on every request this loop makes. */
@@ -290,6 +317,49 @@ function toolFailureKindOf(error: unknown): ToolFailureKind {
       return 'not_configured';
     default:
       return 'unknown';
+  }
+}
+
+/**
+ * Race one tool call against its bound, and clear the timer in a `finally` —
+ * once, here (#352).
+ *
+ * Three shapes of this existed on the caller side and only one of them was
+ * right: `replay-loop.ts` cleared in a `finally`, `compare-stream/route.ts`
+ * and `query-notebook/route.ts` armed a 45-second timer per tool call and
+ * never cleared it (a call that answered in 200 ms left a timer holding the
+ * event loop for the rest of the bound), and `/api/compare` had no bound at
+ * all. The timer is a property of making a bounded call, not of being a
+ * particular caller, so it lives with the call.
+ *
+ * No bound is `undefined`, not a number: a default here would hand every
+ * caller a ceiling it never chose and make "unbounded" inexpressible.
+ *
+ * The message keeps the wording every caller-side copy used, because
+ * `classifyStreamError` reads it — "timed out" is what makes the recorded
+ * failure `timeout` rather than `unknown`. It never reaches a reader or the
+ * model: `describeToolFailureForLlm` restates it (#154).
+ */
+async function boundToolCall(
+  call: Promise<string>,
+  name: string,
+  timeoutMs: number | undefined,
+): Promise<string> {
+  if (timeoutMs === undefined) return call;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      call,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`MCP tool "${name}" timed out after ${timeoutMs / 1000}s`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -524,6 +594,8 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
     systemPrompt,
     tools,
     executeToolCall,
+    portal,
+    toolTimeoutMs,
     maxIterations = DEFAULT_MAX_ITERATIONS,
     maxTokens = DEFAULT_MAX_TOKENS,
     maxCumulativeTokens,
@@ -623,6 +695,50 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
         argumentsMalformed = true;
       }
 
+      /**
+       * Portal injection, ABOVE everything that reads or serialises `args`
+       * (#359). Four callers used to do this inside their `executeToolCall`
+       * closure, which the loop invokes below — after the record, after
+       * `tool_start`, and thirteen lines after the span stringified `args`.
+       * The span therefore reported no `tool.portal_domain` on precisely the
+       * calls a portal had been injected into, while the signed package
+       * (`packager.ts`) and the replay identity key read the mutated object
+       * and did carry it. One site above the record makes the two agree by
+       * construction, for every caller, instead of four sites agreeing by
+       * luck.
+       *
+       * `!argumentsMalformed` is load-bearing and is NEW here. A caller's
+       * closure never ran on a malformed argument set, because the throw
+       * below precedes `executeToolCall`. Injection at this height does run,
+       * on the `{}` the failed parse left behind — so without this clause a
+       * call whose arguments never parsed would be recorded, spanned and
+       * SIGNED carrying a portal it never had. The move creates the exposure;
+       * the clause closes it.
+       *
+       * `name === 'get_data'` stays literal and must not widen to a source
+       * lookup. The data-source server does implement `search` and `fetch`,
+       * but their input schemas are `additionalProperties: false` with no
+       * portal property, so an injected portal would be stripped upstream and
+       * would still corrupt the recorded arguments that feed the signed
+       * package and the replay identity key.
+       *
+       * KNOWN LATENT DIVERGENCE, named here because the trigger is
+       * foreseeable. The data-source server treats `portal` as an alias for
+       * `domain` and resolves them as `domain || portal` — `domain` WINS.
+       * This guard looks only at `portal`. So a `get_data` call that supplied
+       * `domain` and omitted `portal` would receive an injected portal the
+       * server then ignores, and that ignored value would still reach
+       * `tool.arguments`, `tool.portal_domain`, the signed package and the
+       * replay identity key: a signed record asserting a portal that was not
+       * queried. It cannot fire today — this instance's `get_data` schema
+       * advertises no `domain` property, so a model cannot supply one — and
+       * the guard is deliberately left byte-identical rather than widened to
+       * a condition no test could exercise. It becomes live the moment
+       * `src/lib/mcp/tools.ts` gains a `domain` property on `get_data`;
+       * whoever adds one owes this guard a second look.
+       */
+      if (portal && !argumentsMalformed && name === 'get_data' && !args.portal) args.portal = portal;
+
       const operationType = deriveOperationType(name, args);
       const reason = generateToolReason(args);
       // `args` goes onto the record BY REFERENCE and is handed to
@@ -650,7 +766,7 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
         if (argumentsMalformed) throw malformedToolArgumentsError();
 
         const toolStartTime = Date.now();
-        const result = await executeToolCall(name, args);
+        const result = await boundToolCall(executeToolCall(name, args), name, toolTimeoutMs);
         const toolDuration = Date.now() - toolStartTime;
         toolEntry.duration_ms = toolDuration;
         toolEntry.resultSummary = summarizeToolResult(result);

--- a/src/lib/openrouter-streaming.ts
+++ b/src/lib/openrouter-streaming.ts
@@ -224,6 +224,26 @@ export async function queryWithoutMcpStreaming(
   }
 }
 
+/**
+ * The two tool-call concerns the core owns (#359, #352), forwarded rather than
+ * performed here.
+ *
+ * Both of this module's callers — `/api/compare-stream` and
+ * `/api/query-notebook` — used to do these inside the `executeToolCall`
+ * closure they hand down, which is two frames below the seam and, worse,
+ * below the point where the core has already recorded the call and
+ * stringified its arguments onto the `mcp_tool_call` span. Passing them as
+ * values means the span and the record agree on this path too, and the
+ * per-call timer is armed and cleared once, in the core, instead of being
+ * armed per call and never cleared in each route.
+ */
+export interface ToolCallOptions {
+  /** Default portal for a Socrata `get_data` call whose arguments omit one. */
+  portal?: string;
+  /** Per-tool-call timeout in ms. Omitted = unbounded. */
+  toolTimeoutMs?: number;
+}
+
 export async function queryWithMcpStreaming(
   query: string,
   model: ModelIdentity,
@@ -232,6 +252,7 @@ export async function queryWithMcpStreaming(
   systemPrompt: string | undefined,
   callbacks: StreamCallbacks,
   trace?: TraceContext,
+  toolCallOptions?: ToolCallOptions,
 ): Promise<void> {
   const startTime = Date.now();
   const panel: PanelType = 'withMcp';
@@ -247,9 +268,12 @@ export async function queryWithMcpStreaming(
       systemPrompt,
       tools,
       // Handed straight through: whatever this closure injects into `args`
-      // (a portal, most often) is what the record shows, because the loop
-      // hands it the same object it recorded.
+      // is what the record shows, because the loop hands it the same object
+      // it recorded. The portal is no longer one of those things — it is the
+      // option below, applied before the record and the span exist.
       executeToolCall,
+      portal: toolCallOptions?.portal,
+      toolTimeoutMs: toolCallOptions?.toolTimeoutMs,
       maxIterations: MAX_ITERATIONS,
       maxTokens: MAX_TOKENS_PER_RESPONSE,
       maxCumulativeTokens: MAX_TOKENS_PER_REQUEST,


### PR DESCRIPTION
Wave N8, phase P2 (lane 1). Base `96c4f76`. Model: **Opus 5**. Closes #359, #352.

## What changed

`runToolLoop` gains `portal` and `toolTimeoutMs`. Injection runs **above** the tool-call record, the `tool_start` emit and the `mcp_tool_call` span; the timer is raced and cleared in one `finally` in the core. The four in-`src` caller copies are gone, and `/api/compare` gets a per-tool-call bound it has never had.

| File | Change |
|---|---|
| `src/lib/model-loop/run-tool-loop.ts` | two options; the guard above `deriveOperationType`; `boundToolCall` races and clears once |
| `src/lib/model-loop/compare-loop.ts` | closure deleted; passes `portal` + `COMPARE_MCP_TOOL_TIMEOUT_MS` (45s, new) |
| `src/lib/model-loop/replay-loop.ts` | closure deleted; passes `portal` + `toolTimeoutMs` |
| `src/lib/openrouter-streaming.ts` | `queryWithMcpStreaming` grows a trailing `toolCallOptions` and forwards both |
| `src/app/api/compare-stream/route.ts` | transport only; forwards `{ portal, toolTimeoutMs }` |
| `src/app/api/query-notebook/route.ts` | transport only; forwards `{ portal, toolTimeoutMs }` |
| `src/lib/model-loop/injection-and-bound.test.ts` | new — 18 cases across all four callers |

## Why the span and the record disagreed (#359)

The closure runs at `run-tool-loop.ts:653` — after the record at `:630`, after `tool_start` at `:633`, thirteen lines after the span stringified `args` at `:640-647`. So on exactly the calls a portal was injected into, the span carried no `tool.portal_domain`, while `packager.ts` and the replay identity key read the mutated object and did carry it.

Two deliberate details in the guard:

- **`!argumentsMalformed` is new and load-bearing.** A caller's closure never ran on an unparseable argument set, because the core throws first. Injection at this height does run, on the `{}` the failed parse left behind — without the clause, a call whose arguments never parsed would be recorded, spanned and **signed** carrying a portal it never had.
- **`name === 'get_data'` stays literal** rather than widening to a source lookup: `search` and `fetch` have `additionalProperties: false` schemas with no portal property, so an injected portal would be stripped upstream and still corrupt the recorded arguments.

A latent divergence is **named in a comment beside the guard, not fixed**: the data source resolves `domain || portal` with `domain` winning, and the guard looks only at `portal`. It cannot fire while `get_data` advertises no `domain` property. The comment names the trigger for whoever adds one.

## Acceptance

| # | Criterion | Result |
|---|---|---|
| 1 | One injection in `src/` | `git grep -n -P '(args\|toolArgs)\.portal\s*=[^=]'` (all tracked files, no pathspec) → 2 non-test sites: the core, and `scripts/eval-models.mjs:469` (a later phase's) |
| 2 | The span agrees with the record, on every caller | 4 cases: the core, `compare-loop`, `replay-loop`, `queryWithMcpStreaming` |
| 3 | A malformed call is never injected into | record `{}`, span `tool.arguments` `'{}'`, no `tool.portal_domain`, still fails as `unknown` |
| 4 | No timer outlives its call | 6 cases under `mock.timers` + a timer ledger; the bound fires on a hang on all three bounded callers |
| 5 | Nothing lost | `# tests 1110 / # pass 1110 / # fail 0`; 0 base test names absent, 18 added |
| 6 | Trailers | `Signed-off-by` then `Co-Authored-By`, one contiguous block |

## Every criterion shown red before it was accepted

Four probes, each applied to the merged code and reverted:

1. **Drop `!argumentsMalformed`** → criterion 3 fails: `{} !== { portal: 'data.cityofnewyork.us' }`.
2. **Move the injection back below the record and the span** → 5 cases fail, including `queryWithMcpStreaming`, with the exact #359 shape: span args missing `portal`, record args carrying it.
3. **Delete the `finally { clearTimeout }`** → 2 cases fail: `1 !== 0` pending timers.
4. **Delete the race entirely** → 5 cases fail; the hang cases report `'hung' !== 'settled'` after the suite's own 2s real-clock guard.

## Checks

`npm ci` first. `npm test` 1110/1110. `npm run build` compiled successfully. `npm run typecheck` exit 0, no output. `npm run lint` `✖ 4 problems (0 errors, 4 warnings)` — the baseline. `npm run check:compose-env` PASS.

**Draft.** Merge is the ORCH's on evidence-pass; this branch pushes no tag and never touches `main`.
