### PR TITLE
fix: the fourth tool-calling loop drives the shared core, and the guard's scope stops being a list (#356)

### DIFF
--- a/scripts/eval-models.mjs
+++ b/scripts/eval-models.mjs
@@ -3,25 +3,54 @@
 /**
  * Model evaluation harness for civic data queries.
  *
- * Runs a set of test queries against multiple LLMs via OpenRouter,
- * using the Socrata MCP server for tool calls. Captures raw responses,
- * token usage, latency, and tools called for manual scoring.
+ * Runs a set of test queries against multiple LLMs via OpenRouter, using the
+ * Socrata MCP server for tool calls. Captures raw responses, token usage,
+ * latency, and tools called for manual scoring.
+ *
+ * IT DRIVES THE SHARED TOOL-CALLING LOOP (#356). Until this file was migrated
+ * it carried a fourth copy of that loop: its own iteration bound, its own
+ * unguarded `JSON.parse` of the arguments the model chose, its own portal
+ * injection with no `get_data` guard, and a raw `error.message` handed back to
+ * the model. Wave #345 consolidated the application's three loops onto
+ * `src/lib/model-loop/run-tool-loop.ts` and not one of those fixes reached
+ * here, because the census that found the class and the guard that measured it
+ * were both scoped to `src/` and to `.ts`. What remains in this file is what is
+ * genuinely its own: the models it compares, the queries it runs them against,
+ * its MCP transport, its tool schema, and how it writes results up for scoring.
  *
  * THIS HARNESS IS PINNED TO OPENROUTER, AND THE APP IS NOT. Since
  * civic-ai-tools-website#30 the app reaches a configurable endpoint through
  * `src/lib/model-client.ts`, reading `MODEL_API_KEY` (with `OPENROUTER_API_KEY`
  * as its prior-era name) and `MODEL_API_BASE_URL` / `MODEL_API_KIND`. This
- * script reads none of that: it is `.mjs` run as bare `node`, so it cannot
- * import that TypeScript module, and it hardcodes OpenRouter's base URL and
- * requires `OPENROUTER_API_KEY` specifically. That is why the variable name
- * below differs from the one an operator now sets — the statement is accurate
- * about this script, not stale about the app. Repointing the harness at the
- * endpoint layer is tracked in civic-ai-tools#155 and is deliberately not a
+ * script reads none of that: it hardcodes OpenRouter's base URL and requires
+ * `OPENROUTER_API_KEY` specifically. That is why the variable name below
+ * differs from the one an operator now sets — the statement is accurate about
+ * this script, not stale about the app. Repointing the harness at the endpoint
+ * layer is tracked in civic-ai-tools#155 and is deliberately not a
  * find-and-replace.
  *
- * Usage:
+ * THE REASON RECORDED HERE FOR THAT PINNING WAS FALSE, and it is worth naming
+ * rather than quietly deleting: it said this file "is `.mjs` run as bare
+ * `node`, so it cannot import that TypeScript module." Node strips types from
+ * an imported `.ts` module — by default from v22.18, behind
+ * `--experimental-strip-types` before that — and the `runToolLoop` import below
+ * is the standing counter-example. Nothing about the extension prevented the
+ * import. The OpenRouter pinning is unfinished work (civic-ai-tools#155), not a
+ * constraint of the runtime.
+ *
+ * Usage, on Node >= 22.18 where type stripping is on by default:
  *   OPENROUTER_API_KEY=<your-key> SOCRATA_MCP_URL=https://your-mcp-host \
  *     node scripts/eval-models.mjs
+ *
+ * On Node 22.0 – 22.17 the same run needs the flag, because of that import:
+ *   OPENROUTER_API_KEY=<your-key> SOCRATA_MCP_URL=https://your-mcp-host \
+ *     node --experimental-strip-types scripts/eval-models.mjs
+ *
+ * package.json's `engines.node` is ">=22", which admits those versions, so the
+ * floor is load-bearing for the flagless form rather than incidental.
+ * `scripts/eval-models.test.mjs` runs a flagless `node` against that import and
+ * fails by name on a Node that cannot strip, so the gap is reported by the
+ * suite rather than met by an operator.
  *
  * Required env vars:
  *   SOCRATA_MCP_URL  — MCP server URL. No fallback (civic-ai-tools#155 P1
@@ -42,6 +71,8 @@ import { writeFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import OpenAI from 'openai';
+
+import { runToolLoop } from '../src/lib/model-loop/run-tool-loop.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -385,206 +416,58 @@ Examples:
 const QUERY_TIMEOUT_MS = 120_000; // 120 seconds per query
 const QUERY_TOKEN_CAP = 50_000;   // 50K tokens per query
 
-class TokenBudgetExceeded extends Error {
-  constructor(tokens) {
-    super(`Token budget exceeded: ${tokens} tokens used (cap: ${QUERY_TOKEN_CAP})`);
-    this.name = 'TokenBudgetExceeded';
-    this.tokens = tokens;
-  }
-}
+/**
+ * WHAT THE BUDGET GUARDRAIL IS NOW, AND WHAT IT WAS (#356).
+ *
+ * This file used to implement three tiers itself: a soft cap that broke its
+ * own loop and forced a summary turn, a hard cap at twice the soft one that
+ * returned a synthetic `[HARD ABORT]` string with no summary turn at all, and a
+ * per-round estimate that broke *before* a call whose input looked likely to
+ * cross either line.
+ *
+ * The shared loop carries one bound — `maxCumulativeTokens`, checked after each
+ * round — which stops the loop and takes one final answering turn. So the soft
+ * tier survives exactly, and `budgetExceeded` on each result still reports it.
+ * The hard tier does not survive: `hardAbort` is removed from the result rather
+ * than written out as a field that can no longer be true, and a run that would
+ * once have returned a synthetic string now pays for one answering turn and
+ * returns a real answer. Against that cost, the loop truncates every tool
+ * result before it re-enters the transcript (`maxToolResultChars`) — a bound
+ * this harness never had, on exactly the transcript growth the hard tier
+ * existed to catch.
+ *
+ * `QUERY_TIMEOUT_MS` above is unchanged and still bounds a whole query rather
+ * than a tool call. The loop takes an optional per-tool-call bound and this
+ * harness deliberately passes none: it has never had one, and giving it one is
+ * a behaviour change rather than a migration.
+ */
 
 // --- Query execution ---
 
-// Estimate tokens from message content to predict next API call cost.
-// ~4 chars per token is a rough but safe heuristic.
-function estimateMessageTokens(messages) {
-  let chars = 0;
-  for (const msg of messages) {
-    if (typeof msg.content === 'string') chars += msg.content.length;
-    // tool_calls in assistant messages also contribute
-    if (msg.tool_calls) chars += JSON.stringify(msg.tool_calls).length;
-  }
-  return Math.ceil(chars / 4);
-}
-
 async function runQuery(query, model, systemPrompt) {
-  const startTime = Date.now();
-  const toolsCalled = [];
-  let totalInputTokens = 0;
-  let totalOutputTokens = 0;
-  let budgetExceeded = false;
-  let hardAbort = false;
-
-  // Check budget after every token-producing event.
-  // Returns 'ok' | 'soft' (exceeded cap, summarize) | 'hard' (exceeded 2x cap, abort now)
-  function checkBudget() {
-    const total = totalInputTokens + totalOutputTokens;
-    if (total >= QUERY_TOKEN_CAP * 2) return 'hard';
-    if (total >= QUERY_TOKEN_CAP) return 'soft';
-    return 'ok';
-  }
-
-  const messages = [
-    { role: 'system', content: systemPrompt },
-    { role: 'user', content: query.query },
-  ];
-
-  let response = await openrouter.chat.completions.create({
-    model: model.id,
-    messages,
+  const result = await runToolLoop({
+    client: openrouter,
+    endpointModel: model.id,
+    prompt: query.query,
+    systemPrompt,
+    // This harness's own one-tool array, above — not the app's tool set.
+    // Widening it would change what the evaluation measures, which is a
+    // separate decision from where the loop lives.
     tools,
-    tool_choice: 'auto',
-    max_tokens: 2000,
+    executeToolCall: callMcpTool,
+    // Default portal for a `get_data` call whose arguments omit one. The copy
+    // this file used to carry injected into EVERY tool call, guarded only on
+    // `!args.portal`; with the one-tool array above that was the same
+    // behaviour, and the loop's `get_data` guard keeps it the same behaviour if
+    // that array ever grows. The loop injects above the tool-call record and
+    // above the trace span, so what is written out below is what was sent.
+    portal: query.portal,
+    maxIterations: 10,
+    maxTokens: 2000,
+    maxCumulativeTokens: QUERY_TOKEN_CAP,
+    // No `toolTimeoutMs` — see the guardrail note above.
+    logContext: `eval-models ${model.id}`,
   });
-
-  totalInputTokens += response.usage?.prompt_tokens || 0;
-  totalOutputTokens += response.usage?.completion_tokens || 0;
-
-  // Check after initial call
-  let status = checkBudget();
-  if (status === 'hard') {
-    hardAbort = true;
-    budgetExceeded = true;
-  } else if (status === 'soft') {
-    budgetExceeded = true;
-  }
-
-  let iterations = 0;
-  const maxIterations = 10;
-
-  while (
-    !hardAbort &&
-    !budgetExceeded &&
-    response.choices[0]?.message?.tool_calls &&
-    iterations < maxIterations
-  ) {
-    const assistantMessage = response.choices[0].message;
-    messages.push(assistantMessage);
-
-    for (const toolCall of assistantMessage.tool_calls || []) {
-      if (toolCall.type === 'function') {
-        const args = JSON.parse(toolCall.function.arguments);
-
-        // Inject default portal
-        if (!args.portal) args.portal = query.portal;
-
-        toolsCalled.push({ name: toolCall.function.name, args });
-
-        try {
-          const result = await callMcpTool(toolCall.function.name, args);
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: result,
-          });
-        } catch (error) {
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: `Error: ${error.message}`,
-          });
-        }
-      }
-    }
-
-    // Before making the next API call, estimate whether the accumulated
-    // messages would blow past the cap. Each API call charges for the
-    // full conversation, so estimate the next call's input tokens.
-    const estimatedNextInput = estimateMessageTokens(messages);
-    const projectedTotal = totalInputTokens + totalOutputTokens + estimatedNextInput;
-    if (projectedTotal >= QUERY_TOKEN_CAP * 2) {
-      hardAbort = true;
-      budgetExceeded = true;
-      break;
-    }
-    if (projectedTotal >= QUERY_TOKEN_CAP) {
-      budgetExceeded = true;
-      break;
-    }
-
-    response = await openrouter.chat.completions.create({
-      model: model.id,
-      messages,
-      tools,
-      tool_choice: 'auto',
-      max_tokens: 2000,
-    });
-
-    totalInputTokens += response.usage?.prompt_tokens || 0;
-    totalOutputTokens += response.usage?.completion_tokens || 0;
-    iterations++;
-
-    // Check after every API call
-    status = checkBudget();
-    if (status === 'hard') {
-      hardAbort = true;
-      budgetExceeded = true;
-      break;
-    } else if (status === 'soft') {
-      budgetExceeded = true;
-      break;
-    }
-  }
-
-  // Hard abort — don't even attempt a summary, just return what we have
-  if (hardAbort) {
-    const durationMs = Date.now() - startTime;
-    const total = totalInputTokens + totalOutputTokens;
-    return {
-      queryId: query.id,
-      modelId: model.id,
-      modelName: model.name,
-      query: query.query,
-      portal: query.portal,
-      category: query.category,
-      expectedDataset: query.expectedDataset,
-      response: `[HARD ABORT] Token budget exceeded: ${total.toLocaleString()} tokens (2x cap: ${(QUERY_TOKEN_CAP * 2).toLocaleString()})`,
-      toolsCalled,
-      toolCallCount: toolsCalled.length,
-      iterations,
-      inputTokens: totalInputTokens,
-      outputTokens: totalOutputTokens,
-      totalTokens: total,
-      durationMs,
-      budgetExceeded: true,
-      hardAbort: true,
-      timestamp: new Date().toISOString(),
-    };
-  }
-
-  // Soft cap or iteration limit — force a text summary
-  const lastMessage = response.choices[0]?.message;
-  if (!lastMessage?.content && (iterations >= maxIterations || lastMessage?.tool_calls || budgetExceeded)) {
-    if (lastMessage?.tool_calls) {
-      messages.push(lastMessage);
-      const reason = budgetExceeded
-        ? `Token budget exceeded (${(totalInputTokens + totalOutputTokens).toLocaleString()} tokens). Summarize based on data already collected.`
-        : 'Tool call limit reached. Summarize based on data already collected.';
-      for (const tc of lastMessage.tool_calls) {
-        messages.push({
-          role: 'tool',
-          tool_call_id: tc.id,
-          content: reason,
-        });
-      }
-    }
-    response = await openrouter.chat.completions.create({
-      model: model.id,
-      messages: [
-        ...messages,
-        {
-          role: 'user',
-          content: 'Based on the data collected, provide a comprehensive answer.',
-        },
-      ],
-      max_tokens: 2000,
-    });
-    totalInputTokens += response.usage?.prompt_tokens || 0;
-    totalOutputTokens += response.usage?.completion_tokens || 0;
-  }
-
-  const durationMs = Date.now() - startTime;
-  const content = response.choices[0]?.message?.content || '';
 
   return {
     queryId: query.id,
@@ -594,16 +477,19 @@ async function runQuery(query, model, systemPrompt) {
     portal: query.portal,
     category: query.category,
     expectedDataset: query.expectedDataset,
-    response: content,
-    toolsCalled,
-    toolCallCount: toolsCalled.length,
-    iterations,
-    inputTokens: totalInputTokens,
-    outputTokens: totalOutputTokens,
-    totalTokens: totalInputTokens + totalOutputTokens,
-    durationMs,
-    budgetExceeded,
-    hardAbort: false,
+    response: result.content,
+    // The loop's records carry more than the `{ name, args }` pairs this file
+    // used to write: the operation type, the reason line, result row and column
+    // counts, per-call duration, and whether a call failed and how (#321). All
+    // of that is useful for scoring and none of it was available before.
+    toolsCalled: result.toolCalls,
+    toolCallCount: result.toolCalls.length,
+    iterations: result.iterations,
+    inputTokens: result.usage.promptTokens,
+    outputTokens: result.usage.completionTokens,
+    totalTokens: result.usage.totalTokens,
+    durationMs: result.durationMs,
+    budgetExceeded: result.tokenLimitExceeded,
     timestamp: new Date().toISOString(),
   };
 }
@@ -630,7 +516,6 @@ function buildOutput(models, results, errors, skillGuidanceLength) {
       totalErrors: errors.length,
       totalTimeouts: errors.filter((e) => e.isTimeout).length,
       totalBudgetExceeded: results.filter((r) => r.budgetExceeded).length,
-      totalHardAborts: results.filter((r) => r.hardAbort).length,
       skillGuidanceLength,
     },
     results,
@@ -649,7 +534,6 @@ function buildOutput(models, results, errors, skillGuidanceLength) {
         modelName: model.name,
         queriesRun: modelResults.length,
         budgetExceeded: modelResults.filter((r) => r.budgetExceeded).length,
-        hardAborts: modelResults.filter((r) => r.hardAbort).length,
         totalTokens,
         avgTokensPerQuery: modelResults.length > 0 ? Math.round(totalTokens / modelResults.length) : 0,
         totalDurationMs: totalDuration,
@@ -747,11 +631,7 @@ When you get results, summarize clearly and cite the dataset ID used.`;
         );
         results.push(result);
 
-        const flags = result.hardAbort
-          ? ' [HARD ABORT]'
-          : result.budgetExceeded
-            ? ' [BUDGET EXCEEDED]'
-            : '';
+        const flags = result.budgetExceeded ? ' [BUDGET EXCEEDED]' : '';
         console.log(
           `  → ${result.toolCallCount} tool calls, ${result.totalTokens.toLocaleString()} tokens, ${(result.durationMs / 1000).toFixed(1)}s${flags}`
         );

--- a/scripts/eval-models.test.mjs
+++ b/scripts/eval-models.test.mjs
@@ -1,22 +1,37 @@
-// Tests for scripts/eval-models.mjs (civic-ai-tools#155 P1 E4).
+// Tests for scripts/eval-models.mjs.
 //
-// SOCRATA_MCP_URL used to default to https://socrata-mcp.civicaitools.org
-// when unset, silently routing an unconfigured run's queries through
-// infrastructure the caller does not operate. It now refuses with a named
-// error instead. Spawned as a CHILD PROCESS so the refusal is exercised the
-// same way an operator would trigger it, before any model/MCP call is made.
+// TWO REFUSALS (civic-ai-tools#155 P1 E4). SOCRATA_MCP_URL used to default to
+// https://socrata-mcp.civicaitools.org when unset, silently routing an
+// unconfigured run's queries through infrastructure the caller does not
+// operate. It now refuses with a named error instead. Spawned as a CHILD
+// PROCESS so the refusal is exercised the same way an operator would trigger
+// it, before any model/MCP call is made.
+//
+// AND THE RUNNER (#356). The harness imports the shared tool-calling loop from
+// src/lib/model-loop/run-tool-loop.ts — a TypeScript module, imported from a
+// `.mjs` file. Until #356 this file's own header asserted that could not work.
+// It can, and the two spawns below prove it twice over: the refusal tests run
+// the harness itself with no flags, so a broken import would fail them by not
+// reaching the env gate at all, and the third test states the property on its
+// own so a failure names the cause instead of looking like a config bug.
 //
 // Run with: npm test
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SCRIPT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   './eval-models.mjs',
+);
+
+const CORE = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../src/lib/model-loop/run-tool-loop.ts',
 );
 
 test('refuses with a named error when OPENROUTER_API_KEY is unset', () => {
@@ -40,4 +55,56 @@ test('refuses with a named error when SOCRATA_MCP_URL is unset (no reference-hos
   assert.match(result.stderr, /SOCRATA_MCP_URL/);
   // The old default must not appear anywhere in the refusal.
   assert.doesNotMatch(result.stdout + result.stderr, /socrata-mcp\.civicaitools\.org/);
+});
+
+test('#356: a flagless `node` can import the shared tool-calling core', () => {
+  // NO FLAGS, on purpose. `npm test` runs this suite under
+  // --experimental-strip-types, and inheriting that flag here would hide the
+  // one case an operator actually meets: `node scripts/eval-models.mjs`.
+  const source =
+    `import { runToolLoop } from ${JSON.stringify(pathToFileURL(CORE).href)};\n` +
+    'process.stdout.write(typeof runToolLoop);\n';
+
+  const result = spawnSync(process.execPath, ['--input-type=module', '-e', source], {
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    'a flagless `node` could not import src/lib/model-loop/run-tool-loop.ts, which ' +
+      'scripts/eval-models.mjs imports at module scope. Node strips types from an imported `.ts` ' +
+      'by default only from v22.18; below that the harness needs --experimental-strip-types, and ' +
+      `package.json's engines.node is ">=22", which still admits those versions. Running ` +
+      `${process.version}.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assert.equal(result.stdout, 'function');
+});
+
+test('#356: the harness drives the shared core rather than a loop of its own', () => {
+  const source = readFileSync(SCRIPT, 'utf-8');
+
+  assert.match(
+    source,
+    /import \{ runToolLoop \} from '\.\.\/src\/lib\/model-loop\/run-tool-loop\.ts';/,
+    'the harness must import the shared loop, not reimplement one',
+  );
+  assert.match(source, /await runToolLoop\(\{/, 'the harness must actually call it');
+
+  // This file's copy of the wave's own criterion, kept where the migration
+  // happened. The class-wide statement — no second tool-calling loop anywhere
+  // this repository tracks — lives in
+  // src/lib/model-loop/model-call-registry.test.ts, which is where a scan
+  // scoped to one file would be the #356 defect all over again.
+  assert.doesNotMatch(
+    source,
+    /args\.portal\s*=[^=]/,
+    'portal injection is the loop\'s, above the tool-call record and the trace span (#359)',
+  );
+  assert.doesNotMatch(
+    source,
+    /JSON\.parse\(toolCall\./,
+    'parsing the arguments the model chose belongs inside the loop\'s failure path (#349)',
+  );
 });

--- a/src/lib/model-loop/model-call-registry.test.ts
+++ b/src/lib/model-loop/model-call-registry.test.ts
@@ -16,15 +16,35 @@
  * the second list below names exactly one module, and a further entry
  * appearing on it is a regression this test reports by name.
  *
- * WHAT "A FILE" MEANS HERE, because getting this wrong is what #356 was. The
- * scan first rooted at `src/` and accepted only `.ts`/`.tsx`, so a fourth
- * tool-calling loop in `scripts/eval-models.mjs` was invisible to it and the
- * claim in the paragraph above was false as written, with a live
- * counter-example in the tree. It now covers `src/`, `scripts/` and the
- * configuration files at the repository root — every JavaScript or TypeScript
- * file this repository tracks — in every extension of the family (`.ts`,
- * `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, `.cjs`). A guard whose header
- * overstates its reach is worse than no guard, because it is trusted.
+ * WHAT "A FILE" MEANS HERE, because getting this wrong is what #356 was — and
+ * then nearly was again. The scan first rooted at `src/` and accepted only
+ * `.ts`/`.tsx`, so a fourth tool-calling loop in `scripts/eval-models.mjs` was
+ * invisible to it. Widening it to a two-directory list plus a one-level read of
+ * the repository root fixed that instance and left the shape intact: a
+ * hardcoded universe under a header that claimed the repository. That claim was
+ * true only because every file of the JavaScript/TypeScript family this
+ * repository tracks happened to sit in `src`, `scripts` or the root — true by
+ * coincidence of layout, which is a thing one new directory falsifies with
+ * nothing to notice it.
+ *
+ * The universe is now derived rather than listed. `git ls-files` supplies it:
+ * every path this repository tracks, in whatever working tree the suite runs
+ * in, of which the scan reads those whose name matches /\.(c|m)?[jt]sx?$/ and
+ * does not match /\.test\.(c|m)?[jt]sx?$/. There is no directory list and no
+ * depth limit. `node_modules`, `.next` and the build output are absent because
+ * git does not track them, not because this file names them, and a file under a
+ * top-level directory that does not exist yet is covered on the day it is
+ * created.
+ *
+ * Two consequences, stated so no reader has to infer them. A file that exists
+ * but has not been `git add`ed is not tracked and is not scanned — the guard
+ * sees it the moment it is staged, which is before any commit, PR or merge can
+ * carry it. And a tracked file deleted from the working tree is skipped,
+ * because there is nothing to read. If git cannot answer at all, the scan
+ * throws rather than falling back to something narrower: a guard whose header
+ * overstates its reach is worse than no guard, because it is trusted, and a
+ * guard that quietly reduces its own reach is the same failure with no diff to
+ * point at.
  *
  * TWO ASSERTIONS, ONE INSTRUMENT. The first is the registry: who calls the
  * model at all. The second is narrower and is the wave's own criterion: how
@@ -44,18 +64,12 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readdirSync, readFileSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
-
-/**
- * Where the scan looks. `src` and `scripts` are walked; the repository root is
- * read one level deep, which is where the four configuration modules live and
- * is what keeps `node_modules`, `.next` and the build output out of the walk.
- */
-const SCAN_DIRECTORIES = ['src', 'scripts'];
 
 /**
  * Every file permitted to call `chat.completions.create`, with the reason it
@@ -145,9 +159,8 @@ function passesTools(call: ModelCall): boolean {
 }
 
 function modelCallSites(): ModelCall[] {
-  return scannedFiles().flatMap((path) => {
-    const source = readFileSync(path, 'utf8');
-    const file = relative(REPO_ROOT, path).split(sep).join('/');
+  return trackedSourceFiles().flatMap((file) => {
+    const source = readFileSync(join(REPO_ROOT, file), 'utf8');
     const calls: ModelCall[] = [];
     let from = 0;
     for (;;) {
@@ -208,33 +221,39 @@ function endOfString(source: string, start: number): number {
   return source.length;
 }
 
-/** Every JavaScript/TypeScript source file in the scanned scope. */
-function scannedFiles(): string[] {
-  return [
-    ...rootLevelFiles(),
-    ...SCAN_DIRECTORIES.flatMap((dir) => sourceFiles(join(REPO_ROOT, dir))),
-  ];
-}
-
-/** The configuration modules at the repository root — read, never walked. */
-function rootLevelFiles(): string[] {
-  return readdirSync(REPO_ROOT, { withFileTypes: true })
-    .filter((entry) => entry.isFile() && isSource(entry.name))
-    .map((entry) => join(REPO_ROOT, entry.name));
-}
-
-function sourceFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) return sourceFiles(full);
-    return isSource(entry.name) ? [full] : [];
+/**
+ * Every source file this repository tracks, as repository-relative paths — the
+ * same form the two registries are keyed by, so no normalisation stands between
+ * what is scanned and what is listed.
+ *
+ * `--full-name` makes the paths repository-relative however the suite is
+ * invoked, and `-z` keeps a name containing a newline from splitting into two.
+ * A failure to run git at all propagates: the scan has no narrower fallback on
+ * purpose, because falling back is how a guard loses reach without a diff.
+ */
+function trackedSourceFiles(): string[] {
+  const listing = execFileSync('git', ['ls-files', '-z', '--full-name'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
   });
+  const tracked = listing.split('\0').filter((name) => name !== '' && isSource(name));
+  assert.ok(
+    tracked.length > 0,
+    'git ls-files reported no source files at all. The scan has stopped measuring, which looks ' +
+      'exactly like a tree with nothing to find — see the header.',
+  );
+  // The one exclusion: a tracked file deleted from the working tree has nothing
+  // to read. Nothing a model call could hide in is removed by it.
+  return tracked.filter((name) => existsSync(join(REPO_ROOT, name)));
 }
 
 /**
- * A source file of the JavaScript/TypeScript family, tests excluded. Written
- * as one predicate over the whole family rather than as `.tsx?`, because the
- * gap #356 found was an extension the filter had never been asked about.
+ * A source file of the JavaScript/TypeScript family, tests excluded — matched
+ * against a repository-relative path, which the suffix test handles as readily
+ * as a bare name. Written as one predicate over the whole family rather than as
+ * `.tsx?`, because the gap #356 found was an extension the filter had never
+ * been asked about.
  */
 function isSource(name: string): boolean {
   return /\.(c|m)?[jt]sx?$/.test(name) && !/\.test\.(c|m)?[jt]sx?$/.test(name);

--- a/src/lib/model-loop/model-call-registry.test.ts
+++ b/src/lib/model-loop/model-call-registry.test.ts
@@ -10,10 +10,11 @@
  *
  * This test says it out loud. Adding a `chat.completions.create` call to a
  * file that is not on the list below fails the suite, and the list carries one
- * line of justification per entry. The wave closed with every tool-calling
- * loop in the application consolidated: the second list below names the shared
- * core and one script, and a further entry appearing on it is a regression
- * this test reports by name.
+ * line of justification per entry. Wave #345 consolidated every tool-calling
+ * loop in the application onto one core; #356 then found a fourth loop outside
+ * `src/`, in `scripts/eval-models.mjs`, and it has since been migrated too. So
+ * the second list below names exactly one module, and a further entry
+ * appearing on it is a regression this test reports by name.
  *
  * WHAT "A FILE" MEANS HERE, because getting this wrong is what #356 was. The
  * scan first rooted at `src/` and accepted only `.ts`/`.tsx`, so a fourth
@@ -74,27 +75,24 @@ const ALLOWED_MODEL_CALLERS: Record<string, string> = {
     'The second copy of that same rubric call, caller-keyed. Out of this wave by ruling D4 (#348).',
   'src/app/api/evidence/generate-summary/route.ts':
     'One summary call, no loop. Out of this wave.',
-  'scripts/eval-models.mjs':
-    'The model-selection harness: a fourth tool-calling loop that carries the full class. Migration is the next wave’s (#356).',
 };
 
 /**
  * Modules carrying a tool-calling loop — a `chat.completions.create` that
- * passes `tools`. Three in `src/` when this wave opened
+ * passes `tools`. Three in `src/` when wave #345 opened
  * (`openrouter-streaming.ts`, `evidence/[slug]/replay/route.ts`,
- * `openrouter.ts`); one now. That count is the wave's own first acceptance
- * criterion, and this is where it is measured.
+ * `openrouter.ts`), and a fourth its census could not see because the census
+ * was scoped to `src/` and to `.ts`: `scripts/eval-models.mjs` (#356). One now.
+ * That count is the criterion both waves were written around, and this is where
+ * it is measured.
  *
- * The second entry is the debt #356 found, listed rather than fixed: the point
- * of naming it here is that it stops being invisible to the suite. It is not a
- * fourth application loop — nothing it writes is served, signed or
- * user-facing — but it is the same shape, and it chooses which models this
- * instance offers.
+ * A second entry appearing here is a regression, reported by name. The
+ * assertions below run in both directions, so this list also cannot outlive
+ * what it describes: an entry that stops being a real tool-calling loop fails
+ * the suite exactly as an unlisted one does.
  */
 const ALLOWED_TOOL_LOOPS: Record<string, string> = {
-  'src/lib/model-loop/run-tool-loop.ts': 'The shared core.',
-  'scripts/eval-models.mjs':
-    'The model-selection harness: carries the full class; migration is the next wave’s (#356).',
+  'src/lib/model-loop/run-tool-loop.ts': 'The shared core — the one implementation.',
 };
 
 const MODEL_CALL = 'chat.completions.create';


### PR DESCRIPTION
**Wave N8 — Phase P3 (lane 1). Closes #356.** Base `cecc959`. Model: **Opus 5**. Draft.

## What changed

`scripts/eval-models.mjs` drives `runToolLoop`. Its own loop, its unguarded argument parse, its raw-error-to-the-model path and its portal injection are **deleted, not wrapped**. `ALLOWED_TOOL_LOOPS` drops to one entry and `ALLOWED_MODEL_CALLERS` loses the harness in the same commit. The registry guard's universe is now derived from `git ls-files` rather than a two-directory list, and its header says exactly what the scan does.

## Blast zone

Exactly the three declared files, no more:

```
 scripts/eval-models.mjs                        | 322 ++++++++-----------------
 scripts/eval-models.test.mjs                   |  81 ++++++-
 src/lib/model-loop/model-call-registry.test.ts | 139 ++++++-----
 3 files changed, 253 insertions(+), 289 deletions(-)
```

`src/lib/model-loop/run-tool-loop.ts` is **untouched** — this phase is a consumer of the core, not an editor of it. `package.json` needed no change (there is no `eval-models` script; P1 measured this and the chartered zone was wrong). The throwaway `tools/x.mjs` does not exist on this branch.

## Acceptance

| # | Criterion | Evidence |
|---|---|---|
| 1 | One loop | `ALLOWED_TOOL_LOOPS` has one entry and the bidirectional assertion passes, so the tool-passing set is exactly `{run-tool-loop.ts}` across every tracked file |
| 2 | One injection, at last | `git grep -n -P '(args\|toolArgs)\.portal\s*=[^=]'` over all tracked files, no pathspec → **one** non-test site, `run-tool-loop.ts:740`. The wave's criterion 1 |
| 3 | Scope true by construction, red **on a runner** | Draft PR #368, run [`33196411536`](https://github.com/npstorey/civic-ai-tools-website/actions/runs/33196411536), check **`build / test / lint / typecheck`**, job `98934572252` — **fail**, both assertions naming `tools/x.mjs`, `# tests 1131 / # fail 2`. Closed unmerged, branch deleted |
| 4 | Bidirectional | Four probes shown red — a removed real entry and a stale entry, on each registry |
| 5 | Header states what the scan does | Rewritten, including the two consequences a reader would otherwise infer |
| 6 | Nothing lost | 1129 → **1131**, `# fail 0`; TAP name sets diffed, absent set **empty**, added set exactly the two new tests |
| 7 | Trailers | Both commits: `Signed-off-by` then `Co-Authored-By`, contiguous |

## One forced behaviour change, disclosed

The harness's budget guardrail had three tiers it implemented itself: a soft cap, a hard cap at 2× that returned a synthetic `[HARD ABORT]` string with no summary turn, and a per-round projection. The core carries one bound. The soft tier survives exactly; **`hardAbort` is removed from the result** rather than written out as a field that can no longer be true. Stated in the file beside the constants, and flagged for the gate.
