### PR TITLE
fix: the generated notebook stops claiming what it did not do (#340, #341, #342, #324)

### DIFF
--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -42,7 +42,13 @@ Examples:
           },
           query: {
             type: 'string',
-            description: 'For type=catalog: search query. For type=metadata: the dataset ID. For type=query: optional full-text search within data.',
+            // #340: this used to describe only the $q branch. The data-access
+            // handler splits on whether the value starts with SELECT, and the
+            // SoQL branch supersedes the individual clauses AND drops
+            // limit/offset — so a model reading the old text could send both a
+            // SELECT and a limit and be silently given neither bound it asked
+            // for. Both branches are stated here because both are reachable.
+            description: 'For type=catalog: search query. For type=metadata: the dataset ID. For type=query: either a full SoQL statement starting with SELECT, which is applied as the entire query and supersedes select/where/order/group (limit and offset are not applied either — bound the rows with the statement\'s own LIMIT), or a search phrase, applied as a full-text search within the data alongside the other clauses.',
           },
           dataset_id: {
             type: 'string',

--- a/src/lib/notebook-author/helpers/fetch-socrata-contract.test.ts
+++ b/src/lib/notebook-author/helpers/fetch-socrata-contract.test.ts
@@ -1,0 +1,400 @@
+// The contract between a generated cell and the helper it calls (Wave N8 P5,
+// #340).
+//
+// Two halves, and the defect lived in the gap between them:
+//
+//   1. `src/lib/mcp/tools.ts` advertises `query` on `get_data`, the model
+//      sends it, and `tool-to-cell.ts` renders it into a `fetch_socrata(...)`
+//      call. At the base `fetch_socrata` had no `query` parameter, so the cell
+//      raised `TypeError` on execution and the reader was told live data could
+//      not be fetched — in a notebook whose cover text called itself
+//      reproducible.
+//   2. The helper is not a wrapper around the data-access service: it talks to
+//      the portal directly. So it cannot inherit the service's precedence for
+//      `query`; it has to implement the same rule itself. A reader can re-run
+//      this cell with different arguments, and the mapping has to hold for
+//      THEIR arguments too, not only for the ones we rendered.
+//
+// THE COUPLING THIS FILE PINS, AND WHAT TO DO WHEN IT MOVES.
+// `_is_full_soql_query` in fetch_socrata.py is a copy of a regular expression
+// that lives in ANOTHER repository:
+//
+//     socrata-mcp-server/src/tools/socrata-tools.ts:546
+//     at commit 116f46ce1e84e3608014599f9b63ea01acfd913a
+//
+//         if (queryField && /^\s*select/i.test(queryField)) { … }
+//
+//   matching  → `$query` alone; select/where/order/group/having/q are set
+//               aside (:547-553) and the request carries neither $limit nor
+//               $offset (:283-293);
+//   otherwise → `$q`, with every other clause preserved (:555-557);
+//   and, third, a non-SoQL `query` with no dataset_id BECOMES the dataset id
+//               (:531) — the one behaviour this helper deliberately does not
+//               reproduce.
+//
+// IF THE SERVICE CHANGES ITS SNIFF, THE FIX IS AN ISSUE ON THIS REPOSITORY, so
+// that this copy, the TypeScript predicate in `tool-to-cell.ts` and the
+// service all move together. A change made on one side alone is a silent
+// divergence, and it surfaces only in a published notebook — where a reader is
+// told a `limit=` applied that never did.
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { HELPER_PARAMETERS, renderFetchToolCell } from '../tool-to-cell.ts';
+import { mcpTools } from '../../mcp/tools.ts';
+
+const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+function helperSource(file: string): string {
+  return fs.readFileSync(path.join(HELPERS_DIR, file), 'utf8');
+}
+
+/**
+ * Stub `requests` and `pandas` into `sys.modules`, then execute the helper
+ * source as written. Stdlib only — the suite must not need the scientific
+ * stack installed to check what the helper sends.
+ *
+ * The captured request deliberately excludes headers: they carry
+ * `X-App-Token` when the environment supplies one, and a test that printed
+ * them would print a credential into a CI log.
+ */
+const PY_PREAMBLE = [
+  'import json, sys, types',
+  'captured = {}',
+  'class _Response:',
+  '    def raise_for_status(self): return None',
+  '    def json(self): return []',
+  'def _get(url, params=None, headers=None, timeout=None):',
+  "    captured['url'] = url",
+  "    captured['params'] = params",
+  '    return _Response()',
+  "requests_stub = types.ModuleType('requests')",
+  'requests_stub.get = _get',
+  "pandas_stub = types.ModuleType('pandas')",
+  'pandas_stub.DataFrame = lambda data=None: data',
+  "sys.modules['requests'] = requests_stub",
+  "sys.modules['pandas'] = pandas_stub",
+  'ns = {}',
+  "exec(compile(sys.stdin.read(), 'helper.py', 'exec'), ns)",
+].join('\n');
+
+/** Call `fetch_socrata(**kwargs)` and report the query string it would send. */
+const PY_CALL = [
+  PY_PREAMBLE,
+  'kwargs = json.loads(sys.argv[1])',
+  'try:',
+  "    ns['fetch_socrata'](**kwargs)",
+  "    print(json.dumps({'raised': None, 'url': captured.get('url'), 'params': captured.get('params')}))",
+  'except Exception as err:',
+  "    print(json.dumps({'raised': type(err).__name__, 'message': str(err)}))",
+].join('\n');
+
+/**
+ * Report a helper's parameter names, plus whether it declares `*args` /
+ * `**kwargs`, by parsing the .py rather than importing it.
+ *
+ * A structural read of the source, not `inspect.signature` on an imported
+ * module: the other helpers evaluate their annotations at definition time, so
+ * importing them needs an interpreter new enough for the syntax those
+ * annotations use. A test whose verdict depends on the interpreter version on
+ * the machine is a test that can pass here and fail on a runner for a reason
+ * that has nothing to do with the code.
+ */
+const PY_SIGNATURE = [
+  'import ast, json, sys',
+  'tree = ast.parse(sys.stdin.read())',
+  'want = sys.argv[1]',
+  'out = None',
+  'for node in ast.walk(tree):',
+  '    if isinstance(node, ast.FunctionDef) and node.name == want:',
+  '        a = node.args',
+  "        out = {'params': [x.arg for x in a.posonlyargs + a.args + a.kwonlyargs],",
+  "               'vararg': a.vararg.arg if a.vararg else None,",
+  "               'kwarg': a.kwarg.arg if a.kwarg else None}",
+  '        break',
+  'print(json.dumps(out))',
+].join('\n');
+
+interface CallResult {
+  raised: string | null;
+  url?: string;
+  params?: Record<string, string>;
+  message?: string;
+}
+
+function runPython(script: string, arg: string, source: string): string {
+  const result = spawnSync('python3', ['-c', script, arg], { input: source, encoding: 'utf-8' });
+  assert.equal(
+    result.status,
+    0,
+    `python3 probe failed (exit ${result.status})\n--- stderr ---\n${result.stderr}`,
+  );
+  return result.stdout;
+}
+
+function callFetchSocrata(kwargs: Record<string, unknown>): CallResult {
+  return JSON.parse(runPython(PY_CALL, JSON.stringify(kwargs), helperSource('fetch_socrata.py')));
+}
+
+interface HelperSignature {
+  params: string[];
+  vararg: string | null;
+  kwarg: string | null;
+}
+
+function helperSignature(file: string, fn: string): HelperSignature {
+  const parsed = JSON.parse(runPython(PY_SIGNATURE, fn, helperSource(file)));
+  assert.ok(parsed, `${file} declares no function named ${fn}`);
+  return parsed as HelperSignature;
+}
+
+/** The service's regex, transcribed literally from the line cited above. */
+const SERVICE_SOQL_SNIFF = /^\s*select/i;
+
+/**
+ * The fixture from the service's own suite —
+ * `socrata-mcp-server/src/__tests__/search.test.ts:165`,
+ * `test('handles full SoQL query')`. It drives this exact string, asserts the
+ * request carries `{ $query: <it> }` and nothing else, and gets 42 rows from a
+ * single call. The 42 comes from the statement's own LIMIT, which is what
+ * bounds the rows once `$limit` is no longer sent.
+ */
+const SERVICE_SUITE_SOQL = 'SELECT * WHERE category = "test" LIMIT 42';
+
+test('#340: the helper accepts `query`, and a full SoQL statement becomes the whole query', () => {
+  // RED at the base: `fetch_socrata` had no `query` parameter at all, so this
+  // call raised TypeError — which is exactly what the generated cell did.
+  //
+  // The service's fixture, driven through OUR helper: the request must carry
+  // $query alone. Not $select, not $where — and not $limit or $offset either,
+  // which is the half a "query wins" implementation usually gets wrong.
+  const result = callFetchSocrata({
+    portal: 'data.test.gov',
+    dataset_id: 'soql-dataset',
+    query: SERVICE_SUITE_SOQL,
+    select: 'category, count(*)',
+    where: "category = 'other'",
+    order: 'count DESC',
+    group: 'category',
+    limit: 5,
+    offset: 20,
+  });
+
+  assert.equal(result.raised, null, `unexpected ${result.raised}: ${result.message}`);
+  assert.equal(result.url, 'https://data.test.gov/resource/soql-dataset.json');
+  assert.deepEqual(result.params, { $query: SERVICE_SUITE_SOQL });
+});
+
+test('#340: a search phrase becomes $q, with every other clause preserved', () => {
+  // The service's other branch (:555-557). A helper that mapped `query` to
+  // `$query` unconditionally would reproduce a phrase-branch analysis
+  // DIFFERENTLY than it ran — turning #340 into the defect #341 is about.
+  const result = callFetchSocrata({
+    portal: 'data.test.gov',
+    dataset_id: 'soql-dataset',
+    query: 'noise complaints',
+    where: "borough = 'BROOKLYN'",
+    limit: 5,
+  });
+
+  assert.equal(result.raised, null, `unexpected ${result.raised}: ${result.message}`);
+  assert.deepEqual(result.params, {
+    $q: 'noise complaints',
+    $where: "borough = 'BROOKLYN'",
+    $limit: '5',
+  });
+});
+
+test('#340: the helper applies the sniff itself, on arguments no cell rendered', () => {
+  // A reader can re-run this cell with their own `query`. So the branch is
+  // theirs to take, and the helper must map THEIR argument the way the
+  // service would have mapped it — not merely reproduce the one case the
+  // renderer happened to emit.
+  //
+  // RED: `query.strip().upper().startswith('SELECT')`, or a sniff without
+  // `\s*`. Both pass on the fixture above and diverge on the rows below.
+  const cases = [
+    SERVICE_SUITE_SOQL,
+    'select * from x',
+    '   SELECT count(*) AS n',
+    'SeLeCt 1',
+    'noise complaints',
+    'selected noise complaints',
+    'WHERE complaint_type = "Noise"',
+    ' 311 selected complaints',
+  ];
+  for (const query of cases) {
+    const result = callFetchSocrata({ portal: 'data.test.gov', dataset_id: 'ds', query, limit: 5 });
+    assert.equal(result.raised, null, `${JSON.stringify(query)}: ${result.message}`);
+    const params = result.params ?? {};
+    const wentSoql = Object.prototype.hasOwnProperty.call(params, '$query');
+    assert.equal(
+      wentSoql,
+      SERVICE_SOQL_SNIFF.test(query),
+      `the helper took the wrong branch for ${JSON.stringify(query)}: ${JSON.stringify(params)}`,
+    );
+    // And the branch it took is the whole behaviour: a $query travels alone.
+    if (wentSoql) assert.deepEqual(params, { $query: query });
+    else assert.equal(params.$q, query);
+  }
+});
+
+test('#340 (rider c): dataset_id is required and never inferred from `query`', () => {
+  // The service's third behaviour (socrata-tools.ts:531): given a non-SoQL
+  // `query` and no dataset_id, it uses the query string AS the dataset id.
+  //
+  // RED: exactly that fallback here — the helper would fetch
+  // `/resource/noise complaints.json` and report whatever came back as the
+  // dataset the analysis read. A dataset id guessed from a search phrase is a
+  // guess, and a notebook that guesses which dataset it read is not
+  // reproducing anything. A stricter helper than the service is a safe
+  // divergence; a guessing one is not.
+  const inferred = callFetchSocrata({ portal: 'data.test.gov', query: 'noise complaints' });
+  assert.equal(inferred.raised, 'SocrataDatasetIdRequired');
+  assert.match(inferred.message ?? '', /never[\s\S]*inferred from the query field/);
+  assert.equal(inferred.url, undefined, 'no request may be sent at all');
+
+  // Empty string is absence too, not a dataset named "".
+  const empty = callFetchSocrata({ portal: 'data.test.gov', dataset_id: '', query: 'noise' });
+  assert.equal(empty.raised, 'SocrataDatasetIdRequired');
+
+  // The error is a ValueError subclass, so a reader's own `except ValueError`
+  // still catches it — and the notebook's per-step guard prints its NAME,
+  // which is why the name has to say what is wrong.
+  const isValueError = runPython(
+    [
+      PY_PREAMBLE,
+      "print(json.dumps(issubclass(ns['SocrataDatasetIdRequired'], ValueError)))",
+    ].join('\n'),
+    '',
+    helperSource('fetch_socrata.py'),
+  );
+  assert.equal(isValueError.trim(), 'true');
+});
+
+test('#340: the renderer\'s helper-parameter lists match the helpers themselves', () => {
+  // `tool-to-cell.ts` will only emit a kwarg that is in its list for that
+  // helper. The list is therefore load-bearing in both directions, and neither
+  // failure is visible at render time:
+  //
+  //   - a name in the list that the .py does not have puts back exactly the
+  //     TypeError #340 is about;
+  //   - a parameter in the .py that is missing from the list is silently
+  //     dropped from every generated cell, and the analysis is reproduced with
+  //     an argument the original run did not have.
+  //
+  // Credential and transport parameters are the declared exception: a
+  // generated cell never writes them.
+  const NEVER_RENDERED = new Set(['app_token', 'api_key', 'timeout_s']);
+  const cases: Array<[string, string, readonly string[]]> = [
+    ['fetch_socrata.py', 'fetch_socrata', HELPER_PARAMETERS.fetch_socrata],
+    ['fetch_data_commons.py', 'fetch_data_commons', HELPER_PARAMETERS.fetch_data_commons],
+  ];
+  for (const [file, fn, declared] of cases) {
+    const signature = helperSignature(file, fn);
+    for (const name of declared) {
+      assert.ok(
+        signature.params.includes(name),
+        `${fn}: the renderer may emit ${name}=, which ${file} has no parameter for`,
+      );
+    }
+    for (const name of signature.params) {
+      if (NEVER_RENDERED.has(name)) continue;
+      assert.ok(
+        declared.includes(name),
+        `${fn}: ${file} has a parameter ${name} the renderer never emits — an argument the original call carried would be silently dropped`,
+      );
+    }
+    // No `**kwargs`. A helper that swallowed unknown keywords would make the
+    // check above pass while doing the thing it exists to prevent: the cell
+    // would run, the argument would have no effect, and nothing would say so.
+    assert.equal(signature.kwarg, null, `${fn}: a **kwargs catch-all silently ignores arguments`);
+  }
+});
+
+/** Every keyword argument the generated cell passes to a `fetch_*` call. */
+const PY_EMITTED_KWARGS = [
+  'import ast, json, sys',
+  'tree = ast.parse(sys.stdin.read())',
+  'names = []',
+  'for node in ast.walk(tree):',
+  '    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) '
+    + "and node.func.id.startswith('fetch_'):",
+  '        names.extend([kw.arg for kw in node.keywords])',
+  'print(json.dumps(names))',
+].join('\n');
+
+function emittedKwargs(cellSource: string): string[] {
+  return JSON.parse(runPython(PY_EMITTED_KWARGS, '', cellSource));
+}
+
+test('#340: every argument get_data advertises reaches a parameter that exists, or is not passed', () => {
+  // Wave criterion 9, as a property over the SCHEMA rather than over the one
+  // argument the issue named. `mcpTools` is what the model is told it may
+  // send, `fetch_socrata.py` is what the cell may call, and the renderer is
+  // the only thing between them — so the three are read here together.
+  //
+  // RED at the base: `query` is advertised, the renderer emitted it, and the
+  // helper had no such parameter. It goes red again the moment a property is
+  // added to the schema without a home on the other side.
+  const getData = mcpTools.find(
+    (t): t is Extract<typeof t, { type: 'function' }> =>
+      t.type === 'function' && t.function.name === 'get_data',
+  );
+  assert.ok(getData, 'get_data must still be advertised');
+  const advertised = Object.keys(
+    (getData!.function.parameters as { properties: Record<string, unknown> }).properties,
+  );
+  assert.ok(advertised.includes('query'), 'the argument #340 is about is still advertised');
+
+  // `type` selects which renderer runs; it is not an argument to any helper
+  // and is deliberately never written into the Python. Every OTHER advertised
+  // argument must reach a parameter that exists.
+  const ROUTING_ONLY = new Set(['type']);
+  const helperParams = helperSignature('fetch_socrata.py', 'fetch_socrata').params;
+
+  // A phrase-shaped `query` is the branch that supersedes nothing, so this
+  // call is the one that renders the widest set of kwargs.
+  const args: Record<string, unknown> = {};
+  for (const name of advertised) {
+    args[name] = name === 'type' ? 'query'
+      : name === 'portal' ? 'data.test.gov'
+      : name === 'dataset_id' ? 'abcd-1234'
+      : name === 'query' ? 'noise complaints'
+      : name === 'limit' || name === 'offset' ? 5
+      : `${name}-value`;
+  }
+  const rendered = renderFetchToolCell({ name: 'get_data', args }, {
+    dataFrameIndex: 1,
+    defaultPortal: 'data.test.gov',
+  });
+  assert.ok(rendered, 'a type=query call must render a cell');
+  const code = rendered!.cells.find(c => c.cell_type === 'code');
+  assert.ok(code, 'a type=query call must render a code cell');
+  const emitted = emittedKwargs(code!.source.join(''));
+
+  for (const name of emitted) {
+    assert.ok(
+      helperParams.includes(name),
+      `the cell passes ${name}=, which fetch_socrata has no parameter for — ` +
+        'Python raises TypeError and the reader is told live data could not be fetched',
+    );
+  }
+  for (const name of advertised) {
+    if (ROUTING_ONLY.has(name)) {
+      assert.ok(!emitted.includes(name), `${name} is call routing and must never be written into Python`);
+      continue;
+    }
+    assert.ok(
+      emitted.includes(name),
+      `get_data advertises ${name}, the model can send it, and this cell neither passes it nor ` +
+        'discloses it — it would be dropped from the reproduction in silence',
+    );
+  }
+});

--- a/src/lib/notebook-author/helpers/fetch_socrata.py
+++ b/src/lib/notebook-author/helpers/fetch_socrata.py
@@ -4,16 +4,59 @@ Embedded inline in cell-3 of executed civic-ai-tools notebooks (ADR-0005 §3).
 Self-contained: only requires `requests` and `pandas` (pinned in the notebook
 environment). When a portal honors `X-App-Token`, the caller may pass one;
 unauthenticated calls work but are rate-limited.
+
+`query` mirrors the data-access service the original analysis ran through, so
+a cell generated from that analysis reproduces what actually happened:
+
+  * A full SoQL statement (one that starts with SELECT) is sent as the whole
+    query. `select` / `where` / `group` / `order` — and `limit` / `offset` —
+    are then NOT sent, exactly as the service does not send them. The number
+    of rows you get back is whatever the statement's own LIMIT allows, or the
+    portal's default page size when it carries none.
+  * Anything else is a search phrase, sent as a full-text search across the
+    dataset, with every other clause applied alongside it.
+
+One deliberate difference from the service: this helper always requires an
+explicit `dataset_id` and never derives one from `query`. See
+`SocrataDatasetIdRequired`.
 """
+# Type hints are not evaluated at import time, so this helper also loads on
+# interpreters older than the 3.13 the notebook pins.
+from __future__ import annotations
+
 import os
+import re
 import requests
 import pandas as pd
 
 
+class SocrataDatasetIdRequired(ValueError):
+    """Raised when `fetch_socrata` is called without an explicit dataset_id.
+
+    The data-access service this helper mirrors will, for a `query` that is
+    NOT a full SoQL statement, fall back to treating the query string itself
+    as the dataset id. This helper deliberately does not: a dataset id
+    inferred from a search phrase is a guess, and a notebook that guesses
+    which dataset it read is not reproducing the analysis it claims to
+    reproduce. Pass `dataset_id` explicitly.
+    """
+
+
+def _is_full_soql_query(query: str) -> bool:
+    """True when `query` is a full SoQL statement rather than a search phrase.
+
+    Mirrors the sniff the data-access service applies to the same field. Kept
+    as one named function so a reader re-running this cell with different
+    arguments can see which branch their own `query` takes.
+    """
+    return re.match(r"^\s*select", query, re.IGNORECASE) is not None
+
+
 def fetch_socrata(
     portal: str,
-    dataset_id: str,
+    dataset_id: str | None = None,
     *,
+    query: str | None = None,
     select: str | None = None,
     where: str | None = None,
     group: str | None = None,
@@ -28,6 +71,11 @@ def fetch_socrata(
     Args:
         portal: Hostname of the Socrata portal (e.g. `data.cityofnewyork.us`).
         dataset_id: Dataset identifier (the 4x4 slug, e.g. `erm2-nwe9`).
+            Required: never inferred from `query`.
+        query: Either a full SoQL statement (starting with SELECT), which is
+            sent as the whole query and supersedes `select`, `where`, `group`,
+            `order`, `limit` and `offset`; or a search phrase, run as a
+            full-text search across the dataset alongside the other clauses.
         select, where, group, order, limit, offset: SoQL clauses. Strings.
         app_token: Optional Socrata app token; falls back to env
             `SOCRATA_APP_TOKEN`. Anonymous access works but is throttled.
@@ -35,21 +83,37 @@ def fetch_socrata(
 
     Returns:
         A pandas DataFrame; one row per record returned by the portal.
+
+    Raises:
+        SocrataDatasetIdRequired: when `dataset_id` is missing or empty.
     """
+    if not dataset_id:
+        raise SocrataDatasetIdRequired(
+            "fetch_socrata requires an explicit dataset_id; it is never "
+            "inferred from the query field."
+        )
     url = f"https://{portal}/resource/{dataset_id}.json"
     params: dict[str, str] = {}
-    if select is not None:
-        params["$select"] = select
-    if where is not None:
-        params["$where"] = where
-    if group is not None:
-        params["$group"] = group
-    if order is not None:
-        params["$order"] = order
-    if limit is not None:
-        params["$limit"] = str(limit)
-    if offset is not None:
-        params["$offset"] = str(offset)
+    if query is not None and _is_full_soql_query(query):
+        # The full statement IS the query: no $select/$where/$group/$order and
+        # no $limit/$offset travel with it, so nothing here silently narrows
+        # what the statement asked for.
+        params["$query"] = query
+    else:
+        if query is not None:
+            params["$q"] = query
+        if select is not None:
+            params["$select"] = select
+        if where is not None:
+            params["$where"] = where
+        if group is not None:
+            params["$group"] = group
+        if order is not None:
+            params["$order"] = order
+        if limit is not None:
+            params["$limit"] = str(limit)
+        if offset is not None:
+            params["$offset"] = str(offset)
     headers: dict[str, str] = {}
     token = app_token or os.environ.get("SOCRATA_APP_TOKEN")
     if token:

--- a/src/lib/notebook-author/notebook-claims.test.ts
+++ b/src/lib/notebook-author/notebook-claims.test.ts
@@ -69,6 +69,13 @@ const FAILED_CALL = {
   failureKind: 'timeout' as const,
 };
 
+const SUCCESSFUL_DISCOVERY = {
+  name: 'get_data',
+  operationType: 'catalog',
+  args: { type: 'catalog', portal: 'data.cityofnewyork.us', query: 'noise complaints' },
+  resultSummary: { rows: 40, columns: 4 },
+};
+
 const FAILED_DISCOVERY = {
   name: 'get_data',
   operationType: 'catalog',
@@ -106,15 +113,33 @@ test('#341: a notebook whose every fetch failed does not claim a reproducible an
   const cover = coverText(notebook);
 
   assert.doesNotMatch(cover, new RegExp(CLAIM));
-  assert.match(cover, /No data was fetched when this notebook ran/);
+  assert.match(cover, /This notebook reproduces no data fetch/);
+  assert.match(cover, /why each step produced nothing to re-run/);
   // And it names the specific trap: the synthesis cell falls back to the
   // original answer text, so its figures are not this notebook's output.
-  assert.match(cover, /come from the\noriginal analysis text, not from data this notebook fetched/);
+  assert.match(cover, /come from that analysis text, not from data this\nnotebook fetched/);
   assert.equal(
     notebook.cells.filter(c => c.cell_type === 'code' && c.source.join('').includes('= fetch_')).length,
     0,
     'the fixture must really contain no fetch — otherwise this test proves nothing',
   );
+});
+
+test('#341: a notebook that never fetched is not told its requests failed', () => {
+  // The false-precision trap on the other side of the same conditional. An
+  // analysis can answer from discovery alone — catalog searches that all
+  // SUCCEEDED — and still render no fetch step. The cover text for zero
+  // reproduced fetches is therefore written about the DOCUMENT ("no step
+  // re-runs a request"), never about the requests: telling this reader that
+  // every request "returned no data" would be a new false claim in the cell
+  // that exists to stop one.
+  const cover = coverText(
+    synthesizeNotebook({ ...BASE_INPUTS, toolCalls: [SUCCESSFUL_DISCOVERY] }).notebook,
+  );
+  assert.doesNotMatch(cover, new RegExp(CLAIM));
+  assert.match(cover, /reproduces no data fetch/);
+  assert.doesNotMatch(cover, /returned no data/, 'the discovery call did return data');
+  assert.doesNotMatch(cover, /every request/);
 });
 
 test('#341: a notebook with one surviving fetch keeps the claim', () => {

--- a/src/lib/notebook-author/notebook-claims.test.ts
+++ b/src/lib/notebook-author/notebook-claims.test.ts
@@ -1,0 +1,220 @@
+// What a generated notebook is allowed to say about itself (Wave N8 P5, #341
+// and the notebook-identity half of #324).
+//
+// Two claims live in the cover cell of every notebook, and at the base both
+// were made unconditionally:
+//
+//   1. "This notebook contains a complete, reproducible analysis of the query
+//      above" (prompt.ts:81). A notebook whose every fetch FAILED said this
+//      too — and `validateExecutedNotebook` reported it `ok`, because the two
+//      validators it ran check extension shape and an all-failed notebook is
+//      perfectly well shaped. Its synthesis cell falls back to displaying the
+//      original chat answer, so the original figures rendered as the
+//      document's conclusion with nothing behind them, under cover text
+//      telling the reader they could re-run it and get the same numbers.
+//
+//   2. The title `# Civic AI Data Analysis` (prompt.ts:73, notebook.ts:106) —
+//      the reference deployment's name, hardcoded into a file every instance's
+//      readers download, three lines above an attribution line that was
+//      already honest about an instance having declared no identity (#258 A2).
+//
+// Run with: npm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCell0Source } from './prompt.ts';
+import { synthesizeNotebook } from './synthesize.ts';
+import { stampExecutedNotebook } from './phase-d.ts';
+import { validateExecutedNotebook, validateReproducedFetches } from './validate.ts';
+import { generateNotebook } from '../notebook.ts';
+import { modelAccessPhrase } from '../model-catalog.ts';
+
+const CLAIM = 'complete, reproducible analysis';
+
+const BASE_INPUTS = {
+  query: 'Top 5 complaint types in Brooklyn over the past 30 days',
+  defaultPortal: 'data.cityofnewyork.us',
+  modelName: 'anthropic/claude-sonnet-4-6',
+  modelAccess: modelAccessPhrase('openai-compatible'),
+  generatedAt: '2026-05-21T14:00:00.000Z',
+  finalAnswer: 'Noise complaints led with 4,812 reports.',
+};
+
+const SUCCESSFUL_CALL = {
+  name: 'get_data',
+  operationType: 'query',
+  args: {
+    type: 'query',
+    portal: 'data.cityofnewyork.us',
+    dataset_id: 'erm2-nwe9',
+    select: 'complaint_type, count(*) as count',
+    group: 'complaint_type',
+    limit: 5,
+  },
+  reason: 'to aggregate by complaint_type',
+  resultSummary: { rows: 5, columns: 2 },
+};
+
+const FAILED_CALL = {
+  name: 'get_data',
+  operationType: 'query',
+  args: {
+    type: 'query',
+    portal: 'data.cityofnewyork.us',
+    dataset_id: 'erm2-nwe9',
+    select: 'complaint_type, count(*) as count',
+  },
+  reason: 'to aggregate by complaint_type',
+  failed: true,
+  failureKind: 'timeout' as const,
+};
+
+const FAILED_DISCOVERY = {
+  name: 'get_data',
+  operationType: 'catalog',
+  args: { type: 'catalog', portal: 'data.cityofnewyork.us', query: 'noise complaints' },
+  failed: true,
+  failureKind: 'unavailable' as const,
+};
+
+function allFailed() {
+  return synthesizeNotebook({ ...BASE_INPUTS, toolCalls: [FAILED_DISCOVERY, FAILED_CALL] });
+}
+
+function oneSucceeded() {
+  return synthesizeNotebook({ ...BASE_INPUTS, toolCalls: [FAILED_DISCOVERY, SUCCESSFUL_CALL] });
+}
+
+function coverText(notebook: { cells: Array<{ source: string[] }> }): string {
+  return notebook.cells[0].source.join('');
+}
+
+function stamp(synth: ReturnType<typeof synthesizeNotebook>) {
+  stampExecutedNotebook(
+    synth.notebook,
+    { executedAt: '2026-05-21T14:23:45.000Z', executionDuration_ms: 12340 },
+    synth.dataFrameVariables,
+  );
+  return synth.notebook;
+}
+
+test('#341: a notebook whose every fetch failed does not claim a reproducible analysis', () => {
+  // RED at the base: prompt.ts:81 was unconditional, so this notebook — which
+  // contains no fetch at all — told the reader that re-running its cells would
+  // reproduce the same numbers.
+  const notebook = allFailed().notebook;
+  const cover = coverText(notebook);
+
+  assert.doesNotMatch(cover, new RegExp(CLAIM));
+  assert.match(cover, /No data was fetched when this notebook ran/);
+  // And it names the specific trap: the synthesis cell falls back to the
+  // original answer text, so its figures are not this notebook's output.
+  assert.match(cover, /come from the\noriginal analysis text, not from data this notebook fetched/);
+  assert.equal(
+    notebook.cells.filter(c => c.cell_type === 'code' && c.source.join('').includes('= fetch_')).length,
+    0,
+    'the fixture must really contain no fetch — otherwise this test proves nothing',
+  );
+});
+
+test('#341: a notebook with one surviving fetch keeps the claim', () => {
+  // The positive control. A conditional that is always false would satisfy the
+  // test above while removing a true statement from every notebook.
+  const cover = coverText(oneSucceeded().notebook);
+  assert.match(cover, new RegExp(CLAIM));
+  assert.doesNotMatch(cover, /No data was fetched/);
+});
+
+test('#341: validateExecutedNotebook reports an all-failed notebook', () => {
+  // RED at the base: validate.ts:140-145 merged the provenance and execution
+  // validators only, so this notebook validated `ok: true` and the pipeline
+  // emitted it as valid.
+  const result = validateExecutedNotebook(stamp(allFailed()));
+  assert.equal(result.ok, false);
+  const messages = result.issues.map(i => i.message).join(' | ');
+  assert.match(messages, /no step re-runs a data fetch/);
+  assert.ok(
+    result.issues.some(i => i.path === 'cells'),
+    `the issue must point at the cells, not at a metadata path: ${JSON.stringify(result.issues)}`,
+  );
+});
+
+test('#341: a stamped notebook that reproduces a fetch still validates clean', () => {
+  // The other positive control — and the one that would catch a check written
+  // so broadly that every notebook fails it.
+  const result = validateExecutedNotebook(stamp(oneSucceeded()));
+  assert.deepEqual(result.issues, [], `unexpected issues: ${JSON.stringify(result.issues)}`);
+  assert.ok(result.ok);
+});
+
+test('#341: the cover claim and the validator answer the same question', () => {
+  // The two halves are computed by different means on purpose: the cover cell
+  // from the tool calls (it is written before any step cell exists), the
+  // validator from the cells themselves (so it cannot be satisfied by a claim
+  // the metadata makes). They must still agree — a notebook that says it
+  // reproduces nothing while validating clean, or the reverse, is a document
+  // arguing with itself.
+  for (const [label, synth] of [['all failed', allFailed()], ['one succeeded', oneSucceeded()]] as const) {
+    const claimsReproducible = coverText(synth.notebook).includes(CLAIM);
+    const validates = validateReproducedFetches(synth.notebook).ok;
+    assert.equal(claimsReproducible, validates, `${label}: cover text and validator disagree`);
+  }
+});
+
+// --- #324: the notebook's own identity -------------------------------------
+
+const TITLE_VARS = ['PUBLISHER_PLATFORM_AGENT_TITLE', 'EVIDENCE_PLATFORM_AGENT_TITLE'] as const;
+
+function withPlatformTitle<T>(title: string | null, fn: () => T): T {
+  const saved: Record<string, string | undefined> = {};
+  for (const name of TITLE_VARS) {
+    saved[name] = process.env[name];
+    delete process.env[name];
+  }
+  if (title !== null) process.env.PUBLISHER_PLATFORM_AGENT_TITLE = title;
+  try {
+    return fn();
+  } finally {
+    for (const name of TITLE_VARS) {
+      if (saved[name] === undefined) delete process.env[name];
+      else process.env[name] = saved[name];
+    }
+  }
+}
+
+test('#324: the executed notebook is titled by the instance, or by nothing', () => {
+  // RED at the base: `# Civic AI Data Analysis` on every instance, in a file
+  // readers download — while the "via …" line immediately below already
+  // omitted an identity the instance had not declared (#258 A2). One line
+  // borrowed a name; the next refused to.
+  const declared = withPlatformTitle('Harbor City Data Lab', () =>
+    buildCell0Source({ query: 'How many permits?', generatedAt: '2026-06-01', portals: [] }));
+  assert.match(declared, /^# Harbor City Data Lab Data Analysis$/m);
+  assert.doesNotMatch(declared, /Civic AI/);
+
+  const undeclared = withPlatformTitle(null, () =>
+    buildCell0Source({ query: 'How many permits?', generatedAt: '2026-06-01', portals: [] }));
+  assert.match(undeclared, /^# Data Analysis$/m);
+  assert.doesNotMatch(undeclared, /Civic AI/, 'no borrowed name on an instance that declared none');
+});
+
+test('#324: the downloadable skeleton notebook is titled the same way', () => {
+  // The second copy of the same hardcoded line (notebook.ts:106). It takes its
+  // identity as a threaded parameter rather than from the environment, because
+  // it is bundled into client components — so the conditional is on the
+  // threaded value, and both copies had to move for the defect to close.
+  const declared = generateNotebook('q', 'data.example.gov', [], 'answer', {
+    origin: 'https://harbor.example.org',
+    host: 'harbor.example.org',
+    platformTitle: 'Harbor City Data Lab',
+  });
+  assert.equal(declared.cells[0].source[0], '# Harbor City Data Lab Data Analysis\n');
+
+  const undeclared = generateNotebook('q', 'data.example.gov', [], 'answer', {
+    origin: null,
+    host: null,
+    platformTitle: null,
+  });
+  assert.equal(undeclared.cells[0].source[0], '# Data Analysis\n');
+  assert.doesNotMatch(JSON.stringify(undeclared), /Civic AI/);
+});

--- a/src/lib/notebook-author/prompt.ts
+++ b/src/lib/notebook-author/prompt.ts
@@ -60,6 +60,18 @@ export function buildCell0Source(args: {
   query: string;
   generatedAt: string;
   portals: readonly string[];
+  /**
+   * How many steps in this notebook re-run a data fetch (#341). Zero switches
+   * the cover text to the honest version below: a notebook whose every fetch
+   * failed contains no reproducible analysis, and the synthesis cell falls
+   * back to displaying the original answer, so its figures would otherwise
+   * read as a conclusion with nothing behind them.
+   *
+   * Optional so the parameter can be added without a silent behaviour change
+   * at call sites that do not know the count; the production caller
+   * (`synthesize.ts`) always passes it, and a test pins that it does.
+   */
+  reproducedFetchCount?: number;
 }): string {
   const portalLine = args.portals.length === 0
     ? ''
@@ -69,8 +81,15 @@ export function buildCell0Source(args: {
   const host = getPublicationHost();
   const origin = getEvidenceSiteOrigin();
   const viaSuffix = host && origin ? ` via [${host}](${origin})` : '';
+  // #324: the same conditional, applied to the title one line up. The heading
+  // used to name the reference deployment on every instance, inside a file
+  // readers download — while the attribution three lines below was already
+  // honest about an undeclared identity. An instance that has declared none
+  // gets the description without the name, never a borrowed one.
+  const platformTitle = getPlatformTitle();
+  const nothingReproduced = args.reproducedFetchCount === 0;
   return [
-    '# Civic AI Data Analysis',
+    platformTitle ? `# ${platformTitle} Data Analysis` : '# Data Analysis',
     '',
     `**Query:** ${args.query}  `,
     portalLine.trimEnd(),
@@ -78,10 +97,20 @@ export function buildCell0Source(args: {
     '',
     '## How to use this notebook',
     '',
-    'This notebook contains a complete, reproducible analysis of the query above.',
-    'Every code cell that fetches data uses the helper functions defined below,',
-    'so the same numbers can be reproduced against live data by re-running cells',
-    'top-to-bottom. The final "Synthesis" cell explains what the data shows.',
+    ...(nothingReproduced
+      ? [
+        'No data was fetched when this notebook ran: every request to a live data',
+        'source returned no data, so no step below reproduces one. The steps record',
+        'what was attempted. Any figures in the "Synthesis" cell come from the',
+        'original analysis text, not from data this notebook fetched — re-running',
+        'the cells will not reproduce them.',
+      ]
+      : [
+        'This notebook contains a complete, reproducible analysis of the query above.',
+        'Every code cell that fetches data uses the helper functions defined below,',
+        'so the same numbers can be reproduced against live data by re-running cells',
+        'top-to-bottom. The final "Synthesis" cell explains what the data shows.',
+      ]),
     '',
     '## Notebook structure',
     '',

--- a/src/lib/notebook-author/prompt.ts
+++ b/src/lib/notebook-author/prompt.ts
@@ -67,6 +67,12 @@ export function buildCell0Source(args: {
    * back to displaying the original answer, so its figures would otherwise
    * read as a conclusion with nothing behind them.
    *
+   * The alternative text says what is true of the DOCUMENT — that no step
+   * re-runs a fetch — rather than asserting that every request failed. Zero
+   * also covers an analysis that only ever ran discovery calls, and telling
+   * that reader their catalog searches "returned no data" would be the same
+   * false precision one step to the left.
+   *
    * Optional so the parameter can be added without a silent behaviour change
    * at call sites that do not know the count; the production caller
    * (`synthesize.ts`) always passes it, and a test pins that it does.
@@ -99,11 +105,11 @@ export function buildCell0Source(args: {
     '',
     ...(nothingReproduced
       ? [
-        'No data was fetched when this notebook ran: every request to a live data',
-        'source returned no data, so no step below reproduces one. The steps record',
-        'what was attempted. Any figures in the "Synthesis" cell come from the',
-        'original analysis text, not from data this notebook fetched — re-running',
-        'the cells will not reproduce them.',
+        'This notebook reproduces no data fetch: no step below re-runs a request',
+        'against a live data source. The steps record what the original analysis',
+        'attempted, and why each step produced nothing to re-run. Any figures in',
+        'the "Synthesis" cell come from that analysis text, not from data this',
+        'notebook fetched — re-running the cells will not reproduce them.',
       ]
       : [
         'This notebook contains a complete, reproducible analysis of the query above.',

--- a/src/lib/notebook-author/synthesize.test.ts
+++ b/src/lib/notebook-author/synthesize.test.ts
@@ -63,7 +63,11 @@ test('synthesizeNotebook: produces an executed-flavor notebook with the expected
   // Cell 0: title
   assert.equal(cells[0].cell_type, 'markdown');
   const cell0Source = cells[0].source.join('');
-  assert.match(cell0Source, /Civic AI Data Analysis/);
+  // #324: the heading is the instance's declared identity plus the
+  // description, or the description alone when no identity is declared. This
+  // suite runs with no identity env, so it is the latter — and in particular
+  // it is no longer the reference deployment's name on every instance.
+  assert.match(cell0Source, /^# Data Analysis$/m);
   assert.match(cell0Source, /Show me top 5 311 complaint types/);
   assert.match(cell0Source, /data\.cityofnewyork\.us/);
 

--- a/src/lib/notebook-author/synthesize.ts
+++ b/src/lib/notebook-author/synthesize.ts
@@ -39,6 +39,7 @@ import {
 } from './prompt.ts';
 import {
   type PhaseAToolCall,
+  countReproducibleFetches,
   renderDiscoverySummaryCell,
   renderFetchToolCell,
 } from './tool-to-cell.ts';
@@ -102,11 +103,15 @@ export function synthesizeNotebook(inputs: PhaseAOutputs): SynthesisOutputs {
 
   const notebook = emptyNotebook(PYTHON_RUNTIME_VERSION);
 
-  // Cell 0 — branding + query + onboarding
+  // Cell 0 — branding + query + onboarding. The fetch count is computed from
+  // the tool calls, not from the cells: cell 0 is written before the step
+  // cells exist, and its claim about what this notebook reproduces has to be
+  // true of the document that follows it (#341).
   notebook.cells.push(markdownCell(buildCell0Source({
     query: inputs.query,
     generatedAt,
     portals,
+    reproducedFetchCount: countReproducibleFetches(inputs.toolCalls),
   })));
   // Cell 1 — environment setup
   notebook.cells.push(codeCell(buildCell1Source()));

--- a/src/lib/notebook-author/tool-to-cell.test.ts
+++ b/src/lib/notebook-author/tool-to-cell.test.ts
@@ -21,6 +21,9 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import type { NotebookCell } from './cells.ts';
 import {
+  SOQL_QUERY_SNIFF,
+  countReproducedFetchCells,
+  isFullSoqlQuery,
   renderDiscoverySummaryCell,
   renderFetchToolCell,
   TOOL_FAILURE_KINDS,
@@ -487,4 +490,346 @@ test('#321: a failed call with no failureKind still renders, reading as `unknown
   assert.equal(out!.cells.filter(c => c.cell_type === 'code').length, 0);
   assert.match(md, /could not be completed/);
   assert.doesNotMatch(md, /undefined/);
+});
+
+// --- #340: the `query` argument -------------------------------------------
+//
+// Wave N8 P5. `get_data` advertises `query`, the data-access service honours
+// it, and the generated cell forwarded it to a helper that had no such
+// parameter: Python raised `TypeError` and the reader was told live data could
+// not be fetched. The fix is the helper parameter PLUS the service's own
+// precedence, made visible — a cell must never carry a `select=` or `where=`
+// that had no effect on the numbers above it.
+//
+// THE COUPLING THIS SECTION PINS, AND WHAT TO DO WHEN IT MOVES.
+// The sniff below is a copy of a regular expression that lives in ANOTHER
+// repository:
+//
+//     socrata-mcp-server/src/tools/socrata-tools.ts:546
+//     at commit 116f46ce1e84e3608014599f9b63ea01acfd913a
+//
+//         if (queryField && /^\s*select/i.test(queryField)) { … }
+//
+//   matching  → `$query` alone; select/where/order/group/having/q are set
+//               aside (:547-553) and the request carries neither $limit nor
+//               $offset (:283-293);
+//   otherwise → `$q`, with every other clause preserved (:555-557).
+//
+// IF THE SERVICE CHANGES ITS SNIFF, THE FIX IS AN ISSUE ON THIS REPOSITORY —
+// so this copy, `helpers/fetch_socrata.py`'s `_is_full_soql_query` and the
+// service move together. A change made on one side alone is a silent
+// divergence that surfaces only in a published notebook, where a reader is
+// told a `limit=` applied that never did.
+
+/** The service's regex, transcribed literally from the line cited above. */
+const SERVICE_SOQL_SNIFF = /^\s*select/i;
+
+/**
+ * A fixture lifted from the service's own suite —
+ * `socrata-mcp-server/src/__tests__/search.test.ts:165`,
+ * `test('handles full SoQL query')`: it drives
+ * `soqlQuery: 'SELECT * WHERE category = "test" LIMIT 42'`, asserts the
+ * request carries `{ $query: <that string> }` and nothing else, and gets 42
+ * rows back from a single call. 42 because the statement's own LIMIT says so —
+ * which is exactly the row bound our generated comment must name once `limit=`
+ * is gone.
+ */
+const SERVICE_SUITE_SOQL = 'SELECT * WHERE category = "test" LIMIT 42';
+
+const SOQL_QUERY_CALL: PhaseAToolCall = {
+  name: 'get_data',
+  operationType: 'query',
+  args: {
+    type: 'query',
+    portal: 'data.cityofnewyork.us',
+    dataset_id: 'erm2-nwe9',
+    query: SERVICE_SUITE_SOQL,
+    // Carried by the same call and superseded by the statement above. Before
+    // the fix these rendered beside it as arguments with no effect.
+    select: 'complaint_type, count(*) as count',
+    where: 'complaint_type IS NOT NULL',
+    limit: 5,
+  },
+  reason: 'to aggregate by complaint_type',
+  resultSummary: { rows: 42, columns: 2 },
+};
+
+const PHRASE_QUERY_CALL: PhaseAToolCall = {
+  name: 'get_data',
+  operationType: 'query',
+  args: {
+    type: 'query',
+    portal: 'data.cityofnewyork.us',
+    dataset_id: 'erm2-nwe9',
+    query: 'noise complaints',
+    where: "borough = 'BROOKLYN'",
+    limit: 5,
+  },
+  resultSummary: { rows: 5, columns: 3 },
+};
+
+test("#340: our sniff IS the service's sniff, character for character", () => {
+  // RED: any re-spelling of the predicate — `startsWith('SELECT')`,
+  // `/^select/i` without `\s*`, a `.trim()` first — passes a behavioural test
+  // on well-formed input and diverges on the inputs that differ. So compare
+  // the patterns themselves, then the behaviour, then the service's fixture.
+  assert.equal(SOQL_QUERY_SNIFF.source, SERVICE_SOQL_SNIFF.source);
+  assert.equal(SOQL_QUERY_SNIFF.flags, SERVICE_SOQL_SNIFF.flags);
+
+  const cases = [
+    SERVICE_SUITE_SOQL,
+    'select * from x',
+    '   SELECT count(*) AS n',
+    '\n\tSELECT complaint_type',
+    'SeLeCt 1',
+    'noise complaints',
+    'selected noise complaints',
+    '',
+    'WHERE complaint_type = "Noise"',
+    ' 311 selected complaints',
+  ];
+  for (const value of cases) {
+    assert.equal(
+      isFullSoqlQuery(value),
+      SERVICE_SOQL_SNIFF.test(value),
+      `divergence from the service's sniff on ${JSON.stringify(value)}`,
+    );
+  }
+  // The service's own fixture takes the SoQL branch, as its suite asserts.
+  assert.equal(isFullSoqlQuery(SERVICE_SUITE_SOQL), true);
+});
+
+test('#340: a SoQL query renders `query=` and no superseded kwarg', () => {
+  // RED at the base: `query` was absent from SOCRATA_QUERY_KWARGS, so pyKwargs
+  // appended it as an unenumerated key AND emitted select/where/limit beside
+  // it — a helper TypeError on execution, and a cell showing three arguments
+  // that had no effect on the rows the analysis actually got.
+  const [cell] = codeCells(SOQL_QUERY_CALL);
+  const source = cell.source.join('');
+  assertParsesAsPython(cell, 'socrata SoQL query');
+  assertFetchIsGuarded(cell, 'socrata SoQL query');
+
+  assert.match(source, /query="SELECT \\?\* WHERE category = \\"test\\" LIMIT 42"/);
+  for (const superseded of ['select=', 'where=', 'group=', 'order=', 'limit=', 'offset=']) {
+    assert.doesNotMatch(
+      source,
+      new RegExp(superseded),
+      `${superseded} had no effect on this call and must not appear in the cell:\n${source}`,
+    );
+  }
+  assert.equal(source.split('query=').length - 1, 1, 'query= renders exactly once');
+});
+
+test('#340: the SoQL comment names the supersession AND the row bound', () => {
+  // RED: a comment that says only "the portal applies the full SoQL instead of
+  // the individual clauses". The reader can see that `limit=5` is gone; what
+  // they cannot see is what bounds the rows in its place, and a notebook that
+  // drops a bound without naming its replacement invites the reader to assume
+  // the one they wrote still applied.
+  const [cell] = codeCells(SOQL_QUERY_CALL);
+  const comment = cell.source.join('').split('try:')[0];
+
+  assert.match(comment, /full SoQL statement/);
+  assert.match(comment, /are not\n# sent alongside it/);
+  assert.match(comment, /Superseded on this call, for that reason: select, where, limit\./);
+  // The row bound — the half a supersession-only comment leaves out.
+  assert.match(comment, /bounded by the statement's own LIMIT/);
+  assert.match(comment, /portal's default page size/);
+  // Reader-facing language (design-principles.md Principle 9), no repo paths.
+  assert.doesNotMatch(comment, /MCP/i);
+  assert.doesNotMatch(comment, /socrata-mcp-server|socrata-tools\.ts/);
+});
+
+test('#340 (rider c): the comment discloses that dataset_id is never inferred', () => {
+  // The service has a third behaviour (socrata-tools.ts:531): a NON-SoQL query
+  // with no dataset_id BECOMES the dataset id. This notebook is deliberately
+  // stricter, and a divergence a reader discovers is worse than one they are
+  // told about — so it is stated in the same comment block.
+  for (const call of [SOQL_QUERY_CALL, PHRASE_QUERY_CALL]) {
+    const comment = codeCells(call)[0].source.join('').split('try:')[0];
+    assert.match(comment, /always requires\n# an explicit dataset_id and never derives one from `query`/);
+  }
+});
+
+test('#340: a phrase query renders `query=` alongside the clauses it does not supersede', () => {
+  // The other branch of the same split: `$q` is a full-text search and the
+  // service preserves every other clause, so the cell must keep them. A helper
+  // that mapped `query` to `$query` unconditionally would reproduce this
+  // analysis differently than it ran.
+  const [cell] = codeCells(PHRASE_QUERY_CALL);
+  const source = cell.source.join('');
+  assertParsesAsPython(cell, 'socrata phrase query');
+  assert.match(source, /query="noise complaints"/);
+  assert.match(source, /where="borough = 'BROOKLYN'"/);
+  assert.match(source, /limit=5/);
+  assert.match(source, /full-text search/);
+  assert.doesNotMatch(source, /Superseded on this call/);
+});
+
+test('#340: a call with no `query` renders exactly as it did before', () => {
+  // The no-query path is the common one and must not gain a comment block it
+  // has no reason to carry. The byte-exact assertion for it is above; this
+  // pins the absence of the new material.
+  const source = codeCells(SOCRATA_CALL)[0].source.join('');
+  assert.ok(source.startsWith('try:'), `no comment block without a query arg:\n${source}`);
+  assert.doesNotMatch(source, /query=/);
+});
+
+test('#340: an arg the helper has no parameter for is disclosed, never emitted', () => {
+  // The general form of the same defect. `pyKwargs` forwarded every
+  // unenumerated key, so ANY arg outside the helper's signature — not only
+  // `query` — became a TypeError at execution and a "live data could not be
+  // fetched" line in a published notebook. RED: restore the unfiltered append.
+  const withHaving: PhaseAToolCall = {
+    ...PHRASE_QUERY_CALL,
+    args: { ...PHRASE_QUERY_CALL.args, having: 'count > 3' },
+  };
+  const [cell] = codeCells(withHaving);
+  const source = cell.source.join('');
+  assertParsesAsPython(cell, 'socrata query with an unsupported arg');
+  assert.doesNotMatch(source, /having=/, 'an unsupported kwarg must not be emitted');
+  assert.match(source, /The original call also passed having, which this helper has/);
+  assert.match(source, /no parameter for; disclosed here rather than passed and silently ignored\./);
+});
+
+test('#340 (rider c): a query call that named no dataset is not reproduced, and says why', () => {
+  // RED at the base: `dataset_id` fell back to the literal string 'unknown',
+  // so the cell fetched `https://…/resource/unknown.json` — a dataset id that
+  // never existed, written into a file the reader downloads and cited in the
+  // footer as the source of the step.
+  const unnamed: PhaseAToolCall = {
+    name: 'get_data',
+    operationType: 'query',
+    args: { type: 'query', portal: 'data.cityofnewyork.us', query: 'noise complaints' },
+    resultSummary: { rows: 12, columns: 3 },
+  };
+  const out = renderFetchToolCell(unnamed, CTX);
+  assert.ok(out, 'it must not return null — that would sweep it into the discovery summary');
+  assert.equal(out!.cells.filter(c => c.cell_type === 'code').length, 0);
+  assert.equal(out!.producedDataFrame, false);
+  assert.equal(out!.citation, null, 'nothing may be cited: we cannot say which dataset was read');
+
+  const md = out!.cells[0].source.join('');
+  assert.doesNotMatch(md, /unknown/, 'no placeholder standing where a dataset id would be');
+  assert.match(md, /did not name/);
+  assert.match(md, /does not derive dataset ids/);
+});
+
+// --- #342: the failed-call note describes what was attempted ---------------
+
+test('#342: a failed catalog search is described as a search, not as a dataset query', () => {
+  // RED: `tool-to-cell.ts:336` at the base dispatched on `call.name` alone, so
+  // EVERY failed get_data call read "tried to query the `unknown` dataset on
+  // …" — the wrong operation, against a dataset that was never named, with a
+  // placeholder rendered as if it were one. Three false claims in one
+  // sentence, in a document a reader downloads to scrutinise.
+  const failedCatalog: PhaseAToolCall = {
+    name: 'get_data',
+    operationType: 'catalog',
+    args: { type: 'catalog', portal: 'data.cityofnewyork.us', query: 'noise complaints' },
+    failed: true,
+    failureKind: 'unavailable',
+  };
+  const md = renderFetchToolCell(failedCatalog, CTX)!.cells[0].source.join('');
+
+  assert.match(md, /search the `data\.cityofnewyork\.us` data catalog for `noise complaints`/);
+  assert.doesNotMatch(md, /unknown/, 'no dataset named `unknown`');
+  assert.doesNotMatch(md, /query the/, 'a catalog search is not a dataset query');
+});
+
+test('#342: each get_data operation type is described as itself', () => {
+  const base = { name: 'get_data', failed: true, failureKind: 'timeout' } as const;
+  const expectations: Array<[Record<string, unknown>, RegExp]> = [
+    [{ type: 'catalog', portal: 'data.sfgov.org' }, /search the `data\.sfgov\.org` data catalog/],
+    [
+      { type: 'metadata', portal: 'data.sfgov.org', dataset_id: 'abcd-1234' },
+      /look up the description of the `abcd-1234` dataset/,
+    ],
+    // The service reads the id from `query` when dataset_id is absent, for
+    // metadata and metrics (socrata-tools.ts:509, :574) — so the note does too.
+    [{ type: 'metadata', portal: 'data.sfgov.org', query: 'abcd-1234' }, /the `abcd-1234` dataset/],
+    [
+      { type: 'metrics', portal: 'data.sfgov.org', dataset_id: 'abcd-1234' },
+      /check row counts and update times for the `abcd-1234` dataset/,
+    ],
+    [
+      { type: 'query', portal: 'data.sfgov.org', dataset_id: 'abcd-1234' },
+      /query the `abcd-1234` dataset/,
+    ],
+    // No dataset id, and none derivable: say less rather than invent one.
+    [{ type: 'query', portal: 'data.sfgov.org' }, /query a dataset on `data\.sfgov\.org`/],
+    // No type at all — the args carry only the portal, so that is all it says.
+    [{ portal: 'data.sfgov.org' }, /request data from `data\.sfgov\.org`/],
+  ];
+  for (const [args, expected] of expectations) {
+    const md = renderFetchToolCell({ ...base, args }, CTX)!.cells[0].source.join('');
+    assert.match(md, expected, `args ${JSON.stringify(args)} produced:\n${md}`);
+    assert.doesNotMatch(md, /`unknown`/, `args ${JSON.stringify(args)} produced a placeholder:\n${md}`);
+  }
+});
+
+test('#342: the other tools drop their `unknown` placeholders too', () => {
+  const cases: Array<[PhaseAToolCall, RegExp]> = [
+    [
+      { name: 'get_observations', args: {}, failed: true },
+      /fetch an indicator from Google Data Commons/,
+    ],
+    [
+      { name: 'get_observations', args: { variable_dcid: 'Count_Person' }, failed: true },
+      /fetch `Count_Person` from Google Data Commons/,
+    ],
+    [
+      { name: 'ckan__query_data', args: {}, failed: true },
+      /fetch records from the Boston open-data store/,
+    ],
+  ];
+  for (const [call, expected] of cases) {
+    const md = renderFetchToolCell(call, CTX)!.cells[0].source.join('');
+    assert.match(md, expected, `produced:\n${md}`);
+    assert.doesNotMatch(md, /`unknown`/, `produced a placeholder:\n${md}`);
+  }
+});
+
+// --- #341's detector: which cells re-run a fetch ---------------------------
+
+test('#341: a rendered fetch cell is recognised as one; nothing else is', () => {
+  // The detector `validate.ts` uses to decide whether a notebook reproduces
+  // anything at all. It lives beside the renderers that emit the shape it
+  // looks for, so a change to the emitted assignment is made next to its only
+  // detector. RED: have `guardedFetch` emit `dfN=fetch_x(` without spaces —
+  // this fails here, in the file that made the change, instead of silently
+  // reporting every notebook as reproducing nothing.
+  for (const [label, call] of ALL_FIXTURES) {
+    assert.equal(
+      countReproducedFetchCells(codeCells(call)),
+      1,
+      `${label}: its code cell must count as a reproduced fetch`,
+    );
+  }
+  // A failed call's note is markdown, and markdown never counts.
+  const failed = renderFetchToolCell(FAILED_SOCRATA_CALL, CTX)!;
+  assert.equal(countReproducedFetchCells(failed.cells), 0);
+});
+
+test('#341: the detector is not fooled by the helper-definitions cell', () => {
+  // A meta-test on the check itself. Cell 3 of every notebook carries the full
+  // text of `fetch_socrata`, including the characters `fetch_socrata(` in its
+  // own `def` line. A detector that searched for the helper NAME would count
+  // that cell and report every all-failed notebook as reproducing a fetch: the
+  // check would pass on exactly the document it exists to reject.
+  const decoy: NotebookCell = {
+    cell_type: 'code',
+    id: 'decoy',
+    metadata: {},
+    source: [
+      'def fetch_socrata(\n',
+      '    portal: str,\n',
+      '    dataset_id: str | None = None,\n',
+      ') -> pd.DataFrame:\n',
+      '    """A helper definition is not a fetch."""\n',
+      '    return pd.DataFrame()\n',
+    ],
+  };
+  assert.ok(decoy.source.join('').includes('fetch_socrata('), 'the decoy does contain the name');
+  assert.equal(countReproducedFetchCells([decoy]), 0);
 });

--- a/src/lib/notebook-author/tool-to-cell.ts
+++ b/src/lib/notebook-author/tool-to-cell.ts
@@ -100,25 +100,157 @@ function pyKwargs(
   args: Record<string, unknown>,
   order: readonly string[],
   handledKeys: readonly string[] = [],
+  supportedKeys?: readonly string[],
 ): string {
   const lines: string[] = [];
   const seen = new Set<string>(handledKeys);
+  const supported = supportedKeys ? new Set<string>(supportedKeys) : null;
   for (const key of order) {
+    // A key the caller has already accounted for is never emitted here, even
+    // when it is in `order`: since #340 a renderer can hand a clause to
+    // `handledKeys` because the generated comment explains its absence.
+    if (seen.has(key)) continue;
     if (args[key] === undefined || args[key] === null) continue;
     lines.push(`    ${key}=${pyRepr(args[key], '    ')},`);
     seen.add(key);
   }
-  // Append any extra args we did not enumerate so nothing silently drops.
+  // Append any extra args we did not enumerate so nothing silently drops —
+  // unless the helper has no such parameter, in which case emitting it would
+  // make the cell raise `TypeError` on execution and the reader would be told
+  // live data could not be fetched (#340). Those keys are reported by
+  // `unsupportedArgKeys` and disclosed in the cell instead.
   for (const [key, value] of Object.entries(args)) {
     if (seen.has(key)) continue;
     if (value === undefined || value === null) continue;
+    if (supported && !supported.has(key)) continue;
     lines.push(`    ${key}=${pyRepr(value, '    ')},`);
   }
   return lines.join('\n');
 }
 
+/**
+ * Args this call carried that the target helper has no parameter for, and
+ * that the caller has not accounted for by hand — the set `pyKwargs` refuses
+ * to emit. Named so a renderer can disclose them in the generated cell:
+ * nothing is silently ignored, because nothing ignored is written.
+ */
+function unsupportedArgKeys(
+  args: Record<string, unknown>,
+  supportedKeys: readonly string[],
+  handledKeys: readonly string[],
+): string[] {
+  const supported = new Set<string>(supportedKeys);
+  const handled = new Set<string>(handledKeys);
+  return Object.keys(args)
+    .filter(key => args[key] !== undefined && args[key] !== null)
+    .filter(key => !supported.has(key) && !handled.has(key))
+    .sort();
+}
+
 const SOCRATA_QUERY_KWARGS = ['select', 'where', 'group', 'order', 'limit', 'offset'] as const;
 const DC_OBS_KWARGS = ['date', 'child_place_type'] as const;
+
+/**
+ * Parameters of `helpers/fetch_socrata.py` a generated cell may pass, and the
+ * only keys the Socrata renderer will emit. Credential and transport
+ * parameters (`app_token`, `timeout_s`) are deliberately absent: a generated
+ * cell never writes them.
+ *
+ * Pinned against the helper's real signature by a test — a parameter added to
+ * the .py and not added here would be silently dropped from every cell, and a
+ * name here that the .py does not have would put back exactly the `TypeError`
+ * #340 is about.
+ */
+const FETCH_SOCRATA_PARAMS = [
+  'portal', 'dataset_id', 'query', 'select', 'where', 'group', 'order', 'limit', 'offset',
+] as const;
+
+/** Same contract as `FETCH_SOCRATA_PARAMS`, for `helpers/fetch_data_commons.py`. */
+const FETCH_DATA_COMMONS_PARAMS = [
+  'variable_dcid', 'place_dcid', 'date', 'child_place_type',
+] as const;
+
+/** Test-only view of the helper-parameter constants above. */
+export const HELPER_PARAMETERS: Record<string, readonly string[]> = {
+  fetch_socrata: FETCH_SOCRATA_PARAMS,
+  fetch_data_commons: FETCH_DATA_COMMONS_PARAMS,
+};
+
+/**
+ * The sniff that decides what a `query` argument on `get_data` means — copied
+ * deliberately, because the behaviour it selects belongs to another
+ * repository.
+ *
+ * MIRRORS: `socrata-mcp-server/src/tools/socrata-tools.ts:546`, at commit
+ * `116f46ce1e84e3608014599f9b63ea01acfd913a`:
+ *
+ *     if (queryField && /^\s*select/i.test(queryField)) { … }
+ *
+ * A `query` that matches becomes the whole SoQL request (`$query`) and the
+ * service sets `select`/`where`/`order`/`group`/`having`/`q` aside (`:547-553`);
+ * the request it then builds carries `$query` alone — `$limit` and `$offset`
+ * are not sent either (`:283-293`). A `query` that does not match becomes a
+ * full-text search term (`$q`, `:555-557`) with every other clause preserved.
+ *
+ * This constant, `helpers/fetch_socrata.py`'s `_is_full_soql_query`, and the
+ * service's line above are three copies of one rule. If the service changes
+ * its sniff, the fix is an issue on THIS repository so both copies move
+ * together — not a silent divergence discovered later in a published notebook.
+ * `tool-to-cell.test.ts` carries the service's regex literally and drives a
+ * fixture lifted from its own suite.
+ */
+export const SOQL_QUERY_SNIFF = /^\s*select/i;
+
+/** True when a `query` argument is a full SoQL statement rather than a phrase. */
+export function isFullSoqlQuery(query: string): boolean {
+  return SOQL_QUERY_SNIFF.test(query);
+}
+
+/**
+ * Clauses a full SoQL `query` supersedes: the service sets each aside
+ * (`socrata-tools.ts:547-553`) and then sends neither `$limit` nor `$offset`
+ * with a `$query` (`:283-293`). A cell that wrote any of them beside `query=`
+ * would show the reader an argument that had no effect on the numbers below —
+ * the false precision docs/design-principles.md Principle 3 forbids.
+ */
+const SOQL_SUPERSEDED_KWARGS = [
+  'select', 'where', 'group', 'order', 'having', 'q', 'limit', 'offset',
+] as const;
+
+/**
+ * The assignment every fetch cell in this module emits, as a fact about the
+ * rendered source: `dfN = fetch_<helper>(`, at any indentation (the fetch sits
+ * inside a `try` body). Owned here, beside the renderers that emit it, so a
+ * change to the emitted shape is made next to its only detector rather than
+ * silently breaking a scan that lives in another file (`validate.ts`).
+ */
+const REPRODUCED_FETCH_ASSIGNMENT = /^[ \t]*df\d+ = fetch_[a-z_]+\(/m;
+
+/** True when this cell re-runs a data fetch — see `REPRODUCED_FETCH_ASSIGNMENT`. */
+export function isReproducedFetchCell(cell: NotebookCell): boolean {
+  if (cell.cell_type !== 'code') return false;
+  return REPRODUCED_FETCH_ASSIGNMENT.test(cell.source.join(''));
+}
+
+/**
+ * How many of a notebook's cells re-run a data fetch. Zero means no step in
+ * the document rests on data it fetched itself (#341).
+ */
+export function countReproducedFetchCells(cells: readonly NotebookCell[]): number {
+  return cells.filter(isReproducedFetchCell).length;
+}
+
+/**
+ * How many of this analysis's tool calls will render as a re-runnable fetch —
+ * computed from the calls rather than from the cells, so a caller can ask
+ * before any cell exists (`synthesize.ts` builds the cover cell first).
+ */
+export function countReproducibleFetches(calls: readonly PhaseAToolCall[]): number {
+  return calls.filter(call => {
+    const out = renderFetchToolCell(call, { dataFrameIndex: 1, defaultPortal: '' });
+    return out !== null && out.producedDataFrame;
+  }).length;
+}
 
 export interface ToolCellOutput {
   /** Cells appended to the notebook for this tool call. */
@@ -190,14 +322,116 @@ function guardedFetch(dfVar: string, stepLabel: string, fetchCode: string): stri
   ].join('\n');
 }
 
+/**
+ * The generated comment that makes a `query` argument's effect legible (#340).
+ *
+ * Two things a reader cannot see from the arguments alone, and both change how
+ * they should read the numbers below:
+ *
+ *   - which clauses the data source did NOT apply, and why they are therefore
+ *     absent from the cell (they would be arguments with no effect);
+ *   - what bounds the row count once `limit` is gone — the statement's own
+ *     LIMIT, or the portal's default page, never the `limit` the original call
+ *     carried.
+ *
+ * Reader-facing text: "data source", never "MCP server" (design-principles.md
+ * Principle 9), and no repository paths — the coupling those cite is recorded
+ * beside `SOQL_QUERY_SNIFF`, in source a notebook reader never downloads.
+ */
+function socrataQueryComment(args: Record<string, unknown>, soql: boolean): string[] {
+  const lines: string[] = [];
+  if (soql) {
+    const superseded = SOQL_SUPERSEDED_KWARGS.filter(k => args[k] !== undefined && args[k] !== null);
+    lines.push(
+      '# `query` here is a full SoQL statement, so the data source applied it as the',
+      '# whole query: select / where / group / order — and limit / offset — are not',
+      '# sent alongside it. They are omitted below rather than written as arguments',
+      '# that would have no effect on the rows this cell returns.',
+    );
+    if (superseded.length > 0) {
+      lines.push(`# Superseded on this call, for that reason: ${superseded.join(', ')}.`);
+    }
+    lines.push(
+      '# The row count is therefore bounded by the statement\'s own LIMIT, or by the',
+      '# portal\'s default page size when the statement carries none.',
+    );
+  } else {
+    lines.push(
+      '# `query` here is a search phrase rather than a SoQL statement, so the data',
+      '# source ran it as a full-text search across the dataset and applied the',
+      '# clauses below alongside it.',
+    );
+  }
+  lines.push(
+    '# One deliberate difference from the original run: this helper always requires',
+    '# an explicit dataset_id and never derives one from `query`.',
+  );
+  return lines;
+}
+
+/**
+ * A `type=query` call that named no dataset (#340, rider c).
+ *
+ * The data source has a third behaviour here: given a `query` that is not a
+ * SoQL statement and no `dataset_id`, it treats the query string itself as the
+ * dataset id. This notebook does not reproduce that. A dataset id guessed from
+ * a search phrase is a guess, and a step that reads a dataset it cannot name
+ * is not a reproduction of anything.
+ *
+ * So the step becomes a markdown note, for the reason `renderFailedToolCell`
+ * already records: a cell that always raises is a broken step in a document
+ * whose cover text tells the reader it runs.
+ */
+function renderUnnamedDatasetCell(
+  call: PhaseAToolCall,
+  ctx: ToolCellContext,
+): ToolCellOutput {
+  const portal = (call.args.portal as string) || ctx.defaultPortal;
+  const reason = call.reason ? ` ${call.reason}` : '';
+  const md = [
+    `#### Not reproduced: \`get_data\` on \`${portal}\``,
+    '',
+    `The original analysis queried a dataset it did not name${reason}. The data source ` +
+      'derived one from the search phrase it was given; this notebook does not derive ' +
+      'dataset ids, because a dataset id guessed from a phrase is a guess.',
+    '',
+    'No code cell is generated for it. To reproduce this step, add the dataset ' +
+      'identifier to a `fetch_socrata(...)` call of your own.',
+  ].join('\n');
+  return {
+    cells: [markdownCell(md)],
+    producedDataFrame: false,
+    dataFrameVariable: null,
+    // Nothing may be cited: we cannot say which dataset was read.
+    citation: null,
+  };
+}
+
 function renderSocrataQueryCell(
   call: PhaseAToolCall,
   ctx: ToolCellContext,
 ): ToolCellOutput {
   const portal = (call.args.portal as string) || ctx.defaultPortal;
-  const datasetId = (call.args.dataset_id as string) || 'unknown';
+  const datasetId = typeof call.args.dataset_id === 'string' && call.args.dataset_id
+    ? call.args.dataset_id
+    : null;
+  if (!datasetId) return renderUnnamedDatasetCell(call, ctx);
+
+  const rawQuery = typeof call.args.query === 'string' && call.args.query.length > 0
+    ? call.args.query
+    : null;
+  const soql = rawQuery !== null && isFullSoqlQuery(rawQuery);
+
   const dfVar = `df${ctx.dataFrameIndex}`;
   const reason = call.reason ? ` ${call.reason}` : '';
+  // Under a full SoQL query the superseded clauses are accounted for by the
+  // generated comment, so `pyKwargs` must not emit them; they are "handled",
+  // exactly as `portal` and `dataset_id` are.
+  const handledKeys = soql
+    ? ['portal', 'dataset_id', 'type', 'query', ...SOQL_SUPERSEDED_KWARGS]
+    : ['portal', 'dataset_id', 'type', 'query'];
+  const unsupported = unsupportedArgKeys(call.args, FETCH_SOCRATA_PARAMS, handledKeys);
+
   const md = [
     `### Step ${ctx.dataFrameIndex}: Query \`${datasetId}\``,
     '',
@@ -206,13 +440,27 @@ function renderSocrataQueryCell(
       ? `Original execution returned ${call.resultSummary.rows} rows × ${call.resultSummary.columns} columns.`
       : '',
   ].filter(Boolean).join('\n');
-  const code = guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, [
-    `${dfVar} = fetch_socrata(`,
-    `    portal=${JSON.stringify(portal)},`,
-    `    dataset_id=${JSON.stringify(datasetId)},`,
-    pyKwargs(call.args, SOCRATA_QUERY_KWARGS, ['portal', 'dataset_id', 'type']),
-    ')',
-  ].filter(Boolean).join('\n'));
+
+  const commentLines = rawQuery !== null ? socrataQueryComment(call.args, soql) : [];
+  if (unsupported.length > 0) {
+    commentLines.push(
+      `# The original call also passed ${unsupported.join(', ')}, which this helper has`,
+      '# no parameter for; disclosed here rather than passed and silently ignored.',
+    );
+  }
+
+  const code = [
+    ...commentLines,
+    guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, [
+      `${dfVar} = fetch_socrata(`,
+      `    portal=${JSON.stringify(portal)},`,
+      `    dataset_id=${JSON.stringify(datasetId)},`,
+      rawQuery !== null ? `    query=${JSON.stringify(rawQuery)},` : '',
+      pyKwargs(call.args, SOCRATA_QUERY_KWARGS, handledKeys, FETCH_SOCRATA_PARAMS),
+      ')',
+    ].filter(Boolean).join('\n')),
+  ].join('\n');
+
   return {
     cells: [markdownCell(md), codeCell(code)],
     producedDataFrame: true,
@@ -236,13 +484,27 @@ function renderDataCommonsObsCell(
       ? `Original execution returned ${call.resultSummary.rows} observation rows.`
       : '',
   ].filter(Boolean).join('\n');
-  const code = guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, [
-    `${dfVar} = fetch_data_commons(`,
-    `    variable_dcid=${JSON.stringify(variable)},`,
-    `    place_dcid=${JSON.stringify(place)},`,
-    pyKwargs(call.args, DC_OBS_KWARGS, ['variable_dcid', 'place_dcid']),
-    ')',
-  ].filter(Boolean).join('\n'));
+  // Same bound as the Socrata renderer (#340): a key `fetch_data_commons` has
+  // no parameter for is disclosed, never emitted — emitting it would raise
+  // `TypeError` and the reader would be told live data could not be fetched.
+  const handledKeys = ['variable_dcid', 'place_dcid'];
+  const unsupported = unsupportedArgKeys(call.args, FETCH_DATA_COMMONS_PARAMS, handledKeys);
+  const commentLines = unsupported.length > 0
+    ? [
+        `# The original call also passed ${unsupported.join(', ')}, which this helper has`,
+        '# no parameter for; disclosed here rather than passed and silently ignored.',
+      ]
+    : [];
+  const code = [
+    ...commentLines,
+    guardedFetch(dfVar, `Step ${ctx.dataFrameIndex}`, [
+      `${dfVar} = fetch_data_commons(`,
+      `    variable_dcid=${JSON.stringify(variable)},`,
+      `    place_dcid=${JSON.stringify(place)},`,
+      pyKwargs(call.args, DC_OBS_KWARGS, handledKeys, FETCH_DATA_COMMONS_PARAMS),
+      ')',
+    ].filter(Boolean).join('\n')),
+  ].join('\n');
   return {
     cells: [markdownCell(md), codeCell(code)],
     producedDataFrame: true,
@@ -331,24 +593,72 @@ const FAILURE_REASON: Record<ToolFailureKind, string> = {
  * the same args the matching renderer would have used. Falls back to the tool
  * name for a call with no dedicated renderer (a discovery call that failed),
  * which is still more than the reader had before.
+ *
+ * `get_data` dispatches on name AND `args.type` (#342), the way
+ * `renderFetchToolCell` does. It used to dispatch on the name alone, so a
+ * rejected CATALOG SEARCH was reported to the reader as "tried to query the
+ * `unknown` dataset on …" — an operation that never ran, against a dataset
+ * that never existed, named by a placeholder. Three false claims in one
+ * sentence, in a document a reader downloads to scrutinise.
+ *
+ * There is no `unknown` here any more, in either direction: a field the call
+ * did not carry is left out of the sentence rather than filled with a word
+ * that looks like a value (docs/design-principles.md Principle 3). The
+ * `metadata` and `metrics` branches read the id from `query` when
+ * `dataset_id` is absent because that is what the data source does with it.
  */
 function describeAttempt(call: PhaseAToolCall, ctx: ToolCellContext): string {
   if (call.name === 'get_data') {
     const portal = (call.args.portal as string) || ctx.defaultPortal;
-    const datasetId = (call.args.dataset_id as string) || 'unknown';
-    return `query the \`${datasetId}\` dataset on \`${portal}\``;
+    const datasetId = typeof call.args.dataset_id === 'string' && call.args.dataset_id
+      ? call.args.dataset_id
+      : null;
+    const queryArg = typeof call.args.query === 'string' && call.args.query
+      ? call.args.query
+      : null;
+    const type = typeof call.args.type === 'string' ? call.args.type : undefined;
+    const namedDataset = datasetId ?? queryArg;
+    if (type === 'catalog') {
+      return queryArg
+        ? `search the \`${portal}\` data catalog for \`${queryArg}\``
+        : `search the \`${portal}\` data catalog`;
+    }
+    if (type === 'metadata') {
+      return namedDataset
+        ? `look up the description of the \`${namedDataset}\` dataset on \`${portal}\``
+        : `look up a dataset description on \`${portal}\``;
+    }
+    if (type === 'metrics') {
+      return namedDataset
+        ? `check row counts and update times for the \`${namedDataset}\` dataset on \`${portal}\``
+        : `check row counts and update times for a dataset on \`${portal}\``;
+    }
+    if (type === 'query') {
+      return datasetId
+        ? `query the \`${datasetId}\` dataset on \`${portal}\``
+        : `query a dataset on \`${portal}\``;
+    }
+    // No `type` at all: say what we know — the portal — and nothing else.
+    return `request data from \`${portal}\``;
   }
   if (call.name === 'get_observations') {
-    const variable = (call.args.variable_dcid as string) || 'unknown';
-    const place = (call.args.place_dcid as string) || 'unknown';
-    return `fetch \`${variable}\` for \`${place}\` from Google Data Commons`;
+    const variable = typeof call.args.variable_dcid === 'string' ? call.args.variable_dcid : null;
+    const place = typeof call.args.place_dcid === 'string' ? call.args.place_dcid : null;
+    if (variable && place) return `fetch \`${variable}\` for \`${place}\` from Google Data Commons`;
+    if (variable) return `fetch \`${variable}\` from Google Data Commons`;
+    if (place) return `fetch an indicator for \`${place}\` from Google Data Commons`;
+    return 'fetch an indicator from Google Data Commons';
   }
   if (call.name === 'ckan__execute_sql') {
     return 'run the analyst-authored SQL statement against the Boston open-data store';
   }
   if (call.name === 'ckan__query_data') {
-    const resourceId = (call.args.resource_id as string) || 'unknown';
-    return `fetch records from Boston open-data resource \`${resourceId}\``;
+    const resourceId = typeof call.args.resource_id === 'string' && call.args.resource_id
+      ? call.args.resource_id
+      : null;
+    return resourceId
+      ? `fetch records from Boston open-data resource \`${resourceId}\``
+      : 'fetch records from the Boston open-data store';
   }
   return `run the \`${call.name}\` request`;
 }

--- a/src/lib/notebook-author/tool-to-cell.ts
+++ b/src/lib/notebook-author/tool-to-cell.ts
@@ -90,11 +90,19 @@ function pyRepr(value: unknown, indent = ''): string {
  *
  * `handledKeys` lists args the caller has already accounted for elsewhere in
  * the generated cell — rendered by hand as explicit kwargs (e.g.
- * `portal=...`), or consumed only as call-routing metadata that never
- * appears in the rendered Python at all (e.g. `type`, which selects which
- * renderer runs and is not itself a `fetch_*` parameter). Either way,
- * `pyKwargs` must not append them a second time — the caller, not a
- * hard-coded list here, owns which keys those are.
+ * `portal=...`), consumed only as call-routing metadata that never appears in
+ * the rendered Python at all (e.g. `type`, which selects which renderer runs
+ * and is not itself a `fetch_*` parameter), or explained by a generated
+ * comment (the clauses a full SoQL `query` supersedes, #340). Either way,
+ * `pyKwargs` must not emit them — the caller, not a hard-coded list here, owns
+ * which keys those are.
+ *
+ * `supportedKeys`, when given, is the target helper's parameter list and
+ * bounds the unenumerated append: "emitted instead of silently dropped" holds
+ * only for a key the helper can actually receive. Emitting any other key makes
+ * the cell raise `TypeError` and tells the reader live data could not be
+ * fetched — which is #340, and is a worse outcome than not writing it. The
+ * caller discloses those keys instead; see `unsupportedArgKeys`.
  */
 function pyKwargs(
   args: Record<string, unknown>,

--- a/src/lib/notebook-author/validate.ts
+++ b/src/lib/notebook-author/validate.ts
@@ -9,6 +9,11 @@
  * exist, mandatory fields are present, and types are roughly right. It
  * does NOT do deep canonical-JSON validation — that lives in the
  * `civic-ai-tools-website/src/lib/evidence/packager.ts` Phase 3 work.
+ *
+ * One check reads the CELLS rather than the metadata (#341): whether any step
+ * re-runs a data fetch. A notebook whose every fetch failed has perfectly
+ * well-formed extensions, so a validator that only ever looked at shape
+ * reported it as valid while it told its reader the analysis was reproducible.
  */
 import type { Notebook } from './cells.ts';
 import { EXECUTION_EXTENSION_KEY, NOTEBOOK_EXTENSION_KEY } from './prompt.ts';

--- a/src/lib/notebook-author/validate.ts
+++ b/src/lib/notebook-author/validate.ts
@@ -162,9 +162,9 @@ export function validateReproducedFetches(notebook: Notebook): ValidationResult 
     issues.push({
       path: 'cells',
       message:
-        'no step re-runs a data fetch — every fetching tool call in the original ' +
-        'analysis returned no data, so nothing in this notebook is reproducible ' +
-        'against a live source',
+        'no step re-runs a data fetch, so nothing in this notebook is reproducible ' +
+        'against a live source — whatever it concludes rests on no request this ' +
+        'document can repeat',
     });
   }
   return { ok: issues.length === 0, issues };

--- a/src/lib/notebook-author/validate.ts
+++ b/src/lib/notebook-author/validate.ts
@@ -12,6 +12,7 @@
  */
 import type { Notebook } from './cells.ts';
 import { EXECUTION_EXTENSION_KEY, NOTEBOOK_EXTENSION_KEY } from './prompt.ts';
+import { countReproducedFetchCells } from './tool-to-cell.ts';
 
 export interface ValidationIssue {
   path: string;
@@ -136,10 +137,39 @@ export function validateExecutionExtension(notebook: Notebook): ValidationResult
   return { ok: issues.length === 0, issues };
 }
 
-/** Run both validators and merge their issues. */
+/**
+ * Report a notebook in which no step re-runs a data fetch (#341).
+ *
+ * Until this existed, a notebook whose every fetching tool call had failed
+ * validated `ok`: the two validators above check extension shape, and the
+ * shape of an all-failed notebook is perfectly well formed. Meanwhile its
+ * synthesis cell falls back to displaying the original answer text, so the
+ * original figures rendered as the document's conclusion with nothing behind
+ * them, under cover text that called the analysis reproducible.
+ *
+ * Derived from the cells rather than from a stamped count, so it cannot be
+ * satisfied by a claim: `isReproducedFetchCell` recognises the assignment the
+ * renderer emits, and it is exported from the module that emits it.
+ */
+export function validateReproducedFetches(notebook: Notebook): ValidationResult {
+  const issues: ValidationIssue[] = [];
+  if (countReproducedFetchCells(notebook.cells) === 0) {
+    issues.push({
+      path: 'cells',
+      message:
+        'no step re-runs a data fetch — every fetching tool call in the original ' +
+        'analysis returned no data, so nothing in this notebook is reproducible ' +
+        'against a live source',
+    });
+  }
+  return { ok: issues.length === 0, issues };
+}
+
+/** Run every validator and merge their issues. */
 export function validateExecutedNotebook(notebook: Notebook): ValidationResult {
   const provenance = validateNotebookProvenance(notebook);
   const execution = validateExecutionExtension(notebook);
-  const issues = [...provenance.issues, ...execution.issues];
+  const fetches = validateReproducedFetches(notebook);
+  const issues = [...provenance.issues, ...execution.issues, ...fetches.issues];
   return { ok: issues.length === 0, issues };
 }

--- a/src/lib/notebook.ts
+++ b/src/lib/notebook.ts
@@ -102,8 +102,15 @@ export function generateNotebook(
     attribution.host && attribution.origin
       ? ` via [${attribution.host}](${attribution.origin})`
       : '';
+  // #324: the same conditional, one line up. The heading hardcoded the
+  // reference deployment's name on every instance, inside a file readers
+  // download — an instance that has declared no identity gets the description
+  // without the name, never a borrowed one.
+  const title = attribution.platformTitle
+    ? `# ${attribution.platformTitle} Data Analysis`
+    : '# Data Analysis';
   cells.push(markdownCell([
-    '# Civic AI Data Analysis',
+    title,
     '',
     `**Query:** ${query}  `,
     `**Portal${uniquePortals.length > 1 ? 's' : ''}:** ${displayPortal}  `,


### PR DESCRIPTION
## Phase P5 — the notebook renderer (Wave N8, lane 2)

**Model:** Opus 5 (1M context). **Base:** `cecc959`. **Branch:** `sprint-363/p5-notebook-renderer`.
**Head:** `8ab83f5`. Four commits.

Closes #340, #341, #342, and the notebook-identity half of #324 (per ruling D5).

### Diff stat

```
 src/lib/mcp/tools.ts                               |   8 +-
 .../helpers/fetch-socrata-contract.test.ts         | 400 +++++++++++++++++++++
 src/lib/notebook-author/helpers/fetch_socrata.py   |  90 ++++-
 src/lib/notebook-author/notebook-claims.test.ts    | 245 +++++++++++++
 src/lib/notebook-author/prompt.ts                  |  45 ++-
 src/lib/notebook-author/synthesize.test.ts         |   6 +-
 src/lib/notebook-author/synthesize.ts              |   7 +-
 src/lib/notebook-author/tool-to-cell.test.ts       | 345 ++++++++++++++++++
 src/lib/notebook-author/tool-to-cell.ts            | 374 +++++++++++++++++--
 src/lib/notebook-author/validate.ts                |  39 +-
 src/lib/notebook.ts                                |   9 +-
 11 files changed, 1516 insertions(+), 52 deletions(-)
```

### Blast zone — nine of eleven files are the chartered zone; **two are itemised additions**

Chartered and touched: `tool-to-cell.ts` + `tool-to-cell.test.ts`, `prompt.ts`, `validate.ts`,
`helpers/fetch_socrata.py`, `notebook.ts` (D5 only), `mcp/tools.ts` (the `query` description only),
plus two new test files matching `src/**/*.test.ts`.

**Additions, file by file:**

1. **`src/lib/notebook-author/synthesize.ts`** (+7/-2). Criterion 5's first half is not reachable
   without it. `buildCell0Source` has exactly one production caller, and cell 0 is written **before**
   the step cells exist — so the claim "this notebook contains a complete, reproducible analysis" can
   only become conditional if its caller passes what it knows. The edit is one import and one
   argument.
2. **`src/lib/notebook-author/synthesize.test.ts`** (+6/-2, one assertion). `:66` asserted
   `/Civic AI Data Analysis/` — the exact string ruling D5 removes. The test name is unchanged; the
   assertion now pins the D5 conditional (`/^# Data Analysis$/m` under no declared identity).

Same shape as the zone correction G2 §2 made for P2: a zone derived from the issue rather than from
the call graph. Neither file is touched by P3 (`scripts/eval-models.mjs`, its test, the registry
test) — lane disjointness holds.

### Evidence

| Check | Result |
|---|---|
| `npm ci` | clean (run before every measurement below) |
| `npm test` | `# tests 1156 · # suites 10 · # pass 1156 · # fail 0` — same on the runner, job `98940870819` of run `33198255316`, read from the job-log API |
| `npm run build` | `✓ Compiled successfully`, Route (app) table emitted |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | `✖ 4 problems (0 errors, 4 warnings)` — the baseline four, unchanged |
| `npm run check:compose-env` | `RESULT: PASS — every variable this profile reads can reach the container.` |

**Nothing lost.** TAP name sets, base `cecc959` vs branch head, sorted and `comm`-diffed:
**0 names present at the base and absent at the head**; **27 added** (13 in `tool-to-cell.test.ts`,
6 in `fetch-socrata-contract.test.ts`, 8 in `notebook-claims.test.ts`). 1129 → **1156**.

### The ruling, implemented

**#340.** The helper gains `query` and implements the service's split itself — it talks to the
portal directly, and a reader can re-run the cell with their own arguments. On the SoQL branch the
cell renders `query=` alone; the superseded clauses are omitted, not written as arguments with no
effect. The generated comment, verbatim, for the fixture the tests drive:

```python
# `query` here is a full SoQL statement, so the data source applied it as the
# whole query: select / where / group / order — and limit / offset — are not
# sent alongside it. They are omitted below rather than written as arguments
# that would have no effect on the rows this cell returns.
# Superseded on this call, for that reason: select, where, limit.
# The row count is therefore bounded by the statement's own LIMIT, or by the
# portal's default page size when the statement carries none.
# One deliberate difference from the original run: this helper always requires
# an explicit dataset_id and never derives one from `query`.
```

Rider (a) — the cross-repo coupling is pinned by name in both test files: the service's regex
transcribed literally, `socrata-tools.ts:546` at `116f46ce1e84e3608014599f9b63ea01acfd913a`, the
fixture from `search.test.ts:165`, and a header stating that a service-side change is an issue on
**this** repository rather than a silent divergence. Rider (b) — the row bound is named, with its own
red demonstration below. Rider (c) — the helper raises `SocrataDatasetIdRequired` and never infers;
the divergence from `:531` is stated in the same comment block; a query call that named no dataset
renders a note instead of a cell that always raises, and the `unknown` placeholder is gone.

Beyond the letter of #340, the same bound now applies to **every** argument rather than to `query`
alone: a key no helper parameter matches is disclosed in the cell instead of emitted, and a test
reads the helpers' real signatures (and asserts they carry no `**kwargs`) so neither list can drift.

**#341.** The cover claim is conditional on at least one fetch surviving, and
`validateExecutedNotebook` gains a third validator that reports a notebook in which no step re-runs
a fetch. The two are computed by different means on purpose — the cover cell from the tool calls
(it is written first), the validator from the cells (so it cannot be satisfied by a claim) — and a
test pins that they still answer the same question.

**#342.** `describeAttempt` dispatches on name **and** `args.type`. Every `unknown` placeholder in
that function is gone, in all four tool branches.

**#324 (D5).** Both hardcoded titles become the `#258 A2` conditional: the declared platform title,
or the description alone.

### Red demonstrations — eleven, each on the test that names it

| # | Reverted | Red |
|---|---|---|
| R1 | superseded kwargs back into the cell | `#340: a SoQL query renders query= and no superseded kwarg` — `select= had no effect on this call and must not appear in the cell` |
| R2 | the row-bound comment lines deleted | `#340: the SoQL comment names the supersession AND the row bound` |
| R3 | `SOQL_QUERY_SNIFF` → `/^select/i` | `#340: our sniff IS the service's sniff, character for character` |
| R4 | the Python sniff → `query.upper().startswith("SELECT")` | `#340: the helper applies the sniff itself…` — `wrong branch for "   SELECT count(*) AS n"` |
| R5 | the cover claim unconditional again | `#341: a notebook whose every fetch failed…`, `#341: the cover claim and the validator answer the same question` |
| R5b | the same, re-run after the copy fix | the two above **plus** `#341: a notebook that never fetched is not told its requests failed` |
| R6 | the third validator dropped | `#341: validateExecutedNotebook reports an all-failed notebook` |
| R7 | `query` removed from the helper (the base state) | all six contract tests — `TypeError: fetch_socrata() got an unexpected keyword argument 'query'` |
| R8 | the helper infers `dataset_id` from `query`, as the service does | `#340 (rider c): dataset_id is required and never inferred` |
| R9 | `describeAttempt` back to name-only dispatch | both `#342` tests |
| R10 | the fetch detector matches the helper NAME | `#341: the detector is not fooled by the helper-definitions cell` |

R4 and R10 are the two that matter most: both are re-spellings that pass a naive check. R4 diverges
only on leading whitespace; R10 counts the helper-**definitions** cell and would report every
all-failed notebook as reproducing a fetch — the check passing on exactly the document it exists to
reject.

No test instrument in this phase uses timers, `.unref()`, or any asynchronous guard, so no red case
can be converted into a cancelled file (the shape P2 hit).

### One defect this phase introduced and then removed (commit `8ab83f5`)

The first version of the no-fetch cover text said *"every request to a live data source returned no
data"* — true of the all-failed notebook it was written for, false of the other document that
reaches the same branch: an analysis answered from discovery alone, whose catalog searches all
**succeeded** and which simply has no fetch step. That is this phase's own defect class one step to
the left. The text now says what is true of the document — no step re-runs a request — and a test
drives the discovery-only notebook. Found by re-reading the diff; the test came second.

### Flagged, not fixed

1. **`src/lib/notebook.ts:60-72` carries the #340 shape** — `buildSocrataUrl` builds a direct
   `/resource/<id>.json?$select=…` URL and ignores `query` and `offset` entirely. My contract limits
   that file to D5. P7's cold read is already pointed at it.
2. **`renderOpenContextQueryCell` silently drops every arg but `resource_id`/`filters`/`limit`.**
   Satisfies "does not pass it", but with no disclosure — the CKAN half of the class #340 names.
3. **`fetch_socrata`'s default `limit=1000` vs the service's `10`** for `type=query`. Pre-existing;
   a cell carrying no explicit `limit` already reproduces a wider page than the original run.
   Changing it would move row counts in existing notebooks, so it is a decision, not a fix.
4. **`get_data`'s schema advertises no `having` or `q`, and does not set `additionalProperties`.**
   The model can therefore still send a key nothing expects — now disclosed rather than fatal.
5. **`docs/` is untouched**: the helper's `query` parameter and the `dataset_id` divergence are
   described nowhere outside the code. A P6-adjacent docs line.
6. **A partial-failure notebook still carries the full claim.** The conditional is binary, as the
   contract specifies; a notebook where three of four fetches failed says "complete, reproducible
   analysis" while its per-step notes say otherwise. Worth a ruling, not a silent widening.

### Runner

All six checks pass on head `8ab83f5`: `build / test / lint / typecheck`, `container image build`, `Vercel`, `DCO` (the four required) plus `standalone build + asset check` and `Vercel Preview Comments`. The standalone job is the one that re-copies the edited `.py` helper and byte-compares it, so the helper change is covered on a host as well as in the container.
