### PR TITLE
fix: absent token usage is absent from every trace span (#312)

### DIFF
--- a/src/lib/model-loop/absent-usage.test.ts
+++ b/src/lib/model-loop/absent-usage.test.ts
@@ -1,0 +1,516 @@
+// Acceptance tests for #312: absent token usage is ABSENT from the trace — on
+// every span — and a genuine zero still is not.
+//
+// WHY THIS IS A PROPERTY OVER SPANS AND NOT A FIX TO FOUR LINES. The trace
+// goes inside the signed record package, so a span asserting
+// `gen_ai.response.prompt_tokens: 0` for a call the endpoint said nothing
+// about is a false statement under a signature. Wave N4 P3 fixed exactly that
+// one layer up for `cost.promptTokens` (`packager.ts`: "Zero is not a
+// measurement… Absent usage is now absent"), leaving a package that could
+// carry `cost` with the counts correctly absent while the span beside it
+// claimed zero.
+//
+// The issue named four sites. There are SIX, across TWO mechanisms, and the
+// second is why a grep for the `|| 0` shape could not find it:
+//
+//   mechanism one — `llm_inference`, both sites: an inline `|| 0` on
+//     `response.usage`, coalescing absence to zero at the span;
+//   mechanism two — `synthesis`, the answering turn that produces the
+//     PUBLISHED answer: two locals initialised to `0` that simply stay `0`
+//     when no usage arrives (the streamed path guarded `if (chunk.usage)`,
+//     the blocking path used its own `|| 0`). `0` from "never set" and `0`
+//     from "the endpoint reported zero" are the same bytes unless something
+//     tracks the difference.
+//
+// So the cases below drive the REAL loop to completion and assert over EVERY
+// span the trace finalizes, not over the two lines an issue pointed at. The
+// synthesis span gets its own case, with the tool turns REPORTING usage, so
+// that a fix addressing only mechanism one goes red here rather than passing.
+//
+// AND ASSERTED OVER THE CANONICAL FORM, which #312 asks for explicitly. Two
+// different traps make a naive presence check the wrong instrument:
+//
+//   - `produce-core` leaves an `undefined` property present on an object and
+//     the JCS canonicalizer drops it, so a `hasOwnProperty` assertion can fail
+//     while the behaviour is correct;
+//   - and in the OTHER direction, measured here: `TraceBuilder` turns an
+//     attribute record into an ARRAY of `{key, value}` pairs via
+//     `Object.entries`, so setting an attribute to `undefined` does NOT remove
+//     it — it survives canonicalization as
+//     `{"key":"gen_ai.response.prompt_tokens","value":{}}`, a valueless
+//     attribute inside the signature, which is worse than the zero it
+//     replaced.
+//
+// Every case therefore asserts over `jcs(trace)` — the bytes the signature
+// actually covers — as well as over the span structure.
+//
+// The RED baseline, measured at f117665 before the fix, driving the
+// tool-then-silence script with an endpoint that reports no usage at all:
+// every `llm_inference` span carried `prompt_tokens` `intValue: "0"` and the
+// `synthesis` span carried it too, by the second mechanism. And with a
+// falsy-check fix in place of the absence check, the genuine-zero case below
+// goes red instead — the same defect pointing the other way.
+//
+// No live endpoint, no credential, no MCP server, no database. Every key value
+// is an obviously fake fixture and every address is loopback.
+//
+// Run with: npm test
+//   (or: node --test --experimental-strip-types src/lib/model-loop/absent-usage.test.ts)
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { runToolLoop, type ToolLoopOptions } from './run-tool-loop.ts';
+import { _resetDefaultModelClientForTests, getModelClient } from '../model-client.ts';
+import { TraceBuilder, CIVICAITOOLS_TRACE_CONFIG } from '../evidence/trace.ts';
+import { jcs } from '../evidence/canonicalization.ts';
+
+const FIXTURE_KEY = 'not-a-real-key-p4b-absent-usage-fixture';
+const PROMPT = 'How long do these requests take to close?';
+const REAL_ANSWER =
+  'Across both years the portal recorded 4,812 requests of this type. The median time to close ' +
+  'was 9 days, and 71% closed within 14 days (dataset abcd-1234).';
+const ONE_ROW = JSON.stringify({ data: [{ request_type: 'A', days_to_close: 9 }], total_rows: 1 });
+
+const PROMPT_TOKENS = 'gen_ai.response.prompt_tokens';
+const COMPLETION_TOKENS = 'gen_ai.response.completion_tokens';
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ['OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'MODEL_API_BASE_URL'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  _resetDefaultModelClientForTests();
+});
+
+// --- The instrument --------------------------------------------------------
+
+/**
+ * A scripted endpoint whose `usage` reporting is the variable.
+ *
+ * `test-harness.ts`'s `startScriptedModelServer` is this family's instrument
+ * everywhere else and would be the right home for this, as a `usage` field on
+ * `ScriptedReply` — it hardcodes `{prompt_tokens: 10, completion_tokens: 5}`
+ * on every reply and offers no way to express "the endpoint reported none",
+ * which is the entire subject of this file. That file is outside this phase's
+ * blast zone, so the capability lives here and the duplication is flagged
+ * rather than taken: see the phase report.
+ *
+ * Real HTTP and real SSE on purpose. The claim is that the loop records
+ * nothing when the ENDPOINT reports nothing, and a hand-built async iterable
+ * of chunk objects would assert that about a fixture rather than about the
+ * client's own parsing of a response that genuinely omits the field.
+ */
+interface UsageScript {
+  content?: string | null;
+  toolCalls?: { id: string; name: string; args: Record<string, unknown> }[];
+  /**
+   * The `usage` object the endpoint returns for this reply. Omitted here means
+   * omitted on the wire: no `usage` key in the JSON body, and no usage frame
+   * in the SSE stream at all — which is what an endpoint that reports nothing
+   * actually sends.
+   */
+  usage?: Record<string, number>;
+}
+
+function startUsageScriptedServer(
+  replies: UsageScript[],
+): Promise<{ server: Server; url: string; requests: number }> {
+  return new Promise((resolve) => {
+    let served = 0;
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+        const reply = replies[Math.min(served++, replies.length - 1)];
+
+        if (body.stream === true) {
+          res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+          const frame = (payload: Record<string, unknown>) =>
+            `data: ${JSON.stringify({
+              id: 'chatcmpl-test-p4b',
+              object: 'chat.completion.chunk',
+              created: 1,
+              model: 'fake/model',
+              ...payload,
+            })}\n\n`;
+          res.write(frame({
+            choices: [{ index: 0, delta: { content: reply.content ?? '' }, finish_reason: null }],
+          }));
+          if (reply.usage) res.write(frame({ choices: [], usage: reply.usage }));
+          res.write('data: [DONE]\n\n');
+          res.end();
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          id: 'chatcmpl-test-p4b',
+          object: 'chat.completion',
+          created: 1,
+          model: 'fake/model',
+          choices: [{
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: reply.content ?? null,
+              ...(reply.toolCalls
+                ? {
+                    tool_calls: reply.toolCalls.map((tc) => ({
+                      id: tc.id,
+                      type: 'function',
+                      function: { name: tc.name, arguments: JSON.stringify(tc.args) },
+                    })),
+                  }
+                : {}),
+            },
+            finish_reason: reply.toolCalls ? 'tool_calls' : 'stop',
+          }],
+          ...(reply.usage ? { usage: reply.usage } : {}),
+        }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}/v1`, requests: served });
+    });
+  });
+}
+
+interface RawAttribute {
+  key: string;
+  value: { stringValue?: string; intValue?: string; boolValue?: boolean };
+}
+interface RawSpan {
+  name: string;
+  attributes: RawAttribute[];
+}
+
+function spansOf(trace: Record<string, unknown>): RawSpan[] {
+  const resourceSpans = trace.resourceSpans as { scopeSpans: { spans: RawSpan[] }[] }[];
+  return resourceSpans.flatMap((rs) => rs.scopeSpans.flatMap((ss) => ss.spans));
+}
+
+function spansNamed(trace: Record<string, unknown>, name: string): RawSpan[] {
+  return spansOf(trace).filter((s) => s.name === name);
+}
+
+/** True when the KEY exists on the span at all — regardless of its value. */
+function carriesKey(span: RawSpan, key: string): boolean {
+  return span.attributes.some((a) => a.key === key);
+}
+
+function intAttr(span: RawSpan, key: string): string | undefined {
+  return span.attributes.find((a) => a.key === key)?.value?.intValue;
+}
+
+/**
+ * The criterion, over the bytes the signature covers.
+ *
+ * Structure and canonical form are both asserted because they fail in
+ * different directions: a key whose value is `undefined` is invisible to an
+ * assertion on VALUES but plainly visible in the canonical bytes, and a key
+ * the canonicalizer drops would be visible in the object but not in the bytes.
+ *
+ * Canonicalized PER SPAN rather than over the whole trace, because most cases
+ * here have some spans that legitimately carry a count and some that must not:
+ * a whole-trace `includes` cannot tell those apart, and one written anyway
+ * would fail for a reason that has nothing to do with the property. JCS is
+ * deterministic per object, so a span's canonical bytes are the bytes that
+ * span contributes to the signed document.
+ */
+function assertNoTokenAttributes(spans: RawSpan[], because: string) {
+  assert.ok(spans.length > 0, `${because}: no spans to assert over — the case measures nothing`);
+  for (const span of spans) {
+    for (const key of [PROMPT_TOKENS, COMPLETION_TOKENS]) {
+      assert.equal(
+        carriesKey(span, key),
+        false,
+        `${because}: span "${span.name}" carries ${key} = ` +
+          `${JSON.stringify(span.attributes.find((a) => a.key === key)?.value)}`,
+      );
+      assert.equal(
+        jcs(span as unknown as Record<string, unknown>).includes(key),
+        false,
+        `${because}: ${key} survives into the canonical bytes of span "${span.name}" — ` +
+          'the bytes the signature covers',
+      );
+    }
+  }
+}
+
+/** The whole signed document mentions neither count, anywhere. */
+function assertCanonicalTraceOmitsBoth(trace: Record<string, unknown>, because: string) {
+  const canonical = jcs(trace);
+  for (const key of [PROMPT_TOKENS, COMPLETION_TOKENS]) {
+    assert.equal(
+      canonical.includes(key),
+      false,
+      `${because}: ${key} survives into the canonical bytes the signature covers`,
+    );
+  }
+}
+
+/**
+ * Every attribute this trace carries has a value.
+ *
+ * The regression guard for the omission-by-`undefined` shape, stated over the
+ * WHOLE trace rather than over the two keys this issue is about:
+ * `attrsFromRecord` maps `Object.entries`, so `{key: undefined}` becomes
+ * `{"key":"…","value":{}}` and canonicalizes intact. Nothing in a signed trace
+ * should assert a key and then decline to say what it is.
+ */
+function assertNoValuelessAttributes(trace: Record<string, unknown>) {
+  for (const span of spansOf(trace)) {
+    for (const a of span.attributes) {
+      assert.ok(
+        a.value && Object.keys(a.value).length > 0,
+        `span "${span.name}" carries attribute "${a.key}" with no value at all — ` +
+          'an attribute set to `undefined` rather than omitted',
+      );
+    }
+  }
+}
+
+async function runWithScript(
+  replies: UsageScript[],
+  overrides: Partial<ToolLoopOptions> = {},
+): Promise<{ trace: Record<string, unknown>; usage: { promptTokens: number; completionTokens: number; totalTokens: number } }> {
+  const { server, url } = await startUsageScriptedServer(replies);
+  const builder = new TraceBuilder(CIVICAITOOLS_TRACE_CONFIG);
+  builder.startRoot('analysis');
+  try {
+    process.env.OPENROUTER_API_KEY = FIXTURE_KEY;
+    process.env.MODEL_API_BASE_URL = url;
+    _resetDefaultModelClientForTests();
+
+    const result = await runToolLoop({
+      client: getModelClient(),
+      endpointModel: 'fake/model',
+      prompt: PROMPT,
+      tools: [],
+      executeToolCall: async () => ONE_ROW,
+      trace: { builder, parentSpanId: builder.rootSpanId },
+      ...overrides,
+    });
+    builder.endRoot();
+    return {
+      trace: builder.finalize() as unknown as Record<string, unknown>,
+      usage: result.usage,
+    };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+const FETCH_CALL = {
+  id: 'call_1',
+  name: 'get_data',
+  args: { type: 'query', dataset_id: 'abcd-1234' },
+};
+
+const REPORTED = { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 };
+const REPORTED_ZERO = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+
+/**
+ * Two tool-calling turns and then an answering turn, so ONE run produces all
+ * three span sites: `llm_inference` at inference index 0, `llm_inference` at
+ * index 1, and `synthesis` from the answering turn. Reply 2 answers nothing,
+ * which is what routes the run into the answering turn the synthesis span
+ * measures.
+ */
+function toolThenSilence(usage: UsageScript['usage'], answerUsage: UsageScript['usage']): UsageScript[] {
+  return [
+    { toolCalls: [FETCH_CALL], usage },
+    { content: null, usage },
+    { content: REAL_ANSWER, usage: answerUsage },
+  ];
+}
+
+/** The run really did produce the three spans the cases assert over. */
+function assertShape(trace: Record<string, unknown>) {
+  const inference = spansNamed(trace, 'llm_inference');
+  const synthesis = spansNamed(trace, 'synthesis');
+  assert.equal(inference.length, 2, 'expected two llm_inference spans from this script');
+  assert.equal(synthesis.length, 1, 'expected one synthesis span from this script');
+  assert.ok(
+    synthesis[0].attributes.some((a) => a.key === 'output.hash'),
+    'the synthesis span must have been ENDED — an unended span would carry no attributes ' +
+      'and would pass an absence assertion for the wrong reason',
+  );
+  return { inference, synthesis: synthesis[0] };
+}
+
+// --- Criterion 1: absent usage is absent, on every span --------------------
+
+for (const finalTurn of ['blocking', 'stream'] as const) {
+  test(`#312: an endpoint reporting no usage leaves no token attribute on any span (${finalTurn} answering turn)`, async () => {
+    const { trace } = await runWithScript(
+      toolThenSilence(undefined, undefined),
+      { finalTurn },
+    );
+
+    assertShape(trace);
+    assertNoTokenAttributes(spansOf(trace), 'the endpoint reported no usage');
+    assertCanonicalTraceOmitsBoth(trace, 'the endpoint reported no usage');
+    assertNoValuelessAttributes(trace);
+  });
+}
+
+// --- Criterion 2: the synthesis span specifically ---------------------------
+//
+// The tool turns REPORT usage here and the answering turn does not, so a fix
+// that only reaches mechanism one leaves the two `llm_inference` spans correct
+// and the synthesis span still asserting `0`. This case is the one that cannot
+// be passed by accident.
+
+for (const finalTurn of ['blocking', 'stream'] as const) {
+  test(`#312: an answering turn whose endpoint reports no usage leaves the synthesis span with neither count (${finalTurn})`, async () => {
+    const { trace } = await runWithScript(
+      toolThenSilence(REPORTED, undefined),
+      { finalTurn },
+    );
+
+    const { inference, synthesis } = assertShape(trace);
+
+    // Mechanism one is untouched: what WAS reported is still recorded.
+    for (const span of inference) {
+      assert.equal(intAttr(span, PROMPT_TOKENS), '10', 'a reported prompt count must survive');
+      assert.equal(intAttr(span, COMPLETION_TOKENS), '5', 'a reported completion count must survive');
+    }
+
+    assertNoTokenAttributes([synthesis], 'the answering turn reported no usage');
+    assertNoValuelessAttributes(trace);
+
+    // The canonical assertion above is scoped to the synthesis span's keys, so
+    // state the whole-trace half explicitly: the strings ARE in the bytes,
+    // because the inference spans legitimately carry them.
+    const canonical = jcs(trace);
+    assert.ok(
+      canonical.includes(PROMPT_TOKENS),
+      'the inference spans must still put a reported count into the canonical bytes',
+    );
+  });
+}
+
+// --- Criterion 3: a genuine zero is still a measurement ---------------------
+//
+// The other direction. A falsy check erases an endpoint that truthfully
+// reported zero, which is the same class of defect: the trace would say
+// nothing was measured when something was.
+
+for (const finalTurn of ['blocking', 'stream'] as const) {
+  test(`#312: an endpoint reporting a genuine zero still gets 0 on every span (${finalTurn} answering turn)`, async () => {
+    const { trace } = await runWithScript(
+      toolThenSilence(REPORTED_ZERO, REPORTED_ZERO),
+      { finalTurn },
+    );
+
+    const { inference, synthesis } = assertShape(trace);
+
+    for (const span of [...inference, synthesis]) {
+      assert.equal(
+        intAttr(span, PROMPT_TOKENS),
+        '0',
+        `span "${span.name}" dropped a prompt count the endpoint truthfully reported as 0`,
+      );
+      assert.equal(
+        intAttr(span, COMPLETION_TOKENS),
+        '0',
+        `span "${span.name}" dropped a completion count the endpoint truthfully reported as 0`,
+      );
+    }
+    assertNoValuelessAttributes(trace);
+  });
+}
+
+// --- The two counts are independent ----------------------------------------
+//
+// An endpoint reporting one count and not the other gets one attribute. A fix
+// that gates both on the presence of the `usage` OBJECT passes every case
+// above and fails this one.
+
+for (const finalTurn of ['blocking', 'stream'] as const) {
+  test(`#312: a partially-reported usage records the count that was reported and omits the one that was not (${finalTurn})`, async () => {
+    const partial = { prompt_tokens: 12, total_tokens: 12 };
+    const { trace } = await runWithScript(
+      toolThenSilence(partial, partial),
+      { finalTurn },
+    );
+
+    const { inference, synthesis } = assertShape(trace);
+
+    for (const span of [...inference, synthesis]) {
+      assert.equal(
+        intAttr(span, PROMPT_TOKENS),
+        '12',
+        `span "${span.name}" dropped the prompt count the endpoint did report`,
+      );
+      assert.equal(
+        carriesKey(span, COMPLETION_TOKENS),
+        false,
+        `span "${span.name}" asserts a completion count the endpoint never reported`,
+      );
+    }
+    assert.equal(
+      jcs(trace).includes(COMPLETION_TOKENS),
+      false,
+      'an unreported completion count reached the canonical bytes',
+    );
+    assertNoValuelessAttributes(trace);
+  });
+}
+
+// --- The pass-through synthesis span ----------------------------------------
+//
+// A run the model answered on its own account takes NO answering turn, so its
+// synthesis span covers delivery rather than a model call and has no token
+// counts to report. It is already compliant; pinned so that a later pass
+// "completing" the span by copying the cumulative totals onto it — which would
+// attribute the whole run's tokens to a call that never happened — goes red.
+
+test('#312: a pass-through run leaves the synthesis span with no token counts, because no model call backs it', async () => {
+  const { trace } = await runWithScript([{ content: REAL_ANSWER, usage: REPORTED }]);
+
+  const inference = spansNamed(trace, 'llm_inference');
+  const synthesis = spansNamed(trace, 'synthesis');
+  assert.equal(inference.length, 1, 'a pass-through run makes exactly one model call');
+  assert.equal(synthesis.length, 1);
+  assert.equal(intAttr(inference[0], PROMPT_TOKENS), '10', 'the one model call reported usage');
+
+  assertNoTokenAttributes(synthesis, 'no model call backs a pass-through synthesis span');
+  assertNoValuelessAttributes(trace);
+});
+
+// --- What the RETURNED usage does, stated rather than assumed ---------------
+//
+// The loop's `usage` is a SUM over the turns, and it stays a number: absent
+// contributes nothing to a total. `packager.ts` and `openrouter-streaming.ts`
+// each apply their own `|| undefined` at the boundary where absence is
+// expressible, so a run with no usage anywhere still produces a package with
+// the counts absent. Pinned so the accumulator's semantics are a decision on
+// the record rather than an accident — and so that a later phase changing the
+// return type has to change this line and say why.
+
+test('#312: with no usage reported anywhere the returned totals are zero, and the counts are omitted at the boundary', async () => {
+  const { usage } = await runWithScript(toolThenSilence(undefined, undefined));
+
+  assert.deepEqual(usage, { promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  // The idiom both consumers apply — `packager.ts` for the signed `cost`
+  // block, `openrouter-streaming.ts` for the wire.
+  assert.equal(usage.promptTokens || undefined, undefined);
+  assert.equal(usage.completionTokens || undefined, undefined);
+});

--- a/src/lib/model-loop/run-tool-loop.ts
+++ b/src/lib/model-loop/run-tool-loop.ts
@@ -412,6 +412,66 @@ export function responseModelAttributes(
 }
 
 /**
+ * The token counts an endpoint actually reported, as span attributes — and
+ * NOTHING when it reported none (#312).
+ *
+ * The trace goes INSIDE the signed record package, so `prompt_tokens: 0` on a
+ * call the endpoint said nothing about is a false statement under a signature:
+ * it asserts that zero tokens were consumed — a measurement — when the truth
+ * is that no measurement was taken. Wave N4 P3 fixed exactly this one layer up
+ * for `cost.promptTokens` (`packager.ts`: "Zero is not a measurement… Absent
+ * usage is now absent"), which left a package able to carry `cost` with the
+ * counts correctly absent while the span beside it claimed zero. This is that
+ * same rule, on the span.
+ *
+ * OMISSION MEANS THE KEY IS NEVER BUILT — not that its value is `undefined`.
+ * `TraceBuilder` turns an attribute record into an ARRAY of `{key, value}`
+ * pairs via `Object.entries`, so a key whose value is `undefined` does not
+ * disappear the way an object property would: it survives as
+ * `{"key":"gen_ai.response.prompt_tokens","value":{}}`, measured, and the JCS
+ * canonicalizer keeps it, because the only thing it drops is the `undefined`
+ * INSIDE the value object. A valueless attribute under the signature is worse
+ * than the zero it replaced. Hence the conditional spread: the key exists only
+ * when there is a number to put in it.
+ *
+ * A GENUINE ZERO IS STILL A MEASUREMENT, so the test is presence, not truth.
+ * A falsy check here would erase an endpoint that really did report
+ * `prompt_tokens: 0` — the same defect pointing the other way.
+ * `Number.isFinite` is the outer bound: a count arriving as a string, a `NaN`
+ * or an `Infinity` is not a measurement either, and `"NaN"` asserted in a
+ * signed trace is the failure this function exists to prevent.
+ *
+ * The two counts are independent. An endpoint reporting one and not the other
+ * gets one attribute — not two, and not none.
+ *
+ * Deliberately not exported. The loop is the only thing that builds these
+ * spans, and the acceptance suite asserts the property over the trace the real
+ * loop finalizes rather than over this function's return value: a helper that
+ * is right in isolation and called at two of three sites is exactly the shape
+ * #312 was in.
+ */
+function responseTokenAttributes(
+  usage: { prompt_tokens?: number; completion_tokens?: number } | null | undefined,
+): Record<string, number> {
+  const promptTokens = reportedCount(usage?.prompt_tokens);
+  const completionTokens = reportedCount(usage?.completion_tokens);
+  return {
+    ...(promptTokens !== undefined ? { 'gen_ai.response.prompt_tokens': promptTokens } : {}),
+    ...(completionTokens !== undefined ? { 'gen_ai.response.completion_tokens': completionTokens } : {}),
+  };
+}
+
+/**
+ * One token count as the endpoint reported it, or `undefined` if it reported
+ * none. The single place this module decides what counts as "reported" — see
+ * `responseTokenAttributes` above for why the bound is `Number.isFinite` and
+ * not truthiness.
+ */
+function reportedCount(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
  * Bound one tool result before it is fed back as context, keeping what is fed
  * back READABLE (#331) and keeping it INSIDE THE BUDGET (#355).
  *
@@ -634,8 +694,7 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
   });
   if (llmSpanId) {
     trace!.builder.endSpan(llmSpanId, {
-      'gen_ai.response.prompt_tokens': response.usage?.prompt_tokens || 0,
-      'gen_ai.response.completion_tokens': response.usage?.completion_tokens || 0,
+      ...responseTokenAttributes(response.usage),
       ...responseModelAttributes(declaredModel, response.model, logContext),
     });
   }
@@ -839,8 +898,7 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
     lastMessageAlreadyInTranscript = false;
     if (llmSpanId) {
       trace!.builder.endSpan(llmSpanId, {
-        'gen_ai.response.prompt_tokens': response.usage?.prompt_tokens || 0,
-        'gen_ai.response.completion_tokens': response.usage?.completion_tokens || 0,
+        ...responseTokenAttributes(response.usage),
         ...responseModelAttributes(declaredModel, response.model, logContext),
       });
     }
@@ -913,8 +971,22 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
 
     let content = '';
     let finalCallTokens = 0;
-    let finalPromptTokens = 0;
-    let finalCompletionTokens = 0;
+    /**
+     * `undefined` until an endpoint says otherwise — the whole of #312's
+     * second mechanism (this phase's C1). These were `0`-initialised numbers,
+     * and `0` arriving from "never set" is indistinguishable from `0` arriving
+     * from "the endpoint reported zero". The synthesis span is the answering
+     * turn — the one that produces the PUBLISHED answer — so that is the span
+     * where the difference matters most, and a grep for the `|| 0` shape at
+     * the other two sites could not see it.
+     *
+     * `finalCallTokens` stays a `0`-initialised number on purpose: it is
+     * summed into `cumulativeTokens`, and "absent contributes nothing to a
+     * sum" is the correct semantic for a total. Only the two counts that
+     * become span ATTRIBUTES need to distinguish absent from zero.
+     */
+    let finalPromptTokens: number | undefined;
+    let finalCompletionTokens: number | undefined;
     let finalReportedModel: string | undefined;
 
     if (finalTurn === 'stream') {
@@ -935,10 +1007,17 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
         // Every chunk repeats the model the endpoint answered with; the last
         // one wins, so the recorded report is the one that finished the answer.
         if (chunk.model) finalReportedModel = chunk.model;
+        // Last REPORTED value wins, on each count independently — the same
+        // rule as `chunk.model` above. The truthy guards this replaces made a
+        // genuine `prompt_tokens: 0` indistinguishable from a chunk that
+        // carried no count at all, which is #312 in the direction that erases
+        // a real measurement rather than inventing one. `reportedCount` keeps
+        // the old guard's one useful effect — a `NaN` never lands — while
+        // admitting the zero.
         if (chunk.usage) {
-          if (chunk.usage.total_tokens) finalCallTokens = chunk.usage.total_tokens;
-          if (chunk.usage.prompt_tokens) finalPromptTokens = chunk.usage.prompt_tokens;
-          if (chunk.usage.completion_tokens) finalCompletionTokens = chunk.usage.completion_tokens;
+          finalCallTokens = reportedCount(chunk.usage.total_tokens) ?? finalCallTokens;
+          finalPromptTokens = reportedCount(chunk.usage.prompt_tokens) ?? finalPromptTokens;
+          finalCompletionTokens = reportedCount(chunk.usage.completion_tokens) ?? finalCompletionTokens;
         }
       }
     } else {
@@ -949,21 +1028,23 @@ export async function runToolLoop(options: ToolLoopOptions): Promise<ToolLoopRes
       });
       content = finalResponse.choices[0]?.message?.content || '';
       finalReportedModel = finalResponse.model;
-      finalCallTokens = finalResponse.usage?.total_tokens || 0;
-      finalPromptTokens = finalResponse.usage?.prompt_tokens || 0;
-      finalCompletionTokens = finalResponse.usage?.completion_tokens || 0;
+      finalCallTokens = reportedCount(finalResponse.usage?.total_tokens) ?? 0;
+      finalPromptTokens = reportedCount(finalResponse.usage?.prompt_tokens);
+      finalCompletionTokens = reportedCount(finalResponse.usage?.completion_tokens);
     }
 
     cumulativeTokens += finalCallTokens;
-    cumulativePromptTokens += finalPromptTokens;
-    cumulativeCompletionTokens += finalCompletionTokens;
+    cumulativePromptTokens += finalPromptTokens ?? 0;
+    cumulativeCompletionTokens += finalCompletionTokens ?? 0;
 
     if (synthesisSpanId) {
       trace!.builder.endSpan(synthesisSpanId, {
         'output.hash': traceHash(content),
         'output.length': content.length,
-        'gen_ai.response.prompt_tokens': finalPromptTokens,
-        'gen_ai.response.completion_tokens': finalCompletionTokens,
+        ...responseTokenAttributes({
+          prompt_tokens: finalPromptTokens,
+          completion_tokens: finalCompletionTokens,
+        }),
         ...responseModelAttributes(declaredModel, finalReportedModel, logContext),
       });
     }


### PR DESCRIPTION
Wave N8, Phase P4b (lane 1). Base `f117665` (tag `rollback/pre-n8-p4b`). Closes #312.

## Blast zone

Two files, both inside the declared zone. Nothing else in the repository was created, edited or deleted.

```
 src/lib/model-loop/absent-usage.test.ts | 516 ++++++++++++++++++++++++++++++++
 src/lib/model-loop/run-tool-loop.ts     | 113 ++++++-
 2 files changed, 613 insertions(+), 16 deletions(-)
```

`src/lib/model-loop/absent-usage.test.ts` is new and matches `src/**/*.test.ts`, which the zone admits. Nothing P6 owns was touched — in particular `model-call-registry.test.ts`, `socrata-skill.ts`, `preamble-advertised-tools.test.ts`, `mcp/tools.ts`, `evidence/[slug]/evaluate/route.ts`, `evidence/adversarial-eval.ts` and the docs are all unchanged. `test-harness.ts` is unchanged (see the flag below).

## What changed

Six sites, two mechanisms, one construction site now.

**Mechanism one** — both `llm_inference` sites — coalesced absence to zero with an inline `|| 0` on `response.usage`.

**Mechanism two** — the `synthesis` span, the answering turn that produces the published answer — reached the same false zero by a different route, which is why a grep for the `|| 0` shape could not see it: `finalPromptTokens` / `finalCompletionTokens` were `0`-initialised numbers that simply stayed `0` when no usage arrived. They now start `undefined`.

Both now go through one private `responseTokenAttributes(usage)`, which spreads a count in **only when a count was reported**, on each of the two counts independently.

**Omission means the key is never built, not that its value is `undefined`.** Measured against this repo's own dependencies: `TraceBuilder` maps an attribute record through `Object.entries` into an array of `{key, value}` pairs, so a key whose value is `undefined` does **not** vanish the way an object property would — it survives canonicalization as `{"key":"gen_ai.response.prompt_tokens","value":{}}`. A valueless attribute under the signature is worse than the zero it replaced. This inverts the trap #312 names, and the canonical-bytes assertion catches it either way.

**A genuine zero is still a measurement.** The streaming path's truthy guards (`if (chunk.usage.prompt_tokens)`) would have erased an endpoint that truthfully reported `0`; they become absence checks bounded by `Number.isFinite`, which keeps the old guards' one useful effect — a `NaN` never lands in a signed trace — while admitting the zero.

Newly captured traces only. No re-emission, no lifecycle events, no migration.

## The census, re-derived on the branch

`git grep -n -P "gen_ai\.response\.(prompt|completion)_tokens"` over all tracked files, no pathspec:

```
src/lib/model-loop/absent-usage.test.ts:6:// `gen_ai.response.prompt_tokens: 0` for a call the endpoint said nothing
src/lib/model-loop/absent-usage.test.ts:40://     `{"key":"gen_ai.response.prompt_tokens","value":{}}`, a valueless
src/lib/model-loop/absent-usage.test.ts:76:const PROMPT_TOKENS = 'gen_ai.response.prompt_tokens';
src/lib/model-loop/absent-usage.test.ts:77:const COMPLETION_TOKENS = 'gen_ai.response.completion_tokens';
src/lib/model-loop/run-tool-loop.ts:431: * `{"key":"gen_ai.response.prompt_tokens","value":{}}`, measured, and the JCS
src/lib/model-loop/run-tool-loop.ts:459:    ...(promptTokens !== undefined ? { 'gen_ai.response.prompt_tokens': promptTokens } : {}),
src/lib/model-loop/run-tool-loop.ts:460:    ...(completionTokens !== undefined ? { 'gen_ai.response.completion_tokens': completionTokens } : {}),
```

The only emission sites are `:459-460`; every other hit is prose or a test constant. Six unconditional emission sites became one conditional pair.

## Red demonstrations

Criteria 2 and 3 pull in opposite directions, so both were shown red — 2 against the base, 3 against a deliberately-wrong fix, because the base already passes it.

**Criterion 2 — the synthesis span, RED at `f117665`** (the new suite run before the source change):

```
not ok 3 - #312: an answering turn whose endpoint reports no usage leaves the synthesis span with neither count (blocking)
  error: the answering turn reported no usage: span "synthesis" carries gen_ai.response.prompt_tokens = {"intValue":"0"}
not ok 4 - #312: an answering turn whose endpoint reports no usage leaves the synthesis span with neither count (stream)
  error: the answering turn reported no usage: span "synthesis" carries gen_ai.response.prompt_tokens = {"intValue":"0"}
```

That case has the **tool turns reporting usage**, so a fix reaching only mechanism one leaves the `llm_inference` spans correct and this case still red. Ten cases, 3 pass / 7 fail at the base.

**Criterion 3 — a genuine zero, RED under a falsy-check fix.** `reportedCount` temporarily replaced by `return value ? Number(value) : undefined`:

```
ok 1 - ... an endpoint reporting no usage leaves no token attribute on any span (blocking answering turn)
ok 2 - ... (stream answering turn)
ok 3 - ... the synthesis span with neither count (blocking)
ok 4 - ... (stream)
not ok 5 - #312: an endpoint reporting a genuine zero still gets 0 on every span (blocking answering turn)
not ok 6 - #312: an endpoint reporting a genuine zero still gets 0 on every span (stream answering turn)
# tests 10 / # pass 8 / # fail 2
```

**Criterion 4 — omission by `undefined`, RED.** The conditional spreads temporarily replaced by unconditional `'gen_ai.response.prompt_tokens': promptTokens as number`:

```
not ok 1 - ... error: the endpoint reported no usage: span "llm_inference" carries gen_ai.response.prompt_tokens = {}
not ok 3 - ... error: the answering turn reported no usage: span "synthesis" carries gen_ai.response.prompt_tokens = {}
# tests 10 / # pass 4 / # fail 6
```

Both counterfactuals were reverted; `git grep -c COUNTERFACTUAL` over the branch returns nothing.

## The returned `usage` accumulators — argued, not silently left

**Decision: unchanged, and pinned by a test.**

- It is a **sum over turns**, and "absent contributes nothing to a total" is the correct semantic for a sum. A per-span count is a single call's measurement, where absent and zero are exactly distinguishable; a run-wide total where one turn reported and another did not has no honest scalar other than "the sum of what was reported."
- **Both consumers already omit at their own boundary**, which is where absence is expressible: `packager.ts:476` (`promptTokens: input.tokenUsage.promptTokens || undefined`) for the signed `cost` block, and `openrouter-streaming.ts:297-298` for the wire. So a run with no usage anywhere already produces a package with the counts absent.
- Widening `ToolLoopResult['usage']` to `number | undefined` would change the return type for every caller — `openrouter-streaming.ts`, `compare-loop.ts`, `replay-loop.ts`, `evidence/[slug]/replay/route.ts` and `AttestationDialog.tsx` (whose `tokenUsage` requires numbers) — all outside this phase's zone, to express something no consumer currently needs.

The test `#312: with no usage reported anywhere the returned totals are zero, and the counts are omitted at the boundary` states this on the record, so a later phase that changes it has to change that line and say why.

## Flagged, not fixed

1. **`src/lib/model-loop/test-harness.ts` cannot express absent usage.** `startScriptedModelServer` hardcodes `{prompt_tokens: 10, completion_tokens: 5}` on every reply. The right fix is a `usage?: Record<string, number> | null` field on `ScriptedReply`, after which `startUsageScriptedServer` in the new test file deletes entirely. Out of zone for P4b, so the capability is local and the duplication is flagged rather than taken.
2. **`src/lib/openrouter-streaming.ts:209-212`** — the tool-free streaming path tracks `if (chunk.usage?.total_tokens)` and reports `tokens_used: tokensUsed` with `tokensUsed` initialised to `0`. Same class as #312 (absent usage reported as zero) at the wire/display layer rather than on a span, so not under a signature; not fixed, out of zone.
3. **`packager.ts:476` and `openrouter-streaming.ts:297-298` use a falsy check** (`|| undefined`) rather than an absence check. Correct in practice at the sum layer — a run whose endpoints all reported would never total zero prompt tokens — but it is the same shape criterion 3 exists to prevent, one layer up. Out of zone.
4. **The token budget is unenforceable when usage is absent.** `cumulativeTokens` stays `0`, so `maxCumulativeTokens` never trips on an endpoint that reports nothing. Pre-existing, arguably correct (a budget cannot be enforced on an unmeasured quantity), unexamined by any test. Not this phase.
5. **`CLAUDE.md`'s command table is stale at `f117665`**: it documents `npm test` as `# pass 1092` (actual base: 1158) and `npm run lint` as `✖ 4 problems (0 errors, 4 warnings)` (actual base, verified by stashing this branch's changes: `✖ 3 problems (0 errors, 3 warnings)`). Docs are out of zone.

## Contract premises — all six line references verified, one contract-layer detail corrected

Every `file:line` in the phase contract survived the check, at `f117665`:

- `run-tool-loop.ts:637-638`, `:842-843`, `:965-966` — exact, all six attributes.
- `:916-917` locals initialised to `0`; `:938` `if (chunk.usage)`; `:940-941` the assignments; `:953-954` the non-stream `|| 0`; `:645` `cumulativePromptTokens` init; `:849` the add; `:958-959` the final add — all exact.
- `packager.ts:470-478` carries the "Zero is not a measurement (website#30 P3, §2.5)… Absent usage is now absent" comment, the comment opening at `:470` and the two count lines at `:476-477`.
- Baseline `# tests 1158 / # suites 10 / # pass 1158 / # fail 0` reproduced locally at `f117665`, identical to run `33199189643`.

**Corrected:** #312's fix-shape note says an `undefined` property is dropped by the canonicalizer so a `hasOwnProperty` assertion "fails while the behaviour is correct." For a plain object that is true. For a **trace span** it is the opposite, and it was measured here: attributes are an array of `{key, value}` records built by `Object.entries`, so an `undefined` value leaves the key in place with an empty value object, and the canonicalizer keeps it. The instruction that follows — assert over canonical bytes — is right for both, and is what the suite does.

## Checks

`npm ci` first. All five green.

**`npm test`**

```
1..1135
# tests 1168
# suites 10
# pass 1168
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1995.54175
```

Base was `# tests 1158 / # suites 10 / # pass 1158 / # fail 0`; +10, exactly the ten cases added. Test names were captured before and after and diffed: **zero names removed**, ten added.

**`npm run build`** — exit 0.

```
▲ Next.js 16.3.0 (Turbopack)
✓ Running next.config.ts took 10ms

  Creating an optimized production build ...
✓ Compiled successfully in 249ms
  Running TypeScript ...
  Finished TypeScript in 984ms ...
  Collecting page data using 9 workers ...
✓ Generating static pages using 9 workers (32/32) in 186ms
```

followed by the Route (app) table. The two Turbopack warnings are pre-existing (`src/lib/notebook-author/helpers/index.ts:26`, dynamic filesystem access) and untouched by this change.

**`npm run typecheck`** — no output, exit 0.

**`npm run lint`** — exit 0.

```
✖ 3 problems (0 errors, 3 warnings)
```

Three warnings, all pre-existing (`AttestationDialog.tsx:8`, `RenderingCellOutputs.tsx:96`, `bpmn/animation.ts:8`); the base measures 3 as well.

**`npm run check:compose-env`**

```
  RESULT: PASS — every variable this profile reads can reach the container.
```

## Provenance

One commit, both trailers contiguous and in order, verified with `git log --format='%(trailers:only)'`:

```
Signed-off-by: Nathan Storey <npstorey@users.noreply.github.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
```

Exactly one `Signed-off-by`, matching the author `Nathan Storey <npstorey@users.noreply.github.com>` exactly. The message body was written without trailers and composed by `-s` plus `--trailer`.

Model: **Opus 5** (`claude-opus-5[1m]`).

## On the runner

Run `33200662901`, at `70d19dc`. All five required checks pass.

```
DCO                            pass
Vercel                         pass
Vercel Preview Comments        pass
build / test / lint / typecheck  pass  1m30s
container image build          pass  59s
```

`build / test / lint / typecheck` on Node `v22.23.2` reproduces the local figure exactly:

```
# tests 1168
# suites 10
# pass 1168
# fail 0
# cancelled 0
# skipped 0
# todo 0
```
