### PR TITLE
THROWAWAY (do not merge) — N8 cold read criterion 5 red probe

### DIFF
--- a/tools/x.mjs
+++ b/tools/x.mjs
@@ -1,0 +1,15 @@
+// THROWAWAY — cold-read probe for N8 criterion 5. Not merged.
+// A tool-calling model call under a top-level directory the repository did not
+// have. If the registry guard's universe is derived from `git ls-files`, this
+// file reds the suite on the runner. Deleted with its branch.
+import OpenAI from 'openai';
+
+const client = new OpenAI({ apiKey: process.env.NOT_A_REAL_KEY });
+
+export async function probe() {
+  return client.chat.completions.create({
+    model: 'probe',
+    messages: [{ role: 'user', content: 'probe' }],
+    tools: [{ type: 'function', function: { name: 'probe', parameters: {} } }],
+  });
+}


### PR DESCRIPTION
**DO NOT MERGE — closed unmerged as soon as the run reports.**

N8 cold read, acceptance criterion 5: *"A throwaway `tools/x.mjs` (a directory
the repo does not have) calling `chat.completions.create` makes the suite go red
**on a runner**."*

This branch adds exactly that file and nothing else. A branch push dispatches
nothing in this repository; CI triggers on `pull_request` and on pushes to
`main`, so a draft PR is the shape a red demonstration takes.

Expected: the `build / test / lint / typecheck` job fails on
`model-call-registry.test.ts`. The branch and the file are deleted afterward.
