### PR TITLE
fix: what a signed record asserts about identical runs, and what a skeleton URL claims (#363 P8)

### DIFF
--- a/src/components/evidence/AttestationDialog.tsx
+++ b/src/components/evidence/AttestationDialog.tsx
@@ -2,6 +2,11 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { parseModelsResponse, type Model } from '@/lib/model-list';
+// The tool-call identity key, in ONE place. It used to be a private function
+// here with a verbatim copy in `replay-loop.test.ts`, because no `.test.ts` in
+// this tree can import a `.tsx` — so the shipped function had no test and the
+// copy could only ever agree with itself. Both now import this module.
+import { canonicalizeToolCall } from '@/lib/evidence/tool-call-identity';
 
 // --- Types ---
 
@@ -51,16 +56,6 @@ interface AttestationDialogProps {
 }
 
 // --- Metric computation ---
-
-function canonicalizeToolCall(tc: { name: string; args: Record<string, unknown> }): string {
-  const key = [
-    tc.name,
-    tc.args.type as string || '',
-    tc.args.dataset_id as string || '',
-    tc.args.portal as string || '',
-  ].join(':');
-  return key;
-}
 
 function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
   const intersection = new Set([...a].filter(x => b.has(x)));

--- a/src/lib/evidence/tool-call-identity.test.ts
+++ b/src/lib/evidence/tool-call-identity.test.ts
@@ -1,0 +1,184 @@
+// The tool-call identity key a signed consistency attestation is built from.
+//
+// WHY THIS FILE EXISTS. The key used to be a private function inside
+// `AttestationDialog.tsx`, and a verbatim copy of it lived in
+// `replay-loop.test.ts` under a comment saying the copy going stale would be
+// "the loud failure" — because no `.test.ts` in this tree imports a `.tsx`, so
+// the real function had no test at all. Two implementations that can drift is
+// not a guard; it is the defect wearing a guard's clothes. The function now
+// lives in `./tool-call-identity.ts`, the dialog and the tests both import it,
+// and this file is the only place its behaviour is asserted.
+//
+// THE PROPERTY. Any difference in a tool call's arguments must produce a
+// different key. The old key was a hand-picked field list
+// (`name:type:dataset_id:portal`), and a hand-picked list is exactly what
+// failed — twice over: `search` and `fetch` carry none of those four fields,
+// and `where` was never in the list even for `get_data`. Both cases are below.
+//
+// Run with: npm test
+//   (or: node --test --experimental-strip-types src/lib/evidence/tool-call-identity.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { canonicalizeToolCall } from './tool-call-identity.ts';
+
+/** A replay run, as `AttestationDialog` reads it off `/api/records/:slug/replay`. */
+type Run = { name: string; args: Record<string, unknown> }[];
+
+/** The key SET of a run — what `computeConsistencyMetrics` compares pairwise. */
+const keysOf = (run: Run): Set<string> => new Set(run.map(canonicalizeToolCall));
+
+const sameSet = (a: Set<string>, b: Set<string>): boolean =>
+  a.size === b.size && [...a].every(k => b.has(k));
+
+// --- RED 1: two different searches -----------------------------------------
+//
+// Ruling D9 made `search` and `fetch` model-callable. Their schemas are narrow
+// on purpose: `search` takes only `query`, `fetch` only `id`. Neither carries
+// `type`, `dataset_id` or `portal`, so under the old key every search
+// collapsed to `search:::` and every fetch to `fetch:::`. Two runs that
+// searched for entirely different things produced identical key sets, Jaccard
+// returned 1, and `(1 + outputSimilarity)/2 >= 0.9` classified them
+// `highly_reproducible` — in a SIGNED consistency attestation rendering
+// "Tool overlap: 100%".
+
+test('two searches for different phrases are two different keys', () => {
+  const noise = canonicalizeToolCall({ name: 'search', args: { query: 'noise complaints' } });
+  const rats = canonicalizeToolCall({ name: 'search', args: { query: 'rat sightings' } });
+  assert.notEqual(noise, rats, 'a search key must carry the phrase that was searched for');
+});
+
+test('two fetches of different identifiers are two different keys', () => {
+  const a = canonicalizeToolCall({ name: 'fetch', args: { id: 'dataset:data.cityofnewyork.us:erm2-nwe9' } });
+  const b = canonicalizeToolCall({ name: 'fetch', args: { id: 'dataset:data.cityofnewyork.us:zzzz-9999' } });
+  assert.notEqual(a, b, 'a fetch key must carry the identifier that was fetched');
+});
+
+test('two runs that searched for different things do not have identical key sets', () => {
+  // The cold read's fixture, verbatim. Identical key sets are Jaccard 1 by
+  // definition (|A ∩ B| / |A ∪ B| with A === B), which is the input that made
+  // the classification `highly_reproducible`.
+  const runA: Run = [
+    { name: 'search', args: { query: 'noise complaints' } },
+    { name: 'fetch', args: { id: 'dataset:data.cityofnewyork.us:erm2-nwe9' } },
+  ];
+  const runB: Run = [
+    { name: 'search', args: { query: 'rat sightings' } },
+    { name: 'fetch', args: { id: 'dataset:data.cityofnewyork.us:zzzz-9999' } },
+  ];
+  assert.equal(
+    sameSet(keysOf(runA), keysOf(runB)),
+    false,
+    'two runs that read different data must not present as one repeated run',
+  );
+});
+
+// --- RED 2: the same dataset, a different `where` ---------------------------
+//
+// The half the wave did not cause. `where` was never in the key, so two
+// `get_data` calls against the same dataset on the same portal filtering for
+// different things have been indistinguishable since the key was written. This
+// is why the fix is property-shaped — a patch that added `query` and `id` to
+// the field list would leave this case exactly as it is.
+
+test('the same dataset with different WHERE clauses is two different keys', () => {
+  const base = { type: 'query', dataset_id: 'erm2-nwe9', portal: 'data.cityofnewyork.us' };
+  const noise = canonicalizeToolCall({ name: 'get_data', args: { ...base, where: "complaint_type='Noise - Residential'" } });
+  const rodent = canonicalizeToolCall({ name: 'get_data', args: { ...base, where: "complaint_type='Rodent'" } });
+  assert.notEqual(noise, rodent, 'a filter that changes the rows must change the key');
+});
+
+test('every other argument that changes the rows changes the key', () => {
+  const base = { type: 'query', dataset_id: 'erm2-nwe9', portal: 'data.cityofnewyork.us' };
+  const reference = canonicalizeToolCall({ name: 'get_data', args: base });
+  for (const [key, value] of Object.entries({
+    select: 'complaint_type, COUNT(*)',
+    where: "created_date > '2024-01-01'",
+    group: 'complaint_type',
+    order: 'count DESC',
+    limit: 10,
+    offset: 100,
+    query: 'SELECT complaint_type',
+  })) {
+    assert.notEqual(
+      canonicalizeToolCall({ name: 'get_data', args: { ...base, [key]: value } }),
+      reference,
+      `adding ${key} must change the key`,
+    );
+  }
+});
+
+// --- The properties the key must hold ---------------------------------------
+
+test('the tool name still discriminates', () => {
+  assert.notEqual(
+    canonicalizeToolCall({ name: 'search', args: { query: 'x' } }),
+    canonicalizeToolCall({ name: 'ckan__search_datasets', args: { query: 'x' } }),
+  );
+});
+
+test('two identical calls are one key, whatever order the model wrote the arguments in', () => {
+  // Not cosmetic. A tool call\'s arguments arrive as `JSON.parse` of whatever
+  // the endpoint emitted, and object key order is preserved by that parse. Two
+  // genuinely identical calls written in different orders must not read as two
+  // different calls — that failure runs the other way, scoring a reproducible
+  // run as inconsistent, and it is just as false.
+  const a = canonicalizeToolCall({ name: 'get_data', args: { type: 'query', dataset_id: 'erm2-nwe9', limit: 5 } });
+  const b = canonicalizeToolCall({ name: 'get_data', args: { limit: 5, dataset_id: 'erm2-nwe9', type: 'query' } });
+  assert.equal(a, b);
+});
+
+test('a nested argument value is compared by content, not by the order it was written in', () => {
+  const a = canonicalizeToolCall({ name: 'ckan__query_data', args: { filters: { b: 1, a: 2 } } });
+  const b = canonicalizeToolCall({ name: 'ckan__query_data', args: { filters: { a: 2, b: 1 } } });
+  assert.equal(a, b);
+  const c = canonicalizeToolCall({ name: 'ckan__query_data', args: { filters: { a: 2, b: 3 } } });
+  assert.notEqual(a, c, 'a nested value that differs must still change the key');
+});
+
+test('array order is significant — it changes what was asked for', () => {
+  const a = canonicalizeToolCall({ name: 'ckan__aggregate_data', args: { fields: ['a', 'b'] } });
+  const b = canonicalizeToolCall({ name: 'ckan__aggregate_data', args: { fields: ['b', 'a'] } });
+  assert.notEqual(a, b);
+});
+
+test('a call with no arguments is a key, not a crash', () => {
+  assert.equal(typeof canonicalizeToolCall({ name: 'search', args: {} }), 'string');
+});
+
+test('the name and the arguments cannot be confused for one another', () => {
+  // The serialisation of an argument object always starts with `{`, so the
+  // first `:` that precedes a `{` is unambiguously the separator even for a
+  // tool name that contained one. Stated as a test because the old format —
+  // four `:`-joined free-text fields — did not have this property.
+  const a = canonicalizeToolCall({ name: 'a:b', args: {} });
+  const b = canonicalizeToolCall({ name: 'a', args: { 'b:': {} } });
+  assert.notEqual(a, b);
+});
+
+// --- Criterion 14, restated for the new format ------------------------------
+//
+// N7 pinned `toolCallKeys` byte-identical WITH THE INJECTED PORTAL INTACT.
+// This phase's ruling supersedes the format that pin was written against; what
+// must not change is that a `get_data` key still reflects the portal the loop
+// core injected. The end-to-end version of this — the portal injected by the
+// real loop, through the real replay options — is in `replay-loop.test.ts`.
+
+test('an injected portal is part of the key, and a different portal is a different key', () => {
+  const nyc = canonicalizeToolCall({
+    name: 'get_data',
+    args: { type: 'query', dataset_id: 'erm2-nwe9', portal: 'data.cityofnewyork.us' },
+  });
+  const sf = canonicalizeToolCall({
+    name: 'get_data',
+    args: { type: 'query', dataset_id: 'erm2-nwe9', portal: 'data.sfgov.org' },
+  });
+  assert.equal(nyc, 'get_data:{"dataset_id":"erm2-nwe9","portal":"data.cityofnewyork.us","type":"query"}');
+  assert.notEqual(nyc, sf, 'the same query against two portals read two different sources');
+});
+
+test('a call that carries no portal is not given one', () => {
+  const key = canonicalizeToolCall({ name: 'search', args: { query: 'noise complaints' } });
+  assert.equal(key, 'search:{"query":"noise complaints"}');
+  assert.ok(!key.includes('portal'), 'nothing in the key may name a source the call did not carry');
+});

--- a/src/lib/evidence/tool-call-identity.ts
+++ b/src/lib/evidence/tool-call-identity.ts
@@ -1,0 +1,64 @@
+/**
+ * The identity key one tool call gets inside a consistency attestation.
+ *
+ * WHAT IT IS FOR. `AttestationDialog` replays a published analysis N times and
+ * scores how reproducible the runs were. The tool-call half of that score is
+ * the average pairwise Jaccard similarity of the runs' key SETS, and the keys
+ * themselves are written into the attestation package that is then hashed and
+ * SIGNED. So this function decides two things a reader is shown as facts: the
+ * "Tool overlap: N%" figure, and whether the run is labelled
+ * `highly_reproducible`.
+ *
+ * THE PROPERTY: any difference in a call's arguments produces a different key.
+ *
+ * It is stated as a property because the thing it replaces was a hand-picked
+ * field list — `name:type:dataset_id:portal` — and a hand-picked list is what
+ * failed, in two independent ways:
+ *
+ *   - `search` takes only `query` and `fetch` only `id`, so once both became
+ *     model-callable every search collapsed to `search:::` and every fetch to
+ *     `fetch:::`. Two runs that searched for entirely different things had
+ *     identical key sets, Jaccard returned 1, and `(1 + outputSimilarity)/2`
+ *     cleared the 0.9 threshold. A signed attestation reported 100% tool
+ *     overlap for two runs that read different data.
+ *   - `where` was never in the list at all. Two `get_data` queries against the
+ *     same dataset on the same portal filtering for different things have been
+ *     indistinguishable since the key was written — before either of those two
+ *     tools existed.
+ *
+ * Enumerating fields is therefore not a smaller version of the right answer;
+ * it is the defect. The key is the tool name plus a canonical serialisation of
+ * the whole argument object, and a field this repository has never heard of is
+ * discriminated on exactly like one it defines.
+ *
+ * WHY RFC 8785 AND NOT `JSON.stringify`. Arguments reach us as `JSON.parse` of
+ * whatever the model endpoint emitted, and that parse preserves the endpoint's
+ * key order. Two genuinely identical calls written in different orders must be
+ * one key — otherwise the score fails in the other direction, calling a
+ * reproducible run inconsistent, which is just as false a claim to sign.
+ * `jcs()` (RFC 8785, already this repository's canonical-JSON function, and
+ * browser-safe by construction because the verifier runs in a browser too)
+ * sorts object keys at every depth and leaves array order alone — which is
+ * right: `["a","b"]` and `["b","a"]` are different requests.
+ *
+ * THIS IS NOT THE SIGNING CANONICALISATION. The attestation package's own
+ * signed bytes are produced by the route, not here. This function only decides
+ * what counts as "the same tool call"; it happens to want the same well-defined
+ * serialisation, and reusing the one implementation beats growing a second.
+ *
+ * SEPARATOR. A serialised argument object always begins with `{`, so the `:`
+ * before it is unambiguous even for a tool name that contained one — the four
+ * `:`-joined free-text fields it replaces had no such property.
+ *
+ * HISTORICAL ATTESTATIONS ARE NOT AFFECTED. Keys are computed once, at
+ * submission time, from a live replay's results, and stored inside the package
+ * that is hashed and signed. Nothing reads them back and nothing recomputes
+ * them: `AttestationSection` renders the stored `metrics.toolCallOverlap`, and
+ * the backfill signs `row.packageHash` as stored. An attestation signed before
+ * this change keeps the bytes it was signed over.
+ */
+import { jcs } from './canonicalization.ts';
+
+export function canonicalizeToolCall(tc: { name: string; args?: Record<string, unknown> }): string {
+  return `${tc.name}:${jcs(tc.args ?? {})}`;
+}

--- a/src/lib/model-loop/replay-loop.test.ts
+++ b/src/lib/model-loop/replay-loop.test.ts
@@ -45,6 +45,17 @@ import {
 } from './replay-loop.ts';
 import { startScriptedModelServer, type ScriptedReply } from './test-harness.ts';
 import { createModelClient } from '../model-client.ts';
+// THE function `AttestationDialog` calls, not a copy of it. This file used to
+// carry a verbatim copy under a comment arguing that a copy going stale would
+// be "the loud failure" and that a shared helper "would quietly agree with
+// itself". The copy was never the guard it was described as: it agreed with
+// itself for two model-callable tools whose arguments the key did not read,
+// and for a `where` clause the key had never read. The canonicalisation now
+// lives in a `.ts` module both this file and the component import, and its own
+// properties are asserted in `src/lib/evidence/tool-call-identity.test.ts`.
+// What this file still measures is the END-TO-END fact only it can: that the
+// portal the loop core injects into the recorded args reaches those keys.
+import { canonicalizeToolCall } from '../evidence/tool-call-identity.ts';
 
 const FIXTURE_KEY = 'not-a-real-key-p3-replay-fixture';
 const PORTAL = 'data.cityofnewyork.us';
@@ -139,24 +150,6 @@ async function runReplay(
 
 const messagesOf = (requests: Record<string, unknown>[]): Wire[] =>
   requests.flatMap((r) => (r.messages as Wire[] | undefined) ?? []);
-
-/**
- * `AttestationDialog.canonicalizeToolCall`, copied verbatim from
- * `src/components/evidence/AttestationDialog.tsx:55-63`. Copied rather than
- * imported on purpose: the component is a client module behind the `@/` alias
- * that `node --test` cannot resolve, and the point of this test is that the
- * KEYS a signed attestation is built from do not move. If the component's
- * function ever changes, this copy going stale is the loud failure — a shared
- * helper would quietly agree with itself.
- */
-function canonicalizeToolCall(tc: { name: string; args: Record<string, unknown> }): string {
-  return [
-    tc.name,
-    (tc.args.type as string) || '',
-    (tc.args.dataset_id as string) || '',
-    (tc.args.portal as string) || '',
-  ].join(':');
-}
 
 // --- #338: an announcement is not an answer --------------------------------
 //
@@ -278,16 +271,24 @@ test('#331: an oversized envelope reaches the model as valid JSON with a row mar
   assert.ok(body.length <= REPLAY_MAX_TOOL_RESULT_CHARS, 'the bound is still enforced on the body');
 });
 
-// --- The attestation payload changes only additively -----------------------
+// --- The injected portal reaches the attestation identity keys -------------
 //
-// `AttestationDialog` keys a replay run on
-// `name:args.type:args.dataset_id:args.portal` and derives a consistency score
-// from the keys of N runs. The portal in that key is injected by this caller
-// INTO THE OBJECT THE CORE ALREADY RECORDED. If the loop ever clones or
-// freezes `args`, the injection stops reaching the record, every key changes,
-// and nothing in the diff points at the cause. These are the keys, spelled out.
+// `AttestationDialog` keys a replay run on the tool name plus a canonical
+// serialisation of the call's whole argument object
+// (`lib/evidence/tool-call-identity.ts`), and derives a consistency score from
+// the keys of N runs. The portal in those keys is injected by this caller INTO
+// THE OBJECT THE CORE ALREADY RECORDED. If the loop ever clones or freezes
+// `args`, the injection stops reaching the record, every key changes, and
+// nothing in the diff points at the cause. These are the keys, spelled out.
+//
+// The FORMAT below is new. N7's criterion 8 pinned the four-field key
+// `name:type:dataset_id:portal` byte-identical; N8 P8's ruling supersedes that
+// format, because a four-field key could not tell two different searches — or
+// two different `where` clauses — apart, and those keys are signed. What the
+// pin still holds, and the only thing it was ever protecting, is that the
+// injected portal survives into the keys.
 
-test('the attestation identity keys are unchanged, injected portal included', async () => {
+test('the attestation identity keys carry the injected portal', async () => {
   const { payload } = await runReplay(
     [
       {
@@ -308,13 +309,17 @@ test('the attestation identity keys are unchanged, injected portal included', as
   );
 
   assert.deepEqual(payload.toolCalls.map(canonicalizeToolCall), [
-    // portal injected by this caller — absent from what the endpoint sent
-    'get_data:catalog::data.cityofnewyork.us',
-    'get_data:query:erm2-nwe9:data.cityofnewyork.us',
+    // portal injected by this caller — absent from what the endpoint sent.
+    // `query` is in the key now; under the four-field format this call and any
+    // other catalog search on this portal were the same key.
+    'get_data:{"portal":"data.cityofnewyork.us","query":"noise complaints","type":"catalog"}',
+    'get_data:{"dataset_id":"erm2-nwe9","portal":"data.cityofnewyork.us","type":"query"}',
     // an explicit portal is never overwritten
-    'get_data:metrics:erm2-nwe9:data.sfgov.org',
-    // a non-Socrata tool gets no portal at all
-    'get_variables:::',
+    'get_data:{"dataset_id":"erm2-nwe9","portal":"data.sfgov.org","type":"metrics"}',
+    // a non-Socrata tool gets no portal at all — and its own argument is what
+    // now distinguishes it, rather than the three empty fields it used to
+    // collapse into
+    'get_variables:{"place":"geoId/36061"}',
   ]);
 });
 

--- a/src/lib/notebook.test.ts
+++ b/src/lib/notebook.test.ts
@@ -1,0 +1,245 @@
+// The skeleton notebook: what a step's URL is allowed to claim.
+//
+// WHAT THIS FILE GUARDS. `generateNotebook` builds the notebook that
+// `PublishEvidenceDialog` puts into a SIGNED record package when the session
+// did not execute in the sandbox (`executedNotebook ?? generateNotebook(...)`),
+// and that the response panel offers as a download. Its code cells are the
+// reader's way to re-run the analysis, so a URL in one of them is a claim
+// about what the analysis read.
+//
+// Two properties, both measured here by rendering rather than by reading:
+//
+//   1. No URL is emitted for a call this builder cannot address. The step
+//      filter is `operationType === 'query'`, which admits Data Commons' and
+//      CKAN's query tools as well as Socrata's — none of which carry a portal
+//      or a dataset id. The builder used to interpolate them anyway and emit
+//      `https://undefined/resource/undefined.json` under a row count from a
+//      different query.
+//
+//   2. A rendered URL carries every argument that affects its result and none
+//      that does not. `query` and `offset` are advertised on `get_data` and
+//      were silently dropped, so the cell returned the dataset's unfiltered
+//      default page under the original run's row count. That is worse than the
+//      #340 it mirrors: #340 raised a `TypeError` and told the reader live data
+//      could not be fetched; this ran clean and was confidently wrong.
+//
+// Run with: npm test
+//   (or: node --test --experimental-strip-types src/lib/notebook.test.ts)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateNotebook } from './notebook.ts';
+import { SOQL_QUERY_SNIFF } from './notebook-author/tool-to-cell.ts';
+
+const NO_ATTRIBUTION = { origin: null, host: null, platformTitle: null };
+const PORTAL = 'data.cityofnewyork.us';
+
+type ToolCallFixture = {
+  name: string;
+  args: Record<string, unknown>;
+  resultSummary?: { rows: number; columns: number };
+  operationType?: string;
+  reason?: string;
+};
+
+/** Every source line of every cell, as one string — what a reader downloads. */
+function render(tools: ToolCallFixture[], response = 'An analysis.'): string {
+  const nb = generateNotebook('How many complaints?', PORTAL, tools, response, NO_ATTRIBUTION);
+  return nb.cells.map(c => c.source.join('')).join('\n');
+}
+
+/** Just the code cells — where a URL would live. */
+function renderCode(tools: ToolCallFixture[]): string {
+  const nb = generateNotebook('How many complaints?', PORTAL, tools, '', NO_ATTRIBUTION);
+  return nb.cells.filter(c => c.cell_type === 'code').map(c => c.source.join('')).join('\n');
+}
+
+const socrataQuery = (args: Record<string, unknown>, extra: Partial<ToolCallFixture> = {}): ToolCallFixture => ({
+  name: 'get_data',
+  operationType: 'query',
+  args: { type: 'query', portal: PORTAL, dataset_id: 'erm2-nwe9', ...args },
+  ...extra,
+});
+
+// --- Property 1: no URL this builder cannot honestly address ----------------
+
+test('a Data Commons observation step renders no fabricated Socrata URL', () => {
+  const out = render([
+    {
+      name: 'get_observations',
+      operationType: 'query',
+      args: { variable_dcid: 'Median_Income_Person', place_dcid: 'geoId/36061' },
+      resultSummary: { rows: 47, columns: 3 },
+      reason: 'Median income',
+    },
+  ]);
+  assert.ok(!out.includes('undefined'), 'no cell may contain the word undefined');
+  assert.ok(!/https:\/\/[^"\s]*\/resource\//.test(out), 'no Socrata resource URL for a non-Socrata call');
+});
+
+test('a CKAN query step renders no fabricated Socrata URL', () => {
+  for (const name of ['ckan__query_data', 'ckan__execute_sql', 'ckan__aggregate_data']) {
+    const out = render([
+      {
+        name,
+        operationType: 'query',
+        args: { resource_id: 'abc-123', sql: 'SELECT 1' },
+        resultSummary: { rows: 12, columns: 2 },
+      },
+    ]);
+    assert.ok(!out.includes('undefined'), `${name}: no cell may contain the word undefined`);
+    assert.ok(!/https:\/\/[^"\s]*\/resource\//.test(out), `${name}: no Socrata resource URL`);
+  }
+});
+
+test('a query call missing its portal or dataset id renders no URL', () => {
+  for (const args of [
+    { type: 'query', dataset_id: 'erm2-nwe9' },
+    { type: 'query', portal: PORTAL },
+    { type: 'query' },
+  ]) {
+    const out = render([{ name: 'get_data', operationType: 'query', args }]);
+    assert.ok(!out.includes('undefined'), `no undefined for ${JSON.stringify(args)}`);
+    assert.ok(!out.includes('url = "'), `no URL assignment for ${JSON.stringify(args)}`);
+  }
+});
+
+test('a step with no URL is still a step, and still says what it read', () => {
+  // Dropping it would make the notebook claim the analysis rested on fewer
+  // sources than it did, which is the same false-precision failure pointing
+  // the other way (docs/design-principles.md Principle 3, Principle 2).
+  const out = render([
+    {
+      name: 'get_observations',
+      operationType: 'query',
+      args: { variable_dcid: 'Median_Income_Person', place_dcid: 'geoId/36061' },
+      resultSummary: { rows: 47, columns: 3 },
+      reason: 'Median income',
+    },
+    socrataQuery({}, { reason: 'Complaint counts' }),
+  ]);
+  assert.match(out, /Step 1: Median income/);
+  assert.match(out, /Step 2: Complaint counts/);
+  assert.match(out, /47 rows, 3 columns/, 'the original row count stays with its own step');
+  assert.match(out, /get_observations/, 'the step names the operation it could not reproduce');
+});
+
+test('a step with no URL contributes no data-source link', () => {
+  const out = render([
+    {
+      name: 'ckan__query_data',
+      operationType: 'query',
+      args: { resource_id: 'abc-123' },
+    },
+  ]);
+  assert.ok(!/\]\(https:\/\//.test(out), 'nothing may be linked as a source this notebook did not address');
+});
+
+// --- Property 2: every argument that affects the result --------------------
+
+test('an offset argument reaches the URL', () => {
+  const code = renderCode([socrataQuery({ limit: 50, offset: 100 })]);
+  assert.match(code, /\$offset=100/, 'a page the analysis read must be the page the cell reads');
+  assert.match(code, /\$limit=50/);
+});
+
+test('a search-phrase query argument reaches the URL as a full-text search', () => {
+  const code = renderCode([socrataQuery({ query: 'noise', where: "borough='QUEENS'" })]);
+  assert.ok(!SOQL_QUERY_SNIFF.test('noise'), 'the fixture is a phrase, not a statement');
+  assert.match(code, /\$q=noise/);
+  assert.match(code, /\$where=/, 'a phrase query does not supersede the clauses');
+});
+
+test('a full SoQL query argument becomes the whole query and supersedes the clauses', () => {
+  // The precedence the data source applies, and that P5 established for the
+  // executed-notebook renderer: a `query` matching SOQL_QUERY_SNIFF is sent as
+  // `$query` alone, and `$limit`/`$offset` are not sent alongside it.
+  const soql = 'SELECT complaint_type, count(*) GROUP BY complaint_type LIMIT 5';
+  assert.ok(SOQL_QUERY_SNIFF.test(soql), 'the fixture is a statement, not a phrase');
+  const code = renderCode([
+    socrataQuery({ query: soql, where: "borough='QUEENS'", limit: 10, offset: 20, select: 'complaint_type' }),
+  ]);
+  assert.match(code, /\$query=/);
+  assert.ok(!code.includes('$where='), 'a superseded clause is not written as an argument with no effect');
+  assert.ok(!code.includes('$select='), 'a superseded clause is not written as an argument with no effect');
+  assert.ok(!code.includes('$limit='), 'no $limit is sent with a $query');
+  assert.ok(!code.includes('$offset='), 'no $offset is sent with a $query');
+  assert.ok(!code.includes('$q='), 'a statement is not also sent as a search phrase');
+});
+
+test('the superseded clauses are disclosed, not silently dropped', () => {
+  const code = renderCode([
+    socrataQuery({ query: 'SELECT complaint_type LIMIT 5', where: "borough='QUEENS'", limit: 10 }),
+  ]);
+  assert.match(code, /Superseded on this call[^\n]*where/);
+  assert.match(code, /Superseded on this call[^\n]*limit/);
+});
+
+test('an argument this URL has no parameter for is disclosed, not silently dropped', () => {
+  const code = renderCode([socrataQuery({ some_future_arg: 'x' })]);
+  assert.match(code, /some_future_arg/, 'an unrecognised argument is named in the cell');
+  assert.ok(!code.includes('$some_future_arg='), 'and is not invented as a query parameter');
+});
+
+test('a clause whose value this URL cannot express is disclosed, not stringified into it', () => {
+  // Every advertised clause is typed string or number. Anything else would
+  // render as `$where=%5Bobject%20Object%5D` — a parameter with no effect on
+  // the rows, which is what the URL may not contain.
+  const code = renderCode([socrataQuery({ where: { column: 'borough' } })]);
+  assert.ok(!code.includes('$where='), 'no parameter is written from a value it cannot express');
+  assert.ok(!code.includes('object Object'), 'and nothing is stringified into the URL');
+  assert.match(code, /also passed where/, 'the argument is named in the cell instead');
+});
+
+test('the six advertised clauses still reach the URL', () => {
+  const code = renderCode([
+    socrataQuery({
+      select: 'complaint_type, COUNT(*) as count',
+      where: "created_date > '2024-01-01'",
+      group: 'complaint_type',
+      order: 'count DESC',
+      limit: 10,
+      offset: 5,
+    }),
+  ]);
+  for (const p of ['$select=', '$where=', '$group=', '$order=', '$limit=10', '$offset=5']) {
+    assert.ok(code.includes(p), `${p} must be in the URL`);
+  }
+});
+
+test('a limit of zero is a limit, not an absent argument', () => {
+  const code = renderCode([socrataQuery({ limit: 0 })]);
+  assert.match(code, /\$limit=0/);
+});
+
+test('the routing argument `type` is not invented as a query parameter', () => {
+  const code = renderCode([socrataQuery({})]);
+  assert.ok(!code.includes('$type='), '`type` selects the operation; it is not a Socrata parameter');
+  assert.ok(!code.includes('type'), 'and it is not disclosed as a dropped argument either');
+});
+
+// --- What did not change ----------------------------------------------------
+
+test('a reproducible Socrata step still renders the fetch it always did', () => {
+  const nb = generateNotebook(
+    'How many complaints?',
+    PORTAL,
+    [socrataQuery({ limit: 5 }, { resultSummary: { rows: 5, columns: 3 }, reason: 'Sample rows' })],
+    'An analysis.',
+    NO_ATTRIBUTION,
+  );
+  const all = nb.cells.map(c => c.source.join('')).join('\n');
+  assert.match(all, /url = "https:\/\/data\.cityofnewyork\.us\/resource\/erm2-nwe9\.json\?\$limit=5"/);
+  assert.match(all, /response = requests\.get\(url\)/);
+  assert.match(all, /df = pd\.DataFrame\(data\)/);
+  assert.match(all, /Original query returned 5 rows, 3 columns\./);
+  assert.match(all, /\[erm2-nwe9\]\(https:\/\/data\.cityofnewyork\.us\/d\/erm2-nwe9\)/);
+});
+
+test('non-query tool calls are still excluded from the step list', () => {
+  const out = render([
+    { name: 'get_data', operationType: 'catalog', args: { type: 'catalog', portal: PORTAL, query: '311' } },
+    { name: 'search', operationType: 'search', args: { query: '311' } },
+  ]);
+  assert.ok(!out.includes('Step 1'), 'discovery calls are not analysis steps');
+});

--- a/src/lib/notebook.ts
+++ b/src/lib/notebook.ts
@@ -10,6 +10,16 @@ import type { ToolCall } from '@/hooks/useStreamingComparison';
 // attribution lines are honestly omitted. Type-only import — erased at
 // compile time, so no env read rides into the client bundle.
 import type { InstanceAttribution } from './site-config.ts';
+// The sniff that decides what a `query` argument means is a fact about the data
+// source, not about either renderer, and it already exists exactly once —
+// `SOQL_QUERY_SNIFF`, pinned against the service's own regex by
+// `tool-to-cell.test.ts` and mirrored by `helpers/fetch_socrata.py`. A fourth
+// copy that drifts is precisely the defect this is fixing, so this module
+// imports the rule rather than restating it. The import is value-level and
+// this module ships in client bundles: `tool-to-cell.ts` reaches only
+// `cells.ts`, both pure string builders with no env read and no Node API, so
+// nothing server-only rides in behind it.
+import { isFullSoqlQuery } from './notebook-author/tool-to-cell.ts';
 
 export type { InstanceAttribution };
 
@@ -56,19 +66,202 @@ function codeCell(lines: string[]): NotebookCell {
   };
 }
 
-function buildSocrataUrl(args: Record<string, unknown>): string {
-  const portal = args.portal as string;
-  const datasetId = args.dataset_id as string;
+/**
+ * Socrata query-string parameters this builder emits — the args it can express
+ * in a URL, in the order it writes them.
+ *
+ * This is this module's own parameter list, the analogue of
+ * `notebook-author/tool-to-cell.ts`'s `FETCH_SOCRATA_PARAMS`: what the target
+ * can receive bounds what may be written. An arg outside it is disclosed in
+ * the cell rather than invented as a `$parameter` the portal would ignore.
+ */
+const SOCRATA_URL_CLAUSES = ['select', 'where', 'group', 'order', 'limit', 'offset'] as const;
+
+/**
+ * Args consumed by the URL's path, or by call routing, rather than by its query
+ * string — so they are neither written as parameters nor reported as dropped.
+ * `type` selects which operation ran (and has already selected this renderer);
+ * `portal` and `dataset_id` are the path; `query` is handled by the precedence
+ * rule below.
+ */
+const SOCRATA_URL_STRUCTURAL_ARGS = ['type', 'portal', 'dataset_id', 'query'] as const;
+
+/** An arg the call actually carried — `limit: 0` is a limit, `''` is not a clause. */
+function carriesArg(args: Record<string, unknown>, key: string): boolean {
+  const value = args[key];
+  return value !== undefined && value !== null && value !== '';
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * A value that can become a Socrata query-string parameter, or `null`.
+ *
+ * Every clause `get_data` advertises is typed `string` or `number`, so anything
+ * else is a value this builder cannot express. `String()`-ing it would write
+ * `$where=%5Bobject%20Object%5D` — a parameter with no effect on the rows, which
+ * is exactly what the URL may not contain. It is reported as an argument this
+ * URL has no parameter for instead.
+ */
+function urlParamValue(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+/** One analysis step, planned before any cell is written. */
+type QueryStep =
+  | {
+      kind: 'socrata';
+      url: string;
+      /** Generated comment lines that make the URL's arguments legible. */
+      comments: string[];
+      datasetId: string;
+      portal: string;
+    }
+  | {
+      kind: 'not-reproduced';
+      /** Markdown explaining why this step has no URL. */
+      note: string;
+    };
+
+/**
+ * Why a step gets no URL, in the reader's language.
+ *
+ * The step filter is `operationType === 'query'`, and since `operation-types.ts`
+ * that admits `get_observations`, `ckan__query_data`, `ckan__execute_sql` and
+ * `ckan__aggregate_data` as well as Socrata's `get_data`. None of those carry a
+ * portal or a dataset id, and this builder addresses one thing: a Socrata
+ * dataset over HTTP. Interpolating them anyway produced
+ * `https://undefined/resource/undefined.json` under the original step's row
+ * count — a cell that runs clean and reads nothing, in a notebook that goes
+ * into a signed record package.
+ *
+ * The step is still WRITTEN. Dropping it would make the document claim the
+ * analysis rested on fewer sources than it did, which is the same false
+ * precision pointing the other way (docs/design-principles.md Principle 3, and
+ * Principle 2's persistent source marking). What it must not do is name a
+ * source it did not read — so it says what ran and stops there.
+ */
+function notReproducedNote(toolName: string): string {
+  return (
+    `*Not reproduced below.* This step called \`${toolName}\`, and the cells in this ` +
+    'notebook fetch Socrata datasets by URL. This call named no Socrata portal and ' +
+    'dataset, so no URL is written for it — one written here would name a source the ' +
+    'step did not read. The original result is described above.'
+  );
+}
+
+/**
+ * The comment lines that make a `query` argument's effect legible.
+ *
+ * Two things a reader cannot see from the URL alone, and both change how they
+ * should read the numbers: which clauses the data source did NOT apply (so
+ * their absence from the URL is deliberate rather than a loss), and what bounds
+ * the row count once `$limit` is gone.
+ *
+ * Deliberately the same explanation `notebook-author/tool-to-cell.ts` gives for
+ * the executed notebook: it is the same fact about the same data source, and
+ * two surfaces explaining one behaviour differently is how they drift.
+ */
+function queryPrecedenceComment(soql: boolean, superseded: readonly string[]): string[] {
+  if (!soql) {
+    return [
+      '# `query` here is a search phrase rather than a SoQL statement, so the data',
+      '# source runs it as a full-text search within the data ($q) and applies the',
+      '# clauses below alongside it.',
+    ];
+  }
+  const lines = [
+    '# `query` here is a full SoQL statement, so the data source applies it as the',
+    '# whole query ($query): select / where / group / order — and limit / offset —',
+    '# are not sent alongside it. They are omitted from the URL rather than written',
+    '# as parameters that would have no effect on the rows this cell returns.',
+  ];
+  if (superseded.length > 0) {
+    lines.push(`# Superseded on this call, for that reason: ${superseded.join(', ')}.`);
+  }
+  lines.push(
+    '# The row count is therefore bounded by the statement\'s own LIMIT, or by the',
+    '# portal\'s default page size when the statement carries none.',
+  );
+  return lines;
+}
+
+/**
+ * Plan one analysis step: a Socrata URL that carries every argument affecting
+ * its result, or an honest note that this notebook cannot address the call.
+ *
+ * The URL is emitted only for a `get_data` call naming both a portal and a
+ * dataset. The gate is deliberately stricter than "portal and dataset present":
+ * the shape being built is Socrata's REST API, so the tool that speaks it is
+ * what makes the URL meaningful. Anything else degrades to a note, which is
+ * false about nothing.
+ */
+function planQueryStep(tool: ToolCall): QueryStep {
+  const args = tool.args;
+  const portal = nonEmptyString(args.portal);
+  const datasetId = nonEmptyString(args.dataset_id);
+  if (tool.name !== 'get_data' || !portal || !datasetId) {
+    return { kind: 'not-reproduced', note: notReproducedNote(tool.name) };
+  }
+
+  const rawQuery = nonEmptyString(args.query);
+  // The precedence the data source itself applies, through the one sniff this
+  // repository owns (`notebook-author/tool-to-cell.ts`): a `query` that is a
+  // full SoQL statement becomes `$query` and supersedes the clauses, and no
+  // `$limit`/`$offset` is sent with it.
+  const soql = rawQuery !== null && isFullSoqlQuery(rawQuery);
+
+  // Args this cell accounts for, either by writing them or by explaining their
+  // absence. Accumulated rather than assumed, so a clause whose value could not
+  // be written falls through to the disclosure below instead of vanishing.
+  const accountedFor = new Set<string>(SOCRATA_URL_STRUCTURAL_ARGS);
   const params: string[] = [];
+  const superseded: string[] = [];
+  if (soql) {
+    params.push(`$query=${encodeURIComponent(rawQuery)}`);
+    for (const clause of SOCRATA_URL_CLAUSES) {
+      if (!carriesArg(args, clause)) continue;
+      superseded.push(clause);
+      accountedFor.add(clause);
+    }
+  } else {
+    if (rawQuery !== null) params.push(`$q=${encodeURIComponent(rawQuery)}`);
+    for (const clause of SOCRATA_URL_CLAUSES) {
+      if (!carriesArg(args, clause)) continue;
+      const value = urlParamValue(args[clause]);
+      if (value === null) continue;
+      params.push(`$${clause}=${encodeURIComponent(value)}`);
+      accountedFor.add(clause);
+    }
+  }
 
-  if (args.select) params.push(`$select=${encodeURIComponent(args.select as string)}`);
-  if (args.where) params.push(`$where=${encodeURIComponent(args.where as string)}`);
-  if (args.group) params.push(`$group=${encodeURIComponent(args.group as string)}`);
-  if (args.order) params.push(`$order=${encodeURIComponent(args.order as string)}`);
-  if (args.limit) params.push(`$limit=${args.limit}`);
+  // Anything this URL has no parameter for is named in the cell. Nothing the
+  // call carried is silently absent from the reader's view of it.
+  const undisclosed = Object.keys(args)
+    .filter(key => carriesArg(args, key) && !accountedFor.has(key))
+    .sort();
 
-  const query = params.length > 0 ? '?' + params.join('&') : '';
-  return `https://${portal}/resource/${datasetId}.json${query}`;
+  const comments: string[] = [];
+  if (rawQuery !== null) comments.push(...queryPrecedenceComment(soql, superseded));
+  if (undisclosed.length > 0) {
+    comments.push(
+      `# The original call also passed ${undisclosed.join(', ')}, which this URL has no`,
+      '# parameter for; named here rather than dropped without a trace.',
+    );
+  }
+
+  const search = params.length > 0 ? '?' + params.join('&') : '';
+  return {
+    kind: 'socrata',
+    url: `https://${portal}/resource/${datasetId}.json${search}`,
+    comments,
+    datasetId,
+    portal,
+  };
 }
 
 export function generateNotebook(
@@ -126,13 +319,22 @@ export function generateNotebook(
     'import pandas as pd',
   ]));
 
-  // Filter to query tool calls only
+  // Filter to query tool calls only. NOTE that this admits every tool whose
+  // operation type is `query`, not only Socrata's — see `planQueryStep`.
   const queryTools = toolsCalled.filter(t => t.operationType === 'query');
+
+  // Datasets this notebook actually addressed, in the order it addressed them.
+  // Built from the planned steps rather than from the raw args, so the "Data
+  // sources" list below cites only what a cell in this document fetches. It
+  // used to read `dataset_id` off any query call and fall back to the run's
+  // selected portal for the link, which could publish a portal the call never
+  // named.
+  const datasetPortalMap = new Map<string, string>();
 
   for (let i = 0; i < queryTools.length; i++) {
     const tool = queryTools[i];
     const reason = tool.reason || `Query ${i + 1}`;
-    const url = buildSocrataUrl(tool.args);
+    const step = planQueryStep(tool);
 
     // Description cell
     const descLines = [`## Step ${i + 1}: ${reason}`];
@@ -142,11 +344,25 @@ export function generateNotebook(
         `*Original query returned ${tool.resultSummary.rows} rows, ${tool.resultSummary.columns} columns.*`,
       );
     }
+
+    if (step.kind === 'not-reproduced') {
+      // The step keeps its number and its result summary; it gets no code cell,
+      // because there is no URL this notebook can honestly write for it.
+      descLines.push('', step.note);
+      cells.push(markdownCell(descLines));
+      continue;
+    }
+
     cells.push(markdownCell(descLines));
+
+    if (!datasetPortalMap.has(step.datasetId)) {
+      datasetPortalMap.set(step.datasetId, step.portal);
+    }
 
     // Code cell
     cells.push(codeCell([
-      `url = "${url}"`,
+      ...step.comments,
+      `url = "${step.url}"`,
       '',
       'response = requests.get(url)',
       'response.raise_for_status()',
@@ -167,15 +383,8 @@ export function generateNotebook(
     ]));
   }
 
-  // Attribution cell — use per-dataset portal for correct links
-  const datasetPortalMap = new Map<string, string>();
-  for (const tool of queryTools) {
-    const id = tool.args.dataset_id as string;
-    const p = (tool.args.portal as string) || portal;
-    if (id && !datasetPortalMap.has(id)) {
-      datasetPortalMap.set(id, p);
-    }
-  }
+  // Attribution cell — every dataset a cell above fetches, linked on the portal
+  // that cell fetches it from (collected in the step loop).
   const attrLines = ['---', '', '**Data sources:**'];
   for (const [id, p] of datasetPortalMap) {
     attrLines.push(`- [${id}](https://${p}/d/${id})`);


### PR DESCRIPTION
Wave N8, phase P8 — chartered after the cold read (G12) on findings F1 and F2. Base `de4bd60`, the merged head of all eight prior phases. Model: **Opus 5** (`claude-opus-5[1m]`).

Two commits, one per task, each carrying `Signed-off-by` then `Co-Authored-By`, contiguous and in order.

---

## Task 1 — the tool-call identity key discriminates on every argument

`45c4ce6`

**The defect, verified at base.** `AttestationDialog.tsx:55-62` keyed a tool call as `name:type:dataset_id:portal`. Ruling D9 made `search` and `fetch` model-callable; their schemas are narrow on purpose (`search` takes only `query`, `fetch` only `id`), so neither carries any of those four fields. Every search collapsed to `search:::`. Two runs that searched for entirely different things produced identical key sets, `jaccardSimilarity` returned 1, `(toolCallOverlap + outputSimilarity)/2 >= 0.9` classified them `highly_reproducible`, and `:303` wrote those keys into a **signed** consistency attestation whose overlap renders as "Tool overlap: 100%" (`AttestationSection.tsx:362`).

**The fix is the property, not a longer list.** The key is the tool name plus an RFC 8785 canonical serialisation of the whole argument object. Canonical rather than raw, because arguments arrive as a parse of the endpoint's own key order: two identical calls written in different orders must stay one key, since scoring a reproducible run as *inconsistent* is just as false a claim to sign.

**One implementation.** The canonicalisation moved to `src/lib/evidence/tool-call-identity.ts`; `AttestationDialog.tsx` and `replay-loop.test.ts` both import it, and the verbatim copy at `replay-loop.test.ts:152-159` is gone. That copy existed because no `.test.ts` in this tree imports a `.tsx`, and its own comment argued a shared helper "would quietly agree with itself" — it was the copy that agreed with itself, on both of the failures above.

**Both REDs, shown red against the shipped behaviour before the fix.** The shipped function was extracted verbatim into the new module first, so the REDs ran against the real code rather than a description of it.

RED 1 — two different searches:
```
not ok 1 - two searches for different phrases are two different keys
  error: 'a search key must carry the phrase that was searched for'
  expected: 'search:::'
  actual:   'search:::'
  operator: 'notStrictEqual'

not ok 3 - two runs that searched for different things do not have identical key sets
  error: two runs that read different data must not present as one repeated run
         true !== false
```

RED 2 — the same dataset, a different `where` (the half the wave did not cause; `where` was never in the key):
```
not ok 4 - the same dataset with different WHERE clauses is two different keys
  error: 'a filter that changes the rows must change the key'
  expected: 'get_data:query:erm2-nwe9:data.cityofnewyork.us'
  actual:   'get_data:query:erm2-nwe9:data.cityofnewyork.us'
  operator: 'notStrictEqual'
```
9 of 13 red before, 13 of 13 green after.

**Historical attestations are untouched.** `toolCallKeys` appears exactly once in the tree (`AttestationDialog.tsx:298`, the write site) — nothing reads it back by name. Both production call sites take `completedRuns`, accumulated from live `POST /api/records/:slug/replay` responses; the route hashes and signs the submitted body verbatim; `AttestationSection` renders the stored `metrics.toolCallOverlap` and fetches the stored blob for the expanded view; `attestation-backfill.ts:250` signs `row.packageHash` as stored. No path recomputes a stored attestation.

**Criterion 14's pin is superseded, as the contract directs.** `replay-loop.test.ts`'s `the attestation identity keys are unchanged, injected portal included` is renamed to `the attestation identity keys carry the injected portal` and its expected keys updated to the new format. What the pin protects — that the portal the loop core injects into the recorded args survives into the keys — is unchanged and still asserted end-to-end through the real loop. **This is the one base test name absent from the new run, and it is the one the contract permits.**

---

## Task 2 — a skeleton notebook never emits an undefined URL, and carries every argument

`cd71d0d`

**The defect, verified at base by rendering.** `notebook.ts:59-72` built `https://${portal}/resource/${datasetId}.json` with no guard and handled only select/where/group/order/limit. Its step filter (`:130`) is `operationType === 'query'`, which since `operation-types.ts` also admits `get_observations`, `ckan__query_data`, `ckan__execute_sql` and `ckan__aggregate_data` — none of which carry a portal or dataset id. `PublishEvidenceDialog.tsx:167` puts this notebook into the signed package.

Criterion 4's RED, produced by rendering `generateNotebook` at `de4bd60`:
```
--- markdown ---
## Step 1: Median income

*Original query returned 47 rows, 3 columns.*
--- code ---
url = "https://undefined/resource/undefined.json"

response = requests.get(url)
...
--- markdown ---
## Step 2: Complaint counts

*Original query returned 5 rows, 2 columns.*
--- code ---
url = "https://data.cityofnewyork.us/resource/erm2-nwe9.json?$where=borough%3D'QUEENS'&$limit=10"
```
Step 2 is criterion 5's RED in the same render: the call carried `query: "SELECT complaint_type, count(*) GROUP BY complaint_type LIMIT 5"` and `offset: 100`, both dropped in silence, while `$where` and `$limit` — which the data source sets aside under a `$query` — were written as parameters with no effect. The cell returns a different page than the analysis read, under the analysis's row count. Worse than the #340 it mirrors: #340 raised a `TypeError` and told the reader live data could not be fetched; this runs clean and is confidently wrong.

The same fixture after the fix:
```
--- markdown ---
## Step 1: Median income

*Original query returned 47 rows, 3 columns.*

*Not reproduced below.* This step called `get_observations`, and the cells in this
notebook fetch Socrata datasets by URL. This call named no Socrata portal and
dataset, so no URL is written for it — one written here would name a source the
step did not read. The original result is described above.
--- markdown ---
## Step 2: Complaint counts

*Original query returned 5 rows, 2 columns.*
--- code ---
# `query` here is a full SoQL statement, so the data source applies it as the
# whole query ($query): select / where / group / order — and limit / offset —
# are not sent alongside it. They are omitted from the URL rather than written
# as parameters that would have no effect on the rows this cell returns.
# Superseded on this call, for that reason: where, limit, offset.
# The row count is therefore bounded by the statement's own LIMIT, or by the
# portal's default page size when the statement carries none.
url = "https://data.cityofnewyork.us/resource/erm2-nwe9.json?$query=SELECT%20complaint_type%2C%20count(*)%20GROUP%20BY%20complaint_type%20LIMIT%205"
```

**What a step with no URL renders, and why.** It keeps its number and its result summary and gains a note naming the operation it could not reproduce. Silence was rejected: dropping the step would make the document claim the analysis rested on fewer sources than it did — the same false precision (design-principles.md Principle 3) pointing the other way, and against Principle 2's persistent source marking. The note names the tool and stops there, so it claims no source it did not read.

**Every advertised argument accounted for.** `portal`/`dataset_id` are the path; `type` is routing metadata that already selected this renderer; `query` follows the data source's precedence — SoQL-shaped becomes `$query` alone with no `$limit`/`$offset` beside it, a phrase becomes `$q` alongside the clauses; `select`/`where`/`group`/`order`/`limit`/`offset` become their `$` parameters. Superseded clauses and any argument this URL has no parameter for are named in the cell rather than dropped without a trace. `limit: 0` is now a limit rather than a falsy absence, and a clause whose value the URL cannot express (anything but a string or a finite number) is disclosed rather than stringified into it.

**The SoQL sniff is imported, not copied.** `notebook.ts` imports `isFullSoqlQuery` from `notebook-author/tool-to-cell.ts` — the function whose body is `SOQL_QUERY_SNIFF.test(query)`. No fourth copy, and `tool-to-cell.ts` is unmodified. Rationale and the alternative are in the report.

**The "Data sources" list** is now built from the planned steps, so it cites only datasets a cell in the document actually fetches, on the portal that cell fetches them from. It previously read `dataset_id` off any query call and fell back to the run's selected portal for the link.

---

## Gates

`npm ci` first. All five green; full output in the phase report.

| Gate | Result |
|---|---|
| `npm test` | `# tests 1205 / # suites 10 / # pass 1205 / # fail 0` (base `de4bd60`: 1176) |
| `npm run build` | `✓ Compiled successfully`, Route (app) table |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | `✖ 3 problems (0 errors, 3 warnings)` — the documented baseline |
| `npm run check:compose-env` | `RESULT: PASS — every variable this profile reads can reach the container.` |

`+29` tests, `-0`, one rename. Green on the runner: run `33207707041`, checks `build / test / lint / typecheck` and `container image build`, both **pass**; `DCO` and `Vercel` pass. The two Turbopack `Dynamic filesystem access` warnings are pre-existing — measured at `de4bd60` on this machine, same count, and their import traces run `helpers/index.ts → synthesize.ts → {query-notebook route, notebook-preview page}`, which this diff does not touch.

## Blast zone

Six files, all inside the declared zone:

```
 src/components/evidence/AttestationDialog.tsx |  15 +-
 src/lib/evidence/tool-call-identity.test.ts   | 184 +++++++++++++++++++
 src/lib/evidence/tool-call-identity.ts        |  64 +++++++
 src/lib/model-loop/replay-loop.test.ts        |  71 ++++----
 src/lib/notebook.test.ts                      | 245 +++++++++++++++++++++++++
 src/lib/notebook.ts                           | 253 +++++++++++++++++++++++---
 6 files changed, 767 insertions(+), 65 deletions(-)
```

`tool-to-cell.ts` was **not** modified — the shared sniff needed neither to move nor to be re-exported. Nothing outside the zone was touched; three out-of-zone findings are flagged in the phase report, not fixed.
